### PR TITLE
test(#2034): fix 9 un-gated test failures (symptoms, part 1 of 2)

### DIFF
--- a/architecture/test-suite-acceleration-plan.md
+++ b/architecture/test-suite-acceleration-plan.md
@@ -154,9 +154,9 @@ No accepted item deletes a genuine assertion path or weakens a real regression g
 
 Rationale: quick coverage-neutral flat wins first (Wave 1), then the single fixture that unlocks all parallelism (Wave 2), then de-risk the collection/topology so xdist actually helps (Wave 3), then the high-leverage but contention-sensitive flips behind per-shard ratchets (Wave 4), structural last (Wave 5), and finally publish the local recipe once its preconditions are proven (Wave 6).
 
-**Key file references (all absolute):**
-- CI: `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/.github/workflows/ci-quality.yml` — fast shards (charter ~1322, status ~891), proven xdist pattern (1181/1295/1307), slow-tests (~1895), specify-cli-heavy marker (~1305).
-- HOME hazard: `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/tests/conftest.py:119` (`Path.home() / ".spec-kitty"`) + `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/tests/agent/conftest.py:15-41` (autouse wipe).
-- FSM matrix: `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/tests/status/test_transitions.py:510-541`.
-- Charter timing: `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/tests/charter/test_integration.py:427,450`.
-- HOME-isolation template to copy: `/Users/robert/spec-kitty-dev/spec-kitty-20260614-181143-WQFQqN/spec-kitty/tests/sync/test_sync_boundary_preflight.py:66-79`.
+**Key file references (repo-relative):**
+- CI: `.github/workflows/ci-quality.yml` — fast shards (charter ~1322, status ~891), proven xdist pattern (1181/1295/1307), slow-tests (~1895), specify-cli-heavy marker (~1305).
+- HOME hazard: `tests/conftest.py:119` (`Path.home() / ".spec-kitty"`) + `tests/agent/conftest.py:15-41` (autouse wipe).
+- FSM matrix: `tests/status/test_transitions.py:510-541`.
+- Charter timing: `tests/charter/test_integration.py:427,450`.
+- HOME-isolation template to copy: `tests/sync/test_sync_boundary_preflight.py:66-79`.

--- a/docs/how-to/install-claude-code-plugin.md
+++ b/docs/how-to/install-claude-code-plugin.md
@@ -1,3 +1,8 @@
+---
+title: "How to Install the Spec Kitty Claude Code Plugin"
+description: "How to install Spec Kitty as a native Claude Code plugin that surfaces canonical mission commands and built-in agent profiles."
+---
+
 # How to Install the Spec Kitty Claude Code Plugin
 
 Spec Kitty ships as a native Claude Code plugin that surfaces all canonical

--- a/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/analyze.SKILL.md
@@ -223,6 +223,19 @@ The report file you pass MUST start with the `analysis-findings/v1` carrier from
 
 Treat persistence failure as command failure. The command is not complete until the JSON response reports success and names `analysis-report.md`.
 
+> **⚠️ Caution — Do not write `analysis-report.md` directly**
+>
+> The `analysis-findings/v1` carrier (step 6) is the **input format** for `record-analysis`,
+> not the **persisted format**. `record-analysis` wraps the carrier in the outer-wrapper
+> format (`artifact_type: spec-kitty.analysis-report`) that the implement gate accepts.
+>
+> Writing `analysis-report.md` directly — without piping through `record-analysis` — leaves
+> the file in carrier format, which the implement gate rejects with `carrier_format_not_wrapped`.
+> If this happens, recover by running:
+> ```bash
+> spec-kitty agent mission record-analysis --mission <mission-slug> --input-file analysis-report.md --json
+> ```
+
 ### 8. Provide Next Actions
 
 At end of report, output a concise Next Actions block:

--- a/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/plan.SKILL.md
@@ -99,7 +99,7 @@ required structural rows does **not** count as substantive (no byte-length
 escape hatch).
 
 To advance: populate the Technical Context with real values, then re-run
-`spec-kitty agent mission setup-plan --json`. The substantive plan will be
+`spec-kitty agent mission setup-plan --mission <mission-slug> --json`. The substantive plan will be
 auto-committed and `phase_complete` will report `true`.
 
 Reference: `kitty-specs/charter-e2e-827-followups-01KQAJA0/contracts/specify-plan-commit-boundary.md`.
@@ -260,9 +260,9 @@ If the mission is not a bulk edit, skip this step.
 
 2. **Resolve mission context deterministically** (CRITICAL - prevents wrong mission selection):
    - Prefer an explicit mission slug from user direction or from the current directory path (`kitty-specs/<mission-slug>/...`)
-   - If you do not yet have an explicit mission slug, run `spec-kitty agent mission setup-plan --json` once without `--mission`
-   - If that call succeeds, treat its JSON as the canonical setup payload and skip step 3
-   - If that call returns an ambiguity error with `available_missions`, stop and resolve one explicit mission slug before continuing
+   - The resolver requires `--mission` — always pass an explicit handle. Running `setup-plan` without `--mission` returns `PLAN_CONTEXT_UNRESOLVED` even when exactly one mission is present.
+   - Resolve the handle first: `spec-kitty agent context resolve --action plan --mission <handle> --json`, then pass the resolved slug to `setup-plan`
+   - If the context resolve call returns an ambiguity error with `available_missions`, stop and pick one explicit mission slug before continuing
 
 3. **Setup**: If step 2 did not already return a successful setup payload, run `spec-kitty agent mission setup-plan --mission <mission-slug> --json` from the repository root and parse JSON for:
    - `result`: "success" or error message
@@ -286,7 +286,8 @@ If the mission is not a bulk edit, skip this step.
    # Resolve the active mission handle, then pass it to setup-plan.
    # The --mission flag accepts mission_id (ULID), mid8 (first 8 chars), or mission_slug.
    # The resolver disambiguates by mission_id; ambiguous handles become structured errors.
-   spec-kitty agent context resolve --mission <handle> --json
+   # --action is required for context resolve; use the action matching this step.
+   spec-kitty agent context resolve --action plan --mission <handle> --json
    spec-kitty agent mission setup-plan --mission <handle> --json
    ```
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/analyze.SKILL.md
@@ -223,6 +223,19 @@ The report file you pass MUST start with the `analysis-findings/v1` carrier from
 
 Treat persistence failure as command failure. The command is not complete until the JSON response reports success and names `analysis-report.md`.
 
+> **⚠️ Caution — Do not write `analysis-report.md` directly**
+>
+> The `analysis-findings/v1` carrier (step 6) is the **input format** for `record-analysis`,
+> not the **persisted format**. `record-analysis` wraps the carrier in the outer-wrapper
+> format (`artifact_type: spec-kitty.analysis-report`) that the implement gate accepts.
+>
+> Writing `analysis-report.md` directly — without piping through `record-analysis` — leaves
+> the file in carrier format, which the implement gate rejects with `carrier_format_not_wrapped`.
+> If this happens, recover by running:
+> ```bash
+> spec-kitty agent mission record-analysis --mission <mission-slug> --input-file analysis-report.md --json
+> ```
+
 ### 8. Provide Next Actions
 
 At end of report, output a concise Next Actions block:

--- a/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/plan.SKILL.md
@@ -99,7 +99,7 @@ required structural rows does **not** count as substantive (no byte-length
 escape hatch).
 
 To advance: populate the Technical Context with real values, then re-run
-`spec-kitty agent mission setup-plan --json`. The substantive plan will be
+`spec-kitty agent mission setup-plan --mission <mission-slug> --json`. The substantive plan will be
 auto-committed and `phase_complete` will report `true`.
 
 Reference: `kitty-specs/charter-e2e-827-followups-01KQAJA0/contracts/specify-plan-commit-boundary.md`.
@@ -260,9 +260,9 @@ If the mission is not a bulk edit, skip this step.
 
 2. **Resolve mission context deterministically** (CRITICAL - prevents wrong mission selection):
    - Prefer an explicit mission slug from user direction or from the current directory path (`kitty-specs/<mission-slug>/...`)
-   - If you do not yet have an explicit mission slug, run `spec-kitty agent mission setup-plan --json` once without `--mission`
-   - If that call succeeds, treat its JSON as the canonical setup payload and skip step 3
-   - If that call returns an ambiguity error with `available_missions`, stop and resolve one explicit mission slug before continuing
+   - The resolver requires `--mission` — always pass an explicit handle. Running `setup-plan` without `--mission` returns `PLAN_CONTEXT_UNRESOLVED` even when exactly one mission is present.
+   - Resolve the handle first: `spec-kitty agent context resolve --action plan --mission <handle> --json`, then pass the resolved slug to `setup-plan`
+   - If the context resolve call returns an ambiguity error with `available_missions`, stop and pick one explicit mission slug before continuing
 
 3. **Setup**: If step 2 did not already return a successful setup payload, run `spec-kitty agent mission setup-plan --mission <mission-slug> --json` from the repository root and parse JSON for:
    - `result`: "success" or error message
@@ -286,7 +286,8 @@ If the mission is not a bulk edit, skip this step.
    # Resolve the active mission handle, then pass it to setup-plan.
    # The --mission flag accepts mission_id (ULID), mid8 (first 8 chars), or mission_slug.
    # The resolver disambiguates by mission_id; ambiguous handles become structured errors.
-   spec-kitty agent context resolve --mission <handle> --json
+   # --action is required for context resolve; use the action matching this step.
+   spec-kitty agent context resolve --action plan --mission <handle> --json
    spec-kitty agent mission setup-plan --mission <handle> --json
    ```
 

--- a/tests/specify_cli/test_active_mission_removal.py
+++ b/tests/specify_cli/test_active_mission_removal.py
@@ -320,7 +320,7 @@ def test_verify_setup_passes_feature_dir_to_run_enhanced_verify(tmp_path: Path) 
     ):
         # Call with json_output to avoid console rendering issues, and skip tool checks
         verify_setup(
-            feature="099-research-feature",
+            mission="099-research-feature",
             json_output=True,
             check_files=False,
             check_tools=False,

--- a/tests/tasks/test_tasks_2x_unit.py
+++ b/tests/tasks/test_tasks_2x_unit.py
@@ -51,7 +51,7 @@ class TestFindFeatureSlug:
         """
         from specify_cli.cli.commands.agent.tasks import _find_mission_slug
 
-        slug = _find_mission_slug(explicit_feature="008-test-feature")
+        slug = _find_mission_slug(explicit_mission="008-test-feature")
         assert slug == "008-test-feature"
 
     def test_find_raises_on_missing_slug(self):
@@ -60,7 +60,7 @@ class TestFindFeatureSlug:
         from typer import Exit
 
         with pytest.raises(Exit):
-            _find_mission_slug(explicit_feature=None)
+            _find_mission_slug(explicit_mission=None)
 
 
 class TestStatusInProgressLane:


### PR DESCRIPTION
## What & why

Part 1 of 2 for #2034. This PR fixes the **9 broken tests** that are currently
slipping through CI un-gated, leaving the repo's test suite green by construction.

Per @StijndeJongh's triage, #2034 has two separable workstreams:

1. **This PR — fix the symptoms** (mechanical, high-confidence). These tests run
   in *zero* CI gates today, so they could drift from source unnoticed; this PR
   re-syncs them.
2. **Follow-up PR — close the gate gap (root cause):** add an unfiltered
   `pytest tests/` gate so no test can leak by construction, and dedupe the
   marker registry. It lands *after* this PR, because an unfiltered gate landing
   first would run these 9 broken tests and go red — the gate can only merge
   green once the suite is clean.

## The 9 fixes

| Area | Fix | Source of truth |
|------|-----|-----------------|
| `tests/tasks/test_tasks_2x_unit.py` | `_find_mission_slug(explicit_feature=)` → `explicit_mission=` (2 tests) | `src/specify_cli/cli/commands/agent/tasks.py:794` |
| `tests/specify_cli/test_active_mission_removal.py` | `verify_setup(feature=)` → `mission=` | `verify_setup` renamed the option |
| `architecture/test-suite-acceleration-plan.md` | Scrub 5× `/Users/robert/…` machine-specific home literals; make references repo-relative | `test_command_template_cleanliness.py` |
| `docs/how-to/install-claude-code-plugin.md` | Add required `title`/`description` YAML front matter | `tests/docs/test_docs_seo.py` |
| `tests/specify_cli/skills/__snapshots__/{codex,vibe}/{analyze,plan}.SKILL.md` | Regenerate stale snapshots | drift traced to committed source: #1996 (analyze caution block), #2007 (`setup-plan --mission` flag) |

The snapshot regeneration was verified to contain **only** the expected drift —
the source-template edits were already committed upstream; the snapshots simply
weren't regenerated at the time.

## Scope notes

- 3 further failures in the original report are macOS-runner-specific (timing,
  tmp-path length, non-git fixture) and are intentionally **out of scope** here.
- The root-cause gate fix follows in a separate PR.

## Verification

- Targeted tests for all 9 fixes pass; full `tests/docs/test_docs_seo.py` and
  full `tests/specify_cli/skills/test_command_renderer.py` (102) pass.
- `ruff check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)