### PR TITLE
fix(sync): honor SPEC_KITTY_SAAS_URL in get_server_url; drop hardcoded default (#2146)

### DIFF
--- a/src/specify_cli/sync/config.py
+++ b/src/specify_cli/sync/config.py
@@ -1,4 +1,6 @@
 """Sync configuration management"""
+
+import os
 import sys
 from enum import StrEnum
 from pathlib import Path
@@ -28,8 +30,8 @@ class SyncConfig:
     """Manage sync configuration"""
 
     def __init__(self) -> None:
-        self.config_dir = Path.home() / '.spec-kitty'
-        self.config_file = self.config_dir / 'config.toml'
+        self.config_dir = Path.home() / ".spec-kitty"
+        self.config_file = self.config_dir / "config.toml"
 
     def _load(self) -> dict[str, Any]:
         """Load config.toml, returning empty dict when missing or invalid."""
@@ -47,17 +49,35 @@ class SyncConfig:
         atomic_write(self.config_file, content, mkdir=True)
 
     def get_server_url(self) -> str:
-        """Get server URL from config"""
+        """Resolve the sync server URL.
+
+        Honors decision D-5 (no hardcoded SaaS domain — see
+        ``specify_cli.auth.config``): ``SPEC_KITTY_SAAS_URL`` is the source of
+        truth and takes precedence over config, so auth and sync can never
+        resolve different targets (#2146). Falls back to the ``[sync]
+        server_url`` config key, then to the D-5 env resolver — which raises a
+        clear error when nothing is configured — rather than a hardcoded (and
+        now unreachable) default domain that fails silently.
+        """
+        env_url = os.environ.get("SPEC_KITTY_SAAS_URL", "").strip()
+        if env_url:
+            return env_url.rstrip("/")
         config = self._load()
-        url = config.get('sync', {}).get('server_url', 'https://spec-kitty-dev.fly.dev')
-        return str(url)
+        url = config.get("sync", {}).get("server_url")
+        if url:
+            return str(url).rstrip("/")
+        # D-5: no hardcoded SaaS domain. Defer to the auth resolver, which
+        # raises ConfigurationError when SPEC_KITTY_SAAS_URL is unset.
+        from specify_cli.auth.config import get_saas_base_url
+
+        return str(get_saas_base_url())
 
     def set_server_url(self, url: str) -> None:
         """Set server URL in config"""
         config = self._load()
-        if 'sync' not in config:
-            config['sync'] = {}
-        config['sync']['server_url'] = url
+        if "sync" not in config:
+            config["sync"] = {}
+        config["sync"]["server_url"] = url
         self._save(config)
 
     def get_max_queue_size(self) -> int:
@@ -106,9 +126,7 @@ class SyncConfig:
         stripped = raw.strip()
 
         if stripped == "":
-            raise ValueError(
-                "[sync].background_daemon must be 'auto' or 'manual', not an empty string"
-            )
+            raise ValueError("[sync].background_daemon must be 'auto' or 'manual', not an empty string")
 
         folded = stripped.casefold()
         policy = _BACKGROUND_DAEMON_VALUES.get(folded)

--- a/tests/sync/test_config_server_url.py
+++ b/tests/sync/test_config_server_url.py
@@ -1,0 +1,44 @@
+"""Sync server-URL resolution: D-5 compliance + #2146 target-authority.
+
+`SyncConfig.get_server_url()` must honor `SPEC_KITTY_SAAS_URL` (the D-5 source
+of truth) ahead of config, and must carry NO hardcoded SaaS domain — so `auth`
+and `sync` can never resolve different targets, and an unconfigured checkout
+fails loudly instead of silently pointing at a dead default.
+"""
+
+import pytest
+
+from specify_cli.auth.errors import ConfigurationError
+from specify_cli.sync.config import SyncConfig
+
+
+@pytest.fixture
+def cfg(tmp_path, monkeypatch):
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    config = SyncConfig()
+    config.config_file = tmp_path / "config.toml"
+    return config
+
+
+def test_env_takes_precedence_over_config(cfg, monkeypatch):
+    cfg.set_server_url("https://from-config.example.com")
+    monkeypatch.setenv("SPEC_KITTY_SAAS_URL", "http://localhost:8000")
+    assert cfg.get_server_url() == "http://localhost:8000"
+
+
+def test_config_used_when_env_unset(cfg, monkeypatch):
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    cfg.set_server_url("https://from-config.example.com/")
+    assert cfg.get_server_url() == "https://from-config.example.com"
+
+
+def test_env_trailing_slash_stripped(cfg, monkeypatch):
+    monkeypatch.setenv("SPEC_KITTY_SAAS_URL", "http://localhost:8000/")
+    assert cfg.get_server_url() == "http://localhost:8000"
+
+
+def test_no_hardcoded_default_raises_when_unconfigured(cfg, monkeypatch):
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    # No env, no config key -> must NOT return a hardcoded domain (D-5).
+    with pytest.raises(ConfigurationError):
+        cfg.get_server_url()


### PR DESCRIPTION
**Draft / proposal** — the immediate, surgical slice of #2146 (canonical sync target authority). Folds cleanly into #2131 WP01; opening standalone because it's a small fix that enforces an *existing* architectural decision and resolves a reproduced, real-data bug. Take it as-is or absorb into WP01.

## Problem (reproduced with real data — see #2131)

`auth/config.py` documents **decision D-5**: *"there is NO hardcoded SaaS domain anywhere in the codebase — callers must set `SPEC_KITTY_SAAS_URL`."* The auth subsystem obeys it. But `sync/config.py:get_server_url()` **violated it**: it read `[sync].server_url` only (ignoring `SPEC_KITTY_SAAS_URL`) and fell back to a hardcoded `https://spec-kitty-dev.fly.dev`.

Consequences, observed live:
- `SPEC_KITTY_SAAS_URL=… auth login` authenticated against one target while `sync` resolved a *different* one — the #2146 split-brain (SC-008).
- The hardcoded default (`spec-kitty-dev.fly.dev`) is **unreachable**, so an unconfigured checkout failed *silently* against a dead host.

## Change

`get_server_url()` now resolves in D-5 order:
1. `SPEC_KITTY_SAAS_URL` (the source of truth — takes precedence over config),
2. `[sync].server_url` config key,
3. the D-5 resolver `auth.config.get_saas_base_url()` — which raises a clear `ConfigurationError` when nothing is set, **instead of returning a hardcoded, dead domain**.

So auth and sync can no longer resolve different targets, and "nothing configured" fails loudly with guidance rather than silently hitting a dead host.

## Scope / tests

- One function changed (`sync/config.py`), `import os` added. New: `tests/sync/test_config_server_url.py` — env precedence, config fallback, trailing-slash strip, and raise-when-unconfigured (no hardcoded default).
- Ruff + mypy clean on the changed code; 17 existing `test_config_*` tests still pass. No existing test depended on the removed default (the `fly.dev` references in tests mock `get_server_url` or pass explicit URLs).

## Known sibling violation (NOT in this PR)

`saas_client/auth.py:18` carries its own rogue default (`https://api.spec-kitty.io`) — the same D-5 violation in a different subsystem. WP01's `ResolvedSyncTarget` should unify all of these (auth / sync / saas_client / readiness) through one resolver; flagging rather than fixing here to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
