### PR TITLE
fix: mission close --discard actually tears down coordination-topology missions

### DIFF
--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -23,6 +23,7 @@ from specify_cli.missions._read_path_resolver import (
     primary_feature_dir_for_mission,
     resolve_feature_dir_for_mission,
 )
+import contextlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -606,6 +607,14 @@ def close_cmd(
     # handle while the command reports success.
     mission_slug = feature_dir.name
 
+    # Surface fix (#2120): identity/lane reads (meta.json/lanes.json) and the
+    # teardown below are all PRIMARY-anchored. The resolver above stays the
+    # canonical handle-resolution + structured-error source, but once a
+    # coordination worktree exists it returns that worktree's status-only dir
+    # (no meta.json → _read_mission_mid8 empties → teardown silently no-ops).
+    # Re-anchor to the primary mission dir, matching how `mission reopen` resolves.
+    feature_dir = primary_feature_dir_for_mission(repo_root, mission_slug)
+
     meta_path = feature_dir / "meta.json"
     mid8_value = _read_mission_mid8(meta_path)
 
@@ -618,14 +627,20 @@ def close_cmd(
             meta_path=meta_path,
             force=force,
         )
-
-    # Teardown the coordination worktree. Same path as merge.py:1568.
-    # Idempotent: no-ops on legacy missions / when already torn down.
-    _teardown_coordination_worktree(repo_root, mission_slug, mid8_value)
-
-    if discard:
+        # Fail closed (#2120): a destructive discard must not report success
+        # while leaving worktrees/branches behind. Verify BEFORE flattening so the
+        # legacy-branch check can still read coordination_branch from meta.json.
+        _verify_discard_complete(
+            repo_root, mission_slug, mid8_value, feature_dir, meta_path
+        )
+        # Flatten: drop the now-dangling coordination_branch marker so subsequent
+        # commands for this mission don't trip CoordinationBranchDeleted (#2120).
+        _flatten_discarded_mission(feature_dir)
         console.print(f"[green]✓[/green] Mission {mission_slug} discarded.")
     else:
+        # Teardown the coordination worktree. Same path as merge.py:1568.
+        # Idempotent: no-ops on legacy missions / when already torn down.
+        _teardown_coordination_worktree(repo_root, mission_slug, mid8_value)
         console.print(f"[green]✓[/green] Mission {mission_slug} closed.")
 
 
@@ -653,12 +668,172 @@ def _discard_mission(
     force: bool,
 ) -> None:
     _confirm_discard(mission_slug, force=force)
-    lanes_manifest = _load_lanes_manifest(feature_dir)
+    lanes_manifest = _load_lanes_manifest_for_discard(feature_dir, mission_slug)
+    # Remove ALL worktrees BEFORE deleting their branches (#2120): a branch that
+    # is checked out in a worktree cannot be `git branch -D`'d, so the prior
+    # branch-first order silently leaked the coordination/lane branches.
+    _teardown_coordination_worktree(repo_root, mission_slug, mid8_value)
     if lanes_manifest is not None:
-        _delete_lane_branches(repo_root, mission_slug, lanes_manifest)
         _remove_lane_worktrees(repo_root, mission_slug, mid8_value, lanes_manifest)
+        _delete_lane_branches(repo_root, mission_slug, lanes_manifest)
         return
     _delete_legacy_coordination_branch(repo_root, meta_path)
+
+
+def _load_lanes_manifest_for_discard(feature_dir: Path, mission_slug: str) -> Any | None:
+    """Load ``lanes.json`` for a discard, failing CLOSED on corruption.
+
+    Unlike :func:`_load_lanes_manifest` (which degrades a corrupt manifest to
+    ``None``), a destructive discard must not silently route a modern mission
+    through the legacy single-branch path on a corrupt manifest — that would
+    leave the lane branches/worktrees behind while reporting success (#2120).
+    A *missing* manifest is still a legacy mission (``None``); a *corrupt* one
+    aborts.
+    """
+    from specify_cli.lanes.persistence import (
+        CorruptLanesError,
+        MissingLanesError,
+        require_lanes_json,
+    )
+
+    try:
+        return require_lanes_json(feature_dir)
+    except MissingLanesError:
+        return None
+    except CorruptLanesError as exc:
+        console.print(
+            f"[red]Error:[/red] cannot discard {mission_slug}: lanes.json is "
+            f"corrupt ({exc}). Repair or remove it, then retry."
+        )
+        raise typer.Exit(1) from exc
+
+
+def _branch_exists(repo_root: Path, branch_name: str) -> bool:
+    import subprocess as _subprocess
+
+    result = _subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _registered_worktree_names(repo_root: Path) -> list[str]:
+    """Return the directory names of every git-registered worktree.
+
+    Reads ``git worktree list --porcelain`` so the residual check can catch a
+    stale/broken registration whose on-disk directory is already gone — which a
+    plain ``.worktrees/`` directory scan would miss.
+    """
+    import subprocess as _subprocess
+
+    result = _subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    names: list[str] = []
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            names.append(Path(line[len("worktree "):].strip()).name)
+    return names
+
+
+def _expected_discard_branches(
+    feature_dir: Path, mission_slug: str, meta_path: Path
+) -> list[str]:
+    """The branches a discard is expected to delete (for post-teardown verify).
+
+    Mirrors :func:`_delete_lane_branches` / :func:`_delete_legacy_coordination_branch`
+    so the residual check verifies exactly the set the discard tried to remove.
+    """
+    branches: list[str] = []
+    manifest = _load_lanes_manifest(feature_dir)
+    if manifest is not None:
+        from specify_cli.lanes.branch_naming import lane_branch_name
+        from specify_cli.lanes.compute import is_planning_lane
+
+        for lane in manifest.lanes:
+            if is_planning_lane(lane):
+                continue
+            branches.append(lane_branch_name(mission_slug, lane.lane_id))
+        branches.append(manifest.mission_branch)
+        return branches
+    meta = load_meta(meta_path.parent, allow_missing=True, on_malformed="none")
+    coord_branch = meta.get("coordination_branch") if isinstance(meta, dict) else None
+    if coord_branch:
+        branches.append(str(coord_branch))
+    return branches
+
+
+def _verify_discard_complete(
+    repo_root: Path,
+    mission_slug: str,
+    mid8_value: str,
+    feature_dir: Path,
+    meta_path: Path,
+) -> None:
+    """Fail closed if a discard left worktrees or branches behind (#2120).
+
+    The bug this guards against is a *silent* no-op that still printed success.
+    After teardown, any surviving mission worktree (under ``.worktrees/<slug>-*``,
+    covering both the coordination and lane worktrees) or expected branch is a
+    real leak — surface it as a non-zero error instead of a false ``✓``.
+    """
+    leaks: list[str] = []
+
+    prefix = f"{mission_slug}-"
+    leaked_worktrees: set[str] = set()
+    # On-disk worktree directories under .worktrees/<slug>-* ...
+    worktrees_root = repo_root / ".worktrees"
+    if worktrees_root.exists():
+        for entry in worktrees_root.iterdir():
+            if entry.is_dir() and entry.name.startswith(prefix):
+                leaked_worktrees.add(entry.name)
+    # ... AND git worktree registrations (catches a stale/broken registration
+    # whose directory is already gone — invisible to the on-disk scan).
+    for registered in _registered_worktree_names(repo_root):
+        if registered.startswith(prefix):
+            leaked_worktrees.add(registered)
+    leaks.extend(f".worktrees/{name}" for name in sorted(leaked_worktrees))
+
+    for branch in _expected_discard_branches(feature_dir, mission_slug, meta_path):
+        if _branch_exists(repo_root, branch):
+            leaks.append(f"branch {branch}")
+
+    if not leaks:
+        return
+
+    console.print(
+        f"[red]Error:[/red] discard of {mission_slug} did not complete — these "
+        "artifacts were not removed:"
+    )
+    for leak in leaks:
+        console.print(f"  - {leak}")
+    console.print(
+        "[dim]Remove them manually (git worktree remove --force / git branch -D) "
+        "and retry, or report this as a bug.[/dim]"
+    )
+    raise typer.Exit(1)
+
+
+def _flatten_discarded_mission(feature_dir: Path) -> None:
+    """Drop the dangling ``coordination_branch`` marker after a discard (#2120).
+
+    Tolerant: a missing meta.json (legacy mission) is a no-op — flattening is a
+    best-effort cleanup, never a hard failure of an otherwise-successful discard.
+    """
+    from specify_cli.mission_metadata import clear_coordination_metadata
+
+    with contextlib.suppress(FileNotFoundError):
+        clear_coordination_metadata(feature_dir)
 
 
 def _confirm_discard(mission_slug: str, *, force: bool) -> None:

--- a/src/specify_cli/mission_metadata.py
+++ b/src/specify_cli/mission_metadata.py
@@ -743,6 +743,37 @@ def clear_merge_metadata(feature_dir: Path) -> dict[str, Any]:
     return cleared
 
 
+def clear_coordination_metadata(feature_dir: Path) -> dict[str, Any]:
+    """Remove the ``coordination_branch`` marker from ``meta.json`` (flatten).
+
+    Used by ``spec-kitty mission close --discard``: once the coordination branch
+    and worktree have been torn down, the mission is intentionally flattened to a
+    single-branch/primary topology. Leaving a dangling ``coordination_branch`` key
+    pointing at a now-deleted branch makes ``resolve_action_context`` fail closed
+    (``CoordinationBranchDeleted`` — "data loss") on every subsequent command for
+    that mission. Clearing it is the canonical "flatten the mission" recovery the
+    surface resolver itself recommends.
+
+    Returns a snapshot of the cleared fields (empty when none were present). The
+    write is tolerant (``validate=False``) so it never fails on legacy missions
+    whose ``meta.json`` predates a required field.
+
+    Raises:
+        FileNotFoundError: If ``meta.json`` does not exist in *feature_dir*.
+    """
+    meta = load_meta(feature_dir)
+    if meta is None:
+        raise FileNotFoundError(f"No meta.json in {feature_dir}")
+
+    cleared: dict[str, Any] = {}
+    if "coordination_branch" in meta:
+        cleared["coordination_branch"] = meta.pop("coordination_branch")
+
+    if cleared:
+        write_meta(feature_dir, meta, validate=False)
+    return cleared
+
+
 def get_change_mode(feature_dir: Path) -> str | None:
     """Read ``change_mode`` from meta.json.
 

--- a/tests/integration/test_mission_close_discard_coord_teardown.py
+++ b/tests/integration/test_mission_close_discard_coord_teardown.py
@@ -1,0 +1,144 @@
+"""Regression: ``mission close --discard`` must tear down a coordination mission.
+
+Reproduces a silent no-op: on a coordination-topology mission whose coordination
+worktree is present, ``spec-kitty mission close --discard`` prints
+``✓ Mission <slug> discarded`` but leaves the coordination worktree AND branch in
+place.
+
+Root cause exercised by this fixture (the split-brain surface layout):
+
+* planning/identity artifacts (``meta.json`` / ``lanes.json``) live on the
+  PRIMARY branch's mission dir;
+* the coordination branch's mission dir is status-only (``status.events.jsonl`` /
+  ``status.json``) — the coordination worktree is a full checkout of that branch;
+* ``close_cmd`` resolves ``feature_dir`` via ``resolve_feature_dir_for_mission``
+  (the ``tasks``-action context), which returns the coordination worktree's
+  status-only dir → ``meta.json`` is absent → ``_read_mission_mid8`` returns
+  ``""`` → ``_teardown_coordination_worktree`` early-returns → nothing is torn
+  down, yet the command reports success.
+
+This test asserts the CORRECT post-condition (worktree + branch gone). It FAILS
+on the current code (the bug); the fix flips it green.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import mission_type
+from specify_cli.coordination import CoordinationWorkspace
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+runner = CliRunner()
+
+MISSION_ID = "01J6XW9K000000000000000000"
+MID8 = MISSION_ID[:8]
+# Mission dir / slug follows the real `<base>-<mid8>` identity convention so the
+# coord-surface resolver composes the same mission-dir name on both branches.
+SLUG = f"demo-coord-mission-{MID8}"
+# Branch + worktree names come from the canonical helpers the runtime uses, so
+# the fixture matches exactly what ``CoordinationWorkspace.resolve`` expects.
+COORD_BRANCH = CoordinationWorkspace.branch_name(SLUG, MID8)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def coord_mission(tmp_path: Path) -> Path:
+    """A coordination mission in the split-brain surface layout.
+
+    Primary branch carries meta.json + lanes.json; the coordination branch's
+    mission dir is status-only; a real coordination worktree is materialised.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".kittify").mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    fdir = repo / "kitty-specs" / SLUG
+    fdir.mkdir(parents=True)
+    (fdir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": SLUG,
+                "mission_id": MISSION_ID,
+                "mid8": MID8,
+                "coordination_branch": COORD_BRANCH,
+                "mission_branch": COORD_BRANCH,
+                "target_branch": "main",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fdir / "lanes.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "mission_slug": SLUG,
+                "mission_id": MISSION_ID,
+                "mission_branch": COORD_BRANCH,
+                "target_branch": "main",
+                "computed_at": "2026-01-01T00:00:00+00:00",
+                "computed_from": "test",
+                "lanes": [
+                    {"lane_id": "lane-a", "wp_ids": ["WP01"], "write_scope": [],
+                     "predicted_surfaces": [], "depends_on_lanes": [], "parallel_group": 0},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fdir / "status.events.jsonl").write_text("", encoding="utf-8")
+    (fdir / "status.json").write_text("{}", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "seed primary mission surface")
+
+    # Coordination branch: status-only mission dir (drop planning artifacts).
+    _git(repo, "branch", COORD_BRANCH)
+    _git(repo, "checkout", "-q", COORD_BRANCH)
+    _git(repo, "rm", "-q", f"kitty-specs/{SLUG}/meta.json", f"kitty-specs/{SLUG}/lanes.json")
+    _git(repo, "commit", "-q", "-m", "coord: status-only mission surface")
+    _git(repo, "checkout", "-q", "main")
+
+    # Materialise the real coordination worktree (full checkout of coord branch).
+    CoordinationWorkspace.resolve(repo, SLUG, MID8)
+    assert CoordinationWorkspace.is_present(repo, SLUG, MID8)
+    return repo
+
+
+def test_close_discard_tears_down_coordination_worktree_and_branch(
+    coord_mission: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = coord_mission
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(
+        mission_type.app,
+        ["close", "--mission", SLUG, "--discard", "--force"],
+        env={"PWD": str(repo)},
+    )
+    assert result.exit_code == 0, result.output
+
+    # The command must actually tear down what it claims to.
+    assert not CoordinationWorkspace.is_present(repo, SLUG, MID8), (
+        "coordination worktree still present after `close --discard` "
+        f"(command output: {result.output!r})"
+    )
+    branches = _git(repo, "branch", "--list", COORD_BRANCH).stdout.strip()
+    assert branches == "", f"coordination branch leaked after `close --discard`: {branches!r}"

--- a/tests/integration/test_mission_close_discard_coord_teardown.py
+++ b/tests/integration/test_mission_close_discard_coord_teardown.py
@@ -142,3 +142,114 @@ def test_close_discard_tears_down_coordination_worktree_and_branch(
     )
     branches = _git(repo, "branch", "--list", COORD_BRANCH).stdout.strip()
     assert branches == "", f"coordination branch leaked after `close --discard`: {branches!r}"
+
+
+def test_close_discard_is_idempotent_on_rerun(
+    coord_mission: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second `close --discard` after a successful one is a clean success —
+    the residual verifier must not false-fail when there is nothing left."""
+    repo = coord_mission
+    monkeypatch.chdir(repo)
+
+    first = runner.invoke(
+        mission_type.app, ["close", "--mission", SLUG, "--discard", "--force"],
+        env={"PWD": str(repo)},
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        mission_type.app, ["close", "--mission", SLUG, "--discard", "--force"],
+        env={"PWD": str(repo)},
+    )
+    assert second.exit_code == 0, second.output
+
+
+def test_close_discard_flattens_coordination_branch_from_meta(
+    coord_mission: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After a discard deletes the coord branch, meta.json must no longer declare
+    `coordination_branch` — otherwise subsequent commands trip
+    CoordinationBranchDeleted (the dangling-reference data-loss guard)."""
+    repo = coord_mission
+    monkeypatch.chdir(repo)
+    meta_path = repo / "kitty-specs" / SLUG / "meta.json"
+    assert "coordination_branch" in json.loads(meta_path.read_text())
+
+    result = runner.invoke(
+        mission_type.app, ["close", "--mission", SLUG, "--discard", "--force"],
+        env={"PWD": str(repo)},
+    )
+    assert result.exit_code == 0, result.output
+    assert "coordination_branch" not in json.loads(meta_path.read_text())
+
+
+def test_close_without_discard_tears_down_coord_worktree(
+    coord_mission: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The non-discard `close` (re-anchored too) must tear down the coordination
+    worktree on a coord mission — pre-fix it silently no-op'd as well — while
+    leaving the branches intact (no --discard)."""
+    repo = coord_mission
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(
+        mission_type.app, ["close", "--mission", SLUG], env={"PWD": str(repo)}
+    )
+    assert result.exit_code == 0, result.output
+    assert not CoordinationWorkspace.is_present(repo, SLUG, MID8)
+    # Non-discard leaves branches in place.
+    assert _git(repo, "branch", "--list", COORD_BRANCH).stdout.strip() != ""
+
+
+def test_close_discard_fails_closed_on_corrupt_lanes_json(
+    coord_mission: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt lanes.json must abort the discard (non-zero, no teardown) rather
+    than silently degrade a modern mission to the legacy single-branch path and
+    leave its lane branches/worktrees behind."""
+    repo = coord_mission
+    (repo / "kitty-specs" / SLUG / "lanes.json").write_text("{ not json", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(
+        mission_type.app, ["close", "--mission", SLUG, "--discard", "--force"],
+        env={"PWD": str(repo)},
+    )
+    assert result.exit_code != 0
+    assert "corrupt" in result.output.lower()
+    # Aborted before teardown — coord worktree untouched.
+    assert CoordinationWorkspace.is_present(repo, SLUG, MID8)
+
+
+def test_verify_discard_complete_flags_leaks(tmp_path: Path) -> None:
+    """The residual verifier raises (non-zero) when an expected branch survives,
+    and is silent when everything is gone."""
+    from specify_cli.cli.commands.mission_type import _verify_discard_complete
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".kittify").mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    fdir = repo / "kitty-specs" / SLUG
+    fdir.mkdir(parents=True)
+    meta_path = fdir / "meta.json"
+    meta_path.write_text(
+        json.dumps({"mission_slug": SLUG, "coordination_branch": COORD_BRANCH}),
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "seed")
+
+    # No leftover branch/worktree → clean (no raise).
+    _verify_discard_complete(repo, SLUG, MID8, fdir, meta_path)
+
+    # A surviving coordination branch is a leak → typer.Exit (non-zero).
+    import typer
+
+    _git(repo, "branch", COORD_BRANCH)
+    with pytest.raises(typer.Exit):
+        _verify_discard_complete(repo, SLUG, MID8, fdir, meta_path)


### PR DESCRIPTION
Fixes #2120.

## What was broken

`spec-kitty mission close --discard` on a coordination-topology mission (coord worktree materialized) printed `✓ Mission <slug> discarded` while tearing **nothing** down — the coordination worktree and branches leaked. Root cause (per #2120): `close_cmd` resolved `feature_dir` through `resolve_feature_dir_for_mission`, which returns the coord worktree's status-only dir once a coord worktree exists; with no `meta.json` there, `mid8` came back empty and `_teardown_coordination_worktree` early-returned. A secondary ordering bug deleted branches before the worktrees they were checked out in.

## The fix (four coordinated changes, all in the close path)

1. **Surface.** Re-anchor the discard/close `feature_dir` to `primary_feature_dir_for_mission` **after** the canonical handle resolution. `resolve_feature_dir_for_mission` stays the handle-resolution + structured-error source (the `ActionContextError` contract on unresolvable/ambiguous handles is preserved), but identity/lane reads and teardown now hit the primary surface that actually carries `meta.json`/`lanes.json` — matching how `mission reopen` already resolves.
2. **Ordering.** Tear down all worktrees **before** deleting their branches (a branch checked out in a worktree can't be `git branch -D`'d).
3. **Fail-closed.** A corrupt `lanes.json` now aborts a discard instead of silently degrading a modern mission to the legacy single-branch path; and a residual verifier (on-disk `.worktrees/` dirs **and** `git worktree list --porcelain` registrations, plus expected branches) turns any surviving artifact into a non-zero error rather than a false `✓`.
4. **Flatten.** After teardown, clear the now-dangling `coordination_branch` from `meta.json` (new `clear_coordination_metadata`, mirroring `clear_merge_metadata`). Without this, actually deleting the coord branch would leave every subsequent command for that mission tripping `CoordinationBranchDeleted` — the "flatten the mission" recovery the surface resolver itself recommends.

## Scope / relationship to #2115

Additive, not overlapping. #2115 / the #1716 cluster targets the implement/review/merge loop reading the WP `tasks/` directory off coord (pinned in `_DIR_READ_KNOWN_RESIDUALS` — `agent/workflow.py`, `agent/tasks.py`, `merge.py`); `mission_type.py` is not in that set, and this is a different read (identity/`meta.json`, which the gate allowlists as self-bookkeeping — so the existing dir-read ratchet wouldn't sweep it up). This PR does **not** modify the shared `resolve_feature_dir_for_mission`. Happy to align rather than cut across that remediation if you'd prefer a different shape.

## Testing

- The failing regression (`tests/integration/test_mission_close_discard_coord_teardown.py`) — a coord mission in the split-brain surface layout — flips green.
- Added coverage: idempotent re-run, corrupt-`lanes.json` fail-closed, residual verifier, `coordination_branch` flatten, and the non-discard `close` path.
- Green: the pinned handle-equivalence contracts (`test_handle_equivalence_matrix.py`), `test_mission_close.py`, `test_mission_reopen.py`, and the `test_gate_read_literal_ban.py` / `test_topology_resolution_boundary.py` architectural gates. `ruff` + `mypy` clean.

## Known follow-up (not in this PR)

`_remove_lane_worktrees` targets lane worktrees by `.worktrees/<slug>-*` prefix rather than computing exact names from the manifest. It's pre-existing and mid8-scoped (collision-resistant in practice), and tightening it reaches into the coordination-topology surface under active remediation — so I've left it as a follow-up to avoid widening scope here. The new residual verifier at least makes any miss a loud failure rather than a silent one.

---

*AI-assistance disclosure: diagnosed, implemented, and tested with AI assistance (Claude Code), with the design and the completed code independently reviewed via Codex; the reproduction was validated on a pristine build with real mission state, and all changes are human-reviewed.*
