### PR TITLE
fix(#1060-A): preserve mission selector normalization

### DIFF
--- a/docs/explanation/mission-system.md
+++ b/docs/explanation/mission-system.md
@@ -13,7 +13,7 @@ Terminology note:
 - `Mission Run` = runtime/session instance
 - `Feature` = software-dev compatibility alias for a mission
 
-**3.1.0 naming updates**: The `--mission` flag is now canonical on all commands that previously used `--feature` (e.g., `spec-kitty implement`, `spec-kitty merge`, `spec-kitty next`). `--feature` was a hidden deprecated compatibility alias; as of 3.2.x (#1060-A) it has been **removed from the internal/agent command cluster** (`agent status/tasks/workflow/context/mission`, `charter lint`, `materialize`, `validate-encoding`, `validate-tasks`, `verify`) and remains only on the deferred user-facing top-level commands during the migration window. Additionally, `spec-kitty constitution` has been renamed to `spec-kitty charter`; the old command name no longer exists.
+**3.1.0 naming updates**: The `--mission` flag is now canonical on all commands that previously used `--feature` (e.g., `spec-kitty implement`, `spec-kitty merge`, `spec-kitty next`). `--feature` was a hidden deprecated compatibility alias; as of 3.2.x (#1060-A) it has been **removed from the internal/agent command cluster** (`agent status/tasks/action/context/mission`, `charter lint`, `materialize`, `validate-encoding`, `validate-tasks`, `verify`) and remains only on the deferred user-facing top-level commands during the migration window. Additionally, `spec-kitty constitution` has been renamed to `spec-kitty charter`; the old command name no longer exists.
 
 ## Why Different Missions?
 

--- a/docs/migration/feature-flag-deprecation.md
+++ b/docs/migration/feature-flag-deprecation.md
@@ -9,7 +9,7 @@ description: "Migration guidance for Migration: --feature to --mission in Spec K
 
 **Status**: Deprecated as of Mission `077-mission-terminology-cleanup`.
 **Partial removal (3.2.x, #1060-A)**: the alias has been **removed from the
-internal/agent command cluster** (`agent status/tasks/workflow/context/mission`,
+internal/agent command cluster** (`agent status/tasks/action/context/mission`,
 `charter lint`, `materialize`, `validate-encoding`, `validate-tasks`,
 `verify`/`verify-setup`). On those commands `--feature` is no longer accepted —
 the parser rejects it with "No such option". It remains a hidden alias only on
@@ -47,7 +47,12 @@ alias is gone and `--feature` is rejected with "No such option".
 
 ## Behavioral Changes
 
-1. Passing both `--mission` and `--feature` with different values now fails fast with a deterministic conflict error.
+On the internal/agent command cluster, any `--feature` occurrence is now a
+parser error. The command exits before selector resolution.
+
+On the deferred user-facing commands that still carry the hidden alias:
+
+1. Passing both `--mission` and `--feature` with different values fails fast with a deterministic conflict error.
 2. Passing both flags with the same value succeeds, but still emits the deprecation warning once.
 3. `--feature` is hidden from `--help` output. New examples and docs must use `--mission`.
 

--- a/docs/status-model.md
+++ b/docs/status-model.md
@@ -5,7 +5,10 @@
 
 **Terminology note**
 - Canonical 2.x model: `Mission Type -> Mission -> Mission Run`
-- Status commands now use `--mission` as the canonical tracked-mission selector. Legacy `--feature` remains a hidden deprecated alias for compatibility only.
+- Status commands now use `--mission` as the canonical tracked-mission selector.
+  As of 3.2.x (#1060-A), `spec-kitty agent status ...` no longer accepts the
+  legacy `--feature` alias; it remains only on deferred user-facing top-level
+  commands during the broader migration window.
 - As of mission `083-mission-id-canonical-identity-migration`, a mission's canonical machine identity is `mission_id` (a ULID). The `--mission` flag accepts `mission_id`, `mid8` (first 8 chars of the ULID), or `mission_slug`. The numeric prefix in slug examples below (e.g. `034-feature-name`) is display-only metadata — the event log's aggregate key is `mission_id`, not the prefix. See the [mission identity migration runbook](migration/mission-id-canonical-identity.md).
 
 ## Overview

--- a/src/specify_cli/cli/commands/agent/context.py
+++ b/src/specify_cli/cli/commands/agent/context.py
@@ -62,7 +62,7 @@ def _find_feature_directory(
         resolve_mission_read_path,
     )
 
-    raw_handle = explicit_mission
+    raw_handle = explicit_mission.strip() if explicit_mission else None
     if not raw_handle:
         raise ActionContextError(
             "FEATURE_CONTEXT_UNRESOLVED", "--mission <slug> is required"
@@ -120,7 +120,7 @@ def resolve_context(
                 f"Invalid action '{action}'. Expected one of: {', '.join(ACTION_NAMES)}.",
             )
 
-        raw_handle = mission
+        raw_handle = mission.strip() if mission else None
         if not raw_handle:
             raise ActionContextError("MISSING_MISSION", "--mission <slug> is required")
         mission_resolved = resolve_mission_handle(raw_handle, repo_root, json_mode=json_output)

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -1220,13 +1220,14 @@ def _find_feature_directory(
         resolve_mission_read_path,
     )
 
-    if not explicit_feature:
+    raw_handle = explicit_feature.strip() if explicit_feature else None
+    if not raw_handle:
         raise ActionContextError("FEATURE_CONTEXT_UNRESOLVED", "--mission <slug> is required")
     try:
         feature_dir = resolve_mission_read_path(
             repo_root,
-            explicit_feature,
-            mid8_from_slug(explicit_feature),
+            raw_handle,
+            mid8_from_slug(raw_handle),
             require_exists=True,
         )
     except MissionSelectorAmbiguous as exc:
@@ -1234,7 +1235,7 @@ def _find_feature_directory(
     except StatusReadPathNotFound as exc:
         raise ActionContextError(
             "FEATURE_CONTEXT_UNRESOLVED",
-            f"Mission not found for handle {explicit_feature!r}; checked the coordination worktree and the primary checkout. {exc}",
+            f"Mission not found for handle {raw_handle!r}; checked the coordination worktree and the primary checkout. {exc}",
         ) from exc
     return feature_dir
 

--- a/src/specify_cli/cli/commands/validate_tasks.py
+++ b/src/specify_cli/cli/commands/validate_tasks.py
@@ -20,6 +20,14 @@ from specify_cli.task_metadata_validation import (
 from specify_cli.task_utils import TaskCliError, find_repo_root
 
 
+def _normalize_mission_option(value: object) -> str | None:
+    """Return a stripped mission selector, treating Typer sentinels as unset."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def validate_tasks(
     mission: str | None = typer.Option(
         None, "--mission", help="Mission slug to validate"
@@ -98,10 +106,10 @@ def validate_tasks(
         raise typer.Exit(0 if total_mismatches == 0 or fix else 1)
 
     # Validate single feature
-    if not mission or not mission.strip():
+    mission_slug = _normalize_mission_option(mission)
+    if mission_slug is None:
         console.print("[red]Error:[/red] --mission <slug> is required (or use --all)")
         raise typer.Exit(1)
-    mission_slug = mission.strip()
     feature_dir = resolve_feature_dir_for_slug(repo_root, mission_slug)
 
     if not feature_dir.exists():

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -1312,6 +1312,22 @@ class TestFindFeatureDirectory:
         # Verify
         assert result == kitty_specs / "001-test-feature"
 
+    def test_strips_explicit_mission_slug(self, tmp_path: Path):
+        """Whitespace around the mission selector should not change resolution."""
+        from specify_cli.cli.commands.agent.mission import _find_feature_directory
+
+        kitty_specs = tmp_path / "kitty-specs"
+        kitty_specs.mkdir()
+        (kitty_specs / "001-test-feature").mkdir()
+
+        result = _find_feature_directory(
+            tmp_path,
+            tmp_path,
+            explicit_feature="  001-test-feature  ",
+        )
+
+        assert result == kitty_specs / "001-test-feature"
+
     def test_raises_error_when_no_explicit_slug(self, tmp_path: Path):
         """WP06 / C-CTX-4: a missing handle raises a structured ActionContextError
         (was ValueError before the read-primitive consolidation)."""

--- a/tests/contract/test_feature_alias_scope.py
+++ b/tests/contract/test_feature_alias_scope.py
@@ -24,8 +24,10 @@ All tests are offline / loopback — no network calls, no real git operations.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from specify_cli import app
@@ -57,6 +59,7 @@ _INSCOPE_FILES: tuple[str, ...] = (
 _INSCOPE_COMMAND_NAMES: tuple[str, ...] = (
     "agent status",
     "agent tasks",
+    "agent action",
     "agent workflow",
     "agent context",
     "agent mission",
@@ -403,6 +406,23 @@ def test_validate_tasks_requires_selector_cleanly() -> None:
     assert result.exit_code == 1, result.output
     assert not isinstance(result.exception, TypeError), result.output
     assert "required" in result.output.lower()
+
+
+def test_validate_tasks_direct_call_without_selector_clean_error(tmp_path: Path) -> None:
+    """Programmatic calls must not leak Typer ``OptionInfo`` into ``.strip()``."""
+    from specify_cli.cli.commands.validate_tasks import validate_tasks
+
+    with (
+        patch("specify_cli.cli.commands.validate_tasks.find_repo_root", return_value=tmp_path),
+        patch(
+            "specify_cli.cli.commands.validate_tasks.get_project_root_or_exit",
+            return_value=tmp_path,
+        ),
+        pytest.raises(typer.Exit) as excinfo,
+    ):
+        validate_tasks(check_all=False)
+
+    assert excinfo.value.exit_code == 1
 
 
 def test_validate_encoding_requires_selector_cleanly() -> None:

--- a/tests/specify_cli/cli/commands/agent/test_context_find_feature_directory.py
+++ b/tests/specify_cli/cli/commands/agent/test_context_find_feature_directory.py
@@ -9,13 +9,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
 from mission_runtime import ActionContextError
-from specify_cli.cli.commands.agent.context import _find_feature_directory
+from specify_cli.cli.commands.agent.context import _find_feature_directory, app as context_app
 
 pytestmark = [pytest.mark.fast]
+runner = CliRunner()
 
 
 def _seed_mission(tmp_path: Path, *, slug: str, mission_id: str) -> Path:
@@ -40,6 +44,64 @@ def test_mid8_resolves_same_as_full_slug(tmp_path: Path) -> None:
 
     assert via_slug == expected
     assert via_mid8 == expected
+
+
+def test_find_feature_directory_strips_explicit_mission(tmp_path: Path) -> None:
+    """Whitespace around ``--mission`` preserves resolver compatibility."""
+    mission_id = "01KTPKSTABCDEFGHJKMNPQRSTV"
+    slug = "083-my-feature"
+    expected = _seed_mission(tmp_path, slug=slug, mission_id=mission_id)
+
+    resolved = _find_feature_directory(
+        tmp_path,
+        tmp_path,
+        explicit_mission=f"  {slug}  ",
+    )
+
+    assert resolved == expected
+
+
+def test_context_resolve_strips_explicit_mission(tmp_path: Path) -> None:
+    """CLI path must strip ``--mission`` before mission handle resolution."""
+    mission_id = "01KTPKSTABCDEFGHJKMNPQRSTV"
+    slug = "083-my-feature"
+    _seed_mission(tmp_path, slug=slug, mission_id=mission_id)
+    context = SimpleNamespace(
+        to_dict=lambda: {
+            "mission_slug": slug,
+            "detection_method": "test",
+            "target_branch": "main",
+            "wp_id": None,
+            "workspace_path": None,
+            "commands": {},
+        }
+    )
+
+    with (
+        patch(
+            "specify_cli.cli.commands.agent.context.locate_project_root",
+            return_value=tmp_path,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent.context.resolve_action_context",
+            return_value=context,
+        ),
+    ):
+        result = runner.invoke(
+            context_app,
+            [
+                "--action",
+                "status",
+                "--mission",
+                f"  {slug}  ",
+                "--json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["success"] is True
+    assert payload["mission_slug"] == slug
 
 
 def test_unresolvable_handle_raises_structured_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1985 from adversarial review.

- Preserve resolve_selector whitespace normalization for agent context and agent mission handles.
- Preserve clean direct-call behavior for validate-tasks when Typer OptionInfo sentinels are present.
- Tighten alias-scope guards so agent action is covered, not only the implementation filename workflow.
- Update migration/status docs to describe the partial --feature removal accurately.

## Verification

- ruff check on touched Python files: passed.
- focused pytest slice covering context, mission, alias scope, terminology guards, materialize, validate-encoding, selector errors, charter lint: 73 passed.
- docs freshness with SPEC_KITTY_ENABLE_SAAS_SYNC=1: exit 0; existing HELP-DRIFT warning only.
