### PR TITLE
fix(orchestrator-api): read PRIMARY artifacts off the primary surface, not coord (#2118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 🐛 Fixed
+
+- **Orchestrator no longer stalls on a coord/`pr_bound` mission rooted on a writable
+  target branch (#2118).** Continuing the split-brain remediation: the `#2090`
+  write-surface change routes planning artifacts (`lanes.json` → `LANE_STATE`, WP
+  `tasks/` → `WORK_PACKAGE_TASK`) to the primary `target_branch`, but the
+  `orchestrator-api` read path still read them off the coordination worktree (which
+  carries only status). Under coordination topology the dependency graph came back
+  empty, so `list-ready`/`mission-state` saw no schedulable work and the orchestrator
+  stalled with every WP stuck at `lane=planned`. The orchestrator's PRIMARY-partition
+  reads (`require_lanes_json`, `read_lanes_json`, `build_dependency_graph`, WP
+  `tasks/` lookup) now resolve through the kind-aware `resolve_planning_read_dir`
+  seam (primary surface for all topologies), mirroring the existing `meta.json`
+  treatment in `_resolve_merge_target_branch`; STATUS reads (`read_events` /
+  `materialize`) stay on the coordination worktree. Related: #2115 (the
+  implement/review/merge read-surface twin), #1716 / #1878 (coordination-topology
+  coherence).
+
 ## [3.2.2] - 2026-06-24
 
 Patch release continuing the post-3.2.0 stabilization, focused on the

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -321,6 +321,38 @@ def _resolve_mission_dir_or_fail(command: str, main_repo_root: Path, mission_slu
     return mission_dir
 
 
+def _planning_read_dir(main_repo_root: Path, mission_slug: str) -> Path:
+    """Return the PRIMARY-surface mission dir for planning-artifact reads (#2118).
+
+    PRIMARY-partition artifacts — ``lanes.json`` (``LANE_STATE``) and the WP
+    ``tasks/`` files (``WORK_PACKAGE_TASK``) — live with their mission on the
+    primary ``target_branch`` for EVERY topology since the write-surface-coherence
+    work (#2090): planning never transits the coordination branch. The coord-aware
+    :func:`_resolve_mission_dir` returns the *coordination worktree*, which carries
+    ONLY status artifacts (``status.events.jsonl`` / ``status.json``) +
+    coordination-owned ones (``analysis-report.md``). Reading ``lanes.json`` or
+    ``tasks/`` off that surface under coordination topology silently no-ops — the
+    dependency graph comes back empty and the orchestrator stalls with every WP
+    stuck at ``lane=planned`` (#2118).
+
+    This routes PRIMARY-partition reads through the canonical per-kind read seam
+    :func:`resolve_planning_read_dir`, the read-side twin of the write-side
+    partition (``mission_runtime.is_primary_artifact_kind``): a PRIMARY kind
+    resolves the topology-blind primary dir, so both ``LANE_STATE`` and
+    ``WORK_PACKAGE_TASK`` co-resolve here. STATUS reads (``read_events`` /
+    ``reduce`` / ``materialize`` / status-event writes) MUST keep the coord-aware
+    :func:`_resolve_mission_dir` — the append-only event log stays on coordination
+    for coord-topology missions. This mirrors the meta.json treatment already in
+    :func:`_resolve_merge_target_branch`.
+    """
+    from mission_runtime import MissionArtifactKind
+    from specify_cli.missions._read_path_resolver import resolve_planning_read_dir
+
+    return resolve_planning_read_dir(
+        main_repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK
+    )
+
+
 def _mission_identity_payload(mission_dir: Path) -> dict[str, str]:
     """Return canonical mission identity fields for machine-facing payloads."""
     identity = resolve_mission_identity(mission_dir)
@@ -392,7 +424,6 @@ def _resolve_merge_target_branch(main_repo_root: Path, mission_slug: str, target
 
 def _build_merge_preflight(
     main_repo_root: Path,
-    mission_dir: Path,
     mission_slug: str,
     target: str | None,
 ) -> _MergePreflightResult:
@@ -427,7 +458,9 @@ def _build_merge_preflight(
             errors.append(f"Target branch '{resolved_target}' does not exist locally or on origin.")
 
     try:
-        require_lanes_json(mission_dir)
+        # lanes.json is a PRIMARY-partition artifact — read from the primary
+        # surface, NOT the coord worktree mission_dir (#2118).
+        require_lanes_json(_planning_read_dir(main_repo_root, mission_slug))
     except (MissingLanesError, CorruptLanesError) as exc:
         errors.append(str(exc))
 
@@ -489,7 +522,9 @@ def _execute_lane_merge(
     from specify_cli.policy.config import load_policy_config
     from specify_cli.policy.merge_gates import evaluate_merge_gates
 
-    lanes_manifest = require_lanes_json(mission_dir)
+    # lanes.json is PRIMARY-partition — read from the primary surface, not the
+    # coord worktree mission_dir (#2118).
+    lanes_manifest = require_lanes_json(_planning_read_dir(main_repo_root, mission_slug))
     lanes_manifest.target_branch = target_branch
     merge_strategy = MergeStrategy(strategy)
 
@@ -652,13 +687,17 @@ def mission_state(
     from specify_cli.status import read_events
     from specify_cli.core.dependency_graph import build_dependency_graph
 
+    # STATUS reads stay on the coord-aware dir; PRIMARY reads (dep graph from WP
+    # frontmatter, tasks/ enumeration) come from the primary surface (#2118).
+    planning_dir = _planning_read_dir(main_repo_root, mission)
+
     # Query endpoint: reduce from event log without rewriting status.json.
     snapshot = reduce(read_events(mission_dir))
-    dep_graph = build_dependency_graph(mission_dir)
+    dep_graph = build_dependency_graph(planning_dir)
 
     # Build the full WP set from task files + dep graph + snapshot
     # so that untouched WPs (no events yet) still appear as "planned"
-    tasks_dir = mission_dir / "tasks"
+    tasks_dir = planning_dir / "tasks"
     task_file_wp_ids: set[str] = set()
     if tasks_dir.exists():
         for p in tasks_dir.iterdir():
@@ -711,8 +750,11 @@ def list_ready(
     from specify_cli.core.dependency_graph import build_dependency_graph, dependency_readiness_for_wp
 
     # Query endpoint: reduce from event log without rewriting status.json.
+    # STATUS read off the coord-aware dir; the dependency graph (WP frontmatter,
+    # PRIMARY-partition) off the primary surface (#2118 — an empty dep graph here
+    # is exactly what stalls the orchestrator under coordination topology).
     snapshot = reduce(read_events(mission_dir))
-    dep_graph = build_dependency_graph(mission_dir)
+    dep_graph = build_dependency_graph(_planning_read_dir(main_repo_root, mission))
     wp_states = snapshot.work_packages
     wp_lanes = {
         dep_id: wp_state_for(state.get("lane", Lane.PLANNED)).lane
@@ -837,7 +879,8 @@ def _resolve_start_workspace(
     from specify_cli.lanes.branch_naming import worktree_path as _wt_path
     from specify_cli.lanes.persistence import read_lanes_json
 
-    manifest = read_lanes_json(mission_dir)
+    # lanes.json is PRIMARY-partition — read from the primary surface (#2118).
+    manifest = read_lanes_json(_planning_read_dir(main_repo_root, mission))
     lane = manifest.lane_for_wp(wp) if manifest is not None else None
     if manifest is None or lane is None:
         # Legacy WP-based worktree form ({mission}-{wp}, no mid8): the seam's
@@ -909,7 +952,7 @@ def start_implementation(
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir_or_fail(cmd, main_repo_root, mission)
 
-    wp_path = _resolve_wp_file(mission_dir / "tasks", wp)
+    wp_path = _resolve_wp_file(_planning_read_dir(main_repo_root, mission) / "tasks", wp)
     if wp_path is None:
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
@@ -1044,7 +1087,7 @@ def start_review(
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir_or_fail(cmd, main_repo_root, mission)
 
-    wp_path = _resolve_wp_file(mission_dir / "tasks", wp)
+    wp_path = _resolve_wp_file(_planning_read_dir(main_repo_root, mission) / "tasks", wp)
     if wp_path is None:
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
@@ -1124,7 +1167,8 @@ def _enforce_for_review_commit_gate(
     from specify_cli.lanes.branch_naming import worktree_path as _wt_path
     from specify_cli.lanes.persistence import read_lanes_json
 
-    manifest = read_lanes_json(mission_dir)
+    # lanes.json is PRIMARY-partition — read from the primary surface (#2118).
+    manifest = read_lanes_json(_planning_read_dir(main_repo_root, mission))
     if manifest is None:
         return
     lane = manifest.lane_for_wp(wp)
@@ -1210,7 +1254,7 @@ def transition(
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir_or_fail(cmd, main_repo_root, mission)
 
-    wp_path = _resolve_wp_file(mission_dir / "tasks", wp)
+    wp_path = _resolve_wp_file(_planning_read_dir(main_repo_root, mission) / "tasks", wp)
     if wp_path is None:
         _fail(cmd, "WP_NOT_FOUND", f"Work package '{wp}' not found in {mission}")
         return
@@ -1426,8 +1470,10 @@ def accept_mission(
     from specify_cli.status import materialize
     from specify_cli.core.dependency_graph import build_dependency_graph
 
+    # STATUS read off the coord-aware dir; dependency graph (WP frontmatter,
+    # PRIMARY-partition) off the primary surface (#2118).
     snapshot = materialize(mission_dir)
-    dep_graph = build_dependency_graph(mission_dir)
+    dep_graph = build_dependency_graph(_planning_read_dir(main_repo_root, mission))
 
     # Check all WPs (from dep_graph) are approved/done; WPs with no events are implicitly planned.
     all_wp_ids = set(dep_graph.keys()) | set(snapshot.work_packages.keys())
@@ -1524,7 +1570,7 @@ def merge_mission(
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir_or_fail(cmd, main_repo_root, mission)
 
-    preflight = _build_merge_preflight(main_repo_root, mission_dir, mission, target)
+    preflight = _build_merge_preflight(main_repo_root, mission, target)
     if preflight.errors:
         _fail(
             cmd,

--- a/tests/agent/test_orchestrator_primary_read_surface_coord.py
+++ b/tests/agent/test_orchestrator_primary_read_surface_coord.py
@@ -1,0 +1,195 @@
+"""Regression: orchestrator-api reads PRIMARY-partition artifacts off the primary
+surface, not the coordination worktree (#2118).
+
+The split-brain bug: for a ``topology: coord`` / ``pr_bound`` mission rooted on a
+*writable* target branch, the write-surface-coherence work (#2090) routes planning
+artifacts — ``lanes.json`` (``LANE_STATE``) and the WP ``tasks/`` files
+(``WORK_PACKAGE_TASK``) — to the primary ``target_branch``. The orchestrator used
+to read them off the coordination worktree (``_resolve_mission_dir`` →
+``resolve_handle_to_read_path``), which carries only STATUS artifacts. The
+dependency graph came back empty → ``list-ready`` returned nothing → the
+orchestrator stalled with every WP stuck at ``lane=planned``.
+
+This fixture reproduces the genuine split: ``lanes.json`` + ``tasks/`` live ONLY on
+the target branch (the primary checkout HEAD); the coordination worktree (a checkout
+of the coord branch) has only ``meta.json`` + the status event log. The endpoints
+must still discover the WPs (PRIMARY reads → primary surface) while status continues
+to resolve the coord worktree (STATUS reads → coord).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.coordination.workspace import CoordinationWorkspace
+from specify_cli.orchestrator_api.commands import (
+    _planning_read_dir,
+    _resolve_mission_dir,
+    app,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.git_repo]
+
+runner = CliRunner()
+
+MISSION_SLUG = "split-coord"
+MID8 = "01KSPLIT"
+MISSION_ID = "01KSPLIT000000000000000000"
+MISSION_DIRNAME = f"{MISSION_SLUG}-{MID8}"
+COORD_BRANCH = f"kitty/mission-{MISSION_DIRNAME}"
+TARGET_BRANCH = "feat/split-target"
+
+_WP01 = (
+    "---\n"
+    "work_package_id: WP01\n"
+    "title: First\n"
+    "dependencies: []\n"
+    "---\n\n# WP01\n"
+)
+_WP02 = (
+    "---\n"
+    "work_package_id: WP02\n"
+    "title: Second\n"
+    "dependencies: [WP01]\n"
+    "---\n\n# WP02\n"
+)
+_LANES_JSON = {
+    "version": 1,
+    "feature_slug": MISSION_DIRNAME,
+    "target_branch": TARGET_BRANCH,
+    "lanes": [
+        {"lane_id": "lane-a", "wp_ids": ["WP01"]},
+        {"lane_id": "lane-b", "wp_ids": ["WP02"]},
+    ],
+}
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def split_repo(tmp_path: Path) -> Path:
+    """Coord-topology mission whose planning artifacts live ONLY on the target branch.
+
+    The coordination worktree (coord branch) carries meta.json + status only — NO
+    ``lanes.json`` and NO ``tasks/`` — exactly the #2118 split.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+    feature_dir = repo / "kitty-specs" / MISSION_DIRNAME
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": MISSION_SLUG,
+                "mission_id": MISSION_ID,
+                "mid8": MID8,
+                "coordination_branch": COORD_BRANCH,
+                "target_branch": TARGET_BRANCH,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # Seed ONLY meta.json on main, then branch coord from it — so the coord branch
+    # has the mission dir (for status writes) but NO planning artifacts.
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-q", "-m", "seed mission meta")
+    _git(repo, "branch", COORD_BRANCH)
+
+    # Planning artifacts (lanes.json + WP tasks/) land on the writable target branch
+    # — the post-#2090 PRIMARY write surface. The operator is ON the target branch.
+    _git(repo, "checkout", "-q", "-b", TARGET_BRANCH)
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir()
+    (tasks_dir / "WP01.md").write_text(_WP01, encoding="utf-8")
+    (tasks_dir / "WP02.md").write_text(_WP02, encoding="utf-8")
+    (feature_dir / "lanes.json").write_text(
+        json.dumps(_LANES_JSON) + "\n", encoding="utf-8"
+    )
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-q", "-m", "planning artifacts on target branch")
+
+    # Materialize the coordination worktree (status read/write surface).
+    coord_worktree = CoordinationWorkspace.worktree_path(repo, MISSION_SLUG, MID8)
+    _git(repo, "worktree", "add", "-q", str(coord_worktree), COORD_BRANCH)
+    return repo
+
+
+def _coord_feature_dir(repo: Path) -> Path:
+    return (
+        CoordinationWorkspace.worktree_path(repo, MISSION_SLUG, MID8)
+        / "kitty-specs"
+        / MISSION_DIRNAME
+    )
+
+
+def test_planning_read_dir_resolves_primary_not_coord(split_repo: Path) -> None:
+    """``_planning_read_dir`` returns the primary surface; ``_resolve_mission_dir``
+    the coord worktree. The planning artifacts exist at the former, not the latter."""
+    planning_dir = _planning_read_dir(split_repo, MISSION_DIRNAME)
+    status_dir = _resolve_mission_dir(split_repo, MISSION_DIRNAME)
+
+    assert status_dir is not None
+    assert planning_dir != status_dir, (
+        "Under coord topology the planning surface must differ from the status "
+        "(coord worktree) surface — else the split cannot be exercised."
+    )
+    # PRIMARY artifacts live on the planning surface ...
+    assert (planning_dir / "lanes.json").exists()
+    assert (planning_dir / "tasks" / "WP01.md").exists()
+    # ... and are absent from the coord worktree (the bug's read surface).
+    assert not (status_dir / "lanes.json").exists()
+    assert not (status_dir / "tasks").exists()
+
+
+def _invoke(repo: Path, *args: str) -> object:
+    with patch(
+        "specify_cli.orchestrator_api.commands._get_main_repo_root",
+        return_value=repo,
+    ):
+        return runner.invoke(app, list(args))
+
+
+def test_mission_state_discovers_wps_from_primary_surface(split_repo: Path) -> None:
+    """``mission-state`` enumerates WPs from the primary ``tasks/`` + dep graph even
+    though the coord worktree (its status surface) has neither (#2118 stall fix)."""
+    result = _invoke(split_repo, "mission-state", "--mission", MISSION_DIRNAME)
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)["data"]
+    wp_ids = {wp["wp_id"] for wp in data["work_packages"]}
+    assert wp_ids == {"WP01", "WP02"}, (
+        "WPs not discovered — mission-state read tasks/ off the coord worktree "
+        "(empty) instead of the primary surface (#2118)."
+    )
+    by_id = {wp["wp_id"]: wp for wp in data["work_packages"]}
+    assert by_id["WP02"]["dependencies"] == ["WP01"]
+
+
+def test_list_ready_returns_unblocked_wp_under_coord_split(split_repo: Path) -> None:
+    """``list-ready`` returns WP01 (no deps, planned). Pre-fix the dependency graph
+    was read off the empty coord worktree → no ready WPs → orchestrator stall."""
+    result = _invoke(split_repo, "list-ready", "--mission", MISSION_DIRNAME)
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)["data"]
+    ready = {wp["wp_id"] for wp in data["ready_work_packages"]}
+    assert "WP01" in ready, (
+        "WP01 should be schedulable; an empty ready-set is the #2118 stall "
+        "(dependency graph read off the coord worktree instead of primary)."
+    )
+    # WP02 depends on the not-yet-approved WP01 → not ready.
+    assert "WP02" not in ready


### PR DESCRIPTION
## Summary

Fixes the orchestrator stall on a `coord`/`pr_bound` mission rooted on a **writable** target branch (#2118).

The write-surface-coherence change (#2090) routes planning artifacts to the primary `target_branch` for every topology:
- `lanes.json` → `LANE_STATE` (PRIMARY)
- WP `tasks/` files → `WORK_PACKAGE_TASK` (PRIMARY)

…but `orchestrator_api/commands.py` still read them off the **coordination worktree** (`_resolve_mission_dir` → `resolve_handle_to_read_path`), which carries only STATUS artifacts. Under coordination topology, `build_dependency_graph` and the `tasks/` enumeration came back empty → `list-ready` / `mission-state` saw no schedulable work → the orchestrator stalled with every WP stuck at `lane=planned`.

This is the same class as the already-fixed `meta.json` read in `_resolve_merge_target_branch` (whose docstring explicitly avoids the coord worktree), and #2090 is the commit that cemented the split (it changed the write side but not this read path).

## Change

Route every PRIMARY-partition read through the canonical kind-aware seam `resolve_planning_read_dir` (primary surface for all topologies) via a small `_planning_read_dir` helper:

- `require_lanes_json` (preflight + lane merge)
- `read_lanes_json` (start-workspace allocation + for-review commit gate)
- `build_dependency_graph` (`mission-state`, `list-ready`, `accept-mission`)
- WP `tasks/` lookup (`start-implementation`, `start-review`, `transition`)

STATUS reads (`read_events` / `reduce` / `materialize`) and status-event **writes** (`feature_dir=`) stay on the coord-aware `mission_dir` — the append-only event log remains on coordination for coord-topology missions.

`_build_merge_preflight` drops its now-unused `mission_dir` parameter (the caller already performs the coord-aware existence/typed-error gate).

## Tests

New `tests/agent/test_orchestrator_primary_read_surface_coord.py` builds the genuine split — `lanes.json` + `tasks/` live **only** on the target branch; the coord worktree has only `meta.json` + status — and asserts:
- `_planning_read_dir` resolves the primary surface (with the artifacts) while `_resolve_mission_dir` resolves the coord worktree (without them) — non-vacuity;
- `mission-state` discovers WP01/WP02 from the primary surface;
- `list-ready` returns the unblocked WP01 (pre-fix: empty → the stall).

Existing orchestrator-api + architectural read-ban suites pass (97 tests); the `orchestrator_api` reads are outside the `_DIR_READ_KNOWN_RESIDUALS` scan scope so no pin changes. `ruff` + `mypy --strict` clean on the changed module.

## Scope / follow-ups

- Identity payloads (`_mission_identity_payload` → `meta.json`, also PRIMARY) are left unchanged: `load_meta` tolerates the coord surface today, so this is pre-existing and not the stall — worth a follow-up for full coherence.
- Related: #2115 (implement/review/merge read-surface twin — distinct, tracked surfaces; this orchestrator-api read was **not** in that pin), #1716 / #1878 (coordination-topology coherence cluster).

Closes #2118.