### PR TITLE
fix(sync): allow loopback HTTP in `sync server` URL validation (#2146)

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -3742,11 +3742,13 @@ _Synchronization commands_
  Show or set sync server URL.
 
  Examples:
- spec-kitty sync server
- spec-kitty sync server https://spec-kitty-dev.fly.dev
+spec-kitty sync server
+spec-kitty sync server https://spec-kitty-dev.fly.dev
+spec-kitty sync server http://localhost:8000
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│   url      [URL]  Sync server URL to set (must be https://...)               │
+│   url      [URL]  Sync server URL to set (HTTPS, or loopback HTTP for local  │
+│                   development)                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1799,7 +1799,7 @@ def _check_server_connection(server_url: str) -> tuple[str, str]:
 def sync_server(
     url: str | None = typer.Argument(
         None,
-        help="Sync server URL to set (must be https://...)",
+        help="Sync server URL to set (HTTPS, or loopback HTTP for local development)",
     ),
 ) -> None:
     """Show or set sync server URL.
@@ -1807,6 +1807,7 @@ def sync_server(
     Examples:
         spec-kitty sync server
         spec-kitty sync server https://spec-kitty-dev.fly.dev
+        spec-kitty sync server http://localhost:8000
     """
     from specify_cli.sync.config import SyncConfig
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1818,10 +1818,17 @@ def sync_server(
 
     normalized_url = url.strip().rstrip("/")
     parsed = urlparse(normalized_url)
-    if parsed.scheme != "https" or not parsed.netloc:
+    # HTTPS is required for remote targets, but loopback HTTP is a deliberate
+    # local-development special case (e.g. http://localhost:8000 against a local
+    # Docker SaaS) — don't force HTTPS on loopback.
+    host = (parsed.hostname or "").lower()
+    is_loopback = host in {"localhost", "127.0.0.1", "::1"}
+    scheme_ok = parsed.scheme == "https" or (parsed.scheme == "http" and is_loopback)
+    if not scheme_ok or not parsed.netloc:
         console.print(
-            "[red]Error:[/red] Invalid server URL. Use a full HTTPS URL, "
-            "for example: https://spec-kitty-dev.fly.dev"
+            "[red]Error:[/red] Invalid server URL. Use a full HTTPS URL "
+            "(or http://localhost[:port] for local development), "
+            "for example: https://your-teamspace.example.com"
         )
         raise typer.Exit(1)
 

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -360,12 +360,20 @@ class TestSyncServerCommand:
         assert exc.value.exit_code == 1
         mock_config.set_server_url.assert_not_called()
 
-    def test_set_server_url_accepts_loopback_http(self):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:8000",
+            "http://127.0.0.1:8000",
+            "http://[::1]:8000",
+        ],
+    )
+    def test_set_server_url_accepts_loopback_http(self, url):
         """Loopback HTTP is allowed for local development (e.g. local Docker SaaS)."""
         mock_config = MagicMock()
         with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config):
-            sync_server(url="http://localhost:8000")
-        mock_config.set_server_url.assert_called_once_with("http://localhost:8000")
+            sync_server(url=url)
+        mock_config.set_server_url.assert_called_once_with(url)
 
     def test_set_server_url_rejects_non_loopback_http(self):
         """Non-loopback HTTP is still rejected (HTTPS required for remote)."""

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -360,6 +360,21 @@ class TestSyncServerCommand:
         assert exc.value.exit_code == 1
         mock_config.set_server_url.assert_not_called()
 
