### PR TITLE
Fix uv-tool upgrades pinned to old rc releases

### DIFF
--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -348,7 +348,8 @@ def _agent_check_payload() -> dict[str, object]:
     result = compat_plan(invocation, now=now)
     cli_status = result.cli_status
     install_method = detect_install_method()
-    hint = build_upgrade_hint(install_method)
+    latest_version = cli_status.latest_version
+    hint = build_upgrade_hint(install_method, target_version=latest_version)
 
     payload: dict[str, object] = {
         "schema_version": 1,
@@ -367,7 +368,6 @@ def _agent_check_payload() -> dict[str, object]:
         payload["reason"] = "nag_disabled"
         return payload
 
-    latest_version = cli_status.latest_version
     if not _version_is_newer(latest_version, cli_status.installed_version):
         return payload
 

--- a/src/specify_cli/compat/messages.py
+++ b/src/specify_cli/compat/messages.py
@@ -9,7 +9,7 @@ render_json    -- render the JSON-contract dict for a Plan.
 Security properties
 -------------------
 CHK016  All interpolated values are sanitised against
-        ``^[A-Za-z0-9.\\-+_ /:]{1,256}$`` before insertion.
+        ``^[A-Za-z0-9.\\-+_ /=:]{1,256}$`` before insertion.
         Values that do not pass the regex are replaced with
         ``<unavailable>``.
 NFR-007 Rendered human message is at most 4 lines.
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 # Safe-value regex for all interpolated fields (CHK016)
 # ---------------------------------------------------------------------------
 
-_SAFE_VALUE_RE = re.compile(r"^[A-Za-z0-9.\-+_ /:]{1,256}$")
+_SAFE_VALUE_RE = re.compile(r"^[A-Za-z0-9.\-+_ /=:]{1,256}$")
 _UNAVAILABLE = "<unavailable>"
 
 

--- a/src/specify_cli/compat/planner.py
+++ b/src/specify_cli/compat/planner.py
@@ -896,7 +896,7 @@ def _plan_impl(
     install_method = detect_install_method()
 
     # --- Step 5: Build upgrade hint ---
-    upgrade_hint = build_upgrade_hint(install_method)
+    upgrade_hint = build_upgrade_hint(install_method, target_version=latest_version)
 
     # --- Step 6: Decide ---
     decision, fr023_case = decide(project_status, safety, cli_status, invocation)

--- a/src/specify_cli/compat/upgrade_hint.py
+++ b/src/specify_cli/compat/upgrade_hint.py
@@ -27,6 +27,7 @@ from specify_cli.compat._detect.install_method import InstallMethod
 # ---------------------------------------------------------------------------
 
 _COMMAND_RE = re.compile(r"^[A-Za-z0-9 .\-+_/=:]{1,128}$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9.\-+]{1,64}$")
 
 
 # ---------------------------------------------------------------------------
@@ -78,7 +79,7 @@ _HINT_TABLE: dict[InstallMethod, tuple[str | None, str | None]] = {
         None,
     ),
     InstallMethod.UV_TOOL: (
-        "uv tool upgrade spec-kitty-cli",
+        "uv tool install --force spec-kitty-cli",
         None,
     ),
     InstallMethod.PIP_USER: (
@@ -122,10 +123,17 @@ for _method, (_cmd, _note) in _HINT_TABLE.items():
 # ---------------------------------------------------------------------------
 
 
+def _targeted_uv_tool_command(package: str, target_version: str | None) -> str | None:
+    if target_version is None or not _VERSION_RE.match(target_version):
+        return None
+    return f"uv tool install --force {package}=={target_version}"
+
+
 def build_upgrade_hint(
     install_method: InstallMethod,
     *,
-    package: str = "spec-kitty-cli",  # noqa: ARG001  (reserved for future parametrisation)
+    package: str = "spec-kitty-cli",
+    target_version: str | None = None,
 ) -> UpgradeHint:
     """Return the :class:`UpgradeHint` for *install_method*.
 
@@ -134,11 +142,14 @@ def build_upgrade_hint(
 
     Args:
         install_method: The detected :class:`InstallMethod`.
-        package: Reserved for future parametrisation (currently unused; the
-            table is keyed solely on *install_method*).
+        package: Package name to include in dynamic hints.
+        target_version: Optional latest version. For uv-tool installs this is
+            used to override exact prerelease pins in uv receipts.
 
     Returns:
         A :class:`UpgradeHint` from the static table.
     """
     command, note = _HINT_TABLE[install_method]
+    if install_method == InstallMethod.UV_TOOL:
+        command = _targeted_uv_tool_command(package, target_version) or command
     return UpgradeHint(install_method=install_method, command=command, note=note)

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -26,6 +26,7 @@ call ``_render_nag_if_needed`` directly and is unchanged.
 from __future__ import annotations
 
 import os
+import re
 import subprocess  # noqa: S404 — required to invoke the existing `spec-kitty upgrade` binary
 import sys
 from collections.abc import Callable
@@ -66,6 +67,7 @@ ENV_UPGRADE_NEVER_ASK = "SPEC_KITTY_UPGRADE_NEVER_ASK"
 ENV_UPGRADE_DISABLED = "SPEC_KITTY_UPGRADE_DISABLED"
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+_VERSION_RE = re.compile(r"^[A-Za-z0-9.\-+]{1,64}$")
 
 
 def _truthy(raw: str | None) -> bool:
@@ -214,7 +216,7 @@ def is_currently_snoozed(
 # ---------------------------------------------------------------------------
 
 
-def _default_upgrade_runner(method: object) -> int:
+def _default_upgrade_runner(method: object, *, latest_version: str | None = None) -> int:
     """Invoke the owning installer's upgrade command via subprocess.
 
     Returns the process exit code.  Never raises; on OSError / timeout
@@ -233,9 +235,9 @@ def _default_upgrade_runner(method: object) -> int:
     if not isinstance(method, InstallMethod):
         return 1
 
-    uv_tool_argv = ["uv", "tool", "upgrade"]
+    uv_tool_argv = ["uv", "tool", "install", "--force"]
     uv_tool_argv.extend(_uv_tool_python_args())
-    uv_tool_argv.append("spec-kitty-cli")
+    uv_tool_argv.append(_package_arg_for_latest(latest_version))
     argv_by_method = {
         InstallMethod.PIPX: ["pipx", "upgrade", "spec-kitty-cli"],
         InstallMethod.UV_TOOL: uv_tool_argv,
@@ -302,6 +304,12 @@ def _active_uv_tool_receipt() -> dict[str, object] | None:
     except Exception:  # noqa: BLE001
         return None
     return None
+
+
+def _package_arg_for_latest(latest_version: str | None) -> str:
+    if latest_version is not None and _VERSION_RE.match(latest_version):
+        return f"spec-kitty-cli=={latest_version}"
+    return "spec-kitty-cli"
 
 
 def _active_uv_tool_dir() -> Path | None:
@@ -509,10 +517,15 @@ def _run_auto_upgrade_if_safe(
     *,
     safe: bool,
     method: object,
+    latest_version: str | None,
     upgrade_runner: Callable[[], int] | None,
 ) -> tuple[bool, int | None, bool]:
     if safe:
-        runner_exit = _default_upgrade_runner(method) if upgrade_runner is None else upgrade_runner()
+        runner_exit = (
+            _default_upgrade_runner(method, latest_version=latest_version)
+            if upgrade_runner is None
+            else upgrade_runner()
+        )
         return True, runner_exit, False
     _print_unsafe_installer_guidance(str(method))
     return False, None, True
@@ -524,11 +537,13 @@ def _handle_always_preference(
     kwargs: dict[str, object],
     safe: bool,
     method: object,
+    current_latest: str | None,
     upgrade_runner: Callable[[], int] | None,
 ) -> UpgradeUxOutcome:
     attempted, exit_code, guidance_only = _run_auto_upgrade_if_safe(
         safe=safe,
         method=method,
+        latest_version=current_latest,
         upgrade_runner=upgrade_runner,
     )
     if exit_code == 0:
@@ -561,6 +576,7 @@ def _handle_prompt_choice(
         auto_upgrade_attempted, exit_code, guidance_only = _run_auto_upgrade_if_safe(
             safe=safe,
             method=method,
+            latest_version=current_latest,
             upgrade_runner=upgrade_runner,
         )
     return _persist_and_return(
@@ -686,6 +702,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
                 kwargs=kwargs,
                 safe=safe,
                 method=method,
+                current_latest=current_latest,
                 upgrade_runner=upgrade_runner,
             )
 

--- a/src/specify_cli/session_presence/upgrade_check.py
+++ b/src/specify_cli/session_presence/upgrade_check.py
@@ -88,24 +88,37 @@ class UpgradeChecker:
 
         try:
             CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-            script = (
-                "import subprocess, json, os; "
-                "from pathlib import Path; "
-                "from datetime import datetime, timezone; "
-                "r = subprocess.run("
-                "    ['uv', 'pip', 'index', 'versions', 'spec-kitty-cli', '--quiet'],"
-                "    capture_output=True, text=True, timeout=10"
-                "); "
-                "v = r.stdout.strip().split('\\n')[0] if r.returncode == 0 and r.stdout.strip() else None; "
-                f"p = Path(r'{CACHE_PATH}'); "
-                "p.parent.mkdir(parents=True, exist_ok=True); "
-                "tmp = p.with_suffix('.tmp'); "
-                "tmp.write_text(json.dumps({"
-                "    'checked_at': datetime.now(timezone.utc).isoformat(),"
-                "    'latest_version': v"
-                "})); "
-                "os.replace(tmp, p)"
-            )
+            script = f"""
+import json
+import os
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+v = None
+try:
+    req = urllib.request.Request(
+        "https://pypi.org/pypi/spec-kitty-cli/json",
+        headers={{"User-Agent": "spec-kitty-cli session-presence-upgrade-check"}},
+    )
+    with urllib.request.urlopen(req, timeout=10) as response:
+        payload = json.load(response)
+    info = payload.get("info") if isinstance(payload, dict) else None
+    candidate = info.get("version") if isinstance(info, dict) else None
+    if isinstance(candidate, str):
+        v = candidate
+except Exception:
+    v = None
+
+p = Path({str(CACHE_PATH)!r})
+p.parent.mkdir(parents=True, exist_ok=True)
+tmp = p.with_suffix(".tmp")
+tmp.write_text(json.dumps({{
+    "checked_at": datetime.now(timezone.utc).isoformat(),
+    "latest_version": v,
+}}))
+os.replace(tmp, p)
+"""
             subprocess.Popen(
                 ["python3", "-c", script],
                 start_new_session=True,

--- a/tests/readiness/test_upgrade_ux.py
+++ b/tests/readiness/test_upgrade_ux.py
@@ -721,7 +721,7 @@ class TestRunUpgradeUxAlwaysSafe:
         assert outcome.auto_upgrade_attempted is True
         assert outcome.prompted is False
 
-    def test_uv_tool_auto_upgrade_uses_uv_tool_upgrade(
+    def test_uv_tool_auto_upgrade_reinstalls_target_version(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(sys, "argv", ["spec-kitty", "status"])
@@ -747,7 +747,7 @@ class TestRunUpgradeUxAlwaysSafe:
             prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
             installer_detector=lambda: InstallMethod.UV_TOOL,
         )
-        assert calls == [["uv", "tool", "upgrade", "spec-kitty-cli"]]
+        assert calls == [["uv", "tool", "install", "--force", "spec-kitty-cli==2.0"]]
         assert outcome.auto_upgrade_attempted is True
         assert outcome.auto_upgrade_exit_code == 0
 
@@ -783,7 +783,7 @@ class TestRunUpgradeUxAlwaysSafe:
             prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
             installer_detector=lambda: InstallMethod.UV_TOOL,
         )
-        assert calls[0][0] == ["uv", "tool", "upgrade", "spec-kitty-cli"]
+        assert calls[0][0] == ["uv", "tool", "install", "--force", "spec-kitty-cli==2.0"]
         assert calls[0][1] is not None
         assert calls[0][1]["UV_TOOL_DIR"] == str(tool_dir)
         assert outcome.auto_upgrade_attempted is True
@@ -823,7 +823,7 @@ class TestRunUpgradeUxAlwaysSafe:
             prompt=lambda: pytest.fail("prompt must not fire on always-upgrade"),
             installer_detector=lambda: InstallMethod.UV_TOOL,
         )
-        assert calls[0] == ["uv", "tool", "upgrade", "--python", "3.13", "spec-kitty-cli"]
+        assert calls[0] == ["uv", "tool", "install", "--force", "--python", "3.13", "spec-kitty-cli==2.0"]
         assert outcome.auto_upgrade_attempted is True
 
 

--- a/tests/specify_cli/cli/commands/test_upgrade_command.py
+++ b/tests/specify_cli/cli/commands/test_upgrade_command.py
@@ -265,6 +265,28 @@ def test_agent_check_guidance_when_upgrade_command_unavailable(
     assert payload["upgrade_note"]
 
 
+def test_agent_check_uv_tool_command_targets_latest_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from specify_cli.compat._detect.install_method import InstallMethod
+    from specify_cli.compat.cache import NagCache
+    from specify_cli.compat.provider import PyPIProvider
+
+    monkeypatch.setattr("specify_cli.compat.cache.NagCache.default", lambda: NagCache(tmp_path / "agent-cache.json"))
+    monkeypatch.setattr(
+        PyPIProvider,
+        "get_latest",
+        lambda self, package: LatestVersionResult("3.2.3", "pypi", None),
+    )
+    monkeypatch.setattr("specify_cli.compat.detect_install_method", lambda: InstallMethod.UV_TOOL)
+    monkeypatch.setattr("specify_cli.compat.is_ci_env", lambda: False)
+
+    result = _invoke_upgrade(["--agent-check", "--json"], cwd=tmp_path)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["action"] == "prompt"
+    assert payload["upgrade_command"] == "uv tool install --force spec-kitty-cli==3.2.3"
+
+
 def test_agent_choice_not_now_records_snooze(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from specify_cli.compat.cache import NagCache
 

--- a/tests/specify_cli/compat/test_messages.py
+++ b/tests/specify_cli/compat/test_messages.py
@@ -85,7 +85,7 @@ def _make_plan(
         max_supported=max_supported,
         metadata_error=metadata_error,
     )
-    upgrade_hint = build_upgrade_hint(install_method)
+    upgrade_hint = build_upgrade_hint(install_method, target_version=latest_version)
     exit_code_map = {
         Decision.ALLOW: 0,
         Decision.ALLOW_WITH_NAG: 0,
@@ -256,6 +256,18 @@ class TestRenderHuman:
         text = render_human(p)
         for line in text.splitlines():
             assert line == line.rstrip(), f"Trailing whitespace in line: {line!r}"
+
+    def test_uv_tool_pinned_command_renders(self) -> None:
+        p = _make_plan(
+            Decision.ALLOW_WITH_NAG,
+            Fr023Case.CLI_UPDATE_AVAILABLE,
+            is_outdated=True,
+            latest_version="3.2.2",
+            install_method=InstallMethod.UV_TOOL,
+        )
+        text = render_human(p)
+        assert "uv tool install --force spec-kitty-cli==3.2.2" in text
+        assert "<unavailable>" not in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/compat/test_upgrade_hint.py
+++ b/tests/specify_cli/compat/test_upgrade_hint.py
@@ -49,7 +49,7 @@ class TestCommandHints:
         "method,expected_fragment",
         [
             (InstallMethod.PIPX, "pipx upgrade"),
-            (InstallMethod.UV_TOOL, "uv tool upgrade"),
+            (InstallMethod.UV_TOOL, "uv tool install --force"),
             (InstallMethod.PIP_USER, "pip install --user --upgrade"),
             (InstallMethod.PIP_SYSTEM, "pip install --upgrade"),
             (InstallMethod.BREW, "brew upgrade"),
@@ -190,6 +190,14 @@ class TestBuildUpgradeHintPackageArg:
         """The *package* kwarg is accepted (reserved for future use)."""
         hint = build_upgrade_hint(InstallMethod.PIPX, package="spec-kitty-cli")
         assert hint.install_method == InstallMethod.PIPX
+
+    def test_uv_tool_target_version_overrides_receipt_pin(self) -> None:
+        hint = build_upgrade_hint(InstallMethod.UV_TOOL, target_version="3.2.2")
+        assert hint.command == "uv tool install --force spec-kitty-cli==3.2.2"
+
+    def test_uv_tool_invalid_target_version_falls_back_to_unpinned(self) -> None:
+        hint = build_upgrade_hint(InstallMethod.UV_TOOL, target_version="3.2.2;rm")
+        assert hint.command == "uv tool install --force spec-kitty-cli"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/session_presence/test_upgrade_checker.py
+++ b/tests/specify_cli/session_presence/test_upgrade_checker.py
@@ -134,6 +134,17 @@ class TestCheckInBackground:
             result = checker.check_in_background()
         assert result is None
 
+    def test_background_probe_uses_pypi_json_not_uv_pip_index(self, patched_cache: Path) -> None:
+        calls: list[list[str]] = []
+
+        with patch("subprocess.Popen", side_effect=lambda argv, **_: calls.append(argv)):
+            UpgradeChecker().check_in_background()
+
+        assert calls
+        script = calls[0][2]
+        assert "https://pypi.org/pypi/spec-kitty-cli/json" in script
+        assert "uv pip index" not in script
+
     def test_mkdir_failure_does_not_raise(
         self, patched_cache: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Closes #2142.

- Replace uv-tool auto-upgrade command with `uv tool install --force spec-kitty-cli==<latest>` so exact rc pins in `uv-receipt.toml` are replaced instead of preserved.
- Thread planner latest-version data into uv-tool upgrade hints for CLI/agent guidance.
- Allow `=` in rendered upgrade commands so `spec-kitty-cli==<latest>` is not sanitized to `<unavailable>`.
- Replace legacy session-presence background `uv pip index` probe with PyPI JSON parsing.

## Verification

- `.venv/bin/ruff check src/specify_cli/readiness/upgrade_ux.py src/specify_cli/compat/upgrade_hint.py src/specify_cli/compat/planner.py src/specify_cli/compat/messages.py src/specify_cli/session_presence/upgrade_check.py src/specify_cli/cli/commands/upgrade.py tests/readiness/test_upgrade_ux.py tests/specify_cli/compat/test_upgrade_hint.py tests/specify_cli/compat/test_messages.py tests/specify_cli/cli/commands/test_upgrade_command.py tests/specify_cli/session_presence/test_upgrade_checker.py`
- `.venv/bin/pytest tests/readiness/test_upgrade_ux.py tests/specify_cli/compat/test_upgrade_hint.py tests/specify_cli/compat/test_messages.py tests/specify_cli/cli/commands/test_upgrade_command.py tests/specify_cli/session_presence/test_upgrade_checker.py tests/specify_cli/compat/test_planner.py -q` (`266 passed`)
- Isolated uv repro: `spec-kitty-cli==3.2.0rc45` -> `uv tool install --force spec-kitty-cli==3.2.2` -> `spec-kitty-cli version 3.2.2`
