### PR TITLE
docs: Common Docs hygiene slice (#651/#2165)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,7 +528,7 @@ npm install --save-dev jsdoc docdash   # JavaScript generator
 ```
 Low-confidence classification: add `---\ntype: tutorial\n---` frontmatter. Unpopulated templates: replace all `[TODO: ...]` placeholders.
 
-**Implementation:** `src/specify_cli/missions/documentation/mission.yaml`, `doc_generators.py`, `gap_analysis.py`, `doc_state.py`. User guide: [docs/documentation-mission.md](docs/documentation-mission.md).
+**Implementation:** `src/specify_cli/missions/documentation/mission.yaml`, `doc_generators.py`, `gap_analysis.py`, `doc_state.py`. User guide: [docs/explanation/documentation-mission.md](docs/explanation/documentation-mission.md).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in the
+Spec Kitty project a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes.
+- Focusing on what is best for the overall community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated promptly and fairly. Maintainers are obligated to respect the
+privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ pytest tests/integration/test_version_isolation.py  # Isolation tests
 
 To run the suite in parallel (typically ≥2× faster on a ≥4-core machine), plus
 the serial daemon pass and the coverage-neutrality gates, see
-[Running the test suite in parallel](development/testing-parallel.md).
+[Running the test suite in parallel](docs/development/testing-parallel.md).
 
 ### Testing Unreleased Main or a Pull Request
 

--- a/architecture/3.x/adr/README.md
+++ b/architecture/3.x/adr/README.md
@@ -51,11 +51,15 @@ Use the shared template at [`../../adr-template.md`](../../adr-template.md).
 | 2026-05-14 | [Stale-lane auto-rebase classifier policy](2026-05-14-1-stale-lane-auto-rebase-classifier-policy.md) |
 | 2026-05-16 | [Doctrine layer merge semantics](2026-05-16-1-doctrine-layer-merge-semantics.md) |
 | 2026-05-19 | [Retrospective default-on policy architecture](2026-05-19-1-retrospective-default-policy-architecture.md) |
+| 2026-05-24 | [Charter freshness UX contract](2026-05-24-1-charter-freshness-ux-contract.md) |
+| 2026-05-24 | [Pack augmentation vocabulary — `overrides` and `enhances` as declarative fields](2026-05-24-2-pack-augmentation-vocabulary.md) |
+| 2026-05-24 | [`shipped` → `built-in` vocabulary cutover for doctrine layer label](2026-05-24-3-shipped-to-built-in-cutover.md) |
 | 2026-06-02 | [Pi agent is skill-only: no prompt templates, invoker deferred](2026-06-02-1-pi-agent-skill-only-support.md) |
 | 2026-06-02 | [Letta agent is skill-only: no slash-command templates, invoker and session model deferred](2026-06-02-2-letta-agent-skill-only-support.md) |
 | 2026-06-03 | [Execution-state domain model](2026-06-03-1-execution-state-domain-model.md) |
 | 2026-06-03 | [ExecutionContext owner and CommitTarget atomicity](2026-06-03-2-executioncontext-owner-and-committarget.md) |
 | 2026-06-03 | [Effector/Actor model](2026-06-03-3-effector-actor-model.md) |
+| 2026-06-05 | [Merge publish-layer boundary](2026-06-05-1-merge-publish-layer-boundary.md) |
 | 2026-06-06 | [Plan concerns to work package traceability](2026-06-06-1-plan-concerns-to-work-package-traceability.md) |
 | 2026-06-07 | [Execution-state canonical surface (`mission_runtime`)](2026-06-07-1-execution-state-canonical-surface.md) |
 | 2026-06-07 | [Session presence: multi-harness architecture](2026-06-07-1-session-presence-multi-harness-architecture.md) |
@@ -66,3 +70,6 @@ Use the shared template at [`../../adr-template.md`](../../adr-template.md).
 | 2026-06-21 | [Protected-branch configuration is a standalone boundary-resolved value, not a nested context sub-object](2026-06-21-1-protected-branch-config-boundary-resolved-value.md) |
 | 2026-06-22 | [MissionTopology SSOT — store the mission shape, resolve it once](2026-06-22-1-mission-topology-ssot.md) |
 | 2026-06-24 | [Kind- and topology-aware artifact placement — one partition, read/write symmetry](2026-06-24-1-kind-and-topology-aware-artifact-placement.md) |
+| 2026-06-24 | [Write-branch resolution anchors `meta.json` on the PRIMARY surface (write-surface twin)](2026-06-24-2-write-branch-resolution-primary-anchor.md) |
+| 2026-06-25 | [Terminal-artifact durable home + topology-aware teardown contract](2026-06-25-1-terminal-artifact-durable-home-teardown.md) |
+| 2026-06-26 | [Single-authority seam + call-site gate for resolution boundaries (Phase 1)](2026-06-26-1-single-authority-seam-and-call-site-gate.md) |

--- a/architecture/ARCHITECTURE_DOCS_GUIDE.md
+++ b/architecture/ARCHITECTURE_DOCS_GUIDE.md
@@ -1,90 +1,13 @@
 # Architecture Documentation Guide
 
-## Scope
+> Retired. This guide described a 2.x-era, version-tiered architecture-docs layout that is no longer current.
 
-Architecture documentation is versioned:
+To find Spec Kitty documentation and architecture, start here instead:
 
-- `architecture/1.x/` for legacy architecture and ADRs
-- `architecture/2.x/` for current architecture and ADRs
-- `architecture/adrs/` as legacy compatibility aliases to moved ADR files
-- `architecture/audience/` for persona references used by architecture journeys
-  - `architecture/audience/internal/` for internal contributors/runtime actors
-  - `architecture/audience/external/` for external stakeholders
+- [Documentation home](../docs/index.md) — the canonical entry point for all documentation.
+- [`docs/llms.txt`](../docs/llms.txt) — intent-routing rubric for agents ("when the question is about X, read Y first").
+- [3.x ADRs](3.x/adr/README.md) — the canonical Architecture Decision Records index, with naming, status, and template conventions.
+- [Architecture README](README.md) — current layout of the `architecture/` tree.
 
-Code and tests remain the source of implementation detail.
-
-## 2.x Modeling Layers
-
-1. Domain responsibility model: `architecture/2.x/README.md#domain-breakdown`
-2. C4 context boundary: `architecture/2.x/01_context/README.md`
-3. C4 container responsibilities: `architecture/2.x/02_containers/README.md`
-4. C4 component behavior: `architecture/2.x/03_components/README.md`
-
-## Audience and Persona Rule
-
-When a user-journey actor table includes a Persona value, it must link to a file
-under `architecture/audience/`.
-
-## What Belongs in an ADR
-
-Create an ADR when a change:
-
-1. Selects between meaningful architectural alternatives.
-2. Affects multiple components or system behavior over time.
-3. Needs preserved rationale for future maintainers.
-
-Do not create ADRs for routine bug fixes or low-impact implementation details.
-
-## ADR Structure
-
-Use `architecture/adr-template.md` and include:
-
-1. Context/problem statement.
-2. Decision drivers.
-3. Considered options.
-4. Decision outcome.
-5. Consequences.
-6. Confirmation signals.
-7. Code/test references.
-
-## Quality Bar
-
-An ADR is complete when:
-
-1. The decision is explicit and testable.
-2. Alternatives and tradeoffs are documented.
-3. Referenced paths exist in repo.
-4. Scope boundaries are clear.
-
-## Lifecycle
-
-1. Start as `Proposed`.
-2. Review and accept.
-3. Keep accepted ADRs immutable.
-4. If the decision changes, publish a superseding ADR.
-
-## Useful Commands
-
-```bash
-ls -1 architecture/3.x/adr | sort
-ls -1 architecture/2.x/adr | sort
-ls -1 architecture/1.x/adr | sort
-rg -n "Status:|Decision Outcome|Consequences" architecture/3.x/adr architecture/2.x/adr architecture/1.x/adr
-```
-
-## Track Assignment Rules
-
-The **current track is 3.x** — new (current-era) ADRs land in `architecture/3.x/adr/`.
-
-Use `architecture/2.x/adr/` only when the decision documents 2.x-era behavior, and
-`architecture/1.x/adr/` only when it documents 1.x-era behavior; both are frozen history.
-
-If a decision spans tracks, place it in the active (3.x) track and cross-reference the
-older track.
-
-## 2.x Gaps Closed in This Cycle
-
-1. Doctrine artifact/governance model ADR.
-2. Living glossary model ADR.
-3. Versioned 1.x/2.x docs-site strategy ADR.
-4. Domain + C4 responsibility alignment and audience persona linkage.
+New (current-era) decisions land in `architecture/3.x/adr/` using the shared
+[ADR template](adr-template.md).

--- a/architecture/NAVIGATION_GUIDE.md
+++ b/architecture/NAVIGATION_GUIDE.md
@@ -1,65 +1,10 @@
 # Architecture Navigation Guide
 
-Use this guide to quickly locate the right architecture artifact set.
+> Retired. This guide described 2.x-era navigation paths that are no longer current.
 
-## Fast Paths
+To navigate Spec Kitty documentation and architecture, start here instead:
 
-### Need full ADR lists?
-
-```bash
-ls -1 architecture/1.x/adr | sort
-ls -1 architecture/2.x/adr | sort
-```
-
-### Need the 2.x architecture model?
-
-1. `architecture/2.x/README.md#domain-breakdown`
-2. `architecture/2.x/01_context/README.md`
-3. `architecture/2.x/02_containers/README.md`
-4. `architecture/2.x/03_components/README.md`
-
-### Need architecture audience/personas?
-
-1. `architecture/audience/README.md`
-2. `architecture/audience/internal/README.md`
-3. `architecture/audience/external/README.md`
-
-### Need doctrine/glossary decisions (2.x)?
-
-1. `architecture/2.x/adr/2026-02-23-1-doctrine-artifact-governance-model.md`
-2. `architecture/2.x/adr/2026-02-23-2-living-glossary-context-and-curation-model.md`
-3. `architecture/2.x/adr/2026-02-23-3-versioned-1x-2x-docs-site-without-hosted-platform-scope.md`
-
-### Need mission runtime and `next` decisions (2.x)?
-
-1. `architecture/2.x/adr/2026-02-17-1-canonical-next-command-runtime-loop.md`
-2. `architecture/2.x/adr/2026-02-17-2-runtime-owned-mission-discovery-loading.md`
-3. `architecture/2.x/adr/2026-02-17-3-events-contract-parity-and-vendor-deprecation.md`
-
-### Need status/event model decisions (2.x)?
-
-1. `architecture/2.x/adr/2026-02-09-1-canonical-wp-status-model.md`
-2. `architecture/2.x/adr/2026-02-09-2-wp-lifecycle-state-machine.md`
-3. `architecture/2.x/adr/2026-02-09-3-event-log-merge-semantics.md`
-4. `architecture/2.x/adr/2026-02-09-4-cross-repo-evidence-completion.md`
-
-### Need user journey artifacts (2.x)?
-
-1. `architecture/2.x/user_journey/`
-2. `architecture/2.x/user_journey/README.md`
-
-## Reading Workflow
-
-1. Read domain breakdown for responsibility boundaries.
-2. Read C4 context, container, and component docs in order.
-3. Check relevant audience personas for stakeholder intent.
-4. Read ADRs for rationale and tradeoffs.
-5. Confirm behavior in code and tests.
-
-## Writing Workflow
-
-1. Copy `architecture/adr-template.md` for new decisions.
-2. Keep one architectural decision per ADR.
-3. Update domain/C4 docs when responsibilities or behavior contracts change.
-4. If actor personas are referenced in journeys, link to `architecture/audience/internal/` or `architecture/audience/external/`.
-5. Keep accepted ADRs immutable; supersede with a new ADR if needed.
+- [Documentation home](../docs/index.md) — the canonical entry point for all documentation.
+- [`docs/llms.txt`](../docs/llms.txt) — intent-routing rubric for agents ("when the question is about X, read Y first").
+- [3.x ADRs](3.x/adr/README.md) — the canonical Architecture Decision Records index.
+- [Architecture README](README.md) — current layout of the `architecture/` tree.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,0 +1,22 @@
+---
+title: "Architecture notes"
+description: "Internal architecture notes covering Spec Kitty connector authentication, GitHub App installation authority, and project feature-detection design."
+---
+
+# Architecture notes
+
+Internal architecture and design notes for Spec Kitty subsystems. These pages capture
+design rationale and gap analyses; they are working engineering material rather than
+end-user documentation.
+
+## In this section
+
+- [Connector auth / binding separation](adr-connector-auth-binding-separation.md) — separating connector authentication from binding.
+- [GitHub App installation authority](adr-github-app-installation-authority.md) — installation-authority model for the GitHub App.
+- [Feature detection](feature-detection.md) — how Spec Kitty detects project frameworks and capabilities.
+- [Gap analysis: connector installation model](gap-analysis-connector-installation-model.md) — open gaps in the connector installation model.
+
+## See also
+
+- [Documentation home](../index.md)
+- [Architecture Decision Records](../../architecture/3.x/adr/README.md)

--- a/docs/assets/index.md
+++ b/docs/assets/index.md
@@ -1,0 +1,20 @@
+---
+title: "Documentation assets"
+description: "Static assets for the Spec Kitty documentation site: stylesheets, images, and the standalone backlog and evolution HTML views."
+---
+
+# Documentation assets
+
+Static assets referenced by the Spec Kitty documentation site. These files are served
+alongside the rendered docs and are not consumed directly by readers.
+
+## In this section
+
+- `css/` — stylesheets for the rendered documentation.
+- `images/` — logos and diagrams used across the docs.
+- [Spec Kitty backlog (HTML)](spec-kitty-backlog.html) — standalone backlog view.
+- [Spec Kitty evolution v1 to v3 (HTML)](spec-kitty-evolution-v1-to-v3.html) — version-evolution overview.
+
+## See also
+
+- [Documentation home](../index.md)

--- a/docs/development/3-2-archive-migration-plan.md
+++ b/docs/development/3-2-archive-migration-plan.md
@@ -72,7 +72,7 @@ contract regex `^>\s*(?:Archive notice|Migration note)\b`.
 | `docs/2x/adr-coverage.md` | archival | move | `docs/archive/2x/adr-coverage.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |
 | `docs/2x/doctrine-and-charter.md` | archival | move | `docs/archive/2x/doctrine-and-charter.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |
 | `docs/2x/glossary-system.md` | archival | move | `docs/archive/2x/glossary-system.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |
-| `docs/2x/index.md` | archival | move | `docs/archive/2x/index.md` | Archive notice (2.x) | Referenced from `docs/3x/index.md:81` as `[\`docs/2x/\`](../2x/index.md)` — **live link**. Execution mission must update this to `../archive/2x/index.md` (relative from `docs/3x/index.md`). |
+| `docs/2x/index.md` | archival | move | `docs/archive/2x/index.md` | Archive notice (2.x) | Referenced from `docs/3x/index.md:81` as `[\`docs/2x/\`](../archive/2x/index.md)` — **live link**. Execution mission must update this to `../archive/2x/index.md` (relative from `docs/3x/index.md`). |
 | `docs/2x/model-discipline-routing.md` | archival | move | `docs/archive/2x/model-discipline-routing.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |
 | `docs/2x/model-to-task_type.md` | archival | move | `docs/archive/2x/model-to-task_type.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |
 | `docs/2x/orchestration-and-api.md` | archival | move | `docs/archive/2x/orchestration-and-api.md` | Archive notice (2.x) | No incoming links from `current` pages detected. |

--- a/docs/development/3-2-cli-reference-methodology.md
+++ b/docs/development/3-2-cli-reference-methodology.md
@@ -3,7 +3,7 @@
 **Status**: Methodology note for mission `spec-kitty-3-2-docs-01KS4KSZ`, WP05.
 **Authority**: Spec FR-006 (recover prior CLI reference methodology from git history).
 **Companion artifacts**:
-- Workspace audit: [`cli-audit-3-2.md`](../../../cli-audit-3-2.md) (192 visible / 5 hidden / 2 deprecated paths; 113 of 192 visible covered today).
+- Workspace audit: `cli-audit-3-2.md` (192 visible / 5 hidden / 2 deprecated paths; 113 of 192 visible covered today).
 - Builder contract: [`contracts/build_cli_reference.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/contracts/build_cli_reference.md).
 - Deferred decision: `01KS4KTM69EG2KVX5MQ54FQ939` (hand vs hybrid vs generated mode).
 

--- a/docs/development/3-2-harness-research-method.md
+++ b/docs/development/3-2-harness-research-method.md
@@ -4,7 +4,7 @@
 
 **Sources of authority:**
 - [`CLAUDE.md`](../../CLAUDE.md) §"Supported AI Agents" — canonical list of installed surfaces.
-- [`kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md) §"Supported Harness Research" plus the current CLI agent registry — 17 candidate subjects.
+- `kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/start-here.md` §"Supported Harness Research" plus the current CLI agent registry — 17 candidate subjects.
 - [`data-model.md`](../../kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/data-model.md) §"HarnessEntry" — schema each row must satisfy.
 
 **Access date for all citations in this revision:** 2026-05-21.

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1933,6 +1933,20 @@
   current_target: false
   citation_refs: []
   notes: null
+- path: docs/architecture/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Architecture-notes section landing page.
+- path: docs/assets/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Documentation-assets section landing page.
 - path: docs/contextive-glossaries.md
   tag: current
   divio_type: none
@@ -1940,6 +1954,13 @@
   current_target: true
   citation_refs: []
   notes: Top-level docs page (contextive-glossaries.md); provisional current.
+- path: docs/development/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Development-notes section landing page.
 - path: docs/development/3-2-coord-merge-issue-hygiene-log.md
   tag: internal
   divio_type: none
@@ -2213,6 +2234,13 @@
   current_target: false
   citation_refs: []
   notes: null
+- path: docs/doctrine/index.md
+  tag: current
+  divio_type: explanation
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: Doctrine section landing page.
 - path: docs/doctrine/README.md
   tag: current
   divio_type: explanation
@@ -2227,6 +2255,13 @@
   current_target: true
   citation_refs: []
   notes: Doctrine explanation; provisional current — confirm in WP08 IA review.
+- path: docs/engineering_notes/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Engineering-notes section landing page.
 - path: docs/engineering_notes/2173-infra-logic-separation/00-SYNTHESIS.md
   tag: internal
   divio_type: none
@@ -2448,6 +2483,13 @@
   current_target: false
   citation_refs: []
   notes: Index for mission-scoped triage artifacts.
+- path: docs/explanation/index.md
+  tag: current
+  divio_type: explanation
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: Explanation section landing page.
 - path: docs/explanation/ai-agent-architecture.md
   tag: current
   divio_type: explanation
@@ -2590,6 +2632,13 @@
   current_target: false
   citation_refs: []
   notes: "2.1 → 2.x cutover checklist moved under docs/migration/ for historical migration context."
+- path: docs/how-to/index.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: How-to guides section landing page.
 - path: docs/how-to/accept-and-merge.md
   tag: current
   divio_type: how-to
@@ -3008,6 +3057,13 @@
   current_target: false
   citation_refs: []
   notes: P0 test-failure baseline refresh working note (dated snapshot); internal-only.
+- path: docs/recovery/index.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: E
+  current_target: true
+  citation_refs: []
+  notes: Recovery guides section landing page.
 - path: docs/recovery/logged-out-teamspace.md
   tag: current
   divio_type: how-to
@@ -3015,6 +3071,13 @@
   current_target: true
   citation_refs: []
   notes: Recovery how-to; provisional current.
+- path: docs/reference/index.md
+  tag: current
+  divio_type: reference
+  owning_workstream: B
+  current_target: true
+  citation_refs: []
+  notes: Reference section landing page.
 - path: docs/reference/README.md
   tag: current
   divio_type: reference
@@ -3155,6 +3218,13 @@
   current_target: true
   citation_refs: []
   notes: Top-level docs page (status-model.md); provisional current.
+- path: docs/templates/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Documentation-templates section landing page.
 - path: docs/trail-model.md
   tag: current
   divio_type: none
@@ -3162,6 +3232,13 @@
   current_target: true
   citation_refs: []
   notes: Top-level docs page (trail-model.md); provisional current.
+- path: docs/tutorials/index.md
+  tag: current
+  divio_type: tutorial
+  owning_workstream: C
+  current_target: true
+  citation_refs: []
+  notes: Tutorials section landing page.
 - path: docs/tutorials/charter-governed-workflow.md
   tag: current
   divio_type: tutorial
@@ -3493,6 +3570,13 @@
   current_target: false
   citation_refs: []
   notes: Internal naming, identity, and read-path SSOT investigation evidence.
+- path: docs/release-goals/index.md
+  tag: internal
+  divio_type: none
+  owning_workstream: none
+  current_target: false
+  citation_refs: []
+  notes: Release-goals section landing page.
 - path: docs/release-goals/3.2.x.md
   tag: internal
   divio_type: none

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,25 @@
+---
+title: "Development notes"
+description: "Internal contributor notes for Spec Kitty: testing policy, review gates, contract pinning, local overrides, and the 3.2 documentation information architecture."
+---
+
+# Development notes
+
+Internal engineering and contributor process notes. These pages document how Spec Kitty
+is built, tested, and reviewed; they target maintainers rather than end users.
+
+## Key pages
+
+- [Testing flakiness policy](testing-flakiness.md) — detection, tiers, and the never-retry-to-green rule.
+- [Review gates](review-gates.md) — the gates a change passes before merge.
+- [Contract pinning](contract-pinning.md) — pinning observable contracts in tests.
+- [Local overrides](local-overrides.md) — dev editable/path overrides that must never be committed.
+- [3.2 information architecture](3-2-information-architecture.md) — the documentation refresh IA.
+
+Many additional `3-2-*` working notes in this directory track the 3.2 documentation
+refresh (publication checklist, navigation plan, version taxonomy, and audit logs).
+
+## See also
+
+- [Documentation home](../index.md)
+- [Contributing guide](../../CONTRIBUTING.md)

--- a/docs/doctrine/index.md
+++ b/docs/doctrine/index.md
@@ -1,0 +1,20 @@
+---
+title: "Doctrine documentation"
+description: "How Spec Kitty doctrine works: the artifact model behind governed missions and the Structured-Prompt-Driven Development (SPDD) REASONS canvas."
+---
+
+# Doctrine documentation
+
+Explanation-oriented pages about Spec Kitty doctrine — the layered artifacts (paradigms,
+directives, tactics, profiles) that compose governed mission behavior.
+
+## In this section
+
+- [Doctrine overview](README.md) — the doctrine artifact model and how artifacts compose.
+- [SPDD / REASONS](spdd-reasons.md) — Structured-Prompt-Driven Development and the REASONS canvas.
+
+## See also
+
+- [Documentation home](../index.md)
+- [How Charter works](../3x/index.md)
+- [Org doctrine layer](../explanation/org-doctrine-layer.md)

--- a/docs/engineering_notes/index.md
+++ b/docs/engineering_notes/index.md
@@ -1,0 +1,27 @@
+---
+title: "Engineering notes"
+description: "Internal engineering notes for Spec Kitty: runtime and state overhaul, surface-resolution clusters, triage logs, architectural reviews, and reflections."
+---
+
+# Engineering notes
+
+Internal engineering material organized into topic clusters. These notes capture
+in-flight design work, investigations, and triage; they are working artifacts for
+maintainers rather than end-user documentation.
+
+## Clusters
+
+- [Runtime and state overhaul](runtime_and_state_overhaul/README.md) — unifying mission execution context and state.
+- [Triage](triage/README.md) — investigation and triage logs.
+- [Architectural review](architectural-review/README.md) — design reviews and findings.
+- [Findings](finding/README.md) — recorded engineering findings.
+- [Reflections](reflections/README.md) — retrospective engineering reflections.
+
+Additional clusters cover infra/logic separation (`2173-infra-logic-separation/`),
+surface-resolution work (`3-2-3-surface-resolution-cluster/`), and naming/identity SSOT
+(`naming-identity-ssot-strangler/`).
+
+## See also
+
+- [Documentation home](../index.md)
+- [Development notes](../development/index.md)

--- a/docs/engineering_notes/triage/2026-05-25-01KSF9HJ-dir013-sub-issues.md
+++ b/docs/engineering_notes/triage/2026-05-25-01KSF9HJ-dir013-sub-issues.md
@@ -2,7 +2,7 @@
 
 This document records the GitHub sub-issues filed per DIR-013
 (Pre-existing Failure Reporting Rule) from the triage in
-[`triage.md`](triage.md). Parent issue: [Priivacy-ai/spec-kitty#1298].
+[`triage.md`](2026-05-25-01KSF9HJ-test-failure-triage.md). Parent issue: [Priivacy-ai/spec-kitty#1298].
 
 All issues filed against `Priivacy-ai/spec-kitty` on 2026-05-25 from the
 WP04 closeout workstation.

--- a/docs/engineering_notes/triage/2026-05-26-01KSF9HJ-post-mission-summary.md
+++ b/docs/engineering_notes/triage/2026-05-26-01KSF9HJ-post-mission-summary.md
@@ -30,7 +30,7 @@ This is expected and documented:
 - The triage classifies **90 of the 249** baseline failures as **pre-existing
   C99-bucket** items that fall outside the mission scope (FR-005 / C-005).
 - Per DIR-013, these are filed as **10 GitHub sub-issues** (see
-  [`dir013-issues.md`](dir013-issues.md)) for follow-up missions to own.
+  [`dir013-issues.md`](2026-05-25-01KSF9HJ-dir013-sub-issues.md)) for follow-up missions to own.
 - The fix-here portion (clusters C1–C11, ~161 failures by triage count) is
   resolved on the mission branch but **not yet merged into `main`**. The full
   post-merge baseline will only be measurable after `spec-kitty merge` lands
@@ -58,7 +58,7 @@ subsequent missions.
 | 9 | C99-j chokepoints — meta.json + lane regression | #1309 |
 | 10 | C99-j misc — auth / invocation / doctrine / mypy / mission switching | #1310 |
 
-See [`dir013-issues.md`](dir013-issues.md) for the full table.
+See [`dir013-issues.md`](2026-05-25-01KSF9HJ-dir013-sub-issues.md) for the full table.
 
 ## Work-package landing summary
 
@@ -81,7 +81,7 @@ See [`dir013-issues.md`](dir013-issues.md) for the full table.
 
 ## Acceptance criteria status
 
-- **FR-001 / FR-002 (triage):** ✅ — [`triage.md`](triage.md) buckets all 249
+- **FR-001 / FR-002 (triage):** ✅ — [`triage.md`](2026-05-25-01KSF9HJ-test-failure-triage.md) buckets all 249
   baseline failures across 13 clusters, owners assigned.
 - **FR-003 / FR-004 (Wave T surgical):** ✅ — WP02 + WP03 landed.
 - **FR-005 (defer-to-sub-issue clarity):** ✅ — 10 DIR-013 issues filed.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,25 @@
+---
+title: "Explanation"
+description: "Understanding-oriented background on Spec Kitty: spec-driven development, the mission system, execution lanes, git workflow, and multi-agent orchestration."
+---
+
+# Explanation
+
+Understanding-oriented pages that explain *why* Spec Kitty works the way it does. Start
+here when you want the mental model behind a feature rather than step-by-step instructions.
+
+## Key pages
+
+- [Spec-driven development](spec-driven-development.md) — the core methodology.
+- [Mission system](mission-system.md) — how missions and work packages relate.
+- [Execution lanes](execution-lanes.md) and [git worktrees](git-worktrees.md) — the parallel execution model.
+- [Git workflow](git-workflow.md) — what git operations the runtime owns versus the agent.
+- [Multi-agent orchestration](multi-agent-orchestration.md) — coordinating work across agents.
+- [Kanban workflow](kanban-workflow.md) and [runtime loop](runtime-loop.md) — the mission control loop.
+- [AI agent architecture](ai-agent-architecture.md) — how supported agents integrate.
+
+## See also
+
+- [Tutorials](../tutorials/index.md) — learning-oriented walkthroughs.
+- [How-to guides](../how-to/index.md) — task-oriented instructions.
+- [Reference](../reference/index.md) — authoritative specifications.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,34 @@
+---
+title: "How-to guides"
+description: "Task-oriented guides for Spec Kitty: install and upgrade, create specs and plans, implement and review work packages, manage agents, and merge missions."
+---
+
+# How-to guides
+
+Focused, task-oriented guides for specific operator goals. Each page assumes you already
+have Spec Kitty installed and walks one task end to end.
+
+## Install and set up
+
+- [Install Spec Kitty](install-spec-kitty.md) — and platform guides for [Linux](install-linux.md), [macOS](install-macos.md), [Windows](install-windows.md).
+- [Install and upgrade](install-and-upgrade.md) — keep an existing project current.
+- [Set up governance](setup-governance.md) — charter interview, generate, and sync.
+
+## Run a mission
+
+- [Create a specification](create-specification.md) and [create a plan](create-plan.md).
+- [Generate tasks](generate-tasks.md) and [handle dependencies](handle-dependencies.md).
+- [Implement a work package](implement-work-package.md) and [review a work package](review-work-package.md).
+- [Accept and merge](accept-and-merge.md) and [merge a feature](merge-feature.md).
+- [Run a governed mission](run-governed-mission.md) and [run an autonomous mission](run-an-autonomous-mission.md).
+
+## Operate and recover
+
+- [Manage agents](manage-agents.md) and [manage the glossary](manage-glossary.md).
+- [Keep main clean](keep-main-clean.md) and [parallel development](parallel-development.md).
+- [Recover from an implementation crash](recover-from-implementation-crash.md) and [from an interrupted merge](recover-from-interrupted-merge.md).
+
+## See also
+
+- [Tutorials](../tutorials/index.md) — learning-oriented walkthroughs.
+- [Reference](../reference/index.md) — authoritative command and schema references.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,3 +27,18 @@ Spec Kitty 3.2 is the current documentation set for the Spec Kitty CLI, Charter 
 - How-to guides solve specific operator tasks.
 - Reference pages define exact CLI, file, schema, and environment behavior.
 - Explanation pages describe mental models, architecture, and tradeoffs.
+
+## Intent Routing
+
+When the question is about X, read Y first:
+
+- Getting started or first project — read `tutorials/index.html`, then `tutorials/getting-started.html`.
+- Installing or upgrading the CLI or a project — read `how-to/install-and-upgrade.html` and the platform guides under `how-to/`.
+- Running a specific task (spec, plan, tasks, implement, review, merge) — read `how-to/index.html`, then the matching task guide.
+- An exact command, flag, file, schema, or environment variable — read `reference/index.html`, then `reference/cli-commands.html`.
+- Why something works the way it does (mental model, architecture, tradeoffs) — read `explanation/index.html`.
+- Governance, Charter, doctrine, or agent profiles — read `3x/index.html` and `doctrine/index.html`.
+- Upgrading from 1.x or 2.x, or finding archived behavior — read `migration/index.html`, then `archive/index.html`.
+- Recovering from a failed or interrupted operation — read `recovery/index.html` and the recovery how-tos under `how-to/`.
+- Which AI harness is supported and how — read `reference/supported-harnesses.html` and `reference/supported-agents.html`.
+- Mission state, work-package lanes, or the status model — read `status-model.html` and `explanation/kanban-workflow.html`.

--- a/docs/recovery/index.md
+++ b/docs/recovery/index.md
@@ -1,0 +1,18 @@
+---
+title: "Recovery guides"
+description: "Recovery procedures for Spec Kitty operational states, such as restoring access after a logged-out teamspace session."
+---
+
+# Recovery guides
+
+Task-oriented recovery procedures for getting an installation or session back to a healthy
+state after a failure or interruption.
+
+## In this section
+
+- [Logged-out teamspace](logged-out-teamspace.md) — restore access when your teamspace session has logged out.
+
+## See also
+
+- [How-to guides](../how-to/index.md) — including crash and interrupted-merge recovery.
+- [Documentation home](../index.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,30 @@
+---
+title: "Reference"
+description: "Authoritative Spec Kitty specifications: CLI and agent subcommands, slash commands, charter commands, configuration, environment variables, and schemas."
+---
+
+# Reference
+
+Precise, authoritative specifications for Spec Kitty's command surfaces, configuration, and
+schemas. Use these pages to look up exact flags, fields, and values.
+
+## Commands
+
+- [CLI commands](cli-commands.md) — the full `spec-kitty` CLI surface.
+- [Agent subcommands](agent-subcommands.md) — the `spec-kitty agent` group.
+- [Slash commands](slash-commands.md) — agent-facing `/spec-kitty.*` commands.
+- [Charter commands](charter-commands.md) — the `charter` subcommands.
+- [Orchestrator API](orchestrator-api.md) — external orchestration contract.
+
+## Configuration and schemas
+
+- [Configuration](configuration.md) and [environment variables](environment-variables.md).
+- [File structure](file-structure.md) — layout of a Spec Kitty project.
+- [Event envelope](event-envelope.md) and [retrospective schema](retrospective-schema.md).
+- [Terminology](terminology.md) — canonical glossary.
+- [Supported agents](supported-agents.md) and [supported harnesses](supported-harnesses.md).
+
+## See also
+
+- [How-to guides](../how-to/index.md) — task-oriented instructions.
+- [Explanation](../explanation/index.md) — conceptual background.

--- a/docs/release-goals/index.md
+++ b/docs/release-goals/index.md
@@ -1,0 +1,20 @@
+---
+title: "Release goals"
+description: "Internal release-goal declarations for Spec Kitty milestones, tracking the focus and intended scope of the 3.2.x and 3.3.x release lines."
+---
+
+# Release goals
+
+Internal release-goal declarations that record the intended focus of each release line.
+These are planning artifacts for maintainers, not user-facing release notes.
+
+## In this section
+
+- [Release goals overview](README.md) — how release goals are declared and tracked.
+- [3.2.x goals](3.2.x.md) — focus for the 3.2.x line.
+- [3.3.x goals](3.3.x.md) — focus for the 3.3.x line.
+
+## See also
+
+- [Documentation home](../index.md)
+- [Development notes](../development/index.md)

--- a/docs/templates/index.md
+++ b/docs/templates/index.md
@@ -1,0 +1,18 @@
+---
+title: "Documentation templates"
+description: "Static templates and front-end assets used to render the Spec Kitty documentation site, including the public stylesheet and script bundle."
+---
+
+# Documentation templates
+
+Templates and front-end assets used when rendering the Spec Kitty documentation site.
+These files are build inputs rather than reader-facing pages.
+
+## In this section
+
+- `spec-kitty/public/` — the public stylesheet (`main.css`) and script (`main.js`) bundle for the rendered site.
+
+## See also
+
+- [Documentation home](../index.md)
+- [Documentation assets](../assets/index.md)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,27 @@
+---
+title: "Tutorials"
+description: "Learning-oriented Spec Kitty walkthroughs: getting started, your first feature, the governed charter workflow, and multi-agent and Claude Code integration."
+---
+
+# Tutorials
+
+Learning-oriented, step-by-step walkthroughs for new users. Work through these in order to
+build a mental model before reaching for the task-focused how-to guides.
+
+## Start here
+
+- [Getting started](getting-started.md) — your first project from scratch.
+- [Your first feature](your-first-feature.md) — spec through merge on a small change.
+- [Missions overview](missions-overview.md) — the mission lifecycle at a glance.
+
+## Going further
+
+- [Governed charter workflow](charter-governed-workflow.md) — set up governance and run a governed mission end to end.
+- [Multi-agent workflow](multi-agent-workflow.md) — run a mission across multiple harnesses.
+- [Claude Code integration](claude-code-integration.md) and [Claude Code workflow](claude-code-workflow.md).
+- [Orchestrator quickstart](orchestrator-quickstart.md) — drive a mission from an external orchestrator.
+
+## See also
+
+- [How-to guides](../how-to/index.md) — task-oriented instructions.
+- [Explanation](../explanation/index.md) — conceptual background.


### PR DESCRIPTION
## Common Docs hygiene slice

The independent, no-dependency **hygiene ship** of the Common Docs consolidation split: in-place edits only (no ADR dependency, no structural moves), de-risking the docs tree ahead of the larger consolidation. Each item was squad-verified (debbie + paula).

### 1. Missing `index.md` section landing pages
Added `index.md` to every real `docs/*/` consumption section that lacked one (12 files): `architecture/`, `assets/`, `development/`, `doctrine/`, `engineering_notes/`, `explanation/`, `how-to/`, `recovery/`, `reference/`, `release-goals/`, `templates/`, `tutorials/`. Each carries SEO frontmatter (`title` + 50–180 char `description`) and a short intro linking its key pages. Shadow dirs `docs/1x|2x|3x` and `*-closeout` are intentionally excluded (owned by Mission B). A matching `page-inventory` row was added for each new file in `docs/development/3-2-page-inventory.yaml` (565 → 577 rows) so the docs-freshness gate stays clean.

### 2. Dead-link fixes
- `CLAUDE.md`/`AGENTS.md` (twin; CLAUDE.md is a symlink) line 531 → `docs/explanation/documentation-mission.md` (added the missing `docs/explanation/` path).
- `CONTRIBUTING.md`: `development/testing-parallel.md` → `docs/development/testing-parallel.md`; the absent `CODE_OF_CONDUCT.md` link is now backed by a new Contributor Covenant stub.
- 7 broken in-body relative links: `docs/development/3-2-*` (3 — archive-migration-plan, harness-research-method, cli-reference-methodology) and `docs/engineering_notes/triage/*` (4) repointed to the correct in-repo targets, or de-linked where the target was a removed transient artifact.

### 3. ADR README backfill
Added the 7 missing ADRs to `architecture/3.x/adr/README.md`: charter-freshness-ux-contract, pack-augmentation-vocabulary, shipped-to-built-in-cutover, merge-publish-layer-boundary, write-branch-resolution-primary-anchor, terminal-artifact-durable-home-teardown, single-authority-seam-and-call-site-gate (inserted in date order).

### 4. Retire 2.x-stale nav guides
`architecture/NAVIGATION_GUIDE.md` and `architecture/ARCHITECTURE_DOCS_GUIDE.md` replaced with short pointers to `docs/index.md` + `docs/llms.txt` (+ 3.x ADR index). Files are **kept, not deleted** — `tests/docs/test_architecture_docs_consistency.py` requires their existence and inbound refs from `architecture/README.md`.

### 5. `llms.txt` intent-routing rubric
Added a "when the question is about X, read Y first" section to `docs/llms.txt`.

### Notes
- The `architecture/adrs/` shim is intentionally **untouched** — it is the sole home of 20 era-less ADRs that Mission B migrates; closing it here would strand them.
- Verification: `check_docs_freshness.py` → **errors=0** (remaining warnings are pre-existing external HTTP-403 / HELP-DRIFT, unrelated to this slice); no new broken links; markdownlint introduces **zero** new violations on touched files; terminology guard + `tests/docs/` (709 tests) green.

🤖 Generated with Claude Code