### PR TITLE
fix: discard targets worktrees by exact name, not a <slug>-* prefix (sibling data-loss)

### DIFF
--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -14,6 +14,9 @@ surface; they operate on per-mission metadata, not doctrine mission types.
 
 from __future__ import annotations
 
+import contextlib
+import json
+
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.paths import get_main_repo_root
 from specify_cli.lanes.branch_naming import resolve_mid8
@@ -23,8 +26,6 @@ from specify_cli.missions._read_path_resolver import (
     primary_feature_dir_for_mission,
     resolve_feature_dir_for_mission,
 )
-import contextlib
-import json
 from dataclasses import dataclass
 from pathlib import Path
 from collections.abc import Iterable
@@ -674,7 +675,7 @@ def _discard_mission(
     # branch-first order silently leaked the coordination/lane branches.
     _teardown_coordination_worktree(repo_root, mission_slug, mid8_value)
     if lanes_manifest is not None:
-        _remove_lane_worktrees(repo_root, mission_slug, mid8_value, lanes_manifest)
+        _remove_lane_worktrees(repo_root, mission_slug, lanes_manifest)
         _delete_lane_branches(repo_root, mission_slug, lanes_manifest)
         return
     _delete_legacy_coordination_branch(repo_root, meta_path)
@@ -783,26 +784,38 @@ def _verify_discard_complete(
     """Fail closed if a discard left worktrees or branches behind (#2120).
 
     The bug this guards against is a *silent* no-op that still printed success.
-    After teardown, any surviving mission worktree (under ``.worktrees/<slug>-*``,
-    covering both the coordination and lane worktrees) or expected branch is a
-    real leak — surface it as a non-zero error instead of a false ``✓``.
+    After teardown, any surviving coordination worktree, EXACT lane worktree, or
+    expected branch is a real leak — surface it as a non-zero error instead of a
+    false ``✓``. Worktrees are matched by exact name (not a ``<slug>-*`` prefix)
+    so a sibling mission sharing the prefix neither masks a leak nor trips a
+    spurious failure.
     """
     leaks: list[str] = []
-
-    prefix = f"{mission_slug}-"
-    leaked_worktrees: set[str] = set()
-    # On-disk worktree directories under .worktrees/<slug>-* ...
     worktrees_root = repo_root / ".worktrees"
-    if worktrees_root.exists():
-        for entry in worktrees_root.iterdir():
-            if entry.is_dir() and entry.name.startswith(prefix):
-                leaked_worktrees.add(entry.name)
-    # ... AND git worktree registrations (catches a stale/broken registration
-    # whose directory is already gone — invisible to the on-disk scan).
-    for registered in _registered_worktree_names(repo_root):
-        if registered.startswith(prefix):
-            leaked_worktrees.add(registered)
-    leaks.extend(f".worktrees/{name}" for name in sorted(leaked_worktrees))
+    # A surviving worktree leaks if its directory is on disk OR a stale/broken git
+    # registration remains (dir gone) — the latter is invisible to an on-disk scan.
+    registered = set(_registered_worktree_names(repo_root))
+
+    # Coordination worktree — exact canonical name, on disk OR still registered.
+    if mid8_value:
+        from specify_cli.coordination import CoordinationWorkspace
+
+        coord_name = CoordinationWorkspace.worktree_path(
+            repo_root, mission_slug, mid8_value
+        ).name
+        if (
+            CoordinationWorkspace.is_present(repo_root, mission_slug, mid8_value)
+            or coord_name in registered
+        ):
+            leaks.append(f".worktrees/{coord_name}")
+
+    # Lane worktrees — EXACT names from the manifest (no prefix over-match),
+    # likewise checked both on disk and in the git worktree registry.
+    manifest = _load_lanes_manifest(feature_dir)
+    if manifest is not None:
+        for name in sorted(_expected_lane_worktree_dir_names(mission_slug, manifest)):
+            if (worktrees_root / name).is_dir() or name in registered:
+                leaks.append(f".worktrees/{name}")
 
     for branch in _expected_discard_branches(feature_dir, mission_slug, meta_path):
         if _branch_exists(repo_root, branch):
@@ -934,32 +947,46 @@ def _force_delete_branch_if_exists(repo_root: Path, branch_name: str) -> None:
     )
 
 
+def _expected_lane_worktree_dir_names(mission_slug: str, lanes_manifest: Any) -> set[str]:
+    """Exact on-disk lane-worktree dir names a discard targets (no prefix match).
+
+    Composed by the canonical ``worktree_dir_name`` grammar, keyed on the same
+    ``mission_slug`` (= ``feature_dir.name``) and lane set as
+    :func:`_delete_lane_branches`, so worktree removal and branch deletion target
+    the SAME lanes. Replaces ``.worktrees/<slug>-*`` prefix matching, which
+    over-matches a *sibling* mission whose name shares the prefix (legacy non-mid8
+    slugs) and could delete its worktree — including uncommitted work.
+    """
+    from specify_cli.lanes.branch_naming import worktree_dir_name
+    from specify_cli.lanes.compute import is_planning_lane
+
+    return {
+        worktree_dir_name(mission_slug, mission_id=None, lane_id=lane.lane_id)
+        for lane in lanes_manifest.lanes
+        if not is_planning_lane(lane)
+    }
+
+
 def _remove_lane_worktrees(
     repo_root: Path,
     mission_slug: str,
-    mid8_value: str,
     lanes_manifest: Any,
 ) -> None:
-    """Remove every operator-visible lane worktree for this mission."""
+    """Remove this mission's operator-visible lane worktrees by EXACT name.
+
+    The coordination worktree is handled separately by
+    :func:`_teardown_coordination_worktree`.
+    """
     import subprocess as _subprocess
 
-    # Lane worktrees are at .worktrees/<slug>-<mid8>-<lane_id>/ by convention.
     worktrees_root = repo_root / ".worktrees"
     if not worktrees_root.exists():
         return
 
-    # Best-effort: scan worktrees that start with the mission slug.
-    prefix_with_mid8 = f"{mission_slug}-{mid8_value}-" if mid8_value else f"{mission_slug}-"
-    prefix_legacy = f"{mission_slug}-"
     removed = 0
-    for entry in worktrees_root.iterdir():
+    for name in sorted(_expected_lane_worktree_dir_names(mission_slug, lanes_manifest)):
+        entry = worktrees_root / name
         if not entry.is_dir():
-            continue
-        name = entry.name
-        if name.endswith("-coord"):
-            # Coordination worktree is handled separately.
-            continue
-        if not (name.startswith(prefix_with_mid8) or name.startswith(prefix_legacy)):
             continue
         _subprocess.run(
             ["git", "-C", str(repo_root), "worktree", "remove", str(entry), "--force"],

--- a/tests/architectural/test_topology_resolution_boundary.py
+++ b/tests/architectural/test_topology_resolution_boundary.py
@@ -102,10 +102,14 @@ _ALLOWLISTED_COORD_PREDICATE_SITES: frozenset[str] = frozenset(
         # proposal is the only signal). Authority-first, shape as last resort.
         "src/specify_cli/workspace/root_resolver.py",
         # ---- NON-coord-routing worktree-context detection (out of seam scope) -
-        # mission_type cleanup loop skips the "-coord" dir while pruning lane
-        # worktree dirs; it is a teardown filter, not a status-surface routing
-        # decision — the registry authority would be the wrong tool here.
-        "src/specify_cli/cli/commands/mission_type.py",
+        # NOTE (#2123 — discard exact-set fix): ``cli/commands/mission_type.py``
+        # used to be allowlisted here for its lane-prune cleanup loop's raw
+        # ``-coord`` dir-shape skip. That loop was migrated to the blessed
+        # ``CoordinationWorkspace`` authority + a manifest-derived exact lane set
+        # (no ``<slug>-*`` prefix / ``-coord`` shape predicate remains), so the
+        # entry is REMOVED — its removal IS the proof the migration completed for
+        # that site. Do NOT re-add it: a new raw predicate there is now a
+        # C-SEAM-1 regression.
         # Operator navigation hint: extracts the main-repo prefix from a
         # ``.worktrees`` cwd to print a "cd <repo>" suggestion. Pure UX string
         # building, no coord routing.

--- a/tests/integration/test_mission_close_discard_coord_teardown.py
+++ b/tests/integration/test_mission_close_discard_coord_teardown.py
@@ -56,6 +56,19 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     )
 
 
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".kittify").mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "seed")
+    return repo
+
+
 @pytest.fixture
 def coord_mission(tmp_path: Path) -> Path:
     """A coordination mission in the split-brain surface layout.
@@ -253,3 +266,85 @@ def test_verify_discard_complete_flags_leaks(tmp_path: Path) -> None:
     _git(repo, "branch", COORD_BRANCH)
     with pytest.raises(typer.Exit):
         _verify_discard_complete(repo, SLUG, MID8, fdir, meta_path)
+
+
+def _single_lane_manifest(slug: str):
+    from specify_cli.lanes.models import ExecutionLane, LanesManifest
+
+    return LanesManifest(
+        version=1,
+        mission_slug=slug,
+        mission_id=slug,
+        mission_branch=f"kitty/mission-{slug}",
+        target_branch="main",
+        lanes=[
+            ExecutionLane(
+                lane_id="lane-a", wp_ids=("WP01",), write_scope=(),
+                predicted_surfaces=(), depends_on_lanes=(), parallel_group=0,
+            )
+        ],
+        computed_at="2026-01-01T00:00:00+00:00",
+        computed_from="test",
+    )
+
+
+def test_expected_lane_worktree_dir_names_are_exact() -> None:
+    """The expected-name set is exact (no `<slug>-*` prefix) and excludes the
+    planning lane — so it can never match a sibling mission's worktree."""
+    from specify_cli.cli.commands.mission_type import _expected_lane_worktree_dir_names
+    from specify_cli.lanes.models import ExecutionLane
+
+    manifest = _single_lane_manifest("alpha")
+    manifest.lanes.append(
+        ExecutionLane(
+            lane_id="lane-planning", wp_ids=(), write_scope=(),
+            predicted_surfaces=(), depends_on_lanes=(), parallel_group=0,
+        )
+    )
+    assert _expected_lane_worktree_dir_names("alpha", manifest) == {"alpha-lane-a"}
+
+
+def test_remove_lane_worktrees_does_not_delete_sibling_mission(tmp_path: Path) -> None:
+    """Data-loss guard (#2120 follow-up): discarding mission `alpha` removes only
+    its OWN lane worktree, never sibling `alpha-beta`'s worktree (whose dir name
+    shares the `alpha-` prefix) — preserving the sibling's uncommitted work. The
+    pre-fix `<slug>-*` prefix scan deleted it."""
+    from specify_cli.cli.commands.mission_type import _remove_lane_worktrees
+
+    repo = _init_repo(tmp_path)
+    _git(repo, "worktree", "add", "--detach", str(repo / ".worktrees" / "alpha-lane-a"))
+    sibling_wt = repo / ".worktrees" / "alpha-beta-lane-a"
+    _git(repo, "worktree", "add", "--detach", str(sibling_wt))
+    (sibling_wt / "uncommitted.txt").write_text("precious sibling work\n", encoding="utf-8")
+
+    _remove_lane_worktrees(repo, "alpha", _single_lane_manifest("alpha"))
+
+    assert not (repo / ".worktrees" / "alpha-lane-a").exists(), "target worktree must be removed"
+    assert sibling_wt.exists(), "SIBLING worktree must be preserved (no prefix over-match)"
+    assert (sibling_wt / "uncommitted.txt").read_text(encoding="utf-8") == "precious sibling work\n"
+
+
+def test_verify_flags_stale_coordination_worktree_registration(tmp_path: Path) -> None:
+    """A broken coord teardown (directory gone, git registration left behind) is
+    still a leak: `is_present` (on-disk) returns False, so the verifier must also
+    check the git worktree registry — else discard falsely reports success."""
+    import shutil
+
+    import typer
+
+    from specify_cli.cli.commands.mission_type import _verify_discard_complete
+
+    repo = _init_repo(tmp_path)
+    fdir = repo / "kitty-specs" / SLUG
+    fdir.mkdir(parents=True)
+    # No coordination_branch / lanes.json → the ONLY possible leak is the
+    # stale coord worktree registration.
+    (fdir / "meta.json").write_text(json.dumps({"mission_slug": SLUG}), encoding="utf-8")
+
+    coord_path = CoordinationWorkspace.worktree_path(repo, SLUG, MID8)
+    _git(repo, "worktree", "add", "--detach", str(coord_path))
+    shutil.rmtree(coord_path)  # broken teardown: dir removed, registration remains
+
+    assert not CoordinationWorkspace.is_present(repo, SLUG, MID8)  # on-disk gone ...
+    with pytest.raises(typer.Exit):  # ... but the stale registration is still a leak
+        _verify_discard_complete(repo, SLUG, MID8, fdir, fdir / "meta.json")


