### PR TITLE
plan: enable hosted sync by default

### DIFF
--- a/MANUAL_TEST_PLAN.md
+++ b/MANUAL_TEST_PLAN.md
@@ -24,7 +24,7 @@
 
 - [ ] Python 3.11+ with `spec-kitty-cli` v2.0.2 installed (`pip install spec-kitty-cli`)
 - [ ] Git configured with SSH access to Priivacy-ai org
-- [ ] `SPEC_KITTY_ENABLE_SAAS_SYNC=1` environment variable set
+- [ ] Hosted auth/sync available by default; do not rely on `SPEC_KITTY_ENABLE_SAAS_SYNC`
 - [ ] `spec-kitty auth login` completed successfully
 - [ ] Local test repository initialized with `spec-kitty init`
 - [ ] Browser with DevTools available (Chrome/Firefox)

--- a/docs/migration/cross-repo-e2e-gate.md
+++ b/docs/migration/cross-repo-e2e-gate.md
@@ -46,7 +46,7 @@ least these scenarios. Future missions add more on top.
 |------|-------------|----------------|
 | `dependent_wp_planning_lane.py` | FR-001, FR-005, FR-038 | A mission with sequential dependent WPs plus a planning-lane WP merges with no silent omission of approved commits. |
 | `uninitialized_repo_fail_loud.py` | FR-032, FR-039 | `spec-kitty specify`/`plan`/`tasks` in a non-Spec-Kitty directory exit non-zero with `SPEC_KITTY_REPO_NOT_INITIALIZED` and write zero files into a sibling initialized repo. |
-| `saas_sync_enabled.py` | FR-040 | A full mission run with `SPEC_KITTY_ENABLE_SAAS_SYNC=1` against a configured dev SaaS endpoint produces sync emits at the endpoint, OR records a structured "endpoint unreachable" outcome that triggers the operator-exception path. |
+| `saas_sync_enabled.py` | FR-040 | A full mission run against a configured dev SaaS endpoint produces sync emits at the endpoint, OR records a structured "endpoint unreachable" outcome that triggers the operator-exception path. |
 | `contract_drift_caught.py` | FR-041 | Staging a fake `spec-kitty-events` candidate that drops a required envelope field causes `pytest tests/contract/` to exit non-zero with a missing-field diagnostic. |
 
 ## How to run the gate
@@ -54,8 +54,6 @@ least these scenarios. Future missions add more on top.
 From the spec-kitty repo:
 
 ```bash
-export SPEC_KITTY_ENABLE_SAAS_SYNC=1
-
 # 0. TeamSpace mission-state gate
 spec-kitty doctor mission-state --audit --fail-on teamspace-blocker
 
@@ -106,8 +104,7 @@ infra, not code."]
 ## Reproduction command
 
 ```bash
-SPEC_KITTY_ENABLE_SAAS_SYNC=1 \
-  pytest spec-kitty-end-to-end-testing/scenarios/saas_sync_enabled.py -v
+pytest spec-kitty-end-to-end-testing/scenarios/saas_sync_enabled.py -v
 ```
 
 ## Follow-up

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -72,13 +72,12 @@ spec-kitty merge
 
 ### SPEC_KITTY_ENABLE_SAAS_SYNC
 
-Opt in to hosted auth, tracker, and sync flows.
+Deprecated compatibility variable. Hosted auth, tracker, and sync flows are enabled by default.
 
-**Purpose**: Enables the SaaS-backed readiness path. Leave it unset for fully local CLI workflows.
+**Purpose**: Retained so old shells and scripts do not break. Its value is ignored in the release channel. Use `spec-kitty sync opt-out` to disable uploads for a checkout/repository.
 
 **Example**:
 ```bash
-export SPEC_KITTY_ENABLE_SAAS_SYNC=1
 spec-kitty auth login
 ```
 
@@ -183,7 +182,7 @@ The codebase also contains test and harness overrides such as `SPEC_KITTY_TEST_M
 | `SPECIFY_TEMPLATE_REPO` | Use a custom remote template repo | `org/templates` |
 | `SPEC_KITTY_NON_INTERACTIVE` | Disable prompts | `1` |
 | `SPEC_KITTY_WORKTREE_REMOVAL_DELAY` | Delay worktree cleanup | `10` |
-| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Opt in to hosted sync/auth flows | `1` |
+| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Deprecated; hosted sync/auth is enabled by default | `0` |
 | `SPEC_KITTY_SAAS_URL` | Override hosted base URL | `https://spec-kitty-dev.fly.dev` |
 | `SPEC_KITTY_SIMPLE_HELP` | Use simpler help output | `1` |
 | `SPEC_KITTY_NO_BANNER` | Suppress startup banner | `1` |

--- a/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-mission-review/SKILL.md
@@ -520,7 +520,7 @@ in Step 9 unless the operator-exception path documented below is used.
 
 ```bash
 cd <spec-kitty-repo>
-SPEC_KITTY_ENABLE_SAAS_SYNC=1 <test-runner> tests/contract/ -v
+<test-runner> tests/contract/ -v
 ```
 
 Non-zero exit ⇒ **HARD FAIL**. There is no exception path for contract
@@ -545,7 +545,7 @@ Record the result under `## Gate Results — Architectural`.
 
 ```bash
 cd <spec-kitty-end-to-end-testing-repo>
-SPEC_KITTY_ENABLE_SAAS_SYNC=1 <test-runner> scenarios/ -v
+<test-runner> scenarios/ -v
 ```
 
 Non-zero exit ⇒ **HARD FAIL** unless an operator-exception artifact
@@ -653,7 +653,7 @@ must be able to understand each finding from the report alone.
 ## Gate Results
 
 ### Gate 1 — Contract tests
-- Command: `SPEC_KITTY_ENABLE_SAAS_SYNC=1 <test-runner> tests/contract/ -v`
+- Command: `<test-runner> tests/contract/ -v`
 - Exit code: <0 | non-zero>
 - Result: PASS | FAIL
 - Notes: <failing test names if any>
@@ -665,7 +665,7 @@ must be able to understand each finding from the report alone.
 - Notes: ...
 
 ### Gate 3 — Cross-repo E2E
-- Command: `SPEC_KITTY_ENABLE_SAAS_SYNC=1 <test-runner> spec-kitty-end-to-end-testing/scenarios/ -v`
+- Command: `<test-runner> spec-kitty-end-to-end-testing/scenarios/ -v`
 - Exit code: <0 | non-zero>
 - Result: PASS | FAIL | EXCEPTION (with link to `kitty-specs/<slug>/mission-exception.md`)
 - Notes: <failing scenarios; if EXCEPTION, quote the operator narrative>

--- a/src/specify_cli/cli/commands/__init__.py
+++ b/src/specify_cli/cli/commands/__init__.py
@@ -54,17 +54,12 @@ def register_commands(app: typer.Typer) -> None:
     from . import research as research_module
     from . import review as review_module
     from . import sync as sync_module
+    from . import tracker as tracker_module
     from . import upgrade as upgrade_module
     from . import validate_encoding as validate_encoding_module
     from . import validate_tasks as validate_tasks_module
     from . import verify as verify_module
     from specify_cli import orchestrator_api as orchestrator_api_module
-    from specify_cli.saas.rollout import is_saas_sync_enabled
-
-    if is_saas_sync_enabled():
-        from . import tracker as tracker_module
-    else:  # pragma: no cover - deterministic environment gate
-        tracker_module = None
 
     app.command()(accept_module.accept)
     app.add_typer(agent_module.app, name="agent")
