### PR TITLE
fix: Filter CLI commands from manifest script detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-01-17
+
+### 🐛 Fixed
+
+**Manifest Script Detection**:
+- Fixed `FileManifest._get_referenced_scripts()` to filter out CLI commands (`spec-kitty`, `git`, etc.) that were incorrectly flagged as missing script files
+- Script detection now only includes files from `.kittify/scripts/` directory, preventing false positives from command templates
+- Added comprehensive filtering for system commands (Python, Node.js, Docker, etc.)
+
 ## [0.11.1] - 2026-01-16
 
 ### 🐛 Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "0.11.1"
+version = "0.11.2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/manifest.py
+++ b/src/specify_cli/manifest.py
@@ -3,6 +3,7 @@ Manifest system for spec-kitty file verification.
 This module generates and checks expected files based on the active mission.
 """
 
+import os
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 import yaml
@@ -124,14 +125,19 @@ class FileManifest:
                             if script_parts:
                                 script_path = script_parts[0]
                                 
-                                # Skip CLI commands and system executables
-                                if script_path in cli_commands:
-                                    continue
-                                    
-                                # Skip absolute paths and commands without .kittify prefix
+                                # Normalize path separators for cross-platform compatibility
+                                script_path = script_path.replace('\\', '/')
+                                
+                                # Check if this is a .kittify-managed script first
                                 # Only include scripts that are in .kittify/scripts/
                                 if not script_path.startswith('.kittify/'):
-                                    # Not a .kittify-managed script
+                                    # Not a .kittify path - could be a CLI command
+                                    # Skip CLI commands and system executables
+                                    # Use basename to handle path prefixes like ./spec-kitty or /usr/bin/git
+                                    script_basename = os.path.basename(script_path)
+                                    if script_basename in cli_commands:
+                                        continue
+                                    # Any other non-.kittify path is also skipped
                                     continue
                                 
                                 # Remove .kittify/ prefix for storage

--- a/src/specify_cli/manifest.py
+++ b/src/specify_cli/manifest.py
@@ -130,21 +130,18 @@ class FileManifest:
                                     
                                 # Skip absolute paths and commands without .kittify prefix
                                 # Only include scripts that are in .kittify/scripts/
-                                if not script_path.startswith('.kittify/scripts/'):
-                                    # Try to normalize paths that start with .kittify/
-                                    if script_path.startswith('.kittify/'):
-                                        # Remove .kittify/ prefix for storage
-                                        script_path = script_path.replace('.kittify/', '', 1)
-                                        # Must be in scripts/ subdirectory
-                                        if not script_path.startswith('scripts/'):
-                                            continue
-                                        scripts.add(script_path)
-                                    # Otherwise skip it (not a .kittify script)
+                                if not script_path.startswith('.kittify/'):
+                                    # Not a .kittify-managed script
                                     continue
-                                else:
-                                    # Remove .kittify/ prefix for storage
-                                    script_path = script_path.replace('.kittify/', '', 1)
-                                    scripts.add(script_path)
+                                
+                                # Remove .kittify/ prefix for storage
+                                script_path = script_path.replace('.kittify/', '', 1)
+                                
+                                # Must be in scripts/ subdirectory
+                                if not script_path.startswith('scripts/'):
+                                    continue
+                                
+                                scripts.add(script_path)
 
         return sorted(list(scripts))
 

--- a/tests/test_manifest_filtering.py
+++ b/tests/test_manifest_filtering.py
@@ -1,0 +1,212 @@
+"""Tests for manifest script filtering to prevent false positives."""
+
+from pathlib import Path
+import tempfile
+import shutil
+from specify_cli.manifest import FileManifest
+
+
+def test_filters_cli_commands(tmp_path):
+    """Ensure CLI commands like spec-kitty and git are not treated as scripts."""
+    # Setup
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    
+    # Create active-mission indicator
+    (kittify_dir / "active-mission").write_text("software-dev")
+    
+    # Create mission.yaml
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+    
+    # Create a command template with CLI commands (should be filtered out)
+    command_content = """---
+description: Test command
+ps: spec-kitty agent --json
+sh: spec-kitty agent --json
+---
+
+# Test Command
+"""
+    (commands_dir / "test.md").write_text(command_content)
+    
+    # Test
+    manifest = FileManifest(kittify_dir)
+    scripts = manifest._get_referenced_scripts()
+    
+    # Verify CLI commands are filtered out
+    assert "spec-kitty" not in scripts
+    assert len(scripts) == 0
+
+
+def test_includes_kittify_scripts(tmp_path):
+    """Ensure actual .kittify/scripts/ files are included."""
+    # Setup
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    
+    # Create active-mission indicator
+    (kittify_dir / "active-mission").write_text("software-dev")
+    
+    # Create mission.yaml
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+    
+    # Create actual script files
+    scripts_dir = kittify_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "helper.sh").write_text("#!/bin/bash\necho 'test'")
+    (scripts_dir / "setup.ps1").write_text("Write-Host 'test'")
+    
+    # Create command template referencing actual scripts
+    command_content = """---
+description: Test command
+ps: .kittify/scripts/setup.ps1
+sh: .kittify/scripts/helper.sh
+---
+
+# Test Command
+"""
+    (commands_dir / "test.md").write_text(command_content)
+    
+    # Test
+    manifest = FileManifest(kittify_dir)
+    scripts = manifest._get_referenced_scripts()
+    
+    # Verify actual scripts are included (platform-specific)
+    import platform
+    if platform.system() == 'Windows':
+        assert "scripts/setup.ps1" in scripts
+    else:
+        assert "scripts/helper.sh" in scripts
+    
+    # Should have exactly one script (for current platform)
+    assert len(scripts) == 1
+
+
+def test_filters_system_commands(tmp_path):
+    """Ensure system commands like git, python are not treated as scripts."""
+    # Setup
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    
+    # Create active-mission indicator
+    (kittify_dir / "active-mission").write_text("software-dev")
+    
+    # Create mission.yaml
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+    
+    # Create command template with various system commands
+    command_content = """---
+description: Test command
+ps: git status
+sh: python3 -c "print('test')"
+---
+
+# Test Command
+"""
+    (commands_dir / "test.md").write_text(command_content)
+    
+    # Test
+    manifest = FileManifest(kittify_dir)
+    scripts = manifest._get_referenced_scripts()
+    
+    # Verify system commands are filtered out
+    assert "git" not in scripts
+    assert "python3" not in scripts
+    assert len(scripts) == 0
+
+
+def test_ignores_non_scripts_directory_paths(tmp_path):
+    """Ensure paths not in .kittify/scripts/ are ignored."""
+    # Setup
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    
+    # Create active-mission indicator
+    (kittify_dir / "active-mission").write_text("software-dev")
+    
+    # Create mission.yaml
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+    
+    # Create command template referencing non-script paths
+    command_content = """---
+description: Test command
+ps: .kittify/memory/something.md
+sh: .kittify/templates/plan.md
+---
+
+# Test Command
+"""
+    (commands_dir / "test.md").write_text(command_content)
+    
+    # Test
+    manifest = FileManifest(kittify_dir)
+    scripts = manifest._get_referenced_scripts()
+    
+    # Verify non-script paths are filtered out
+    assert "memory/something.md" not in scripts
+    assert "templates/plan.md" not in scripts
+    assert len(scripts) == 0
+
+
+def test_mixed_commands_and_scripts(tmp_path):
+    """Ensure mix of CLI commands and real scripts are properly filtered."""
+    # Setup
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    
+    # Create active-mission indicator
+    (kittify_dir / "active-mission").write_text("software-dev")
+    
+    # Create mission.yaml
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+    
+    # Create actual script
+    scripts_dir = kittify_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (scripts_dir / "real-script.ps1").write_text("Write-Host 'test'")
+    
+    # Create command template with mix of CLI and script
+    command_content = """---
+description: Test command
+ps: .kittify/scripts/real-script.ps1
+---
+
+# Test Command
+"""
+    (commands_dir / "cmd1.md").write_text(command_content)
+    
+    # Create another command with CLI commands
+    cli_command_content = """---
+description: CLI command
+ps: spec-kitty agent --json
+---
+
+# CLI Command
+"""
+    (commands_dir / "cmd2.md").write_text(cli_command_content)
+    
+    # Test
+    manifest = FileManifest(kittify_dir)
+    scripts = manifest._get_referenced_scripts()
+    
+    # Verify only real script is included
+    import platform
+    if platform.system() == 'Windows':
+        assert "scripts/real-script.ps1" in scripts
+        assert len(scripts) == 1
+    else:
+        # On non-Windows, the ps: line is ignored, so no scripts
+        assert len(scripts) == 0
+    
+    # Verify CLI commands are excluded
+    assert "spec-kitty" not in scripts

--- a/tests/test_manifest_filtering.py
+++ b/tests/test_manifest_filtering.py
@@ -1,8 +1,6 @@
 """Tests for manifest script filtering to prevent false positives."""
 
-from pathlib import Path
-import tempfile
-import shutil
+import platform
 from specify_cli.manifest import FileManifest
 
 
@@ -76,7 +74,6 @@ sh: .kittify/scripts/helper.sh
     scripts = manifest._get_referenced_scripts()
     
     # Verify actual scripts are included (platform-specific)
-    import platform
     if platform.system() == 'Windows':
         assert "scripts/setup.ps1" in scripts
     else:
@@ -200,7 +197,6 @@ ps: spec-kitty agent --json
     scripts = manifest._get_referenced_scripts()
     
     # Verify only real script is included
-    import platform
     if platform.system() == 'Windows':
         assert "scripts/real-script.ps1" in scripts
         assert len(scripts) == 1


### PR DESCRIPTION
Prevents false positives when FileManifest._get_referenced_scripts() encounters CLI commands like 'spec-kitty' or 'git' in command templates.

Changes:
- Add CLI command filtering (spec-kitty, git, python, npm, etc.)
- Only include scripts from .kittify/scripts/ directory
- Ignore paths in other .kittify/ subdirectories (memory, templates)
- Add comprehensive test coverage

Fixes issue where command frontmatter like 'ps: spec-kitty agent --json' was incorrectly treated as a missing script file.