+    def test_set_server_url_accepts_loopback_http(self):
+        """Loopback HTTP is allowed for local development (e.g. local Docker SaaS)."""
+        mock_config = MagicMock()
+        with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config):
+            sync_server(url="http://localhost:8000")
+        mock_config.set_server_url.assert_called_once_with("http://localhost:8000")
+
+    def test_set_server_url_rejects_non_loopback_http(self):
+        """Non-loopback HTTP is still rejected (HTTPS required for remote)."""
+        mock_config = MagicMock()
+        with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config), pytest.raises(typer.Exit) as exc:
+            sync_server(url="http://example.com")
+        assert exc.value.exit_code == 1
+        mock_config.set_server_url.assert_not_called()
+
 
 class TestSyncNowExitCodes:
     """Tests for sync now --strict/--no-strict exit semantics."""

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -352,8 +352,8 @@ class TestSyncServerCommand:
 
         mock_config.set_server_url.assert_called_once_with("https://spec-kitty-dev.fly.dev")
 
-    def test_set_server_url_rejects_non_https(self):
-        """Non-HTTPS URL is rejected."""
+    def test_set_server_url_rejects_non_loopback_remote_http(self):
+        """Remote HTTP (non-loopback) is rejected; HTTPS is required for remote targets."""
         mock_config = MagicMock()
         with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config), pytest.raises(typer.Exit) as exc:
             sync_server(url="http://spec-kitty-dev.fly.dev")
@@ -365,6 +365,7 @@ class TestSyncServerCommand:
         "url",
         [
             "http://localhost:8000",
+            "http://localhost",
             "http://127.0.0.1:8000",
             "http://[::1]:8000",
         ],
@@ -382,6 +383,15 @@ class TestSyncServerCommand:
         mock_config = MagicMock()
         with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config), pytest.raises(typer.Exit) as exc:
             sync_server(url="http://example.com")
+        assert exc.value.exit_code == 1
+        mock_config.set_server_url.assert_not_called()
+
+    @pytest.mark.unit
+    def test_set_server_url_rejects_zero_addr_http(self):
+        """http://0.0.0.0 is rejected — not in the explicit loopback set."""
+        mock_config = MagicMock()
+        with patch("specify_cli.sync.config.SyncConfig", return_value=mock_config), pytest.raises(typer.Exit) as exc:
+            sync_server(url="http://0.0.0.0:8000")
         assert exc.value.exit_code == 1
         mock_config.set_server_url.assert_not_called()
 

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -360,6 +360,7 @@ class TestSyncServerCommand:
         assert exc.value.exit_code == 1
         mock_config.set_server_url.assert_not_called()
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "url",
         [
@@ -375,6 +376,7 @@ class TestSyncServerCommand:
             sync_server(url=url)
         mock_config.set_server_url.assert_called_once_with(url)
 
+    @pytest.mark.unit
     def test_set_server_url_rejects_non_loopback_http(self):
         """Non-loopback HTTP is still rejected (HTTPS required for remote)."""
         mock_config = MagicMock()


### PR DESCRIPTION
**Draft / proposal** — small `sync` target-hygiene fix in the #2146 family (sibling to #2246).

## Problem

`spec-kitty sync server <url>` rejected any non-HTTPS URL, so `http://localhost:8000` failed with *"Use a full HTTPS URL."* That blocks the documented local-dev workflow (a local Docker SaaS on loopback HTTP — Robert's own pattern is `SPEC_KITTY_SAAS_URL=http://localhost:8000`). It also contradicts the "loopback/local-only HTTP is a special case — don't force HTTPS" guidance. Hit live tonight: had to hand-edit `~/.spec-kitty/config.toml` because the CLI setter wouldn't accept a localhost target.

## Change

`sync_server` now allows **HTTP for loopback hosts** (`localhost`, `127.0.0.1`, `::1`) while still requiring HTTPS for everything remote. One block in `cli/commands/sync.py`; tests added for loopback-accept and non-loopback-HTTP-reject.

## Flag for WP01 (NOT fixed here)

`saas_client/auth.py:18` carries a hardcoded `https://api.spec-kitty.io` default that **contradicts D-5** ("no hardcoded SaaS domain") — but it's enshrined by `test_client.py:121` and has multiple callers. That's a real D-5-vs-tested-behavior tension that WP01 (#2131 target authority) should reconcile deliberately, not a drive-by flip. Flagging, not changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
