### PR TITLE
fix(finalize): align planning surface + lane-aware ownership overlap (#2087/#2088)

### DIFF
--- a/src/doctrine/directives/built-in/034-test-first-development.directive.yaml
+++ b/src/doctrine/directives/built-in/034-test-first-development.directive.yaml
@@ -14,9 +14,12 @@ procedures:
   - Select the appropriate test-first tactic based on scope — acceptance-test-first for feature boundaries, tdd-red-green-refactor for unit-level iteration, zombies-tdd for incremental case discovery.
   - Keep the red-green-refactor cycle short — each cycle should take minutes, not hours.
   - When fixing a bug, write a reproduction test first that fails, then apply the fix.
+  - Reproduce the bug through the PRE-EXISTING (stable) entry point — the command, public function, or seam that exists on the unfixed code — never through the fix's not-yet-written API. A reproduction test must go red BECAUSE THE BUG MANIFESTS in the assertion (the wrong value/status/path/state), not because a new symbol or parameter the fix introduces is missing (ImportError/TypeError at collection).
+  - Prove red-first — run the reproduction test against the unfixed code and confirm it fails for the right reason, then apply the fix and confirm green. New-API unit tests are fine as contract coverage, but they are not the bug-capture.
 integrity_rules:
   - Production code must not be written ahead of a failing test that motivates it.
   - Skipping the test-first cycle requires explicit justification in the commit or PR.
+  - A bug-reproduction test that can only run AFTER the fix exists (it imports the fix's new symbol or passes its new parameter) captures the fix's shape, not the bug — it is invalid; rewrite it to drive the stable entry point, and move any new-API import to lazy/in-test scope so the reproduction still collects and fails red on the unfixed code.
 validation_criteria:
   - Each new behavior has a corresponding test that was written before the production code.
-  - Bug fixes include a regression test that fails without the fix.
+  - Bug fixes include a regression test that fails without the fix — and that failure is the bug's observable symptom (verified by running against the unfixed code), not a missing-new-symbol collection error.

--- a/src/doctrine/directives/built-in/041-tests-as-scaffold-not-friction.directive.yaml
+++ b/src/doctrine/directives/built-in/041-tests-as-scaffold-not-friction.directive.yaml
@@ -19,15 +19,19 @@ procedures:
   - Build test fixtures by delegating to the production seam (a single schema authority), not a parallel hand-rolled copy that silently rots when the schema changes.
   - Use production-shaped test data (real identifier formats and lengths); do not embed handcrafted placeholders that mask real behavior.
   - When remediating a friction test, follow the delete-the-assertion-not-the-test tactic — replace the wrong assertion, preserve the setup and excavated edge-cases, and reserve outright deletion for provably zero-coverage or superseded tests.
+  - On a failing test, do NOT git-archaeology when the failure was introduced; classify the test and act on the verdict — (a) STALE / captures old intent → remediate the assertion to the current contract; (b) PATCHWORK / stub / fakeable → delete it or re-pin its assertion if the setup is worth keeping; (c) VALID + current (drives a real entry point, captures live intent) → it caught a real product break, so FIX THE PRODUCT, never weaken or delete the test.
+  - Establish causation by code-path coupling, not git blame — ask whether the suspect change actually touches the failing path (imports/calls on that code path). If it does not, the test surfaced a pre-existing product defect; fix or file it as a product finding rather than blaming the change.
 integrity_rules:
   - A green test that would stay green if the code under test regressed provides no coverage and must be fixed, not trusted.
   - A test that goes red on a correct, behavior-neutral change is friction; fix the test's coupling, do not revert the correct change.
   - Deleting a test deletes its coverage; never delete a test to dodge a failure — replace the assertion red-first with coverage preserved.
   - Duplicate test knowledge (the same contract asserted in many drifting places) has one source of truth, not N hand-synced copies.
+  - A valid, current test that goes red is never silenced, retried-to-green, or deleted to pass CI — its red is a real product finding to fix or file.
 validation_criteria:
   - New tests assert observable contracts and are shown to fail when those contracts are violated (anti-vacuity).
   - No new xfail or skip masks a known defect, and no new file.py:NNN-keyed ratchet entries are introduced.
   - Touched test fixtures resolve through the production creation seam rather than a parallel hand-roll.
+  - A remediated failing test carries an explicit verdict (stale-intent remediated / stub deleted / valid → product fixed), justified by code-path coupling rather than git-blame archaeology.
 references:
   - type: tactic
     id: delete-the-assertion-not-the-test

--- a/src/doctrine/tactics/built-in/testing/delete-the-assertion-not-the-test.tactic.yaml
+++ b/src/doctrine/tactics/built-in/testing/delete-the-assertion-not-the-test.tactic.yaml
@@ -98,8 +98,6 @@ failure_modes:
      'passes' without delivering the behavior (vacuous acceptance)."
   - "Re-keying a brittle ratchet without draining the debt it allow-lists -
      cheaper-to-maintain debt lives forever."
-applies_to_languages:
-  - any
 references:
   - name: ZOMBIES TDD
     type: tactic

--- a/src/runtime/next/runtime_bridge.py
+++ b/src/runtime/next/runtime_bridge.py
@@ -85,19 +85,26 @@ class DecisionGitLogUnavailable(RuntimeError):
 
 
 def _primary_runtime_feature_dir(repo_root: Path, mission_slug: str) -> Path:
-    """Return the topology-aware mission feature dir for meta.json reads.
+    """Return the PRIMARY-checkout mission feature dir for identity/meta reads.
 
-    Routes through the canonical coord-aware resolver
-    (:func:`candidate_feature_dir_for_mission`) rather than re-deriving a
-    raw mission-spec dir from the repo root and the bare slug by hand (the
-    residual slug-derived path-builder that ignored coord topology and the
-    ``-<mid8>`` suffix). One resolver, one path — FR-007/FR-009/FR-036.
+    Mission identity (``mission_id``, ``coordination_branch``, stored topology)
+    is persisted ONLY on the primary checkout's ``meta.json``. Under coordination
+    topology the topology-aware resolver (``candidate_feature_dir_for_mission``)
+    returns the coordination worktree once it is materialized — whose mission dir
+    has NO ``meta.json`` — so reading identity there found nothing and fell back
+    to the bare slug, yielding an empty ``mid8`` and a malformed
+    ``kitty/mission-<slug>-`` coord branch (#2091). Anchor on the topology-BLIND
+    :func:`primary_feature_dir_for_mission`, mirroring
+    :func:`_mission_routes_through_coordination` above and the canonical
+    precedent in ``core/paths.py`` (the same bug-class fixed for the merge
+    target): the coord-aware resolver fail-closes for a materialized-but-empty
+    coord worktree, so it must not gate primary-anchored identity reads.
     """
     from specify_cli.missions._read_path_resolver import (
-        candidate_feature_dir_for_mission,
+        primary_feature_dir_for_mission,
     )
 
-    return candidate_feature_dir_for_mission(repo_root, mission_slug)
+    return primary_feature_dir_for_mission(repo_root, mission_slug)
 
 
 def _resolve_coordination_branch(mission_slug: str, repo_root: Path) -> str:
@@ -212,6 +219,20 @@ def _wrap_with_decision_git_log(
         from specify_cli.lanes.branch_naming import resolve_mid8 as _resolve_mid8
         _declared_id = mission_id if mission_id != mission_slug else None
         _mid8 = _resolve_mid8(mission_slug, mission_id=_declared_id)
+
+        # Fail loud, never compose a malformed ``kitty/mission-<slug>-`` branch
+        # (#2091): an empty mid8 on a coord-routing mission means identity was
+        # unresolvable, so refuse here with a clear message rather than letting
+        # ``git worktree add`` fail with an opaque exit-128 on a non-existent
+        # branch. With the primary-anchored identity read above this is
+        # belt-and-suspenders, but it closes the dormant mask if any future read
+        # path loses the ULID again.
+        if coord_routing_topology and not _mid8:
+            raise DecisionGitLogUnavailable(
+                f"Cannot resolve mid8 for coordination-topology mission "
+                f"{mission_slug!r} (mission_id unresolvable); refusing to compose "
+                "a malformed coordination branch without durable decision evidence."
+            )
 
         # The decision-target topology SHAPE is READ from the WP02 stored topology
         # (FR-004 / SC-001) — never from ``_coord_path.exists()`` (the retired

--- a/src/specify_cli/cli/commands/agent/mission.py
+++ b/src/specify_cli/cli/commands/agent/mission.py
@@ -1238,6 +1238,38 @@ def _resolve_mission_dir_name_primary_anchored(
     return None
 
 
+def _primary_anchored_feature_dir(
+    repo_root: Path, explicit_feature: str | None
+) -> Path | None:
+    """Resolve a mission handle to its PRIMARY-checkout feature dir, or ``None``.
+
+    The planning-authoring surface companion to finalize-tasks' input read: both
+    must anchor to the SAME primary surface (``primary_feature_dir_for_mission``)
+    so an agent authoring at the reported ``feature_dir`` writes where
+    finalize-tasks reads. Returns ``None`` (so the caller falls back to the
+    coord-aware resolver) when no explicit handle is given or the mission has no
+    primary-surface directory. Propagates :class:`MissionSelectorAmbiguous` — an
+    ambiguous handle is never silently resolved (C-CTX-4 / C-009).
+    """
+    if not explicit_feature or not explicit_feature.strip():
+        return None
+    from specify_cli.missions._read_path_resolver import (
+        MissionSelectorAmbiguous,
+        primary_feature_dir_for_mission,
+    )
+
+    try:
+        dir_name = _resolve_mission_dir_name_primary_anchored(repo_root, explicit_feature)
+    except MissionSelectorAmbiguous as exc:
+        # No silent fallback on an ambiguous selector — surface the structured
+        # error the same way the coord-aware resolver does (C-CTX-4 / C-009).
+        raise ActionContextError(exc.error_code, str(exc)) from exc
+    if not dir_name:
+        return None
+    candidate = primary_feature_dir_for_mission(repo_root, dir_name)
+    return candidate if candidate.is_dir() else None
+
+
 def _list_feature_spec_candidates(repo_root: Path) -> list[dict[str, object]]:
     """List candidate missions with absolute spec.md paths for remediation output."""
     main_repo_root = get_main_repo_root(repo_root)
@@ -1723,14 +1755,31 @@ def check_prerequisites(
             command_name="spec-kitty agent mission check-prerequisites",
         )
 
-        # Determine feature directory (main repo or worktree)
+        # Determine feature directory (main repo or worktree).
+        #
+        # #2017-class surface-split fix: the planning-authoring surface this
+        # command reports MUST agree with where ``finalize-tasks`` reads its
+        # inputs. ``finalize-tasks`` deliberately anchors to the PRIMARY checkout
+        # (``primary_feature_dir_for_mission`` — CWD/topology-invariant, the same
+        # anchoring ``resolve_placement_only`` uses). The coord-aware read
+        # resolver, by contrast, returns the coordination worktree once it is
+        # materialized — so an agent authoring tasks at the reported ``feature_dir``
+        # would write to coord while finalize reads primary, and finalize parses an
+        # empty primary ``tasks/``. Delegate to the SAME primary anchor finalize
+        # uses so the two agree by construction; fall back to the coord-aware
+        # resolver only when the mission has no primary-surface directory (e.g. a
+        # coord-only legacy materialization). The full topology-aware unification
+        # of every planning command onto one surface authority is tracked by the
+        # single-authority-topology-cleanup mission (#1716 write-surface coherence).
         cwd = Path.cwd().resolve()
         try:
-            feature_dir = _find_feature_directory(
-                repo_root,
-                cwd,
-                explicit_feature=feature,
-            )
+            feature_dir = _primary_anchored_feature_dir(repo_root, feature)
+            if feature_dir is None:
+                feature_dir = _find_feature_directory(
+                    repo_root,
+                    cwd,
+                    explicit_feature=feature,
+                )
         except (ValueError, ActionContextError) as detection_error:
             _emit_check_prerequisites_detection_error(
                 repo_root=repo_root,
@@ -3363,7 +3412,17 @@ def finalize_tasks(
         wp_manifests = resolve_wp_manifests(ownership_source)
 
         if wp_manifests:
-            ownership_result = validate_ownership(wp_manifests)
+            # Same-lane sequential WPs (a linearized refactor chain that the lane
+            # allocator places on one worktree, run in dependency order) are
+            # never concurrent, so they may legitimately share owned_files. Pass
+            # the parsed dependency graph so the overlap guard binds only
+            # *parallel* (dependency-unordered) WPs — see validate_no_overlap.
+            _wp_dependencies = {
+                wp_id: list(fm.dependencies)
+                for wp_id, fm in wp_frontmatters.items()
+                if getattr(fm, "dependencies", None)
+            }
+            ownership_result = validate_ownership(wp_manifests, _wp_dependencies)
             for warning in ownership_result.warnings:
                 if not json_output:
                     console.print(f"[yellow]Ownership warning:[/yellow] {warning}")

--- a/src/specify_cli/ownership/validation.py
+++ b/src/specify_cli/ownership/validation.py
@@ -124,17 +124,62 @@ def _globs_overlap(pattern_a: str, pattern_b: str) -> bool:
     return False
 
 
-def validate_no_overlap(manifests: dict[str, OwnershipManifest]) -> list[str]:
-    """Check that no two WPs have overlapping owned_files glob patterns.
+def _dependency_reachability(
+    dependencies: Mapping[str, list[str]],
+) -> dict[str, set[str]]:
+    """Compute, for each WP, the set of WPs it transitively depends on.
 
-    Codebase-wide WPs are excluded from overlap checks because they are
-    expected to overlap with everything -- that is their purpose.
+    ``dependencies[wp]`` is the list of WP ids that ``wp`` directly depends on.
+    The returned mapping ``reach[wp]`` is the transitive closure of those edges
+    — every ancestor reachable by following ``depends-on`` edges from ``wp``.
+
+    Two WPs ``a`` and ``b`` are **sequential** (one runs strictly after the
+    other, never concurrently) iff ``b in reach[a]`` or ``a in reach[b]``; the
+    dependency DAG forces an execution order between them. WPs with no directed
+    path between them are **concurrent** (the lane allocator may place them on
+    parallel lanes), and only those must not share ``owned_files``.
+    """
+    reach: dict[str, set[str]] = {}
+
+    def _walk(node: str, seen: set[str]) -> set[str]:
+        if node in reach:
+            return reach[node]
+        acc: set[str] = set()
+        for dep in dependencies.get(node, ()):  # direct ancestors
+            if dep in seen:
+                continue  # defensive: ignore cycles (validated elsewhere)
+            acc.add(dep)
+            acc |= _walk(dep, seen | {dep})
+        reach[node] = acc
+        return acc
+
+    for wp_id in dependencies:
+        _walk(wp_id, {wp_id})
+    return reach
+
+
+def validate_no_overlap(
+    manifests: dict[str, OwnershipManifest],
+    dependencies: Mapping[str, list[str]] | None = None,
+) -> list[str]:
+    """Check that no two *concurrent* WPs have overlapping owned_files patterns.
+
+    Codebase-wide WPs are excluded (they are expected to overlap with
+    everything). When *dependencies* is supplied, **same-lane sequential** WPs —
+    those with a directed dependency path between them — are also exempt: a
+    linearized refactor chain shares one execution worktree and runs in
+    dependency order, so two such WPs legitimately own the same files. The
+    no-overlap guard exists to stop *parallel* (dependency-unordered) WPs from
+    colliding, so only concurrent pairs are flagged. When *dependencies* is
+    ``None`` the legacy all-pairs behaviour is preserved.
 
     Args:
         manifests: Mapping of WP ID (e.g. ``"WP01"``) to its OwnershipManifest.
+        dependencies: Optional mapping of WP ID to the WP ids it depends on.
+            Used to exempt sequential (same-lane) pairs from the overlap check.
 
     Returns:
-        List of error messages.  Empty list means no overlaps detected.
+        List of error messages.  Empty list means no disallowed overlaps.
     """
     errors: list[str] = []
 
@@ -146,9 +191,21 @@ def validate_no_overlap(manifests: dict[str, OwnershipManifest]) -> list[str]:
     for wp_id in sorted(skipped):
         logger.info("Skipping overlap check for %s (codebase-wide scope)", wp_id)
 
+    reach = _dependency_reachability(dependencies) if dependencies else {}
+
     wp_ids = list(narrow_manifests.keys())
 
     for wp_a, wp_b in combinations(wp_ids, 2):
+        # Same-lane sequential pair (a directed dependency path exists either
+        # way) → never concurrent → sharing owned_files is legitimate.
+        if reach and (wp_b in reach.get(wp_a, ()) or wp_a in reach.get(wp_b, ())):
+            logger.info(
+                "Skipping overlap check for sequential pair %s/%s (dependency-ordered)",
+                wp_a,
+                wp_b,
+            )
+            continue
+
         manifest_a = narrow_manifests[wp_a]
         manifest_b = narrow_manifests[wp_b]
 
@@ -241,19 +298,27 @@ def validate_execution_mode_consistency(manifest: OwnershipManifest) -> list[str
     return warnings
 
 
-def validate_all(manifests: dict[str, OwnershipManifest]) -> ValidationResult:
+def validate_all(
+    manifests: dict[str, OwnershipManifest],
+    dependencies: Mapping[str, list[str]] | None = None,
+) -> ValidationResult:
     """Run all ownership validations across every WP in a feature.
 
     Args:
         manifests: Mapping of WP ID to OwnershipManifest.
+        dependencies: Optional mapping of WP ID to the WP ids it depends on.
+            When supplied, same-lane sequential (dependency-ordered) WPs are
+            exempt from the owned_files overlap check — only concurrent
+            (parallel-lane) WPs must not share files.
 
     Returns:
         A ValidationResult with errors (hard) and warnings (soft).
     """
     result = ValidationResult()
 
-    # Cross-WP: overlap detection (hard error)
-    result.errors.extend(validate_no_overlap(manifests))
+    # Cross-WP: overlap detection (hard error) — concurrent pairs only when a
+    # dependency graph is supplied.
+    result.errors.extend(validate_no_overlap(manifests, dependencies))
 
     # Per-WP: authoritative_surface prefix (hard error)
     # Per-WP: execution_mode consistency (warning)

--- a/tests/specify_cli/events/test_decision_log_coord.py
+++ b/tests/specify_cli/events/test_decision_log_coord.py
@@ -167,6 +167,39 @@ class TestWrapWithDecisionGitLogCoordRouting:
         assert "worktree_root" in captured
         assert captured["worktree_root"] == coord_path
 
+    def test_resolve_mission_ulid_reads_primary_not_coord_worktree(self, tmp_path: Path) -> None:
+        """#2091 red-first: identity (``mission_id``) is persisted ONLY on the
+        primary checkout's meta.json. Under coordination topology the coord-aware
+        resolver returns the materialized coord worktree, whose mission dir has NO
+        meta.json — so reading identity there loses the ULID, ``_declared_id``
+        becomes ``None``, ``resolve_mid8`` declines to ``""`` (its #1918 contract),
+        and ``_wrap_with_decision_git_log`` composes the malformed
+        ``kitty/mission-<slug>-`` branch. ``_resolve_mission_ulid`` must read the
+        PRIMARY surface and return the ULID. RED on the unfixed code (returns the
+        slug), GREEN once the identity read is primary-anchored.
+        """
+        from runtime.next.runtime_bridge import _resolve_mission_ulid
+
+        slug = "my-feature-01KT3YBD"
+        mid8 = "01KT3YBD"
+        base_slug = "my-feature"
+        ulid = "01KT3YBDABCDEFGHIJKLMNOP"
+
+        # mission_id persisted on the PRIMARY checkout's meta.json only.
+        _write_coord_meta(tmp_path, slug)
+        # Materialized coord worktree whose mission dir has NO meta.json — the
+        # surface the coord-aware resolver would (wrongly) read identity from.
+        coord_mission_dir = (
+            tmp_path / ".worktrees" / f"{base_slug}-{mid8}-coord" / "kitty-specs" / slug
+        )
+        coord_mission_dir.mkdir(parents=True)
+        assert not (coord_mission_dir / "meta.json").exists()
+
+        assert _resolve_mission_ulid(slug, tmp_path) == ulid, (
+            "identity read must anchor on the primary checkout's meta.json, not "
+            "the coord worktree (which has no meta.json) — #2091"
+        )
+
     def test_repo_root_used_when_coord_absent(self, tmp_path: Path) -> None:
         """When coord worktree does not exist, repo_root becomes worktree_root (T019)."""
         from runtime.next.runtime_bridge import _wrap_with_decision_git_log

--- a/tests/specify_cli/ownership/test_validation.py
+++ b/tests/specify_cli/ownership/test_validation.py
@@ -81,6 +81,65 @@ class TestValidateNoOverlap:
         assert errors == []
 
 
+class TestValidateNoOverlapSequential:
+    """Dependency-aware overlap: same-lane sequential WPs may share owned_files.
+
+    Captures the #2017-class guard bug — a linearized refactor chain (WPs with a
+    directed dependency path between them) runs in one worktree, in order, never
+    concurrently, so sharing owned_files is legitimate. The no-overlap guard must
+    bind only *concurrent* (dependency-unordered / parallel-lane) WPs.
+    """
+
+    def test_sequential_pair_with_dependency_allows_overlap(self) -> None:
+        # WP02 depends on WP01 → strictly sequential → identical owned_files is OK.
+        manifests = {
+            "WP01": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP02": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+        }
+        errors = validate_no_overlap(manifests, {"WP02": ["WP01"]})
+        assert errors == []
+
+    def test_transitive_sequential_allows_overlap(self) -> None:
+        # WP03→WP02→WP01: WP01 and WP03 share files but are transitively ordered.
+        manifests = {
+            "WP01": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP02": _manifest(owned=("src/bar/**",), surface="src/bar/"),
+            "WP03": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+        }
+        deps = {"WP02": ["WP01"], "WP03": ["WP02"]}
+        errors = validate_no_overlap(manifests, deps)
+        assert errors == []
+
+    def test_concurrent_pair_still_errors_with_deps(self) -> None:
+        # WP01 and WP02 overlap but have NO dependency path → concurrent → ERROR.
+        manifests = {
+            "WP01": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP02": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP03": _manifest(owned=("src/bar/**",), surface="src/bar/"),
+        }
+        # WP03 depends on both, but WP01/WP02 are siblings (no path between them).
+        deps = {"WP03": ["WP01", "WP02"]}
+        errors = validate_no_overlap(manifests, deps)
+        assert len(errors) == 1
+        assert "WP01" in errors[0] and "WP02" in errors[0]
+
+    def test_no_deps_preserves_legacy_all_pairs_behavior(self) -> None:
+        manifests = {
+            "WP01": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP02": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+        }
+        # dependencies=None → legacy all-pairs overlap detection.
+        assert len(validate_no_overlap(manifests, None)) == 1
+
+    def test_validate_all_threads_dependencies(self) -> None:
+        manifests = {
+            "WP01": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+            "WP02": _manifest(owned=("src/foo/**",), surface="src/foo/"),
+        }
+        result = validate_all(manifests, {"WP02": ["WP01"]})
+        assert result.passed, result.errors
+
+
 # ---------------------------------------------------------------------------
 # validate_authoritative_surface
 # ---------------------------------------------------------------------------

--- a/tests/tasks/test_check_prerequisites_surface_agreement.py
+++ b/tests/tasks/test_check_prerequisites_surface_agreement.py
@@ -1,0 +1,133 @@
+"""Regression (#2087): check-prerequisites resolves the PRIMARY planning surface,
+agreeing with finalize-tasks (which anchors to the primary checkout).
+
+Genuine red-first capture through the STABLE entry point (the
+``check-prerequisites`` command), not a test of the fix's new helper. On the
+pre-fix code ``check_prerequisites`` resolved ``feature_dir`` via the coord-aware
+``_find_feature_directory`` → the coordination worktree, while ``finalize-tasks``
+reads its inputs from the PRIMARY checkout. The command test below patches the
+coord-aware resolver to return a coordination-worktree path and asserts the
+command STILL reports the primary dir — it returns the coord path (and the
+assertion FAILS) on the pre-fix code, and the primary path (assertion passes)
+once ``check_prerequisites`` delegates to the primary anchor finalize uses.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import patch
+
+from specify_cli.cli.commands.agent.mission import app
+from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+
+pytestmark = [pytest.mark.unit, pytest.mark.git_repo]
+
+runner = CliRunner()
+
+# Production-shaped mission slug (human-slug + mid8).
+_SLUG = "single-authority-topology-cleanup-01KVRJ6P"
+_MISSION_ID = "01KVRJ6PC66DWS32M30YVPAE28"
+
+
+def _git_init(repo: Path) -> None:
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+    _git("init", "-q", "-b", "feat/x")
+    _git("config", "user.email", "t@example.invalid")
+    _git("config", "user.name", "Test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git("add", "README.md")
+    _git("commit", "-q", "-m", "init")
+
+
+def _write_mission_dir(base: Path, *, coordination: bool) -> Path:
+    feature_dir = base / "kitty-specs" / _SLUG
+    (feature_dir / "tasks").mkdir(parents=True)
+    meta: dict[str, object] = {
+        "mission_id": _MISSION_ID,
+        "mission_slug": _SLUG,
+        "slug": _SLUG,
+        "target_branch": "feat/x",
+    }
+    if coordination:
+        meta["coordination_branch"] = f"kitty/mission-{_SLUG}"
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (feature_dir / "spec.md").write_text(
+        "# Spec\n## Functional Requirements\n"
+        "| ID | Requirement | Acceptance | Status |\n| - | - | - | - |\n"
+        "| FR-001 | x | y | proposed |\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text("## WP01\n**Requirement Refs**: FR-001\n", encoding="utf-8")
+    return feature_dir
+
+
+def _json_payload(stdout: str) -> dict[str, object]:
+    lines = [line for line in stdout.splitlines() if line.strip().startswith("{")]
+    assert lines, stdout
+    return json.loads(lines[-1])
+
+
+def test_check_prerequisites_reports_primary_not_coord(tmp_path: Path) -> None:
+    """The command reports the PRIMARY dir even when the coord-aware resolver
+    would return a coordination worktree — capturing the #2087 surface split."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    primary = _write_mission_dir(repo, coordination=True)
+    # The coordination worktree the coord-aware resolver would pick.
+    coord_dir = _write_mission_dir(repo / ".worktrees" / f"{_SLUG}-coord", coordination=True)
+    assert ".worktrees" in str(coord_dir)
+
+    with (
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=repo),
+        patch("specify_cli.cli.commands.agent.mission._enforce_git_preflight"),
+        # The coord-aware resolver returns the coordination worktree. Pre-fix the
+        # command used THIS as feature_dir; post-fix it must prefer the primary anchor.
+        patch(
+            "specify_cli.cli.commands.agent.mission._find_feature_directory",
+            return_value=coord_dir,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["check-prerequisites", "--mission", _SLUG, "--json", "--paths-only", "--include-tasks"],
+        )
+
+    payload = _json_payload(result.stdout)
+    feature_dir = str(payload.get("feature_dir", ""))
+    assert ".worktrees" not in feature_dir, f"reported the coord worktree: {feature_dir}"
+    assert feature_dir == str(primary)
+
+
+# --- pure helper contract tests (supporting the command behaviour above) ------
+
+
+def test_primary_anchored_dir_agrees_with_finalize_anchor(tmp_path: Path) -> None:
+    # Lazy import: the new helper does not exist on pre-fix code; keeping this out
+    # of module scope lets the command-level capture above still collect+run RED.
+    from specify_cli.cli.commands.agent.mission import _primary_anchored_feature_dir
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    primary = _write_mission_dir(repo, coordination=True)
+    resolved = _primary_anchored_feature_dir(repo, _SLUG)
+    assert resolved == primary == primary_feature_dir_for_mission(repo, _SLUG)
+
+
+def test_primary_anchored_dir_none_when_absent_or_empty(tmp_path: Path) -> None:
+    from specify_cli.cli.commands.agent.mission import _primary_anchored_feature_dir
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    assert _primary_anchored_feature_dir(repo, "no-such-mission-01XXXXXXXX") is None
+    assert _primary_anchored_feature_dir(tmp_path, None) is None
+    assert _primary_anchored_feature_dir(tmp_path, "   ") is None

--- a/tests/tasks/test_finalize_sequential_overlap_allowed.py
+++ b/tests/tasks/test_finalize_sequential_overlap_allowed.py
@@ -1,0 +1,120 @@
+"""Regression (#2088): finalize-tasks must NOT reject same-lane sequential WPs
+that share owned_files.
+
+This is a genuine red-first capture through the STABLE entry point
+(``finalize-tasks --validate-only``), not a test of the fix's new API. On the
+pre-fix code the ownership validator's all-pairs overlap check rejects two WPs
+that share ``owned_files`` even when one transitively depends on the other (a
+linearized refactor chain the lane allocator collapses into one lane). This test
+builds exactly such a sequential-overlap pair and asserts validation PASSES — it
+FAILS ("Ownership validation failed: Overlap …") on the dependency-blind code and
+PASSES once the validator is dependency-aware.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.agent.mission import app
+
+pytestmark = pytest.mark.fast
+
+runner = CliRunner()
+
+_SLUG = "single-authority-topology-cleanup-01KVRJ6P"
+_SHARED = "src/specify_cli/coordination/surface_resolver.py"
+
+
+def _wp(wp_id: str, deps: list[str]) -> str:
+    dep_block = "[]" if not deps else "[" + ", ".join(deps) + "]"
+    return (
+        "---\n"
+        f"work_package_id: {wp_id}\n"
+        f"title: {wp_id} sequential-overlap\n"
+        f"dependencies: {dep_block}\n"
+        "requirement_refs: [FR-001]\n"
+        "execution_mode: code_change\n"
+        "owned_files:\n"
+        f"  - {_SHARED}\n"
+        "authoritative_surface: src/specify_cli/coordination/\n"
+        "---\n"
+        f"# {wp_id}\n"
+    )
+
+
+def _build_sequential_overlap_feature(tmp_path: Path) -> Path:
+    # The shared owned_file must exist so the literal-path-zero-match gate passes
+    # and the OVERLAP check (the behaviour under test) decides the outcome.
+    shared = tmp_path / _SHARED
+    shared.parent.mkdir(parents=True, exist_ok=True)
+    shared.write_text("# stub surface\n", encoding="utf-8")
+
+    feature_dir = tmp_path / "kitty-specs" / _SLUG
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text('{"target_branch": "main"}\n', encoding="utf-8")
+    (feature_dir / "spec.md").write_text(
+        "# Spec\n"
+        "## Functional Requirements\n"
+        "| ID | Requirement | Acceptance Criteria | Status |\n"
+        "| --- | --- | --- | --- |\n"
+        "| FR-001 | Linearized refactor of one surface | Covered by WP01/WP02. | proposed |\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text(
+        "## WP01\n**Requirement Refs**: FR-001\n## WP02\n**Requirement Refs**: FR-001\n",
+        encoding="utf-8",
+    )
+    # WP02 depends on WP01 → strictly sequential → sharing the same file is legitimate.
+    (tasks_dir / "WP01-first.md").write_text(_wp("WP01", []), encoding="utf-8")
+    (tasks_dir / "WP02-second.md").write_text(_wp("WP02", ["WP01"]), encoding="utf-8")
+    return feature_dir
+
+
+def _run_command(cmd: list[str], **_kwargs: object) -> tuple[int, str, str]:
+    if "status" in cmd and "--porcelain" in cmd:
+        return (0, "M tasks.md", "")
+    if "rev-parse" in cmd and "HEAD" in cmd:
+        return (0, "c" * 40, "")
+    return (0, "", "")
+
+
+def _json_payload(stdout: str) -> dict[str, object]:
+    lines = [line for line in stdout.splitlines() if line.strip().startswith("{")]
+    assert lines, stdout
+    return json.loads(lines[-1])
+
+
+def test_sequential_overlap_passes_finalize_validation(tmp_path: Path) -> None:
+    feature_dir = _build_sequential_overlap_feature(tmp_path)
+
+    with (
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch(
+            "specify_cli.cli.commands.agent.mission._find_feature_directory",
+            return_value=feature_dir,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent.mission._show_branch_context",
+            return_value=(tmp_path, "main"),
+        ),
+        patch("specify_cli.cli.commands.agent.mission.run_command", side_effect=_run_command),
+        patch("specify_cli.cli.commands.agent.mission.get_emitter"),
+        patch("specify_cli.cli.commands.agent.mission.safe_commit", return_value=True),
+    ):
+        result = runner.invoke(
+            app,
+            ["finalize-tasks", "--mission", _SLUG, "--json", "--validate-only"],
+        )
+
+    payload = _json_payload(result.stdout)
+    # Pre-fix: exit 1, error "Ownership validation failed", ownership_errors lists
+    # the WP01/WP02 overlap. Post-fix (dependency-aware): validation passes.
+    assert result.exit_code == 0, payload
+    assert payload.get("result") == "validation_passed", payload
+    assert "ownership_errors" not in payload or not payload["ownership_errors"]


### PR DESCRIPTION
Two #2017-class workflow-guard bugs surfaced while dogfooding a coordination-topology mission through `/spec-kitty.tasks` → `finalize-tasks`. Both are fixed structurally (not worked around), test-first with **red-first reproduction** through the stable command entry points.

## #2087 — planning surface split (check-prerequisites ↔ finalize-tasks)
`check-prerequisites` resolved a coord-topology mission's planning `feature_dir` to the **coordination worktree** (coord-aware read resolver), while `finalize-tasks` deliberately anchors its input read to the **primary** checkout (`primary_feature_dir_for_mission`, CWD/topology-invariant). Tasks authored at the reported `feature_dir` were invisible to finalize → "all requirements unmapped".

**Fix:** `check_prerequisites` delegates to `_primary_anchored_feature_dir` — the same primary anchor finalize uses — so authoring and finalize agree by construction; falls back to the coord-aware resolver only when the primary dir is absent. The full topology-aware unification of every planning command onto one surface authority is folded into the single-authority-topology-cleanup mission / #1716.

## #2088 — ownership overlap validator is dependency/lane-blind
`validate_no_overlap` rejected **any** two WPs sharing `owned_files`, even same-lane sequential WPs that the lane allocator's own `write_scope_overlap` rule collapses into one lane (never concurrent) — blocking legitimate linearized refactor chains.

**Fix:** thread the parsed dependency graph; exempt pairs with a transitive dependency path (sequential), keep flagging concurrent (parallel) overlap. Legacy all-pairs behaviour preserved when no graph is supplied.

## Tests (red-first, reproduction-through-stable-entry-point)
- `test_finalize_sequential_overlap_allowed.py` — `finalize-tasks --validate-only` on a sequential-overlap WP pair. RED on pre-fix (`Ownership validation failed: Overlap …`), GREEN on fix.
- `test_check_prerequisites_surface_agreement.py` — the `check-prerequisites` command with the coord resolver patched to return a coord worktree. RED on pre-fix (`reported the coord worktree: …/.worktrees/…-coord/…`), GREEN on fix.
- Both verified red→green by reverting/restoring the source. Plus `validate_no_overlap` dependency-aware unit contract tests. ruff + mypy clean; affected suites green.

Parent epic: #1716 (write-surface coherence). Related: #2084, #2085 (sibling location-resolution gate bugs), #2017 (workflow-guard-friction investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)