### PR TITLE
fix(#2066): surface parsed FR set + classify stale refs in map-requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 3.2.4
 
-_No changes yet — entries land here as missions merge._
+### 🐛 Fixed
+
+- **`map-requirements` now explains *why* a WP `requirement_refs` entry is stale
+  instead of looking like data corruption (#2066).** When the stale/invalid-refs
+  gate trips, the `--json` payload (and console output) now surface the FR-ID set
+  parsed from `spec.md` (`parsed_spec_ids`), classify each offending ref per WP into
+  `malformed` (violates the `FR-NNN` / `NFR-NNN` / `C-NNN` format — e.g. a
+  letter-suffixed `FR-003a` or an unfilled `<FR-XXX>` placeholder) vs
+  `unknown_spec_id` (well-formed but not declared in the spec), and the hint names
+  the format rule. A one-character ID-format mismatch is now obvious rather than
+  reading like invented/orphaned IDs.
 
 ## [3.2.3] - 2026-06-29
 

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -2489,6 +2489,7 @@ def map_requirements(
     from specify_cli.frontmatter import write_frontmatter
     from specify_cli.status import read_wp_frontmatter
     from specify_cli.requirement_mapping import (
+        classify_stale_refs,
         compute_coverage,
         normalize_requirement_refs_value,
         parse_requirement_ids_from_spec_md,
@@ -2762,17 +2763,32 @@ def map_requirements(
                     stale_refs[wp_id] = wp_bad
 
         if stale_refs:
+            # Surface the parsed spec FR set and classify each offender so a simple
+            # format mismatch (e.g. FR-003a) is obvious rather than looking like
+            # invented/orphaned IDs (#2066).
+            stale_ref_reasons = classify_stale_refs(stale_refs, post_merge_malformed)
+            parsed_spec_ids = sorted(all_spec_ids)
             payload = {
                 "error": "Stale or invalid refs in WP frontmatter",
                 "stale_refs": stale_refs,
-                "hint": ("Re-run with --replace to correct, e.g.: map-requirements --wp WP01 --refs FR-001 --replace"),
+                "stale_ref_reasons": stale_ref_reasons,
+                "parsed_spec_ids": parsed_spec_ids,
+                "hint": (
+                    "Requirement IDs must match FR-NNN, NFR-NNN, or C-NNN "
+                    "(e.g. FR-003, not FR-003a). 'malformed' refs violate that format; "
+                    "'unknown_spec_id' refs are well-formed but not declared in spec.md "
+                    "(see parsed_spec_ids). Re-run with --replace to correct, "
+                    "e.g.: map-requirements --wp WP01 --refs FR-001 --replace"
+                ),
             }
             if json_output:
                 print(json.dumps(payload))
             else:
                 console.print("[red]Error:[/red] Stale or invalid refs in WP frontmatter:")
+                console.print("  IDs must match FR-NNN, NFR-NNN, or C-NNN (e.g. FR-003, not FR-003a).")
                 for wp_id, bad_refs in sorted(stale_refs.items()):
                     console.print(f"  {wp_id}: {', '.join(bad_refs)}")
+                console.print(f"  Parsed spec IDs: {', '.join(parsed_spec_ids) or '(none)'}")
                 console.print("  Use --replace to correct mappings")
             raise typer.Exit(1)
 

--- a/src/specify_cli/requirement_mapping.py
+++ b/src/specify_cli/requirement_mapping.py
@@ -58,6 +58,35 @@ def validate_ref_format(refs: list[str]) -> tuple[list[str], list[str]]:
     return well_formed, malformed
 
 
+def classify_stale_refs(
+    stale_refs: dict[str, list[str]],
+    malformed: list[str],
+) -> dict[str, dict[str, list[str]]]:
+    """Split each WP's offending refs into format-malformed vs unknown-spec-id buckets.
+
+    Lets diagnostics explain *why* a ref is stale: a ``malformed`` ref violates the
+    ``FR-NNN`` / ``NFR-NNN`` / ``C-NNN`` shape (e.g. ``FR-003a`` or an unfilled
+    ``<FR-XXX>`` placeholder), whereas an ``unknown_spec_id`` ref is well-formed but
+    not declared in ``spec.md``.
+
+    Args:
+        stale_refs: per-WP offending raw tokens (case preserved).
+        malformed: uppercased tokens that fail the format check (from
+            :func:`validate_ref_format`).
+
+    Returns:
+        ``{wp_id: {"malformed": [...], "unknown_spec_id": [...]}}`` — raw tokens,
+        sorted, each offending token in exactly one bucket.
+    """
+    malformed_set = set(malformed)
+    reasons: dict[str, dict[str, list[str]]] = {}
+    for wp_id, bad_refs in stale_refs.items():
+        wp_malformed = sorted(r for r in bad_refs if r.startswith("<") or r.upper() in malformed_set)
+        wp_unknown = sorted(r for r in bad_refs if not r.startswith("<") and r.upper() not in malformed_set)
+        reasons[wp_id] = {"malformed": wp_malformed, "unknown_spec_id": wp_unknown}
+    return reasons
+
+
 def compute_coverage(mappings: dict[str, list[str]], functional_ids: set[str]) -> CoverageSummary:
     """Compute coverage summary: total, mapped, unmapped FRs."""
     mapped: set[str] = set()

--- a/tests/specify_cli/test_cli/test_map_requirements.py
+++ b/tests/specify_cli/test_cli/test_map_requirements.py
@@ -510,6 +510,48 @@ class TestMapRequirementsValidation:
         payload = json.loads(result.stdout.strip())
         assert payload["error"] == "Stale or invalid refs in WP frontmatter"
         assert "WP02" in payload["stale_refs"]
+        # #2066: payload now surfaces the parsed spec FR set, per-WP offender
+        # classification, and a hint naming the FR-NNN format rule.
+        assert payload["parsed_spec_ids"] == ["FR-001", "FR-002", "FR-003", "NFR-001"]
+        assert payload["stale_ref_reasons"]["WP02"]["malformed"] == ["BOGUS"]
+        assert payload["stale_ref_reasons"]["WP02"]["unknown_spec_id"] == []
+        assert "FR-NNN" in payload["hint"]
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_mission_slug")
+    @patch("specify_cli.cli.commands.agent.tasks._ensure_target_branch_checked_out")
+    def test_stale_refs_classify_format_vs_unknown(
+        self,
+        mock_branch: Mock,
+        mock_slug: Mock,
+        mock_locate: Mock,
+        tmp_path: Path,
+    ):
+        """#2066 Repro A: a letter-suffixed FR-003a reads as malformed, while a
+        well-formed-but-undeclared FR-999 reads as unknown_spec_id — so the
+        operator can tell a format typo from an orphaned ref."""
+        mock_locate.return_value = tmp_path
+        mock_slug.return_value = "001-test"
+        mock_branch.return_value = (tmp_path, "main")
+        feature_dir = _setup_feature(tmp_path)
+        tasks_dir = feature_dir / "tasks"
+        wp_file = next(tasks_dir.glob("WP02*.md"))
+        frontmatter, body = read_frontmatter(wp_file)
+        frontmatter["requirement_refs"] = ["FR-003a", "FR-999"]
+        from specify_cli.frontmatter import write_frontmatter
+
+        write_frontmatter(wp_file, frontmatter, body)
+
+        result = runner.invoke(
+            tasks_app,
+            ["map-requirements", "--wp", "WP01", "--refs", "FR-001", "--json"],
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout.strip())
+        reasons = payload["stale_ref_reasons"]["WP02"]
+        assert reasons["malformed"] == ["FR-003a"]
+        assert reasons["unknown_spec_id"] == ["FR-999"]
 
 
 class TestFinalizeTasksWithFrontmatterRefs:

--- a/tests/specify_cli/test_requirement_mapping.py
+++ b/tests/specify_cli/test_requirement_mapping.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from specify_cli.requirement_mapping import (
+    classify_stale_refs,
     compute_coverage,
     normalize_requirement_refs_value,
     parse_requirement_ids_from_spec_md,
@@ -52,6 +53,35 @@ class TestValidateRefFormat:
         well_formed, malformed = validate_ref_format(["FR-001", "INVALID", "REQ-001"])
         assert well_formed == ["FR-001"]
         assert malformed == ["INVALID", "REQ-001"]
+
+
+class TestClassifyStaleRefs:
+    """Test #2066 stale-ref diagnostics classification."""
+
+    def test_splits_malformed_and_unknown(self):
+        # FR-003a is malformed (letter suffix); FR-999 is well-formed but absent
+        # from spec → unknown_spec_id.
+        reasons = classify_stale_refs(
+            {"WP02": ["FR-003a", "FR-999"]},
+            malformed=["FR-003A"],
+        )
+        assert reasons == {
+            "WP02": {"malformed": ["FR-003a"], "unknown_spec_id": ["FR-999"]}
+        }
+
+    def test_unfilled_placeholder_is_malformed(self):
+        # An unfilled <FR-XXX> template placeholder is classified malformed, not unknown.
+        reasons = classify_stale_refs({"WP01": ["<FR-XXX>"]}, malformed=[])
+        assert reasons["WP01"] == {"malformed": ["<FR-XXX>"], "unknown_spec_id": []}
+
+    def test_preserves_raw_case_and_sorts(self):
+        reasons = classify_stale_refs(
+            {"WP03": ["fr-002", "FR-001"]},
+            malformed=[],
+        )
+        # Both well-formed-but-unknown here; raw case preserved, sorted.
+        assert reasons["WP03"]["unknown_spec_id"] == ["FR-001", "fr-002"]
+        assert reasons["WP03"]["malformed"] == []
 
 
 class TestComputeCoverage:


### PR DESCRIPTION
## Summary

Closes the **`map-requirements` half of #2066** — "Opaque diagnostics when WP `requirement_refs` don't match spec.md FR IDs; no way to see the parsed FR set."

When the stale/invalid-refs gate trips, the error payload was only:

```json
{"error": "Stale or invalid refs in WP frontmatter", "stale_refs": {"WP05": ["FR-003a"]}, "hint": "Re-run with --replace ..."}
```

…which never says *why* a ref is bad or lists the IDs the parser actually found, so a one-character format mismatch (`FR-003a`) reads like invented/orphaned IDs or data corruption (the issue's Repro A).

## What changed

The stale-refs gate (`agent/tasks.py`) now emits:
- **`parsed_spec_ids`** — the FR/NFR/C IDs parsed from `spec.md`.
- **`stale_ref_reasons`** — per-WP classification of each offender into:
  - `malformed` — violates the `FR-NNN` / `NFR-NNN` / `C-NNN` format (e.g. letter-suffixed `FR-003a`, or an unfilled `<FR-XXX>` placeholder), and
  - `unknown_spec_id` — well-formed but not declared in `spec.md`.
- a **hint that names the format rule**.

Console (non-`--json`) output gains the same rule line + parsed-spec-IDs list.

Classification is a new pure helper `classify_stale_refs()` in `requirement_mapping.py` (keeps the command function's complexity down; directly unit-tested).

## Scope / relationship to prior work

- The **finalize-tasks** coverage-diagnostics half of #2066 (Repro B) already landed via the `single-planning-surface-authority` **FR-014 campsite fold** (`mission_finalize.py` now emits `requirement_refs_parsed`, `unmapped_functional_requirements`, etc.). This PR completes the *map-requirements* side the fold explicitly left as "future work."
- **Authoring-time** (`specify`/`plan`) FR-ID validation remains out of scope (also flagged as future work in the issue thread).

## Tests

- `requirement_mapping.py`: `TestClassifyStaleRefs` — malformed vs unknown split, `<FR-XXX>` placeholder → malformed, raw-case preserved + sorted.
- `test_map_requirements.py`: extended `test_reports_stale_invalid_refs` to assert the new payload keys; added `test_stale_refs_classify_format_vs_unknown` exercising Repro A (`FR-003a` malformed vs `FR-999` unknown).
- `ruff` + `mypy` clean on changed files; terminology guard green. No version bump (no `__init__.py` change); CHANGELOG entry under `[Unreleased] - 3.2.4`.