### PR TITLE
fix(accept): resolve mission-artifact path conventions on the primary surface, not repo root (#2162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **`spec-kitty accept` no longer false-positives on a mission's `contracts/` path
+  convention.** The accept gate's path-convention check (`validate_mission_paths`)
+  resolved every mission-declared path against the repo root, so a mission-artifact
+  path like software-dev's `deliverables: contracts/` (also an `artifacts.optional`
+  entry) was sought at `<repo_root>/contracts/` and reported missing — telling the
+  operator to `mkdir -p contracts/` even though `contracts/` existed and was committed
+  at `kitty-specs/<mission>/contracts/`. A declared path that is a mission artifact
+  (member of `mission.config.artifacts`) is now resolved against the mission's primary
+  feature dir via the canonical `planning_read_dir` surface (the same one
+  `_missing_artifacts` uses) — no repo-root fallback; build paths (`src/`/`tests/`/
+  `docs/`) stay repo-root. A residual of the #1716 / #2113 "no resolution to the repo
+  primary for mission artifacts" cluster.
 - Retired the unsupported `specify_cli.mission_read_path` backcompat import path (#2048),
   after its last production caller had moved to `specify_cli.missions._read_path_resolver`.
   Supported callers should use `resolve_handle_to_read_path` /

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -1335,6 +1335,11 @@ def collect_feature_summary(
             repo_root,
             strict=False,
             path_prefix=_path_prefix_for_mission(mission, feature_dir),
+            # Mission-artifact paths (e.g. ``contracts/``) live on the PRIMARY
+            # mission surface, not the repo root — resolve them via the canonical
+            # ``planning_read_dir`` seam (same surface ``_missing_artifacts`` uses),
+            # never ``repo_root`` (#2115 / #1716 residual). Build paths stay repo-root.
+            feature_dir=planning_read_dir,
         )
         if path_result.missing_paths:
             if strict_metadata:

--- a/src/specify_cli/validators/paths.py
+++ b/src/specify_cli/validators/paths.py
@@ -125,12 +125,18 @@ def _prefix_required_path(path_prefix: str | Path | None, relative_path: str) ->
     return joined.as_posix()
 
 
+def _normalize_path_token(token: str) -> str:
+    """Normalise a path/artifact token for membership comparison (strip slashes)."""
+    return str(token).strip().strip("/")
+
+
 def validate_mission_paths(
     mission: Mission,
     project_root: Path,
     *,
     strict: bool = False,
     path_prefix: str | Path | None = None,
+    feature_dir: Path | None = None,
 ) -> PathValidationResult:
     """Validate that project directories follow mission-defined conventions.
 
@@ -142,14 +148,25 @@ def validate_mission_paths(
             mission-declared paths. Research missions use this to validate
             configured deliverable directories instead of fixed repository-root
             directories.
+        feature_dir: The mission's PRIMARY-surface directory
+            (``kitty-specs/<mission>/``). When supplied, a declared path that is
+            also a mission artifact (a member of ``mission.config.artifacts``,
+            e.g. ``contracts/``) is resolved against ``feature_dir`` — those live
+            with the mission, NOT at the repo root. Build/repo paths
+            (``src/``/``tests/``/``docs/``) keep resolving against ``project_root``.
+            There is no repo-root fallback for an artifact path (#2115 / #1716
+            residual of the "no resolution to the repo primary" rule — it mirrors
+            the #2113 ``_planning_read_dir`` seam). Research's ``path_prefix``
+            routing is unaffected.
 
     Returns:
         PathValidationResult summarising the state of each required path.
     """
 
+    declared = dict(mission.config.paths or {})
     required_paths = {
         key: _prefix_required_path(path_prefix, relative_path)
-        for key, relative_path in dict(mission.config.paths or {}).items()
+        for key, relative_path in declared.items()
     }
     result = PathValidationResult(
         mission_name=mission.name,
@@ -159,9 +176,30 @@ def validate_mission_paths(
     if not required_paths:
         return result
 
+    # Mission-artifact path tokens (e.g. ``contracts/``) — resolved against the
+    # mission's feature_dir rather than the repo root. Only consulted when a
+    # feature_dir is supplied and we are not in research's path_prefix mode.
+    artifact_tokens: set[str] = set()
+    if feature_dir is not None and not path_prefix:
+        # Defensive: a real ``MissionConfig`` always carries ``artifacts``, but a
+        # partial mock/config may not — treat its absence as "no artifact paths"
+        # (all paths resolve at the repo root, the pre-feature_dir behaviour).
+        artifacts = getattr(mission.config, "artifacts", None)
+        required = getattr(artifacts, "required", ()) or ()
+        optional = getattr(artifacts, "optional", ()) or ()
+        artifact_tokens = {
+            _normalize_path_token(name) for name in (*required, *optional)
+        }
+
     for key, relative_path in required_paths.items():
         candidate = Path(relative_path)
-        full_path = candidate if candidate.is_absolute() else project_root / candidate
+        if candidate.is_absolute():
+            full_path = candidate
+        elif _normalize_path_token(declared[key]) in artifact_tokens:
+            # Mission artifact → resolve on the mission's primary surface.
+            full_path = feature_dir / candidate  # type: ignore[operator]
+        else:
+            full_path = project_root / candidate
         if full_path.exists():
             result.existing_paths.append(relative_path)
             continue

--- a/tests/agent/test_validators_unit.py
+++ b/tests/agent/test_validators_unit.py
@@ -160,9 +160,22 @@ def test_validation_result_format_report() -> None:
 class _MissionStub:
     """Minimal mission-like object for path validator tests."""
 
-    def __init__(self, name: str, paths: dict[str, str]) -> None:
+    def __init__(
+        self,
+        name: str,
+        paths: dict[str, str],
+        *,
+        required_artifacts: tuple[str, ...] = (),
+        optional_artifacts: tuple[str, ...] = (),
+    ) -> None:
         self.name = name
-        self.config = SimpleNamespace(paths=paths)
+        self.config = SimpleNamespace(
+            paths=paths,
+            artifacts=SimpleNamespace(
+                required=list(required_artifacts),
+                optional=list(optional_artifacts),
+            ),
+        )
 
 
 def test_validate_paths_all_exist(tmp_path: Path) -> None:
@@ -197,6 +210,76 @@ def test_validate_paths_strict_mode_raises(tmp_path: Path) -> None:
 
     assert excinfo.value.result.missing_paths == ["src/"]
     assert "Path Convention Errors" in excinfo.value.result.format_errors()
+
+
+def test_mission_artifact_path_resolves_against_feature_dir(tmp_path: Path) -> None:
+    """A declared path that is also a mission artifact (e.g. ``contracts/``) is
+    resolved against the mission's feature_dir, while build paths (``src/``) stay
+    at the repo root (#2115). No repo-root fallback for the artifact path.
+    """
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)  # build path → repo root
+    feature_dir = repo_root / "kitty-specs" / "010-feature"
+    (feature_dir / "contracts").mkdir(parents=True)  # mission artifact → feature_dir
+    # NOTE: contracts/ deliberately does NOT exist at repo_root.
+
+    mission = _MissionStub(
+        "Software Dev Kitty",
+        {"workspace": "src/", "deliverables": "contracts/"},
+        optional_artifacts=("contracts/",),
+    )
+
+    result = validate_mission_paths(
+        mission, repo_root, strict=False, feature_dir=feature_dir
+    )
+
+    assert result.is_valid, result.warnings
+    assert set(result.existing_paths) == {"src/", "contracts/"}
+    assert not result.missing_paths
+
+
+def test_mission_artifact_path_without_feature_dir_misses_at_repo_root(
+    tmp_path: Path,
+) -> None:
+    """Non-vacuity / documents the pre-#2115 bug: with no feature_dir, ``contracts/``
+    (a mission artifact under the feature dir) is wrongly sought at the repo root
+    and reported missing — the false positive the fix removes by passing feature_dir.
+    """
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    feature_dir = repo_root / "kitty-specs" / "010-feature"
+    (feature_dir / "contracts").mkdir(parents=True)
+
+    mission = _MissionStub(
+        "Software Dev Kitty",
+        {"workspace": "src/", "deliverables": "contracts/"},
+        optional_artifacts=("contracts/",),
+    )
+
+    # Pre-fix call shape (no feature_dir) — contracts/ resolves at repo_root → missing.
+    result = validate_mission_paths(mission, repo_root, strict=False)
+
+    assert result.missing_paths == ["contracts/"]
+
+
+def test_non_artifact_path_stays_repo_root_even_with_feature_dir(tmp_path: Path) -> None:
+    """A declared path that is NOT a mission artifact (``tests/``) resolves against
+    the repo root even when feature_dir is supplied — build paths are repo-relative.
+    """
+    repo_root = tmp_path / "repo"
+    (repo_root / "tests").mkdir(parents=True)  # exists at repo root
+    feature_dir = repo_root / "kitty-specs" / "010-feature"
+    (feature_dir / "tests").mkdir(parents=True)  # decoy under feature_dir
+
+    mission = _MissionStub("Software Dev Kitty", {"tests": "tests/"})
+
+    result = validate_mission_paths(
+        mission, repo_root, strict=False, feature_dir=feature_dir
+    )
+
+    # tests/ is not a mission artifact → repo-root resolution; present there → valid.
+    assert result.is_valid
+    assert result.existing_paths == ["tests/"]
 
 
 def test_suggest_directory_creation_handles_files_and_dirs() -> None:

--- a/tests/specify_cli/acceptance/test_accept_idempotency.py
+++ b/tests/specify_cli/acceptance/test_accept_idempotency.py
@@ -74,7 +74,7 @@ def _create_lane_feature(repo_root: Path, *, with_negative_invariant: bool) -> P
     _git(repo_root, "branch", "-M", "main")
 
     (repo_root / ".kittify").mkdir()
-    for required_dir in ("src", "tests", "contracts", "docs"):
+    for required_dir in ("src", "tests", "docs"):
         path = repo_root / required_dir
         path.mkdir()
         (path / ".gitkeep").write_text("")
@@ -82,6 +82,8 @@ def _create_lane_feature(repo_root: Path, *, with_negative_invariant: bool) -> P
     feature_dir = repo_root / "kitty-specs" / _SLUG
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
+    # contracts/ is a mission artifact → under the feature dir, not repo root (#2115)
+    (feature_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     meta = {
         "mission_number": "099",

--- a/tests/specify_cli/cli/commands/test_accept_clean_tree.py
+++ b/tests/specify_cli/cli/commands/test_accept_clean_tree.py
@@ -80,7 +80,7 @@ def _create_lane_feature(
     # SPECIFY_REPO_ROOT env var set by the test) so mission resolution works
     # regardless of where pytest happens to run.
     (repo_root / ".kittify").mkdir()
-    for required_dir in ("src", "tests", "contracts", "docs"):
+    for required_dir in ("src", "tests", "docs"):
         path = repo_root / required_dir
         path.mkdir()
         (path / ".gitkeep").write_text("")
@@ -88,6 +88,8 @@ def _create_lane_feature(
     feature_dir = repo_root / "kitty-specs" / _SLUG
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
+    # contracts/ is a mission artifact → under the feature dir, not repo root (#2115)
+    (feature_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     meta = {
         "mission_number": "099",

--- a/tests/specify_cli/cli/commands/test_accept_readiness_no_write.py
+++ b/tests/specify_cli/cli/commands/test_accept_readiness_no_write.py
@@ -201,7 +201,7 @@ def _create_acceptready_feature(repo_root: Path) -> Path:
     _git(repo_root, "branch", "-M", "main")
 
     _write_incomplete_config(repo_root)
-    for required_dir in ("src", "tests", "contracts", "docs"):
+    for required_dir in ("src", "tests", "docs"):
         path = repo_root / required_dir
         path.mkdir()
         (path / ".gitkeep").write_text("")
@@ -209,6 +209,8 @@ def _create_acceptready_feature(repo_root: Path) -> Path:
     feature_dir = repo_root / "kitty-specs" / _SLUG
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
+    # contracts/ is a mission artifact → under the feature dir, not repo root (#2115)
+    (feature_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     meta = {
         "mission_number": "099",

--- a/tests/specify_cli/test_accept_no_commit_readonly.py
+++ b/tests/specify_cli/test_accept_no_commit_readonly.py
@@ -212,7 +212,7 @@ def _create_acceptready_lane_feature(repo_root: Path) -> Path:
     _git(repo_root, "branch", "-M", "main")
 
     (repo_root / ".kittify").mkdir()
-    for required_dir in ("src", "tests", "contracts", "docs"):
+    for required_dir in ("src", "tests", "docs"):
         path = repo_root / required_dir
         path.mkdir()
         (path / ".gitkeep").write_text("")
@@ -220,6 +220,8 @@ def _create_acceptready_lane_feature(repo_root: Path) -> Path:
     feature_dir = repo_root / "kitty-specs" / _CLI_SLUG
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
+    # contracts/ is a mission artifact → under the feature dir, not repo root (#2115)
+    (feature_dir / "contracts").mkdir(parents=True, exist_ok=True)
 
     meta = {
         "mission_number": "099",

--- a/tests/specify_cli/test_acceptance_regressions.py
+++ b/tests/specify_cli/test_acceptance_regressions.py
@@ -168,18 +168,19 @@ def _create_test_feature(
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True)
 
-    # The software-dev mission declares required path conventions
-    # (src/, tests/, contracts/, docs/). collect_feature_summary() validates
-    # them against the on-disk repo layout and, under the default strict mode,
-    # turns a missing convention path into a hard ``path_violations`` entry that
-    # forces ``summary.ok`` to False and makes perform_acceptance() raise
-    # AcceptanceError. Create the convention directories (with a committed
-    # ``.gitkeep`` so git tracks the otherwise-empty dirs and the repo stays
-    # clean) so acceptance reflects the WP/lane state under test rather than a
-    # fixture-layout artifact.
-    for convention_dir in ("src", "tests", "contracts", "docs"):
+    # The software-dev mission declares required path conventions. The build dirs
+    # (src/, tests/, docs/) live at the repo root; contracts/ is a MISSION artifact
+    # and lives under the feature dir (#2115). collect_feature_summary() validates
+    # them and, under the default strict mode, turns a missing convention path into
+    # a hard ``path_violations`` entry that forces ``summary.ok`` to False and makes
+    # perform_acceptance() raise AcceptanceError. Create the dirs (with a committed
+    # ``.gitkeep`` so git tracks the otherwise-empty dirs and the repo stays clean)
+    # so acceptance reflects the WP/lane state under test, not a fixture artifact.
+    for convention_dir in ("src", "tests", "docs"):
         (repo_root / convention_dir).mkdir(parents=True, exist_ok=True)
         (repo_root / convention_dir / ".gitkeep").write_text("")
+    (feature_dir / "contracts").mkdir(parents=True, exist_ok=True)
+    (feature_dir / "contracts" / ".gitkeep").write_text("")
 
     # meta.json
     meta = {

--- a/tests/tasks/conftest.py
+++ b/tests/tasks/conftest.py
@@ -62,7 +62,9 @@ def create_mission_fast(project: Path, slug: str, number: int = 1) -> Path:
     feature_dir.mkdir(parents=True, exist_ok=True)
     (feature_dir / "checklists").mkdir(exist_ok=True)
     (feature_dir / "research").mkdir(exist_ok=True)
-    for dirname in ("src", "tests", "contracts", "docs"):
+    # contracts/ is a mission artifact → under the feature dir, not repo root (#2115)
+    (feature_dir / "contracts").mkdir(exist_ok=True)
+    for dirname in ("src", "tests", "docs"):
         (project / dirname).mkdir(exist_ok=True)
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Closes #2162.

## Summary

`spec-kitty accept`'s path-convention check resolved **every** mission-declared path against `repo_root`. For non-research missions `_path_prefix_for_mission` returns `None`, so a mission-artifact path — software-dev's `deliverables: contracts/` (also an `artifacts.optional` entry) — was sought at `<repo_root>/contracts/` and reported missing, telling the operator to `mkdir -p contracts/` even though `contracts/` was committed at `kitty-specs/<mission>/contracts/` (live dogfood false positive).

This is a residual of the **#1716 / #2113** "no resolution to the repo primary for mission artifacts" cluster — #2113 fixed the artifact *reads*, not the path-convention check.

## Fix (aligned with #2113 C-002 "no fallback" / FR-009 "single canonical surface")

`validate_mission_paths` now resolves a declared path against the mission's **primary `feature_dir`** when that path is a declared mission artifact (member of `mission.config.artifacts`), else `repo_root`. The accept gate passes `feature_dir=planning_read_dir` — the same canonical primary surface `_missing_artifacts` already uses — **not** a repo-root fallback.

- Keyed on **artifacts-membership**, not the `deliverables` name (which is repo-relative `docs/` for plan/documentation missions, so the name would misfire).
- Build paths (`src/`/`tests/`/`docs/`) stay repo-root.
- Research's `path_prefix` routing is untouched.
- Defensive: a config without `artifacts` → no artifact paths (prior behavior); backward-compatible for other `validate_mission_paths` callers (new kwarg is optional).

## Tests

- New red-first validator unit tests: an artifact path (`contracts/`) resolves under `feature_dir`; a non-vacuity test shows that *without* `feature_dir` it misses at `repo_root` (the bug); a non-artifact path (`tests/`) stays repo-root even with `feature_dir`.
- 6 accept/tasks fixtures that created `contracts/` at the repo root (to satisfy the old buggy check) now create it under `feature_dir`.
- Accept/validator/tasks sweep: **784 passed**. Broad sweep: **11999 passed**; the 5 failures there are pre-existing on `upstream/main` (stash-verified, unrelated — mid8-routing / workspace-seam / feature-metadata). `ruff` + `mypy` clean.

## Note for reviewers

The path-convention check (`validate_mission_paths`) is a legacy surface separate from the kind-aware `MissionArtifactKind` partition (`contracts/` isn't a `MissionArtifactKind`). This PR routes its mission-artifact resolution onto the canonical `planning_read_dir` surface; modeling `contracts/`/deliverables as a first-class artifact kind would be a larger follow-up if you'd prefer that direction.

Independent of #2149 (the native-flow coord-read PR).