### PR TITLE
fix(tool-surface): lazy-import tomli_w so a stale env can't brick the CLI (#2103)

### DIFF
--- a/src/specify_cli/tool_surface/profiles/codex_renderer.py
+++ b/src/specify_cli/tool_surface/profiles/codex_renderer.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import tomli_w
-
 from charter.profiles import AgentProfile
 
 # Native format identifier (stable string recorded in the manifest).
@@ -72,7 +70,25 @@ class CodexProfileRenderer:
         )
 
     def render(self, profile: AgentProfile) -> str:
-        """Return valid TOML text for the Codex per-project agent format."""
+        """Return valid TOML text for the Codex per-project agent format.
+
+        ``tomli_w`` is imported lazily here rather than at module load: it is a
+        declared runtime dependency but is only needed on this Codex-rendering
+        path, so a stale/mismatched install that is missing it must not brick
+        every CLI command at import time (issue #2103). The guard turns the
+        opaque ``ModuleNotFoundError`` into an actionable message.
+        """
+        try:
+            import tomli_w
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "tomli_w is required to render Codex agent profiles but is not "
+                "available in this environment. spec-kitty declares it as a "
+                "runtime dependency, so this usually means a stale install — "
+                "reinstall or upgrade spec-kitty (e.g. `uv tool upgrade "
+                "spec-kitty`) so its declared dependencies are present."
+            ) from exc
+
         description = profile.description or profile.purpose or ""
         doc: dict[str, object] = {
             "name": profile.name or profile.profile_id,

--- a/tests/specify_cli/tool_surface/profiles/test_renderers.py
+++ b/tests/specify_cli/tool_surface/profiles/test_renderers.py
@@ -259,6 +259,41 @@ def test_codex_renderer_profile_with_empty_description_falls_back_to_purpose() -
 
 
 # ---------------------------------------------------------------------------
+# Issue #2103 — tomli_w must not be a module-level import. It is pulled in
+# during command registration, so a stale install missing the (declared)
+# dependency would brick every CLI command at import time. It is imported
+# lazily inside render() instead, with an actionable error.
+# ---------------------------------------------------------------------------
+
+
+def test_codex_renderer_does_not_import_tomli_w_at_module_level() -> None:
+    """A module-level ``import tomli_w`` would bind it as a module attribute;
+    the lazy import inside ``render()`` does not. Guards the #2103 regression."""
+    from specify_cli.tool_surface.profiles import codex_renderer
+
+    assert not hasattr(codex_renderer, "tomli_w")
+
+
+def test_codex_render_missing_tomli_w_raises_actionable_error(monkeypatch) -> None:
+    """When ``tomli_w`` is unavailable, ``render()`` fails with guidance to
+    reinstall/upgrade — not an opaque ``ModuleNotFoundError`` traceback."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tomli_w":
+            raise ModuleNotFoundError("No module named 'tomli_w'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    profile = make_test_profile(slug="architect-alphonso")
+    with pytest.raises(ModuleNotFoundError, match="upgrade spec-kitty"):
+        CodexProfileRenderer().render(profile)
+
+
+# ---------------------------------------------------------------------------
 # Codex optional-field passthrough (WP08 — covers the *present* branches of
 # codex_renderer._optional_fields, which the absent-only tests above miss).
 # AgentProfile is a frozen pydantic model with no native model/sandbox fields,


### PR DESCRIPTION
Addresses #2103.

**Why this one jumped the queue:** it's been a daily annoyance on my machine — the global launcher dies on `ModuleNotFoundError: tomli_w` on *every* command, so the first thing I run is a traceback. It's been forcing me to drive everything through `uv run spec-kitty`. Worth fixing.

## Root cause
`tomli-w` *is* a declared runtime dependency (`pyproject.toml`), so this isn't a missing-dep bug — it's that `import tomli_w` sat at the **top of `codex_renderer.py`**, which gets pulled in during command registration. So an install whose env predates the dependency (the stale `uv tool` launcher case in #2103) crashes the entire CLI at startup, before any command runs, with an opaque traceback.

`tomli_w` is used in exactly one place — the Codex profile render path (`render()`).

## Fix
- Move `import tomli_w` out of module scope and into `render()`.
- Turn the failure into an actionable message ("reinstall/upgrade spec-kitty") instead of a bare `ModuleNotFoundError`.

Result: the CLI runs normally for every command even if `tomli_w` is missing from the env; only Codex profile rendering errors, and it tells you why.

## Tests
- `test_codex_renderer_does_not_import_tomli_w_at_module_level` — regression guard: the module must not bind `tomli_w` at import time.
- `test_codex_render_missing_tomli_w_raises_actionable_error` — `render()` fails with guidance, not an opaque traceback.

55/55 renderer tests pass; ruff + mypy clean on the touched files.

## What this does *not* do
It doesn't change how `uv tool` resolves the launcher's environment — a genuinely stale install should still be upgraded. This fix just stops a missing optional-path dependency from being catastrophic. If you'd rather also pin/verify the launcher env (suggested fix #2 in the issue), happy to do that as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)