### PR TITLE
fix: tasks phase deadlocks on protected-main missions — work-package files created in the wrong folder (#2101)

### DIFF
--- a/src/specify_cli/cli/commands/agent/context.py
+++ b/src/specify_cli/cli/commands/agent/context.py
@@ -27,6 +27,16 @@ app = typer.Typer(
 
 console = Console()
 
+# #2101: actions whose ``feature_dir`` the agent uses to AUTHOR planning
+# artifacts (spec/plan/tasks/WP files, analysis report). These are authored on
+# the PRIMARY checkout and staged to the coordination branch at commit time, so
+# the reported ``feature_dir`` for these actions must be the primary surface —
+# unlike read-only actions (accept/status) which legitimately resolve the
+# coord-committed surface.
+_AUTHORING_ACTIONS: frozenset[str] = frozenset(
+    {"specify", "plan", "tasks", "tasks_outline", "tasks_packages", "analyze"}
+)
+
 
 def _find_feature_directory(
     repo_root: Path,
@@ -135,8 +145,23 @@ def resolve_context(
             cwd=Path.cwd(),
         )
 
+        payload = context.to_dict()
+        # #2101: planning artifacts are authored on the PRIMARY checkout and only
+        # staged to the coordination branch at commit time (commit_for_mission
+        # stages primary->coord; finalize's change-detection runs in the primary
+        # repo, where .worktrees/ is gitignored). The read-path resolver returns
+        # the coord worktree once materialized — but the step contracts tell the
+        # agent to author at this ``feature_dir``, so for the AUTHORING actions it
+        # must point at the primary checkout, matching where finalize/implement/
+        # check-prerequisites read and where the commit machinery stages from. The
+        # placement/commit target (branch_ref) stays the resolved coordination ref.
+        if action in _AUTHORING_ACTIONS:
+            from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+
+            payload["feature_dir"] = str(primary_feature_dir_for_mission(repo_root, mission_slug))
+
         if json_output:
-            print(json.dumps({"success": True, **context.to_dict()}, indent=2))
+            print(json.dumps({"success": True, **payload}, indent=2))
         else:
             console.print(f"[green]✓[/green] Resolved {action} context")
             console.print(f"  Mission: {context.mission_slug} ({context.detection_method})")

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -379,19 +379,19 @@ def _map_requirements_feature_dir(main_repo_root: Path, mission_slug: str) -> Pa
     slug-only ``mid8_from_slug`` heuristic missed the coord worktree when the
     operator handle carried no mid8 tail, while finalize resolved into it.
 
-    The unified resolver raises ``ActionContextError`` when the directory cannot
-    be located; ``map-requirements`` historically surfaced this as its own
-    ``Mission directory not found: …`` message via an existence guard on the
-    returned path. To preserve that user-facing contract (Risk #1) the typed
-    error is translated back into the non-existent candidate directory so the
-    caller's existing existence guard fires the unchanged message.
+    #2101: anchor on the PRIMARY checkout. Planning artifacts (including
+    ``tasks/WP*.md``) are authored on the primary surface (``context resolve``
+    reports the primary ``feature_dir`` for authoring actions) and only staged to
+    the coordination branch at commit time. ``map-requirements`` reads/writes the
+    WP frontmatter and must therefore see the SAME primary surface ``finalize``,
+    ``check-prerequisites`` and ``implement`` read — the coord-aware
+    ``resolve_feature_dir_for_mission`` (the prior #2064 behaviour) selected the
+    coord worktree, where the commit machinery (which stages primary->coord and
+    change-detects in the primary repo) cannot commit. ``primary_feature_dir_for_mission``
+    is a pure path constructor; a non-existent dir is returned as-is so the
+    caller's existence guard fires the unchanged ``Mission directory not found``.
     """
-    from mission_runtime import ActionContextError
-
-    try:
-        return resolve_feature_dir_for_mission(main_repo_root, mission_slug)
-    except ActionContextError:
-        return candidate_feature_dir_for_mission(main_repo_root, mission_slug)
+    return primary_feature_dir_for_mission(main_repo_root, mission_slug)
 
 
 def _self_review_fallback_option_error(

--- a/tests/specify_cli/test_requirement_mapping_coord_surface.py
+++ b/tests/specify_cli/test_requirement_mapping_coord_surface.py
@@ -1,25 +1,22 @@
-"""#2064 read-surface desync regression: map-requirements and finalize-tasks
-must resolve the WP ``tasks/`` directory through ONE seam-resolved surface.
+"""#2101 read-surface authority: map-requirements and finalize-tasks must resolve
+the WP ``tasks/`` directory on the SAME (PRIMARY) surface.
 
-WP06 / FR-008 / SC-005. The bug: ``tasks.py::map_requirements`` was the lone read
-path on ``resolve_feature_dir_for_slug`` (whose slug-only ``mid8_from_slug``
-heuristic misses the coordination worktree when the operator handle carries no
-mid8 tail), while ``tasks.py::finalize_tasks`` (and the rest of ``tasks.py``)
-resolve through ``resolve_feature_dir_for_mission`` (the
-``resolve_action_context(action="tasks")`` seam, which reads the declared mid8
-from primary ``meta.json``). On a coord topology the two return DIFFERENT
-``tasks/`` directories, so ``map-requirements`` writes/reads one and finalize
-reads the other → spurious ``unmapped_functional_requirements``.
+This supersedes the #2064 framing. #2064 pointed ``map_requirements`` at
+``resolve_feature_dir_for_mission`` (the coord worktree once materialized),
+believing that was "finalize's seam" — but ``finalize_tasks`` anchors its input
+read on ``primary_feature_dir_for_mission``, and the commit machinery
+(``commit_for_mission``) stages PRIMARY->coord and change-detects in the primary
+repo (where ``.worktrees/`` is gitignored). So planning artifacts are authored on
+the PRIMARY checkout (``context resolve`` reports the primary ``feature_dir`` for
+authoring actions) and only staged to the coordination branch at commit time.
 
-These tests are NON-FAKEABLE: ``test_pre_fix_resolvers_diverge_on_coord_topology``
-proves the precondition that makes #2064 real (the two PRE-fix read surfaces
-return different ``Path`` objects for this fixture), and
-``test_map_and_finalize_agree_on_coord_topology`` proves the consequence — that
-the unified resolver ``map_requirements`` now uses agrees with finalize's, so the
-WP frontmatter staged into the coord ``tasks/`` dir is visible to BOTH, yielding
-zero unmapped functional requirements. A bare ``compute_coverage`` assertion in
-isolation would be insufficient (coverage math was never the bug); these tests
-exercise the cross-command directory agreement on a real coord topology.
+``test_pre_fix_resolvers_diverge_on_coord_topology`` documents that the two raw
+resolvers (slug-only vs mission) return different ``Path`` objects on a coord
+topology (the precondition that made the surface split possible).
+``test_map_and_finalize_agree_on_primary_authoring_surface`` proves the fix:
+``_map_requirements_feature_dir`` resolves the SAME primary surface
+``finalize_tasks`` reads, so PRIMARY-authored WP frontmatter is visible to BOTH →
+zero unmapped functional requirements.
 """
 
 from __future__ import annotations
@@ -39,6 +36,7 @@ from specify_cli.cli.commands.agent.tasks import (
 )
 from specify_cli.coordination.workspace import CoordinationWorkspace
 from specify_cli.missions._read_path_resolver import (
+    primary_feature_dir_for_mission,
     resolve_feature_dir_for_mission,
     resolve_feature_dir_for_slug,
 )
@@ -134,35 +132,38 @@ def test_pre_fix_resolvers_diverge_on_coord_topology(tmp_path: Path) -> None:
     assert "-coord" in str(mission_dir)
 
 
-def test_map_and_finalize_agree_on_coord_topology(tmp_path: Path) -> None:
-    """Post-WP06: map_requirements and finalize resolve the SAME coord dir.
+def test_map_and_finalize_agree_on_primary_authoring_surface(tmp_path: Path) -> None:
+    """#2101: map_requirements and finalize resolve the SAME PRIMARY dir.
 
-    ``_map_requirements_feature_dir`` (the unified resolver map_requirements now
-    uses) and ``resolve_feature_dir_for_mission`` (finalize's seam) must return
-    the SAME ``tasks/`` directory, so the WP frontmatter staged into coord is
-    visible to BOTH commands → zero ``unmapped_functional_requirements``.
+    The earlier #2064 fix pointed ``map_requirements`` at
+    ``resolve_feature_dir_for_mission`` believing that was "finalize's seam" — but
+    ``finalize_tasks`` actually anchors its input read on
+    ``primary_feature_dir_for_mission`` (and the commit machinery stages
+    primary->coord, change-detecting in the primary repo where ``.worktrees/`` is
+    gitignored). Planning artifacts are therefore authored on the PRIMARY checkout
+    (``context resolve`` reports the primary ``feature_dir`` for authoring
+    actions) and staged to coord at commit time. ``_map_requirements_feature_dir``
+    must resolve that SAME primary surface, NOT the coord worktree — else
+    map-requirements writes WP refs where finalize cannot read them.
     """
-    coord_tasks = _build_coord_topology(tmp_path)
+    _build_coord_topology(tmp_path)
+    # Author the WP frontmatter on the PRIMARY surface (where the agent writes).
+    primary_dir = primary_feature_dir_for_mission(tmp_path, _SLUG)
+    _write_wp(primary_dir / "tasks", "WP01", ["FR-001", "FR-002"])
+    _write_wp(primary_dir / "tasks", "WP02", ["FR-003"])
 
     map_feature_dir = _map_requirements_feature_dir(tmp_path, _SLUG)
-    finalize_feature_dir = resolve_feature_dir_for_mission(tmp_path, _SLUG)
 
-    # One read surface: same ``tasks/`` Path for both commands.
-    assert map_feature_dir == finalize_feature_dir
-    assert (map_feature_dir / "tasks") == coord_tasks
+    # One read surface: map-requirements resolves the SAME primary dir finalize
+    # reads (``primary_feature_dir_for_mission``), never the coord worktree.
+    assert map_feature_dir == primary_dir
+    assert ".worktrees" not in str(map_feature_dir)
 
-    # Cross-command consequence: reading the WP frontmatter through the unified
-    # surface yields FULL coverage — zero unmapped functional requirements.
+    # Cross-command consequence: reading the WP frontmatter through the shared
+    # primary surface yields FULL coverage — zero unmapped functional requirements.
     refs = read_all_wp_requirement_refs(map_feature_dir / "tasks")
     coverage = compute_coverage(refs, _FUNCTIONAL_IDS)
     assert coverage["unmapped_functional"] == []
-
-    # Witness the bug it replaces: the PRE-fix (divergent) surface reads the
-    # PRIMARY ``tasks/`` dir, which has NO WP frontmatter → every FR is unmapped.
-    pre_fix_dir = resolve_feature_dir_for_slug(tmp_path, _SLUG)
-    pre_fix_refs = read_all_wp_requirement_refs(pre_fix_dir / "tasks")
-    pre_fix_coverage = compute_coverage(pre_fix_refs, _FUNCTIONAL_IDS)
-    assert sorted(pre_fix_coverage["unmapped_functional"]) == sorted(_FUNCTIONAL_IDS)
 
 
 # --- T034: FR-005 predicate routing at the review-currency decision site ------


### PR DESCRIPTION
## What happened

We were running a normal mission on a repo where the `main` branch is protected. Spec Kitty handles that by giving the mission its own separate **coordination folder** to work in. Spec and plan went fine. Then the tasks phase got stuck:

- The step that **creates** the work-package files put them in the **coordination** folder.
- But the next steps — the one that **validates** the tasks, and the one that **starts implementation** — looked in the **main** folder, which only had empty scaffolding.

So every tool reported "no work packages found," even though we'd just created six of them. And there was no single folder that made both sides happy: put the files where the creator wanted, and the validator went blind; put them where the validator looked, and the creator couldn't find them. The mission couldn't move forward.

## Why this was hard to pin down

This took us a while, and it's worth being honest about why: the design notes, the actual code, and the tests don't all agree on which folder is the "real" one. We kept concluding the bug was in one step, then finding evidence it was somewhere else, and going back and forth. That's not a knock on anyone — it lines up with the cleanup work already open in #1716.

What finally settled it was to stop looking for a hidden "right answer" and instead look at the one part of the system that simply *has* to work a certain way: the code that **saves and commits** the files. That code only knows how to take files from the **main** folder and copy them into the coordination folder to commit them — and it even checks for changes by looking in the main folder. The steps that validate and implement also read the main folder. In other words, almost everything already assumes: **you author in the main folder, and the coordination folder is just where things get committed.**

The one piece that disagreed was the step that **tells the agent where to create files** — it pointed at the coordination folder. That single mismatch is the whole bug.

## The fix

We pointed the file-creation steps at the same **main** folder everything else already uses:

- `context resolve` now reports the main folder for the authoring actions (specify, plan, tasks, etc.).
- `map-requirements` now reads the main folder too.

We did **not** change the validate, implement, or save steps — they were already correct. That's why the change is small, and a big part of why we think it's right: it makes the odd-one-out match everything else, instead of rewriting the parts that already work.

## Why we think this honors the original intent

We didn't invent a new model — we made the authoring step agree with the model the rest of the code already enforces. If we've misread the intent and the coordination folder was meant to be the authoritative one, the alternative would be to change the save logic to commit *from* the coordination folder instead; we're happy to go that way if a maintainer prefers it. But every working piece pointed in the direction we chose.

One thing worth flagging: there's a test that was supposed to catch this exact bug, but it compared two helper functions instead of actually running the validate step — and those two helpers happened to agree, so the test passed while the real steps disagreed. We've rewritten it to exercise the real behavior.

## Testing

- Full test suite: no new failures (the pre-existing ones are unchanged).
- Ran a real protected-`main` mission end-to-end through the tasks phase and into implementation — no deadlock, no manual workarounds.

## Related, but not fixed here

The `record-analysis` step has a related version of the same folder confusion, plus a separate problem where it refuses to run because of files Spec Kitty itself left uncommitted (#2102). We left it alone for now — it's tangled up with tests that assume the older behavior and deserves its own change once the folder model is confirmed.

Fixes #2101.
