### PR TITLE
chore(test): dedup pytest marker registry to single source (#2034 workstream 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,30 +178,15 @@ exclude = [
     "src/specify_cli/**/tests/**",
 ]
 
-[tool.pytest.ini_options]
-markers = [
-    "fast: Pure unit tests with no I/O or subprocess calls (CI fast gate)",
-    "integration: Integration tests using real filesystem or in-process I/O, no subprocess/git",
-    "slow: Tests taking >10 seconds or requiring heavy setup",
-    "git_repo: Tests that need a real git repository (integration gate)",
-    "adversarial: Adversarial/security tests for 0.13.0",
-    "doctrine: Doctrine package smoke and integration checks",
-    "distribution: Tests requiring wheel install (slow, no SPEC_KITTY_TEMPLATE_ROOT)",
-    "e2e: End-to-end tests exercising the full CLI workflow (may be slow)",
-    "platform_darwin: macOS-specific tests (case-insensitive FS)",
-    "platform_linux: Linux-specific tests",
-    "requires_symlinks: Tests that need symlink support",
-    "no_readiness_stub: Opt out of any autouse readiness-stub fixture so the test exercises its own readiness wiring (mission 082 tracker CLI tests)",
-    "architectural: Architectural enforcement tests (layer rules, import-graph invariants)",
-    "contract: Consumer-surface contract tests pinning external public APIs (e.g. spec-kitty-events / spec-kitty-tracker) the CLI depends on",
-    "windows_ci: Tests that require a native win32 environment — auto-skipped on non-Windows",
-    "live_adapter: tests that call the real Anthropic API (deselect with -m 'not live_adapter')",
-    "non_sandbox: test is structurally incompatible with mutmut's forked sandbox (subprocess CLI calls, whole-codebase AST walks, wheel builds, or repo-state fixtures outside also_copy). See ADR 2026-04-20-1",
-    "flaky: test passes in the main suite but is non-deterministic under mutmut or forking pipelines. Each entry is debt — root-cause and remove. See ADR 2026-04-20-1",
-    "stress: Concurrency/load stress tests — run separately from the fast suite (mission-coordination-branch-atomic-event-log WP09)",
-    "regression: Issue-pinned regression tests that exercise an exact reproduction sequence end-to-end (mission-coordination-branch-atomic-event-log WP09)",
-    "unit: Pure unit-level tests for a single module (legacy marker used by coordination tests)",
-]
+# NOTE: pytest configuration (markers, pythonpath, testpaths, addopts) lives in
+# `pytest.ini`, which is the single source of truth. pytest reads only one
+# config file and prefers `pytest.ini` over `[tool.pytest.ini_options]` when
+# both are present, so a markers list here would be dead config that silently
+# drifts from the live registry (this block had already drifted ~10 markers out
+# of sync — see Priivacy-ai/spec-kitty#2034). Do not reintroduce
+# `[tool.pytest.ini_options]` here; add markers to `pytest.ini` instead. This
+# invariant is guarded by
+# tests/architectural/test_marker_registry_single_source.py.
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/architectural/test_marker_registry_single_source.py
+++ b/tests/architectural/test_marker_registry_single_source.py
@@ -1,0 +1,65 @@
+"""Architectural guard: the pytest marker registry has a single source of truth.
+
+Background (Priivacy-ai/spec-kitty#2034, workstream 2):
+``pytest.ini`` and ``pyproject.toml [tool.pytest.ini_options]`` both used to
+declare ``markers``. pytest reads exactly one configuration file, preferring
+``pytest.ini`` over ``[tool.pytest.ini_options]`` when both exist — so the
+``pyproject`` copy was dead config that never took effect and had silently
+drifted ~10 markers out of sync with the live ``pytest.ini`` registry.
+
+These tests pin ``pytest.ini`` as the single source of truth and fail if a
+``[tool.pytest.ini_options]`` markers list is reintroduced into
+``pyproject.toml``, so the duplication cannot silently come back.
+
+Like the rest of ``tests/architectural/``, these are pure file-shape
+assertions (parse two text files) and run in milliseconds.
+"""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.architectural
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
+_PYTEST_INI_PATH = _REPO_ROOT / "pytest.ini"
+
+
+def test_pytest_ini_exists_and_declares_markers() -> None:
+    """The single source of truth must exist and carry a non-empty registry.
+
+    If ``pytest.ini`` is renamed or loses its ``markers`` block, the
+    duplication guard below would pass vacuously while the registry silently
+    moved (or vanished); this guard prevents that.
+    """
+    assert _PYTEST_INI_PATH.is_file(), (
+        f"pytest.ini not found at {_PYTEST_INI_PATH}. It is the single source "
+        "of truth for the pytest marker registry (see #2034)."
+    )
+    text = _PYTEST_INI_PATH.read_text(encoding="utf-8")
+    assert "markers =" in text, (
+        "pytest.ini no longer declares a `markers =` block. It is the single "
+        "source of truth for registered markers; restore the block here rather "
+        "than moving markers into pyproject.toml."
+    )
+
+
+def test_pyproject_does_not_redeclare_pytest_markers() -> None:
+    """``pyproject.toml`` must NOT carry a ``[tool.pytest.ini_options].markers``.
+
+    Because ``pytest.ini`` wins when both files are present, any markers
+    declared here are dead config that drifts from the live registry. Keep the
+    registry in ``pytest.ini`` only.
+    """
+    data = tomllib.loads(_PYPROJECT_PATH.read_text(encoding="utf-8"))
+    ini_options = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    assert "markers" not in ini_options, (
+        "pyproject.toml reintroduced [tool.pytest.ini_options].markers. pytest "
+        "reads only pytest.ini when present, so these markers are dead config "
+        "that silently drifts from the live registry (the regression #2034 "
+        "fixed). Declare markers in pytest.ini instead — it is the single "
+        "source of truth."
+    )


### PR DESCRIPTION
Addresses **workstream 2** of #2034 (the marker-registry duplication confirmed as *"point 2 seems good"*).

`pytest` reads only one config file, preferring `pytest.ini` over `[tool.pytest.ini_options]` when both exist. The `markers` list in `pyproject.toml` was therefore dead config that never took effect and had silently drifted ~10 markers out of sync with the live `pytest.ini` registry.

## Change

- Remove the dead `[tool.pytest.ini_options]` markers block; replace with a NOTE documenting why it must not return.
- `pytest.ini` remains the single source of truth (and is a strict superset of the removed markers, so runtime behavior is unchanged — pytest already ignored the pyproject block).
- Add `tests/architectural/test_marker_registry_single_source.py` (`architectural`-marked, runs in the existing architectural gate) to pin the invariant so the duplication cannot silently come back.

Independent of the workstream-1 gate-gap design still under discussion on #2034.

---
*Authored by Kent Gale (kentonium3) & Claude Code (Claude Opus 4.8).*