@@ -92,11 +87,10 @@ def register_commands(app: typer.Typer) -> None:
     app.command()(research_module.research)
     app.command(name="review")(review_module.review_mission)
     app.add_typer(sync_module.app, name="sync", help="Synchronization commands")
-    if tracker_module is not None:
-        app.add_typer(tracker_module.app, name="tracker", help="Task tracker commands")
-        app.command(name="issue-search", help="Search tracker issues via the hosted read path")(
-            tracker_module.issue_search_command
-        )
+    app.add_typer(tracker_module.app, name="tracker", help="Task tracker commands")
+    app.command(name="issue-search", help="Search tracker issues via the hosted read path")(
+        tracker_module.issue_search_command
+    )
     app.command()(upgrade_module.upgrade)
     app.command(name="validate-encoding")(validate_encoding_module.validate_encoding)
     app.command(name="validate-tasks")(validate_tasks_module.validate_tasks)

--- a/src/specify_cli/cli/commands/_auth_doctor.py
+++ b/src/specify_cli/cli/commands/_auth_doctor.py
@@ -387,9 +387,8 @@ def _compute_findings(
             )
 
     # F-005 — daemon expected but not running (informational).
-    # We surface this only when rollout is enabled. The rollout module imports
-    # are deferred so a missing/disabled SaaS surface never breaks the doctor
-    # report.
+    # The rollout module import is deferred so a missing SaaS surface never
+    # breaks the doctor report.
     rollout_enabled = False
     try:
         from specify_cli.saas.rollout import is_saas_sync_enabled

--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -160,11 +160,11 @@ def list_cmd() -> None:
         raise typer.Exit(1) from exc
 
 
-def _detect_current_feature(project_root: Path) -> str | None:
+def _detect_current_feature(_project_root: Path) -> str | None:
     """Return None — no auto-detection (requires explicit --mission).
 
     Args:
-        project_root: Project root path (unused)
+        _project_root: Project root path (unused)
 
     Returns:
         Always None; caller must provide --mission explicitly.
@@ -308,15 +308,10 @@ def create_cmd(
     Example:
         spec-kitty mission create --from-ticket linear:PRI-42
     """
-    from specify_cli.sync.feature_flags import is_saas_sync_enabled, saas_sync_disabled_message
     from specify_cli.tracker.config import load_tracker_config, require_repo_root
     from specify_cli.tracker.saas_client import SaaSTrackerClientError
     from specify_cli.tracker.service import TrackerService, TrackerServiceError
     from specify_cli.tracker.ticket_context import write_pending_origin, write_ticket_context
-
-    if not is_saas_sync_enabled():
-        typer.secho(saas_sync_disabled_message(), err=True, fg=typer.colors.RED)
-        raise typer.Exit(1)
 
     # Parse provider:KEY
     if ":" not in from_ticket:

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -36,11 +36,6 @@ from specify_cli.core.vcs import (
 )
 
 from specify_cli.sync.queue import QueueStats
-from specify_cli.sync.feature_flags import (
-    SAAS_SYNC_ENV_VAR,
-    is_saas_sync_enabled,
-    saas_sync_disabled_message,
-)
 
 console = Console()
 
@@ -305,11 +300,6 @@ def routes() -> None:
     console.print(table)
     console.print()
 