### PR DESCRIPTION
Fixes #2127.

Follow-up to #2121, addressing the review squad's data-loss finding there.

## What was wrong

`mission close --discard` matched a mission's lane worktrees by a `.worktrees/<slug>-*` **prefix** — in both the pre-existing `_remove_lane_worktrees` and the residual verifier added in #2121. When one mission's slug is a prefix of another's (legacy non-mid8 names, e.g. `alpha` vs `alpha-beta`), that over-matches the sibling:

- `_remove_lane_worktrees` could **delete the sibling mission's lane worktree, including uncommitted work** (confirmed silent data loss);
- the verifier could spuriously fail (`EXIT 1`) on the sibling's worktree even though the target teardown succeeded.

## The fix

Compute the **exact** lane-worktree directory-name set from the manifest via the canonical `worktree_dir_name` grammar, keyed on the same `mission_slug` and lane set as `_delete_lane_branches` (so removal and branch-deletion stay paired). The coordination worktree is matched by its canonical name (on-disk via `CoordinationWorkspace.is_present`, plus the git worktree registry to catch a stale/broken registration). No prefix scan remains; `_remove_lane_worktrees` drops its now-unused `mid8_value` arg.

Also addresses the squad's cosmetic nit (group the plain stdlib imports).

## Testing

- **Data-loss regression (real git worktrees):** discarding `alpha` removes only its own lane worktree and leaves sibling `alpha-beta`'s worktree **and its uncommitted file** intact — the old prefix code deleted them.
- Exact-name unit test; stale-coordination-registration test (a broken teardown whose directory is gone but registration remains is still flagged).
- Parity / regression / close suites stay green; `ruff` + `mypy` clean.

## Scope

Confined to the `close --discard` teardown path; no change to the shared resolver. The squad flagged the prefix over-match as a clean standalone follow-up to #2121 — this is it.

---

*AI-assistance disclosure: implemented and tested with AI assistance (Claude Code), with the completed code independently reviewed via Codex (which caught and led to fixing the coord-registration gap); all changes are human-reviewed.*
