### PR TITLE
docs: correct stale shared-dependency setup in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,15 +79,21 @@ These are one time installations required to be able to test your changes locall
 1. Install [Git](https://git-scm.com/downloads)
 1. Have an [AI coding agent available](README.md#-supported-ai-agents)
 
-### Private Dependencies
+### Shared Dependencies
 
-Spec-kitty depends on two private libraries:
-- **[spec-kitty-events](https://github.com/Priivacy-ai/spec-kitty-events)** v3.0.0 - Event system and mission-next integration
-- **[spec-kitty-runtime](https://github.com/Priivacy-ai/spec-kitty-runtime)** v0.4.3 - Runtime execution engine
+Spec-kitty's shared libraries are published to PyPI and resolved automatically by
+`uv sync` — **no SSH access or special repository permissions are required for
+local development**:
 
-For CI/CD setup, see [SSH Deploy Keys documentation](docs/development/ssh-deploy-keys.md).
+- **[spec-kitty-events](https://pypi.org/project/spec-kitty-events/)** — event system and mission-next integration.
+- **[spec-kitty-tracker](https://pypi.org/project/spec-kitty-tracker/)** — tracker consumer surface.
 
-For local development, ensure you have SSH access to the repository.
+Compatibility ranges are declared in `pyproject.toml`; exact pinned versions live
+in `uv.lock`.
+
+`spec-kitty-runtime` is no longer a dependency: the CLI's runtime surface is
+internalized under `src/runtime/next/`, and its absence is enforced by
+`tests/architectural/test_pyproject_shape.py`.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- The CONTRIBUTING "Private Dependencies" section is stale and tells new
  contributors they need SSH/private-repo access that is no longer required.

## Why Now
- I hit this while setting up a local dev environment as a new contributor:
  the doc says `spec-kitty-events`/`spec-kitty-runtime` are private and need
  SSH access, but `uv sync` succeeded with no special access. The doc was the
  only friction in an otherwise clean setup.

## What This PR Does
- Retitles the section "Shared Dependencies" and states the libraries are
  public PyPI packages resolved automatically by `uv sync` — no SSH/private
  access needed.
- Points `spec-kitty-events` / `spec-kitty-tracker` links at PyPI; notes that
  ranges live in `pyproject.toml` and pins in `uv.lock`.
- Documents that `spec-kitty-runtime` is no longer a dependency (internalized
  under `src/runtime/next/`, absence enforced by
  `tests/architectural/test_pyproject_shape.py`).

## Effect on Existing Projects
- Runtime / compatibility: none — docs only.
- Upgrade / migration: none.
- Operator / reviewer impact: new contributors get accurate setup steps.

## Validation
- [x] Verified `uv sync --frozen --all-extras` resolves both deps from PyPI
      with no SSH/private access on a fresh clone.
- [x] `make lint` clean.
- [ ] N/A — documentation-only change, no code tests affected.

## Tickets / Contracts
| Ticket | Relationship |
|--------|--------------|
| —      | none         |

## Follow-ups
- `docs/development/ssh-deploy-keys.md` may now also be partially stale if CI no
  longer needs a deploy key for the (now-public) events package — flagging for a
  maintainer to confirm; intentionally left out of this PR to keep it focused.

---
**AI-assistance disclosure:** I used Claude Code (Anthropic) to help investigate
the dependency state and draft this doc change. I reviewed and verified the
change myself against `pyproject.toml`, `uv.lock`, and a working local `uv sync`.
