### PR TITLE
fixup: version alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.0a1"
+version = "3.2.0a2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -62,7 +62,7 @@ dependencies = [
     "packaging>=23.0",
     "psutil>=5.9.0",  # Cross-platform process management for dashboard
     "spec-kitty-events==3.2.0",
-    "spec-kitty-runtime==0.4.3",
+    "spec-kitty-runtime==0.4.4",
     "spec-kitty-tracker==0.4.2",
     "websockets>=12.0",  # WebSocket client for sync protocol
     "toml>=0.10.2",  # Config file parsing


### PR DESCRIPTION
## Fixes:

 issue with dependency conflict ( indicated by latest CI-quality and release-readiness runs).
 
 ## Root cause
 
Due to full stack release issues, the project upstream dependency on `spec-kitty-events` is missmatched with ` spec-kitty-runtime`.
The new version of `spec-kitty-runtime` depends on a different version of `spec-kitty-events`  than this repository does.

**IMPORTANT:** PR [spec-kitty-runtime:13](https://github.com/Priivacy-ai/spec-kitty-runtime/pull/13) needs to be merged first.