-    if not is_saas_sync_enabled():
-        console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
-        console.print()
-        return
-
     enforce_teamspace_mission_state_ready(
         console=console,
         command_name="spec-kitty sync routes",
@@ -356,10 +346,6 @@ def share(
         RepositorySharingClientError,
         request_repository_share_sync,
     )
-
-    if not is_saas_sync_enabled():
-        console.print(f"[red]{saas_sync_disabled_message()}[/red]")
-        raise typer.Exit(1)
 
     enforce_teamspace_mission_state_ready(
         console=console,
@@ -429,10 +415,6 @@ def unshare(
         RepositorySharingClientError,
         leave_repository_share_sync,
     )
-
-    if not is_saas_sync_enabled():
-        console.print(f"[red]{saas_sync_disabled_message()}[/red]")
-        raise typer.Exit(1)
 
     enforce_teamspace_mission_state_ready(
         console=console,
@@ -508,12 +490,6 @@ def opt_out(
     if not delete_private_data or not routing.project_uuid:
         return
 
-    if not is_saas_sync_enabled():
-        console.print(
-            "[yellow]Skipping private-data deletion because SaaS sync is disabled in this shell.[/yellow]"
-        )
-        return
-
     try:
         _require_authenticated_session(command_name="sync opt-out")
         shares = list_repository_shares_sync(source_project_uuid=routing.project_uuid)
@@ -558,10 +534,6 @@ def opt_in(
 ) -> None:
     """Enable SaaS sync for this checkout."""
     from specify_cli.sync.routing import enable_checkout_sync
-
-    if not is_saas_sync_enabled():
-        console.print(f"[dim]{saas_sync_disabled_message()}[/dim]")
-        return
 
     enforce_teamspace_mission_state_ready(
         console=console,
@@ -868,12 +840,6 @@ def _check_server_connection(server_url: str) -> tuple[str, str]:
     Returns:
         Tuple of (rich-formatted status string, detail message).
     """
-    if not is_saas_sync_enabled():
-        return (
-            "[dim]Disabled[/dim]",
-            saas_sync_disabled_message(),
-        )
-
     import asyncio
 
     from specify_cli.auth import get_token_manager
@@ -1047,11 +1013,6 @@ def now(
     from specify_cli.sync.background import get_sync_service
     from specify_cli.sync.batch import format_sync_summary, write_failure_report
 
-    if not is_saas_sync_enabled():
-        console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
-        console.print(f"[dim]Set {SAAS_SYNC_ENV_VAR}=1 to enable upload.[/dim]")
-        return
-
     enforce_teamspace_mission_state_ready(
         console=console,
         command_name="spec-kitty sync now",
@@ -1160,7 +1121,6 @@ def status(
     # Load configuration
     config = SyncConfig()
     server_url = config.get_server_url()
-    saas_enabled = is_saas_sync_enabled()
     queue = OfflineQueue()
     tm = get_token_manager()
     daemon_status = get_sync_daemon_status()
@@ -1175,11 +1135,7 @@ def status(
     queue_color = "green" if queue_size == 0 else "yellow"
     table.add_row("Queue", f"[{queue_color}]{queue_size} event(s)[/{queue_color}]")
 
-    # Feature flag
-    if saas_enabled:
-        table.add_row("SaaS Sync", "[green]Enabled[/green]")
-    else:
-        table.add_row("SaaS Sync", f"[yellow]Disabled[/yellow] ({SAAS_SYNC_ENV_VAR}=1)")
+    table.add_row("SaaS Sync", "[green]Enabled[/green]")
 
     # Daemon / transport status
     daemon_text = "[green]Running[/green]" if daemon_status.healthy else "[dim]Stopped[/dim]"
@@ -1209,11 +1165,8 @@ def status(
         table.add_row("Failures", f"[yellow]{daemon_status.consecutive_failures} consecutive[/yellow]")
 
     # Auth status
-    if saas_enabled:
-        auth_ok = tm.is_authenticated
-        auth_text = "[green]Authenticated[/green]" if auth_ok else "[yellow]Not authenticated[/yellow]"
-    else:
-        auth_text = "[dim]Disabled by feature flag[/dim]"
+    auth_ok = tm.is_authenticated
+    auth_text = "[green]Authenticated[/green]" if auth_ok else "[yellow]Not authenticated[/yellow]"
     table.add_row("Auth", auth_text)
 
     # Server URL

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -495,7 +495,7 @@ def opt_out(
         shares = list_repository_shares_sync(source_project_uuid=routing.project_uuid)
     except (RepositorySharingClientError, typer.Exit) as exc:
         console.print(f"[yellow]Could not inspect remote share state:[/yellow] {exc}")
-        return
+        raise typer.Exit(1) from exc
 
     if shares:
         console.print(
@@ -515,7 +515,7 @@ def opt_out(
         deletion = delete_private_project_sync(source_project_uuid=routing.project_uuid)
     except RepositorySharingClientError as exc:
         console.print(f"[yellow]Private data was not deleted:[/yellow] {exc}")
-        return
+        raise typer.Exit(1) from exc
 
     console.print(
         f"[green]✓[/green] Deleted private SaaS data for this checkout "

--- a/src/specify_cli/cli/commands/tracker.py
+++ b/src/specify_cli/cli/commands/tracker.py
@@ -32,7 +32,6 @@ from specify_cli.identity.project import ensure_identity
 from specify_cli.tracker.discovery import BindResult, ResolutionResult
 from specify_cli.tracker.factory import normalize_provider
 from specify_cli.saas.readiness import evaluate_readiness
-from specify_cli.saas.rollout import is_saas_sync_enabled, saas_sync_disabled_message
 from specify_cli.sync.config import BackgroundDaemonPolicy, SyncConfig
 from specify_cli.tracker.service import TrackerService, TrackerServiceError, parse_kv_pairs
 
@@ -194,8 +193,7 @@ def _check_sync_readiness(*, is_sync_run: bool = False) -> None:
     the SaaS surface at all: no auth token, no ``SPEC_KITTY_SAAS_URL``, no
     reachability probe, no background daemon.  Their direct connectors handle
     connectivity errors on their own.  For those bindings this helper is a
-    no-op — the rollout gate is already enforced by :func:`tracker_callback`
-    and the binding itself is the proof that setup is complete.
+    no-op — the local binding itself is the proof that setup is complete.
 
     SaaS-backed (or unknown/unconfigured) bindings get the full readiness
     chain plus the manual-mode daemon-policy check.
@@ -247,17 +245,11 @@ def _run_or_exit(fn):  # type: ignore[no-untyped-def]
 
 @app.callback()
 def tracker_callback() -> None:
-    """Defense-in-depth rollout gate for tracker commands.
+    """Tracker command group callback.
 
-    The conditional registration in cli/commands/__init__.py already hides
-    this group entirely when the flag is off.  This callback is a
-    defense-in-depth check in case the env-var state drifts between import
-    time and invocation time.  Per-command readiness checks handle all
-    prerequisite validation beyond the rollout gate.
+    Hosted tracker surfaces are available in the release channel.  Per-command
+    readiness checks handle auth, host configuration, and binding validation.
     """
-    if not is_saas_sync_enabled():
-        typer.secho(saas_sync_disabled_message(), fg=typer.colors.RED, err=True)
-        raise typer.Exit(1)
 
 
 def issue_search_command(
@@ -266,10 +258,6 @@ def issue_search_command(
     as_json: bool = typer.Option(False, "--json", help="Render tickets as a JSON array"),
 ) -> None:
     """Search external tracker issues via the hosted read path."""
-    if not is_saas_sync_enabled():
-        typer.secho(saas_sync_disabled_message(), fg=typer.colors.RED, err=True)
-        raise typer.Exit(1)
-
     _check_readiness(require_mission_binding=False, probe_reachability=False)
 
     def _run() -> None:
@@ -299,10 +287,7 @@ def providers_command(
     Local providers use direct connectors with locally stored credentials.
 
     This command is purely informational and prints the hard-coded provider
-    categories.  It does **not** consult hosted readiness — the rollout gate
-    itself is enforced by ``tracker_callback`` (and by the conditional
-    registration in ``cli/commands/__init__.py``), which is all the gating
-    this static output needs.
+    categories.  It does **not** consult hosted readiness.
     """
 
     def _run() -> None:

--- a/src/specify_cli/dashboard/handlers/api.py
+++ b/src/specify_cli/dashboard/handlers/api.py
@@ -117,7 +117,7 @@ class APIHandler(DashboardHandler):
             )
             if not outcome.started:
                 reason = outcome.skipped_reason or "unknown"
-                if reason in {"rollout_disabled", "policy_manual"}:
+                if reason == "policy_manual":
                     logger.info("Sync daemon not started: %s", reason)
                     self._send_json(202, {"status": "skipped", "manual_mode": True, "reason": reason})
                     return

--- a/src/specify_cli/saas/readiness.py
+++ b/src/specify_cli/saas/readiness.py
@@ -15,10 +15,10 @@ the exception type in ``details["error"]``.
 from __future__ import annotations
 
 import urllib.request
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
-from typing import Mapping
 
 
 # ---------------------------------------------------------------------------
@@ -26,7 +26,7 @@ from typing import Mapping
 # ---------------------------------------------------------------------------
 
 
-class ReadinessState(str, Enum):
+class ReadinessState(StrEnum):
     """Discrete readiness states in check order.
 
     The evaluator checks states in *declaration order* — cheapest and most
@@ -73,10 +73,6 @@ class ReadinessResult:
 # string literals so tests can assert them byte-for-byte.
 
 _WORDING: dict[ReadinessState, tuple[str, str]] = {
-    ReadinessState.ROLLOUT_DISABLED: (
-        "Hosted SaaS sync is not enabled on this machine.",
-        "Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` to opt in.",
-    ),
     ReadinessState.MISSING_AUTH: (
         "No SaaS authentication token is present.",
         "Run `spec-kitty auth login`.",
@@ -121,7 +117,7 @@ def _build_result(state: ReadinessState, **fmt_kwargs: str) -> ReadinessResult:
 
 
 def _probe_rollout() -> bool:
-    """Return True iff SaaS sync is enabled via the environment variable."""
+    """Return True; SaaS sync is no longer environment-gated."""
     from specify_cli.saas.rollout import is_saas_sync_enabled  # avoid circular at module level
 
     try:
@@ -226,12 +222,11 @@ def evaluate_readiness(
 
     Check order (short-circuits on first failure):
 
-    1. Rollout gate (``SPEC_KITTY_ENABLE_SAAS_SYNC``)
-    2. Auth (``TokenManager.is_authenticated``)
-    3. Host config (``SPEC_KITTY_SAAS_URL`` via ``get_saas_base_url()``)
-    4. Reachability — only when ``probe_reachability=True``
-    5. Mission binding — only when ``require_mission_binding=True``
-    6. ``READY``
+    1. Auth (``TokenManager.is_authenticated``)
+    2. Host config (``SPEC_KITTY_SAAS_URL`` via ``get_saas_base_url()``)
+    3. Reachability — only when ``probe_reachability=True``
+    4. Mission binding — only when ``require_mission_binding=True``
+    5. ``READY``
 
     Args:
         repo_root: Absolute path to the repository root; used to locate auth,
@@ -249,24 +244,23 @@ def evaluate_readiness(
         A frozen :class:`ReadinessResult`.
     """
     try:
-        # Step 1: rollout gate
-        if not _probe_rollout():
-            return _build_result(ReadinessState.ROLLOUT_DISABLED)
+        # Historical rollout gate is intentionally ignored in release builds.
+        _probe_rollout()
 
-        # Step 2: auth
+        # Step 1: auth
         if not _probe_auth(repo_root):
             return _build_result(ReadinessState.MISSING_AUTH)
 
-        # Step 3: host config — also captures server_url for later steps
+        # Step 2: host config — also captures server_url for later steps
         server_url = _probe_host_config()
         if server_url is None:
             return _build_result(ReadinessState.MISSING_HOST_CONFIG)
 
-        # Step 4: reachability (optional)
+        # Step 3: reachability (optional)
         if probe_reachability and not _probe_reachability(server_url):
             return _build_result(ReadinessState.HOST_UNREACHABLE, server_url=server_url)
 
-        # Step 5: mission binding (optional)
+        # Step 4: mission binding (optional)
         if require_mission_binding and not _probe_mission_binding(repo_root):
             return _build_result(
                 ReadinessState.MISSING_MISSION_BINDING,

--- a/src/specify_cli/saas/rollout.py
+++ b/src/specify_cli/saas/rollout.py
@@ -1,39 +1,37 @@
-"""Canonical rollout gate for hosted SaaS sync.
+"""Compatibility surface for hosted SaaS sync rollout.
 
 Stability contract: ``contracts/saas_rollout.md``.
 
-This module is the single source of truth for the ``SPEC_KITTY_ENABLE_SAAS_SYNC``
-environment-variable check.  Both ``specify_cli.tracker.feature_flags`` and
-``specify_cli.sync.feature_flags`` are thin re-export shims that delegate here.
+Hosted SaaS sync is release-ready and no longer hidden behind
+``SPEC_KITTY_ENABLE_SAAS_SYNC``.  The symbols in this module remain for
+backwards-compatible imports from tracker/sync code and older tests, but the
+environment variable is intentionally ignored.
 """
 
 from __future__ import annotations
 
-import os
-
 SAAS_SYNC_ENV_VAR = "SPEC_KITTY_ENABLE_SAAS_SYNC"
-_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 
 _DISABLED_MESSAGE = (
-    "Hosted SaaS sync is not enabled on this machine. "
-    "Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` to opt in."
+    "Hosted SaaS sync is enabled by default. "
+    "Use `spec-kitty sync opt-out` to disable uploads for this checkout."
 )
 
 
 def is_saas_sync_enabled() -> bool:
-    """Return True iff SaaS sync is explicitly enabled via the environment.
+    """Return whether hosted SaaS sync is available in this release channel.
 
-    Truthy values (case-insensitive, after strip): ``1``, ``true``, ``yes``, ``on``.
-    Everything else — including an unset or empty variable — returns ``False``.
+    The answer is always ``True``.  Per-checkout and per-repository opt-out
+    still lives in ``specify_cli.sync.routing`` / ``SyncConfig`` and is the
+    supported way to stop uploads.
     """
-    raw = os.environ.get(SAAS_SYNC_ENV_VAR, "")
-    return raw.strip().casefold() in _TRUTHY_VALUES
+    return True
 
 
 def saas_sync_disabled_message() -> str:
-    """Return the stable, byte-wise-frozen message shown when SaaS sync is off.
+    """Return the compatibility message for stale disabled-gate callers.
 
-    Wording is asserted byte-for-byte by tests; do not change without updating
-    ``contracts/saas_rollout.md`` and bumping the contract version.
+    New code should not branch on this message; SaaS sync is no longer
+    feature-flagged off by environment.
     """
     return _DISABLED_MESSAGE

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -12,8 +12,8 @@ Heavy dependencies (requests, websockets) are lazily imported via __getattr__
 so that lightweight imports like ``from specify_cli.sync.events import ...``
 do not pull in optional packages.
 
-SaaS connectivity is feature-flagged and disabled by default. Set
-``SPEC_KITTY_ENABLE_SAAS_SYNC=1`` to enable auth/network sync flows.
+SaaS connectivity is enabled in the release channel. Use
+``spec-kitty sync opt-out`` for checkout/repository-level upload opt-out.
 
 As of mission 080 (browser-mediated OAuth) the legacy
 ``specify_cli.sync.auth`` module has been removed entirely. All callers

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -95,7 +95,7 @@ class WebSocketClient:
         """Establish WebSocket connection with authentication.
 
         Flow:
-        1. Gate on the SaaS-sync feature flag.
+        1. Check the compatibility SaaS-sync rollout shim.
         2. Fetch a fresh ws_token + ws_url via ``provision_ws_token`` (which
            single-flight-refreshes the access token if needed).
         3. Open the WS upgrade at ``ws_url?token=<ws_token>``.

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -640,7 +640,7 @@ def ensure_sync_daemon_running(
     The ``intent`` parameter is keyword-only and mandatory.
 
     Decision matrix (first match wins):
-    1. Rollout disabled → skipped_reason="rollout_disabled"
+    1. Compatibility rollout shim disabled → skipped_reason="rollout_disabled"
     2. intent == LOCAL_ONLY → skipped_reason="intent_local_only"
     3. policy == MANUAL → skipped_reason="policy_manual"
     4. Otherwise → delegate to inner start logic (AUTO policy + REMOTE_REQUIRED intent)
@@ -655,7 +655,7 @@ def ensure_sync_daemon_running(
         config = _SyncConfig()
     policy = config.get_background_daemon()
 
-    # Row 1: rollout disabled
+    # Row 1: compatibility shim disabled (not expected in release builds)
     if not is_saas_sync_enabled():
         return DaemonStartOutcome(started=False, skipped_reason="rollout_disabled", pid=None)
 
@@ -667,7 +667,7 @@ def ensure_sync_daemon_running(
     if policy == BackgroundDaemonPolicy.MANUAL:
         return DaemonStartOutcome(started=False, skipped_reason="policy_manual", pid=None)
 
-    # Row 4 & 5: AUTO + REMOTE_REQUIRED — attempt to start
+    # Row 4: AUTO + REMOTE_REQUIRED — attempt to start
     _daemon_root().mkdir(parents=True, exist_ok=True)
 
     lock_fd = open(DAEMON_LOCK_FILE, "w")  # noqa: SIM115

--- a/src/specify_cli/sync/events.py
+++ b/src/specify_cli/sync/events.py
@@ -64,8 +64,9 @@ def _ensure_dashboard_sync_daemon(repo_root: Path | None, *, ensure_daemon: bool
         if outcome.started:
             pass  # Daemon is up; continue.
         elif outcome.skipped_reason == "rollout_disabled":
-            # Unreachable: the is_saas_sync_enabled() check at line 45 already
-            # bailed before we get here. Present only as a defensive branch.
+            # Unreachable in release builds because the canonical rollout
+            # function always enables hosted sync. Kept for defensive handling
+            # when tests monkeypatch the compatibility shim.
             pass
         elif outcome.skipped_reason == "policy_manual":
             logger.debug("Background sync in manual mode; skipping daemon auto-start")

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -419,17 +419,18 @@ class TestSyncNowExitCodes:
             res = runner.invoke(sync_app, ["now"])
         assert res.exit_code == 1
 
-    def test_now_returns_0_when_saas_feature_disabled(self, monkeypatch):
-        """sync now should no-op safely when SaaS flag is disabled."""
+    def test_now_ignores_legacy_saas_feature_flag(self, monkeypatch):
+        """sync now uses normal queue handling when the old env var is unset."""
         monkeypatch.delenv(SAAS_SYNC_ENV_VAR, raising=False)
+        svc = self._make_service(queue_size=0, result=self._make_result())
 
         runner = CliRunner()
-        with patch("specify_cli.sync.background.get_sync_service") as get_service:
+        with patch("specify_cli.sync.background.get_sync_service", return_value=svc) as get_service:
             res = runner.invoke(sync_app, ["now"])
 
         assert res.exit_code == 0
-        assert "saas sync is not enabled" in res.output.lower()
-        get_service.assert_not_called()
+        assert "Queue is empty" in res.output
+        get_service.assert_called_once()
 
     def test_strict_exits_0_on_success(self, monkeypatch):
         """Strict mode exits 0 when all events sync successfully.

--- a/tests/agent/cli/commands/test_tracker.py
+++ b/tests/agent/cli/commands/test_tracker.py
@@ -59,16 +59,17 @@ def _build_root_app(*, enabled: bool, monkeypatch) -> typer.Typer:
 
 
 # ---------------------------------------------------------------------------
-# Feature flag gating tests (pre-existing)
+# Release-enabled registration tests
 # ---------------------------------------------------------------------------
 
 
-def test_tracker_not_registered_when_flag_disabled(monkeypatch) -> None:
-    """Tracker sub-command absent from help when SAAS_SYNC flag is off."""
+def test_tracker_registered_when_legacy_flag_unset(monkeypatch) -> None:
+    """Tracker sub-command appears even when the legacy env var is unset."""
     app = _build_root_app(enabled=False, monkeypatch=monkeypatch)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "tracker" not in result.output
+    assert "tracker" in result.output
+    assert "issue-search" in result.output
 
 
 def test_tracker_registered_when_flag_enabled(monkeypatch) -> None:
@@ -80,15 +81,15 @@ def test_tracker_registered_when_flag_enabled(monkeypatch) -> None:
     assert "issue-search" in result.output
 
 
-def test_tracker_direct_invocation_fails_when_flag_disabled(monkeypatch) -> None:
-    """Direct tracker invocation exits with code 1 and a flag-disabled message."""
+def test_tracker_direct_invocation_works_when_legacy_flag_unset(monkeypatch) -> None:
+    """Direct tracker invocation ignores the old rollout env var."""
     monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
 
     from specify_cli.cli.commands import tracker as tracker_module
 
     result = runner.invoke(tracker_module.app, ["providers"])
-    assert result.exit_code == 1
-    assert "Hosted SaaS sync is not enabled" in result.output
+    assert result.exit_code == 0
+    assert "Supported providers" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +98,7 @@ def test_tracker_direct_invocation_fails_when_flag_disabled(monkeypatch) -> None
 
 
 def _make_app(monkeypatch) -> typer.Typer:
-    """Return the tracker app with the feature flag enabled."""
+    """Return the tracker app."""
     monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
     from specify_cli.cli.commands import tracker as tracker_module
 
@@ -891,12 +892,12 @@ def test_list_tickets_dispatches(mock_service_fn, monkeypatch) -> None:
 
 
 @pytest.mark.no_readiness_stub
-def test_tracker_hidden_when_rollout_disabled_root_app(monkeypatch) -> None:
-    """Tracker sub-command absent from root app help when rollout is off."""
+def test_tracker_visible_when_legacy_rollout_unset_root_app(monkeypatch) -> None:
+    """Tracker sub-command appears from the root app when legacy env is unset."""
     app = _build_root_app(enabled=False, monkeypatch=monkeypatch)
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "tracker" not in result.output
+    assert "tracker" in result.output
 
 
 @pytest.mark.no_readiness_stub
@@ -913,11 +914,8 @@ def test_providers_ignores_hosted_readiness(monkeypatch) -> None:
     """`tracker providers` is static informational output.
 
     It must run successfully even when hosted readiness would otherwise
-    fail (e.g. no auth token, no SaaS host config).  The rollout gate is
-    still enforced by the conditional registration in
-    ``cli/commands/__init__.py`` and by the defense-in-depth check in
-    ``tracker_callback()``, but the per-command readiness chain is
-    deliberately NOT consulted for this command.
+    fail (e.g. no auth token, no SaaS host config).  The per-command readiness
+    chain is deliberately NOT consulted for this command.
     """
     monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
     from specify_cli.cli.commands import tracker as tracker_module
@@ -945,22 +943,14 @@ def test_providers_ignores_hosted_readiness(monkeypatch) -> None:
 
 
 @pytest.mark.no_readiness_stub
-def test_providers_still_blocked_when_rollout_disabled(monkeypatch) -> None:
-    """When the rollout gate is off, `tracker providers` is unreachable.
-
-    The command group is hidden at registration time in
-    ``cli/commands/__init__.py``; this test exercises the defense-in-depth
-    guard in ``tracker_callback`` by invoking the tracker app object
-    directly with the env var unset.  This verifies that removing the
-    per-command readiness call did not accidentally open a hole in the
-    rollout gate itself.
-    """
+def test_providers_works_when_legacy_rollout_unset(monkeypatch) -> None:
+    """The legacy rollout env var no longer blocks `tracker providers`."""
     monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
     from specify_cli.cli.commands import tracker as tracker_module
 
     result = runner.invoke(tracker_module.app, ["providers"])
-    assert result.exit_code == 1
-    assert "not enabled" in result.output.lower()
+    assert result.exit_code == 0
+    assert "Supported providers" in result.output
 
 
 @pytest.mark.no_readiness_stub

--- a/tests/agent/cli/commands/test_tracker_discover.py
+++ b/tests/agent/cli/commands/test_tracker_discover.py
@@ -7,7 +7,6 @@ Extended by WP05 of feature 082-stealth-gated-saas-sync-hardening (readiness-awa
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -346,8 +345,8 @@ def test_discover_readiness_failure(state, expected_message, monkeypatch, tmp_pa
 
 
 @pytest.mark.no_readiness_stub
-def test_discover_readiness_rollout_disabled(monkeypatch) -> None:
-    """discover is invisible (not registered) when rollout flag is off."""
+def test_discover_readiness_legacy_rollout_env_unset(monkeypatch) -> None:
+    """Tracker remains registered when the retired rollout env var is unset."""
     monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
 
     import importlib
@@ -359,7 +358,7 @@ def test_discover_readiness_rollout_disabled(monkeypatch) -> None:
 
     result = runner.invoke(root, ["--help"])
     assert result.exit_code == 0
-    assert "discover" not in result.output or "tracker" not in result.output
+    assert "tracker" in result.output
 
 
 @pytest.mark.no_readiness_stub

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -54,7 +54,6 @@ def _session() -> StoredSession:
 def test_routes_command_renders_share_state(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_tm = Mock()
     fake_tm.get_current_session.return_value = _session()
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
     monkeypatch.setattr(
         "specify_cli.sync.routing.resolve_checkout_sync_routing",
@@ -96,7 +95,6 @@ def test_routes_command_renders_share_state(monkeypatch: pytest.MonkeyPatch) -> 
 def test_share_command_retries_after_materializing_private_source(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_tm = Mock()
     fake_tm.get_current_session.return_value = _session()
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
     monkeypatch.setattr(
         "specify_cli.sync.routing.resolve_checkout_sync_routing",
@@ -145,7 +143,6 @@ def test_share_command_blocks_when_teamspace_mission_state_migration_pending(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     request_share = Mock()
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr(
         sync_module,
         "enforce_teamspace_mission_state_ready",
@@ -199,7 +196,6 @@ def test_opt_out_command_reports_purged_counts(monkeypatch: pytest.MonkeyPatch) 
 def test_unshare_command_stops_sharing_for_one_team(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_tm = Mock()
     fake_tm.get_current_session.return_value = _session()
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
     monkeypatch.setattr(
         "specify_cli.sync.routing.resolve_checkout_sync_routing",
@@ -229,7 +225,6 @@ def test_unshare_command_stops_sharing_for_one_team(monkeypatch: pytest.MonkeyPa
 def test_opt_out_command_can_delete_private_remote_data(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_tm = Mock()
     fake_tm.get_current_session.return_value = _session()
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
     monkeypatch.setattr(
         "specify_cli.sync.routing.resolve_checkout_sync_routing",
@@ -298,7 +293,6 @@ def test_now_logged_out_nonempty_queue_reports_unauthenticated_failures(
     service.queue.size.return_value = 3
     service.sync_now.return_value = unauthenticated_result
 
-    monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
     monkeypatch.setattr(
         "specify_cli.sync.background.get_sync_service",
         lambda: service,

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -13,6 +13,7 @@ from typer.testing import CliRunner
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.cli.commands import sync as sync_module
 from specify_cli.sync.batch import BatchEventResult, BatchSyncResult
+from specify_cli.sync.sharing_client import RepositorySharingClientError
 
 runner = CliRunner()
 pytestmark = pytest.mark.fast
@@ -266,6 +267,58 @@ def test_opt_out_command_can_delete_private_remote_data(monkeypatch: pytest.Monk
     assert result.exit_code == 0, result.stdout
     assert "Deleted private SaaS data for this checkout" in result.stdout
     assert "4 event(s), 1 build(s)" in result.stdout
+
+
+@pytest.mark.parametrize("failure_stage", ["inspect", "delete"])
+def test_opt_out_remote_delete_failure_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    fake_tm = Mock()
+    fake_tm.get_current_session.return_value = _session()
+    monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
+    monkeypatch.setattr(
+        "specify_cli.sync.routing.resolve_checkout_sync_routing",
+        lambda start=None: type(
+            "Routing",
+            (),
+            {
+                "repo_root": "/tmp/repo",
+                "repo_slug": "acme/spec-kitty",
+                "project_slug": "spec-kitty-local",
+                "project_uuid": "11111111-1111-1111-1111-111111111111",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.routing.disable_checkout_sync",
+        lambda repo_root, remember_repo_default=True: type(
+            "Result",
+            (),
+            {
+                "removed_events": 0,
+                "removed_body_uploads": 0,
+                "remembered_for_repo": False,
+            },
+        )(),
+    )
+
+    def _fail(*args, **kwargs):
+        raise RepositorySharingClientError("remote unavailable")
+
+    monkeypatch.setattr(
+        "specify_cli.sync.sharing_client.list_repository_shares_sync",
+        _fail if failure_stage == "inspect" else lambda source_project_uuid=None: [],
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.sharing_client.delete_private_project_sync",
+        _fail,
+    )
+
+    result = runner.invoke(sync_module.app, ["opt-out", "--delete-private-data", "--yes"])
+
+    assert result.exit_code == 1
+    assert "remote unavailable" in result.stdout
 
 
 def test_now_logged_out_nonempty_queue_reports_unauthenticated_failures(

--- a/tests/e2e/test_charter_epic_golden_path.py
+++ b/tests/e2e/test_charter_epic_golden_path.py
@@ -463,10 +463,9 @@ def _run_charter_flow(project: Path, run_cli: RunCli) -> None:
       project using the default adapter, without hand-seeding
       `.kittify/doctrine/`.
 
-    All subcommands run with `SPEC_KITTY_ENABLE_SAAS_SYNC=1` because the
-    `run_cli` fixture inherits the test environment which sets
+    The `run_cli` fixture inherits the test environment which sets
     `SPEC_KITTY_TEST_MODE=1`; SaaS-touching paths are still exercised
-    end-to-end where applicable (see C-003).
+    end-to-end where applicable.
     """
     # FR-004 Step 1: charter interview (the "setup" phase — non-interactive
     # via --profile minimal --defaults). No public `charter setup`

--- a/tests/saas/conftest.py
+++ b/tests/saas/conftest.py
@@ -1,14 +1,13 @@
 """Shared pytest fixtures for ``tests/saas/`` — readiness evaluator test layers.
 
-Provides dual-mode rollout fixtures and auth/config/binding factory fixtures
+Provides legacy rollout-env fixtures and auth/config/binding factory fixtures
 consumed by both ``test_readiness_unit.py`` (stubbed probes) and
 ``test_readiness_integration.py`` (real evaluator).
 
 Design notes
 ------------
-- ``rollout_disabled`` uses ``monkeypatch.delenv(..., raising=False)`` so it
-  safely overrides the global autouse ``_enable_saas_sync_feature_flag`` that
-  sets ``SPEC_KITTY_ENABLE_SAAS_SYNC=1`` in ``tests/conftest.py:57-60``.
+- ``rollout_disabled`` and ``rollout_enabled`` now exercise compatibility
+  behavior only; the release channel ignores ``SPEC_KITTY_ENABLE_SAAS_SYNC``.
 - Auth fixtures monkey-patch ``specify_cli.auth.get_token_manager`` so the
   probe target ``get_token_manager().is_authenticated`` is fully controlled.
   Monkeypatch target: ``specify_cli.auth.get_token_manager``.
@@ -23,28 +22,28 @@ from __future__ import annotations
 
 import http.server
 import threading
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest.mock import MagicMock
 
 import pytest
 
 
 # ---------------------------------------------------------------------------
-# Rollout gate fixtures
+# Legacy rollout env fixtures
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
 def rollout_disabled(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    """Override the global autouse flag — rollout is OFF for this test."""
+    """Unset the retired rollout env var for compatibility tests."""
     monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
     yield
 
 
 @pytest.fixture()
 def rollout_enabled(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    """Ensure the rollout flag is ON for this test (idempotent with autouse)."""
+    """Set the retired rollout env var for compatibility tests."""
     monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
     yield
 

--- a/tests/saas/test_readiness_unit.py
+++ b/tests/saas/test_readiness_unit.py
@@ -12,8 +12,7 @@ Test inventory
 - Exception conversion: ``_probe_auth`` raising → ``HOST_UNREACHABLE``, no raise.
 - ``probe_reachability=False`` → reachability probe never called.
 - ``require_mission_binding=False`` → binding probe never called.
-- Parametrize over ``rollout_disabled`` / ``rollout_enabled`` modes for the
-  ``ROLLOUT_DISABLED`` path.
+- Rollout probe compatibility is ignored; auth is the first launch blocker.
 """
 
 from __future__ import annotations
@@ -46,31 +45,11 @@ def _stub_all_pass(monkeypatch: pytest.MonkeyPatch, *, server_url: str = "http:/
     )
 
 
-# ---------------------------------------------------------------------------
-# State: ROLLOUT_DISABLED
-# ---------------------------------------------------------------------------
-
-_ROLLOUT_DISABLED_MESSAGE = "Hosted SaaS sync is not enabled on this machine."
-_ROLLOUT_DISABLED_NEXT_ACTION = "Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` to opt in."
-
-
-@pytest.mark.parametrize(
-    "fixture_name",
-    ["rollout_disabled", "rollout_enabled"],
-    ids=["rollout_disabled", "rollout_enabled"],
-)
-def test_rollout_disabled_state(
-    fixture_name: str,
-    request: pytest.FixtureRequest,
+def test_rollout_probe_failure_is_ignored(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ROLLOUT_DISABLED is returned iff the rollout probe fails."""
-    # Load the named rollout fixture
-    request.getfixturevalue(fixture_name)
-
-    rollout_value = fixture_name == "rollout_enabled"
-    monkeypatch.setattr("specify_cli.saas.readiness._probe_rollout", lambda: rollout_value)
-    # Stub remaining probes as passing so the only variable is rollout.
+    """The historical rollout probe no longer blocks hosted readiness."""
+    monkeypatch.setattr("specify_cli.saas.readiness._probe_rollout", lambda: False)
     monkeypatch.setattr("specify_cli.saas.readiness._probe_auth", lambda *_: True)
     monkeypatch.setattr("specify_cli.saas.readiness._probe_host_config", lambda: "http://x")
     monkeypatch.setattr(
@@ -82,15 +61,8 @@ def test_rollout_disabled_state(
 
     result = evaluate_readiness(repo_root=_REPO)
 
-    if fixture_name == "rollout_disabled":
-        assert result.state is ReadinessState.ROLLOUT_DISABLED
-        # Byte-wise wording assertions
-        assert result.message == _ROLLOUT_DISABLED_MESSAGE
-        assert result.next_action == _ROLLOUT_DISABLED_NEXT_ACTION
-        assert not result.is_ready
-    else:
-        assert result.state is ReadinessState.READY
-        assert result.is_ready
+    assert result.state is ReadinessState.READY
+    assert result.is_ready
 
 
 # ---------------------------------------------------------------------------
@@ -259,16 +231,16 @@ def test_ordering_auth_beats_host_config(
     assert result.state is ReadinessState.MISSING_AUTH
 
 
-def test_ordering_rollout_beats_auth(
+def test_ordering_auth_beats_rollout_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When rollout is disabled AND auth fails, ROLLOUT_DISABLED wins (earliest)."""
+    """When rollout probe and auth fail, MISSING_AUTH wins."""
     monkeypatch.setattr("specify_cli.saas.readiness._probe_rollout", lambda: False)
     monkeypatch.setattr("specify_cli.saas.readiness._probe_auth", lambda *_: False)
 
     result = evaluate_readiness(repo_root=_REPO)
 
-    assert result.state is ReadinessState.ROLLOUT_DISABLED
+    assert result.state is ReadinessState.MISSING_AUTH
 
 
 # ---------------------------------------------------------------------------
@@ -351,7 +323,7 @@ def test_is_ready_property(
     result = evaluate_readiness(repo_root=_REPO)
     assert result.is_ready
 
-    monkeypatch.setattr("specify_cli.saas.readiness._probe_rollout", lambda: False)
+    monkeypatch.setattr("specify_cli.saas.readiness._probe_auth", lambda *_: False)
     bad_result = evaluate_readiness(repo_root=_REPO)
     assert not bad_result.is_ready
 

--- a/tests/saas/test_rollout.py
+++ b/tests/saas/test_rollout.py
@@ -1,12 +1,7 @@
 """Unit tests for specify_cli.saas.rollout.
 
-Covers the truthy/falsy env-var table, byte-wise stable disabled message, and
-BC shim identity (each shim must re-export the exact same callable object as
-the canonical module, not a copy of it).
-
-The autouse fixture in ``tests/conftest.py`` sets SPEC_KITTY_ENABLE_SAAS_SYNC=1
-globally.  Every test here uses ``monkeypatch`` to override that value so the
-results are deterministic regardless of fixture ordering.
+Hosted SaaS sync is release-enabled.  The historical env var remains exported
+for compatibility, but its value no longer controls the upload path.
 """
 
 from __future__ import annotations
@@ -17,11 +12,7 @@ from specify_cli.saas.rollout import is_saas_sync_enabled, saas_sync_disabled_me
 
 _ENV_VAR = "SPEC_KITTY_ENABLE_SAAS_SYNC"
 
-# ---------------------------------------------------------------------------
-# Parametrised truthy / falsy tests
-# ---------------------------------------------------------------------------
-
-_TRUTHY_CASES = [
+_ENV_VALUES = [
     "1",
     "true",
     "TRUE",
@@ -32,9 +23,6 @@ _TRUTHY_CASES = [
     "on",
     "ON",
     "On",
-]
-
-_FALSY_CASES = [
     "",
     "0",
     "false",
@@ -50,35 +38,18 @@ _FALSY_CASES = [
 ]
 
 
-@pytest.mark.parametrize("value", _TRUTHY_CASES)
-def test_is_saas_sync_enabled_truthy(
+@pytest.mark.parametrize("value", _ENV_VALUES)
+def test_is_saas_sync_enabled_ignores_env_value(
     monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
-    """Truthy env-var values must return True."""
+    """All env-var values leave SaaS sync enabled in the release channel."""
     monkeypatch.setenv(_ENV_VAR, value)
     assert is_saas_sync_enabled() is True
 
 
-@pytest.mark.parametrize("value", _FALSY_CASES)
-def test_is_saas_sync_enabled_falsy(
-    monkeypatch: pytest.MonkeyPatch, value: str
-) -> None:
-    """Falsy env-var values (including empty string) must return False."""
-    monkeypatch.setenv(_ENV_VAR, value)
-    assert is_saas_sync_enabled() is False
-
-
 def test_is_saas_sync_enabled_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Unset env var must return False."""
+    """Unset env var still returns True."""
     monkeypatch.delenv(_ENV_VAR, raising=False)
-    assert is_saas_sync_enabled() is False
-
-
-def test_is_saas_sync_enabled_strips_whitespace(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Leading/trailing whitespace around a truthy value must still return True."""
-    monkeypatch.setenv(_ENV_VAR, "  1  ")
     assert is_saas_sync_enabled() is True
 
 
@@ -87,13 +58,13 @@ def test_is_saas_sync_enabled_strips_whitespace(
 # ---------------------------------------------------------------------------
 
 _EXPECTED_MESSAGE = (
-    "Hosted SaaS sync is not enabled on this machine. "
-    "Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` to opt in."
+    "Hosted SaaS sync is enabled by default. "
+    "Use `spec-kitty sync opt-out` to disable uploads for this checkout."
 )
 
 
 def test_saas_sync_disabled_message_wording() -> None:
-    """Disabled message must be byte-for-byte identical to the contract wording."""
+    """Compatibility disabled message points to supported opt-out."""
     assert saas_sync_disabled_message() == _EXPECTED_MESSAGE
 
 

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -145,13 +145,18 @@ class TestBatchSyncEmptyQueue:
 
 
 class TestSaasFeatureFlag:
-    """Feature-flag behavior for SaaS upload."""
+    """Compatibility behavior for the retired SaaS upload feature flag."""
 
     @patch("specify_cli.sync.batch.requests.post")
-    def test_batch_sync_skips_network_when_disabled(self, mock_post, populated_queue, monkeypatch):
-        """No HTTP upload should occur when SaaS sync feature is disabled."""
+    def test_batch_sync_ignores_legacy_disabled_env(self, mock_post, populated_queue, monkeypatch):
+        """HTTP upload still occurs when the retired env var is unset."""
         monkeypatch.delenv(SAAS_SYNC_ENV_VAR, raising=False)
-        initial_size = populated_queue.size()
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [{"event_id": f"evt-{i:04d}", "status": "success"} for i in range(100)]
+        }
+        mock_post.return_value = mock_response
 
         result = batch_sync(
             queue=populated_queue,
@@ -160,10 +165,11 @@ class TestSaasFeatureFlag:
             show_progress=False,
         )
 
-        assert populated_queue.size() == initial_size
-        assert result.total_events == 0
-        assert any("not enabled" in msg.lower() for msg in result.error_messages)
-        mock_post.assert_not_called()
+        assert populated_queue.size() == 0
+        assert result.total_events == 100
+        assert result.synced_count == 100
+        assert result.error_messages == []
+        mock_post.assert_called_once()
 
 
 class TestHistoricalMissionStateGuard:

--- a/tests/sync/test_daemon_intent_gate.py
+++ b/tests/sync/test_daemon_intent_gate.py
@@ -8,8 +8,9 @@ Covers:
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from dataclasses import FrozenInstanceError
 from pathlib import Path
-from typing import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,8 +20,8 @@ from specify_cli.sync.config import BackgroundDaemonPolicy, SyncConfig
 from specify_cli.sync.daemon import DaemonIntent, DaemonStartOutcome, ensure_sync_daemon_running
 
 # ---------------------------------------------------------------------------
-# Rollout fixtures (local copies — tests/saas/conftest.py is out of scope
-# for the tests/sync/ package boundary without cross-package import gymnastics)
+# Legacy rollout-env fixtures.  The env var is now ignored, but these remain
+# useful for asserting that release behavior is independent from old shells.
 # ---------------------------------------------------------------------------
 
 
@@ -57,15 +58,31 @@ def _config(policy: BackgroundDaemonPolicy) -> SyncConfig:
 class TestDecisionMatrix:
     """One test per row in the decision matrix from contracts/background_daemon_policy.md."""
 
-    # Row 1: rollout disabled → skipped_reason="rollout_disabled" regardless of intent/policy
-    def test_row1_rollout_disabled(self, rollout_disabled: None) -> None:
-        outcome = ensure_sync_daemon_running(
-            intent=DaemonIntent.REMOTE_REQUIRED,
-            config=_config(BackgroundDaemonPolicy.AUTO),
-        )
-        assert outcome.started is False
-        assert outcome.skipped_reason == "rollout_disabled"
-        assert outcome.pid is None
+    # Row 1: legacy rollout env unset no longer blocks REMOTE_REQUIRED + AUTO.
+    def test_row1_legacy_rollout_disabled_env_ignored(self, rollout_disabled: None, tmp_path: Path) -> None:
+        fake_pid = 99998
+        fake_url = "http://127.0.0.1:9401"
+        fake_port = 9401
+        fake_state_file = tmp_path / "sync-daemon"
+        fake_state_file.write_text(f"{fake_url}\n{fake_port}\ntok\n{fake_pid}\n", encoding="utf-8")
+
+        with (
+            patch(
+                "specify_cli.sync.daemon._ensure_sync_daemon_running_locked",
+                return_value=(fake_url, fake_port, True),
+            ),
+            patch("specify_cli.sync.daemon.DAEMON_STATE_FILE", fake_state_file),
+            patch("specify_cli.sync.daemon.DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock"),
+            patch("specify_cli.sync.daemon.SPEC_KITTY_DIR", tmp_path),
+        ):
+            outcome = ensure_sync_daemon_running(
+                intent=DaemonIntent.REMOTE_REQUIRED,
+                config=_config(BackgroundDaemonPolicy.AUTO),
+            )
+
+        assert outcome.started is True
+        assert outcome.skipped_reason is None
+        assert outcome.pid == fake_pid
 
     # Row 2: rollout on + LOCAL_ONLY → skipped_reason="intent_local_only"
     def test_row2_local_only_intent(self, rollout_enabled: None) -> None:
@@ -160,7 +177,7 @@ class TestIntentMandatory:
 class TestDaemonStartOutcome:
     def test_is_frozen(self) -> None:
         outcome = DaemonStartOutcome(started=False, skipped_reason="rollout_disabled", pid=None)
-        with pytest.raises(Exception):  # frozen dataclass raises on setattr
+        with pytest.raises(FrozenInstanceError):
             outcome.started = True  # type: ignore[misc]
 
     def test_importable(self) -> None:

--- a/tests/sync/test_sync_status_check.py
+++ b/tests/sync/test_sync_status_check.py
@@ -76,14 +76,16 @@ def _mock_response_for_probe(
     return MagicMock(side_effect=_request)
 
 
-def test_check_server_connection_reports_disabled_when_flag_off(monkeypatch):
-    """Flag-off mode should skip connectivity probing entirely."""
+def test_check_server_connection_ignores_legacy_disabled_env(monkeypatch):
+    """Retired flag-off mode still follows normal auth probing."""
     monkeypatch.delenv(SAAS_SYNC_ENV_VAR, raising=False)
+    fake_tm = _fake_token_manager(authenticated=False)
 
-    status, note = _check_server_connection(SERVER_URL)
+    with patch("specify_cli.auth.get_token_manager", return_value=fake_tm):
+        status, note = _check_server_connection(SERVER_URL)
 
-    assert "Disabled" in status
-    assert "not enabled" in note.lower()
+    assert "Not authenticated" in status
+    assert "spec-kitty auth login" in note
 
 
 class TestCheckServerConnectionNoCredentials:

--- a/tests/sync/tracker/test_origin_integration.py
+++ b/tests/sync/tracker/test_origin_integration.py
@@ -704,7 +704,10 @@ class TestOfflineEventQueuing:
             ws_client=None,  # No WebSocket = offline mode
         )
 
-        with patch("specify_cli.sync.events.get_emitter", return_value=emitter):
+        with (
+            patch("specify_cli.sync.events.get_emitter", return_value=emitter),
+            patch.object(EventEmitter, "_current_team_slug", return_value="private-team"),
+        ):
             bind_mission_origin(
                 feature_dir_with_meta,
                 candidate,


### PR DESCRIPTION
## Summary

Planning PR for the TeamSpace launch path where hosted auth/tracker/sync are enabled by default instead of gated by `SPEC_KITTY_ENABLE_SAAS_SYNC`.

This keeps the old rollout symbols as compatibility shims for imports and test seams, but the canonical `is_saas_sync_enabled()` now always returns `True`. User-facing sync/tracker commands no longer no-op or hide themselves based on the env var; explicit checkout/repo opt-out remains through `spec-kitty sync opt-out` and existing routing config.

## Notes

- Draft on purpose; expected to be rebased as launch timing changes.
- This is not intended to land until we are ready for the release channel to treat SaaS sync as default-on.
- Docs were updated to describe `SPEC_KITTY_ENABLE_SAAS_SYNC` as deprecated compatibility only.

## Validation

- `uv run pytest tests/saas tests/sync tests/agent/cli/commands/test_tracker.py tests/agent/cli/commands/test_tracker_discover.py tests/agent/cli/commands/test_tracker_status.py tests/agent/cli/commands/test_sync.py tests/cli/commands/test_sync_routes.py tests/auth/test_auth_doctor_report.py tests/auth/test_auth_doctor_offline.py tests/auth/test_auth_doctor_repair.py -q`  
  Result: 1624 passed, 8 skipped, 1 warning.
- `uv run pytest tests/sync/test_background.py tests/sync/test_background_body.py tests/sync/test_batch_sync.py tests/sync/test_daemon_intent_gate.py tests/sync/test_dossier_trigger.py tests/sync/test_issue_598_hang_fixes.py tests/sync/test_runtime.py tests/sync/test_events.py tests/agent/cli/commands/test_tracker_discover.py tests/auth/test_auth_doctor_offline.py tests/auth/test_auth_doctor_repair.py -q`  
  Result: 257 passed.
- `uv run ruff check <touched focused files>`  
  Result: passed.
- `git diff --check`  
  Result: passed.
- Direct smoke: `SPEC_KITTY_ENABLE_SAAS_SYNC=0` still reports enabled and root help exposes `sync`, `tracker`, and `issue-search`.