### PR TITLE
fix(upgrade): gitignore encoding-provenance log, not just untrack it

### DIFF
--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -177,6 +177,17 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         notes="Machine-local SaaS sync relay queue; never commit.",
     ),
     StateSurface(
+        name="encoding_provenance_global_log",
+        path_pattern=".kittify/encoding-provenance/global.jsonl",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSONL,
+        authority=AuthorityClass.LOCAL_RUNTIME,
+        git_class=GitClass.IGNORED,
+        owner_module="charter/_io",
+        creation_trigger="charter file decoding outside kitty-specs/<mission>/",
+        notes="Machine-local encoding audit log; never commit.",
+    ),
+    StateSurface(
         name="runtime_feature_index",
         path_pattern=".kittify/runtime/feature-runs.json",
         root=StateRoot.PROJECT,

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
@@ -11,11 +11,12 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
-_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
-_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+_PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
+_PROVENANCE_TRACKED_PATH = ".kittify/encoding-provenance/global.jsonl"
+_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
 _LOCAL_RUNTIME_TRACKED_PATHS = (
     ".kittify/charter/context-state.json",
-    _PROVENANCE_ENTRY,
+    _PROVENANCE_TRACKED_PATH,
 )
 
 
@@ -51,8 +52,19 @@ def _untrack(project_path: Path, relative_path: str) -> bool:
     return result.returncode == 0
 
 
+def _read_gitignore_entries(project_path: Path) -> set[str]:
+    gitignore_path = project_path / ".gitignore"
+    if not gitignore_path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in gitignore_path.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
 @MigrationRegistry.register
-class KittifyRuntimeGitHygieneMigration(BaseMigration):
+class KittifyRuntimeGitHygieneMigration(BaseMigration):  # type: ignore[misc]
     """Ignore sync state and untrack known local-runtime files."""
 
     migration_id = "3.2.0rc35_kittify_runtime_git_hygiene"
@@ -60,11 +72,8 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
     target_version = "3.2.0rc35"
 
     def detect(self, project_path: Path) -> bool:
-        gitignore_path = project_path / ".gitignore"
-        gitignore_text = (
-            gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
-        )
-        entry_missing = any(entry not in gitignore_text for entry in _GITIGNORE_ENTRIES)
+        gitignore_entries = _read_gitignore_entries(project_path)
+        entry_missing = any(entry not in gitignore_entries for entry in _GITIGNORE_ENTRIES)
         tracked_runtime = any(
             _is_tracked(project_path, path)
             for path in _LOCAL_RUNTIME_TRACKED_PATHS
@@ -78,6 +87,10 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
 
     def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
         if dry_run:
+            gitignore_entries = _read_gitignore_entries(project_path)
+            missing_entries = [
+                entry for entry in _GITIGNORE_ENTRIES if entry not in gitignore_entries
+            ]
             tracked = [
                 path
                 for path in _LOCAL_RUNTIME_TRACKED_PATHS
@@ -85,19 +98,23 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
             ]
             return MigrationResult(
                 success=True,
-                changes_made=[
-                    f"Would add {entry} to .gitignore" for entry in _GITIGNORE_ENTRIES
-                ]
+                changes_made=[f"Would add {entry} to .gitignore" for entry in missing_entries]
                 + [f"Would untrack local runtime file: {path}" for path in tracked],
             )
 
         changes: list[str] = []
         errors: list[str] = []
 
+        gitignore_entries = _read_gitignore_entries(project_path)
+        missing_entries = [
+            entry for entry in _GITIGNORE_ENTRIES if entry not in gitignore_entries
+        ]
         manager = GitignoreManager(project_path)
         modified = manager.ensure_entries(list(_GITIGNORE_ENTRIES))
-        if modified:
-            changes.append(f"Added gitignore entries: {', '.join(_GITIGNORE_ENTRIES)}")
+        if modified and missing_entries:
+            changes.append(f"Added gitignore entries: {', '.join(missing_entries)}")
+        elif modified:
+            changes.append("Updated .gitignore")
         else:
             changes.append("gitignore entries already present")
 

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
@@ -11,9 +11,11 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
+_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
 _LOCAL_RUNTIME_TRACKED_PATHS = (
     ".kittify/charter/context-state.json",
-    ".kittify/encoding-provenance/global.jsonl",
+    _PROVENANCE_ENTRY,
 )
 
 
@@ -59,15 +61,15 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
 
     def detect(self, project_path: Path) -> bool:
         gitignore_path = project_path / ".gitignore"
-        sync_entry_missing = (
-            not gitignore_path.exists()
-            or _SYNC_STATE_ENTRY not in gitignore_path.read_text(encoding="utf-8")
+        gitignore_text = (
+            gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
         )
+        entry_missing = any(entry not in gitignore_text for entry in _GITIGNORE_ENTRIES)
         tracked_runtime = any(
             _is_tracked(project_path, path)
             for path in _LOCAL_RUNTIME_TRACKED_PATHS
         )
-        return sync_entry_missing or tracked_runtime
+        return entry_missing or tracked_runtime
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:
         if not project_path.exists():
@@ -84,20 +86,20 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
             return MigrationResult(
                 success=True,
                 changes_made=[
-                    f"Would add {_SYNC_STATE_ENTRY} to .gitignore",
-                    *[f"Would untrack local runtime file: {path}" for path in tracked],
-                ],
+                    f"Would add {entry} to .gitignore" for entry in _GITIGNORE_ENTRIES
+                ]
+                + [f"Would untrack local runtime file: {path}" for path in tracked],
             )
 
         changes: list[str] = []
         errors: list[str] = []
 
         manager = GitignoreManager(project_path)
-        modified = manager.ensure_entries([_SYNC_STATE_ENTRY])
+        modified = manager.ensure_entries(list(_GITIGNORE_ENTRIES))
         if modified:
-            changes.append(f"Added {_SYNC_STATE_ENTRY} to .gitignore")
+            changes.append(f"Added gitignore entries: {', '.join(_GITIGNORE_ENTRIES)}")
         else:
-            changes.append(f"{_SYNC_STATE_ENTRY} already present in .gitignore")
+            changes.append("gitignore entries already present")
 
         for path in _LOCAL_RUNTIME_TRACKED_PATHS:
             if not _is_tracked(project_path, path):

--- a/src/specify_cli/upgrade/migrations/m_3_2_3_encoding_provenance_gitignore_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_3_encoding_provenance_gitignore_backfill.py
@@ -1,0 +1,38 @@
+"""Migration: backfill encoding-provenance gitignore coverage for 3.2.x projects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+
+@MigrationRegistry.register
+class EncodingProvenanceGitignoreBackfillMigration(BaseMigration):  # type: ignore[misc]
+    """Re-run the runtime git hygiene repair for already-shipped 3.2.x installs."""
+
+    migration_id = "3.2.3_encoding_provenance_gitignore_backfill"
+    description = "Backfill encoding-provenance gitignore coverage"
+    target_version = "3.2.3"
+
+    def detect(self, project_path: Path) -> bool:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().detect(project_path)
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().can_apply(project_path)
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().apply(project_path, dry_run=dry_run)

--- a/tests/specify_cli/test_gitignore_contract.py
+++ b/tests/specify_cli/test_gitignore_contract.py
@@ -70,9 +70,21 @@ def test_contract_runtime_entries_complete():
     assert len(entries) >= 4, f"Expected at least 4 runtime entries, got {len(entries)}"  # noqa: PLR2004
     assert ".kittify/.dashboard" in entries
     assert ".kittify/merge-state.json" in entries
+    assert ".kittify/encoding-provenance/" in entries
     assert ".kittify/runtime/" in entries
     assert ".kittify/events/" in entries
     assert ".kittify/dossiers/" in entries
+
+
+def test_gitignore_manager_protects_encoding_provenance(tmp_path: Path) -> None:
+    """Fresh init protection hides the global encoding provenance log."""
+    from specify_cli.gitignore_manager import GitignoreManager
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    result = GitignoreManager(tmp_path).protect_all_agents()
+
+    assert result.success
+    assert _is_ignored(tmp_path, ".kittify/encoding-provenance/global.jsonl")
 
 
 def test_research_evidence_logs_are_trackable():

--- a/tests/specify_cli/test_state_contract.py
+++ b/tests/specify_cli/test_state_contract.py
@@ -212,6 +212,7 @@ def test_runtime_gitignore_entries_exact():
         ".kittify/charter/metadata.yaml",
         ".kittify/charter/references.yaml",
         ".kittify/dossiers/",
+        ".kittify/encoding-provenance/",
         ".kittify/events/",
         ".kittify/merge-state.json",
         ".kittify/missions/__pycache__/",

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
@@ -1,0 +1,78 @@
+"""Regression tests for the encoding-provenance gitignore repair.
+
+Covers the bug where ``.kittify/encoding-provenance/global.jsonl`` was listed
+for untracking but never added to ``.gitignore``, so a freshly-generated
+(untracked) provenance log showed up in ``git status`` forever.
+
+- apply() adds the provenance entry to .gitignore
+- detect() returns True when the provenance entry is missing even though
+  sync-state is already present (the already-upgraded-project case)
+- detect() returns False once both entries are present and nothing is tracked
+- apply() is idempotent when both entries are already present
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations.m_3_2_0rc35_sync_state_gitignore import (
+    KittifyRuntimeGitHygieneMigration,
+)
+
+pytestmark = [pytest.mark.unit]
+
+_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_SYNC_STATE_ENTRY = ".kittify/sync-state.json"
+
+
+def _init_git_repo(project_root: Path) -> None:
+    subprocess.run(["git", "-C", str(project_root), "init", "-q"], check=True)
+
+
+def _write_gitignore(project_root: Path, *entries: str) -> None:
+    project_root.joinpath(".gitignore").write_text(
+        "# Added by Spec Kitty CLI (auto-managed)\n" + "\n".join(entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_apply_adds_provenance_entry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    migration = KittifyRuntimeGitHygieneMigration()
+
+    migration.apply(tmp_path)
+
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert _PROVENANCE_ENTRY in gitignore_text
+    assert _SYNC_STATE_ENTRY in gitignore_text
+
+
+def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
+    """Already-upgraded project: sync-state present, provenance entry missing."""
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
+
+
+def test_detect_false_when_both_entries_present(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is False
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+
+    result = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    assert result.success
+    assert result.errors == []
+    # Entry must appear exactly once — no duplication on re-apply.
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert gitignore_text.count(_PROVENANCE_ENTRY) == 1

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
@@ -14,6 +14,7 @@ for untracking but never added to ``.gitignore``, so a freshly-generated
 from __future__ import annotations
 
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -21,10 +22,17 @@ import pytest
 from specify_cli.upgrade.migrations.m_3_2_0rc35_sync_state_gitignore import (
     KittifyRuntimeGitHygieneMigration,
 )
+from specify_cli.upgrade.migrations.m_3_2_3_encoding_provenance_gitignore_backfill import (
+    EncodingProvenanceGitignoreBackfillMigration,
+)
+from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.metadata import ProjectMetadata
+from specify_cli.upgrade.runner import MigrationRunner
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
-_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
+_PROVENANCE_LOG_PATH = ".kittify/encoding-provenance/global.jsonl"
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
 
 
@@ -39,15 +47,35 @@ def _write_gitignore(project_root: Path, *entries: str) -> None:
     )
 
 
-def test_apply_adds_provenance_entry(tmp_path: Path) -> None:
+def _write_metadata(project_root: Path, version: str) -> None:
+    ProjectMetadata(version=version, initialized_at=datetime.now()).save(
+        project_root / ".kittify"
+    )
+
+
+def _is_ignored(project_root: Path, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(project_root), "check-ignore", "--quiet", path],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def test_apply_adds_provenance_entry_and_hides_generated_log(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     migration = KittifyRuntimeGitHygieneMigration()
+    provenance_log = tmp_path / _PROVENANCE_LOG_PATH
+    provenance_log.parent.mkdir(parents=True)
+    provenance_log.write_text("{}\n", encoding="utf-8")
 
     migration.apply(tmp_path)
 
     gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
-    assert _PROVENANCE_ENTRY in gitignore_text
+    assert _PROVENANCE_GITIGNORE_ENTRY in gitignore_text
     assert _SYNC_STATE_ENTRY in gitignore_text
+    assert _is_ignored(tmp_path, _PROVENANCE_LOG_PATH)
 
 
 def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
@@ -60,19 +88,62 @@ def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
 
 def test_detect_false_when_both_entries_present(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
 
     assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is False
 
 
-def test_apply_is_idempotent(tmp_path: Path) -> None:
+def test_detect_ignores_commented_out_provenance_entry(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, f"# {_PROVENANCE_GITIGNORE_ENTRY}")
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
+
+
+def test_apply_reports_only_missing_gitignore_entries(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
 
     result = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
 
-    assert result.success
-    assert result.errors == []
-    # Entry must appear exactly once — no duplication on re-apply.
+    assert result.changes_made[0] == (
+        f"Added gitignore entries: {_PROVENANCE_GITIGNORE_ENTRY}"
+    )
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+
+    first = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+    second = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    assert first.success
+    assert second.success
+    assert second.errors == []
+    # Entry must appear exactly once; no duplication on re-apply.
     gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
-    assert gitignore_text.count(_PROVENANCE_ENTRY) == 1
+    assert gitignore_text.count(_PROVENANCE_GITIGNORE_ENTRY) == 1
+
+
+@pytest.mark.parametrize("from_version", ["3.2.1", "3.2.2", "3.2.3"])
+def test_backfill_migration_repairs_already_current_3_2_x_project(
+    tmp_path: Path,
+    from_version: str,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_metadata(tmp_path, from_version)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
+    provenance_log = tmp_path / _PROVENANCE_LOG_PATH
+    provenance_log.parent.mkdir(parents=True)
+    provenance_log.write_text("{}\n", encoding="utf-8")
+
+    auto_discover_migrations()
+    result = MigrationRunner(tmp_path).upgrade("3.2.3", include_worktrees=False)
+
+    assert result.success
+    assert (
+        EncodingProvenanceGitignoreBackfillMigration.migration_id
+        in result.migrations_applied
+    )
+    assert _is_ignored(tmp_path, _PROVENANCE_LOG_PATH)


### PR DESCRIPTION
## What

The rc35 git-hygiene migration listed `.kittify/encoding-provenance/global.jsonl`
for *untracking* but never added it to `.gitignore`. A freshly-generated
(untracked) provenance log was therefore never ignored and showed up in
`git status` indefinitely.

Refs #2150.

## Changes

- **`apply()`** now passes the provenance entry to `ensure_entries()` (was
  sync-state only), so the file is gitignored — covers issue proposed-fix **#1**.
- **`detect()`** now re-fires when *either* managed gitignore entry is missing
  (was sync-state only), so the migration self-heals on projects crossing rc35
  — covers proposed-fix **#2**.
- **New regression test** (`test_m_3_2_0rc35_provenance_gitignore.py`):
  apply-adds-entry, detect true/false cases, idempotency — covers proposed-fix
  **#4**.

## Scope / what this PR deliberately does NOT do

Proposed-fix **#3** in #2150 — a *new* migration targeting the next release to
repair already-shipped **3.2.1** installs — is intentionally left out. Per the
version-gating caveat in the issue, the rc35 migration cannot reach a 3.2.1
project (`rc35 < 3.2.1`), so repairing those requires a migration with a
higher `target_version` plus a version bump. That's a release decision left to
maintainers. This PR keeps the fix version-neutral: it repairs fresh installs
and anyone crossing rc35 going forward, and leaves the new-migration + bump to
the maintainers' next release.

## Testing

- New test file: 4 tests, all pass.
- Existing `tests/specify_cli/upgrade/migrations/` suite: 96 passed (no
  regression).
- `ruff`/`mypy` were not runnable in the local env (not installed); relying on
  CI for the lint/type gate. The change is small and idiomatic.
