### PR TITLE
fix: accept gate resolves mid8/ULID handles for its primary-partition reads

### DIFF
--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -1242,8 +1242,17 @@ def collect_feature_summary(
 
     snapshot_wps = _collect_snapshot_wps(feature, status_feature_dir, activity_issues)
 
+    # #2122: PRIMARY-partition reads (WP tasks/, planning artifacts) must key on
+    # the canonical PRIMARY slug, not the raw handle. A mid8/ULID/numeric handle
+    # passed straight to the kind-aware seam composes a nonexistent
+    # `kitty-specs/<handle>` dir. `feature_dir` is the already-resolved primary
+    # anchor, so its name is the canonical primary slug (which can legitimately
+    # differ from the coord read-dir name for backfilled legacy missions).
+    # STATUS reads above/below stay coord-aware on the raw `feature` (C-002).
+    primary_slug = feature_dir.name
+
     expected_wp_ids: list[str] = []
-    for wp in _iter_work_packages(repo_root, feature):
+    for wp in _iter_work_packages(repo_root, primary_slug):
         wp_id = wp.work_package_id or wp.path.stem
         title = (wp.title or "").strip('"')
         expected_wp_ids.append(wp_id)
@@ -1290,7 +1299,7 @@ def collect_feature_summary(
     # (status.events.jsonl) and below (acceptance-matrix via _check_lane_gates) stay on
     # the coord-aware status_feature_dir (C-002). The single status_feature_dir variable
     # is split per-partition WITHOUT renaming it (additive: a new planning_read_dir).
-    planning_read_dir = _planning_read_dir(repo_root, feature)
+    planning_read_dir = _planning_read_dir(repo_root, primary_slug)
 
     unchecked_tasks = _find_unchecked_tasks(planning_read_dir / TASKS_FILE)
     needs_clarification = _check_needs_clarification(


### PR DESCRIPTION
Fixes #2122.

## What was broken

`collect_feature_summary` (the accept gate) passed the **raw mission handle** to its PRIMARY-partition reads — `_iter_work_packages` → `_wp_tasks_read_dir`, and `_planning_read_dir`. For a mid8 / ULID / numeric handle that composes a nonexistent `kitty-specs/<handle>` slug dir, so the gate fails with `AcceptanceError: Feature '<handle>' has no tasks directory`. The summary's identity anchor and status reads were already handle-correct; only the primary-partition reads weren't.

## The fix

Key the primary-partition reads on the canonical **primary slug**, derived from the already-resolved `_primary_anchor_feature_dir` (`feature_dir.name`) rather than the raw handle. That name is deliberately *not* recomposed from the coord read-dir (it can differ for backfilled legacy missions whose primary dir lacks the `-<mid8>` suffix). The STATUS reads stay coord-aware on the raw handle, preserving the per-partition split (C-002).

Targeted and caller-local: this does **not** touch the shared `resolve_planning_read_dir` seam — the broader handle-canonicalization cure at that entry point remains the deliberate follow-on. Additive; no change to the shared resolver.

## Testing

- The pre-existing (test-first) regression `test_collect_feature_summary_anchors_feature_dir_on_primary_for_mid8_handle` flips from red to green; full acceptance suite green (56), `ruff` + `mypy` clean.
- **Validated on real mission state:** against a clone of a real coordination-topology mission (mid8 handle `01KVXNDC`), pristine `main` errors `Feature '01KVXNDC' has no tasks directory`; with this fix the gate resolves to the real primary mission dir and reads its work packages.

## Note

This is the pre-existing red check on #2121 (`integration-tests-core-misc` → `test_collect_feature_summary_anchors_feature_dir_on_primary_for_mid8_handle`); merging this greens that shard.

---

*AI-assistance disclosure: diagnosed, implemented, and tested with AI assistance (Claude Code), with the completed code independently reviewed via Codex and validated on real mission state; all changes are human-reviewed.*
