### PR TITLE
fix(contract): green the contract gate on main (#2255)

### DIFF
--- a/kitty-specs/org-pack-subdir-and-doctrine-qol-01KVSRJ6/contracts/config-schema-delta.md
+++ b/kitty-specs/org-pack-subdir-and-doctrine-qol-01KVSRJ6/contracts/config-schema-delta.md
@@ -6,6 +6,7 @@ Target contract file (FR-008): `kitty-specs/layered-doctrine-org-layer-01KRNPEE/
 ## `.kittify/config.yaml` — canonical shape (`doctrine.org.packs[]`)
 
 ```yaml
+# round-trip: skip: canonical .kittify/config.yaml shape sketch — executable single-pack OrgPackConfig round-trip examples are in the "Round-trip example" section below
 doctrine:
   org:
     packs:

--- a/kitty-specs/org-pack-subdir-and-doctrine-qol-01KVSRJ6/contracts/config-schema-delta.md
+++ b/kitty-specs/org-pack-subdir-and-doctrine-qol-01KVSRJ6/contracts/config-schema-delta.md
@@ -30,3 +30,33 @@ doctrine:
 - `doctrine fetch` reports artifact count at the effective root; a wrong `subdir` → "0 artifacts" at fetch (SC-003/FR-007).
 - Round-trip: write→read preserves `subdir`; absent emits no `subdir:` key (FR-005), on both canonical and legacy inline shapes (FR-006).
 - Escape inputs → structured operator-visible error, not "no org packs" degradation (FR-003).
+
+## Round-trip example (FR-140)
+
+A single pack entry is carried by the `OrgPackConfig` Pydantic model
+(`doctrine.drg.org_pack_config.OrgPackConfig`). The frontmatter below pins the
+contract example to that model for the round-trip gate. A pack that sets the new
+`subdir` field round-trips as valid:
+
+```yaml
+# pydantic_model: doctrine.drg.org_pack_config.OrgPackConfig
+# expect: valid
+name: my-pack
+source_type: git
+url: ssh://git@example.com/org/repo.git
+ref: main
+local_path: .doctrine-cache/repo
+subdir: pack
+```
+
+A `subdir` containing a `..` component escapes `local_path` and is rejected at
+model-construction time (per the field contract above):
+
+```yaml
+# pydantic_model: doctrine.drg.org_pack_config.OrgPackConfig
+# expect: invalid
+# expect_message: subdir must not contain
+name: my-pack
+local_path: .doctrine-cache/repo
+subdir: ../escape
+```

--- a/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/contract-round-trip-frontmatter.md
+++ b/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/contract-round-trip-frontmatter.md
@@ -42,13 +42,16 @@ source_kind: local_path
 
 ### Codeblocks NOT subject to round-trip
 
-YAML codeblocks WITHOUT the `pydantic_model:` frontmatter line are skipped — they are documentation prose or shape sketches, not contract examples. The walker counts them in a `skipped:` summary but does not fail.
+In a **non-legacy** contract, discovery is block-level: every YAML codeblock must either carry the `pydantic_model:` frontmatter (executed) OR carry an explicit non-executable marker as a comment line — `# round-trip: skip: <reason>` — with a mandatory reason. A block carrying neither fails the gate on that specific block, so a tagged sibling can never silently mask a forgotten tag. The skip marker is the home for documentation prose, shape sketches, CI-wiring snippets, and non-Pydantic operator config.
+
+In a **legacy** contract (tracked in the allowlist below), the gate keeps file-level leniency: untagged codeblocks are skipped with a warning rather than failing, pending backfill.
 
 ### Legacy contract allowlist (FR-141)
 
 Contracts from missions predating this convention live under an allowlist tracked in `tests/architectural/_baselines.yaml`:
 
 ```yaml
+# round-trip: skip: baseline-format illustration with an <N> placeholder, not a Pydantic payload
 test_example_round_trip:
   legacy_contract_allowlist: <N>
 ```

--- a/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/contract-round-trip-frontmatter.md
+++ b/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/contract-round-trip-frontmatter.md
@@ -64,41 +64,56 @@ Files in this allowlist warn rather than fail when their codeblocks lack frontma
 
 ### Walker behaviour — `tests/contract/test_example_round_trip.py`
 
-```python
-from pathlib import Path
-import importlib
-import yaml
-import re
+Discovery is **block-level** for non-legacy contracts. Each YAML block is
+classified independently — tagged (executed), skip-marked (intentionally
+non-executable), or neither (a per-block gate failure). A tagged sibling can no
+longer mask an untagged block.
 
+```python
 FRONTMATTER_RE = re.compile(r"^# pydantic_model: (?P<model>[\w\.]+)\s*\n# expect: (?P<expect>valid|invalid)", re.MULTILINE)
+SKIP_MARKER_RE = re.compile(r"^# round-trip: skip:[ \t]*(?P<reason>\S.*)$", re.MULTILINE)
+
+def _classify_yaml_block(block):
+    """Return ('execute', info) | ('skip', {'reason': ...}) | ('missing', {})."""
+    fm = FRONTMATTER_RE.search(block)
+    if fm:                                  # frontmatter wins over a stray skip marker
+        return "execute", {"model": fm.group("model"), "expect": fm.group("expect"),
+                           "payload": _strip_frontmatter(block)}
+    skip = SKIP_MARKER_RE.search(block)
+    if skip:                                # mandatory reason; empty reason does NOT match
+        return "skip", {"reason": skip.group("reason").strip()}
+    return "missing", {}
 
 def _discover_examples():
-    """Walk kitty-specs/*/contracts/*.md and yield (file, model, expect, payload)."""
+    """Walk kitty-specs/*/contracts/*.md and yield executable round-trip cases."""
     for contract_md in Path("kitty-specs").glob("*/contracts/*.md"):
-        text = contract_md.read_text()
-        # Extract every fenced ```yaml ...``` block; for each, look at the first two non-blank lines for frontmatter
-        for codeblock in _iter_yaml_codeblocks(text):
-            frontmatter = FRONTMATTER_RE.search(codeblock)
-            if not frontmatter:
-                continue
-            model_path = frontmatter.group("model")
-            expect = frontmatter.group("expect")
-            payload = _strip_frontmatter(codeblock)
-            yield contract_md, model_path, expect, payload
+        blocks = list(_iter_yaml_codeblocks(contract_md.read_text()))
+        for idx, block in enumerate(blocks, start=1):
+            kind, info = _classify_yaml_block(block)
+            if kind == "execute":
+                yield f"{contract_md}::block-{idx}", info["model"], info["expect"], info["payload"]
+            elif kind == "missing" and not _is_legacy(contract_md):
+                # Non-legacy + neither tagged nor skip-marked -> this block FAILS.
+                yield f"{contract_md}::block-{idx}-MISSING_FRONTMATTER", "<MISSING_FRONTMATTER>", "valid", "{}"
+            # kind == "skip", or a legacy file's untagged block -> not executed.
 
-@pytest.mark.parametrize("contract_md,model_path,expect,payload", list(_discover_examples()))
-def test_contract_example_round_trip(contract_md, model_path, expect, payload):
+@pytest.mark.parametrize("label,model_path,expect,payload", list(_discover_examples()))
+def test_contract_example_round_trip(label, model_path, expect, payload):
+    if model_path == "<MISSING_FRONTMATTER>":
+        pytest.fail(f"{label}: add '# pydantic_model:' frontmatter OR '# round-trip: skip: <reason>'.")
     module_name, _, class_name = model_path.rpartition(".")
-    module = importlib.import_module(module_name)
-    model = getattr(module, class_name)
+    model = getattr(importlib.import_module(module_name), class_name)
     parsed = yaml.safe_load(payload)
-
     if expect == "valid":
         model.model_validate(parsed)  # MUST succeed
     else:
         with pytest.raises(pydantic.ValidationError):
             model.model_validate(parsed)
 ```
+
+The ``# round-trip: skip:`` set in non-legacy contracts is itself ratcheted in
+`tests/architectural/_baselines.yaml::test_example_round_trip.skip_marker_blocks`,
+so adding a new permanently-non-executable block is an explicit, reviewable event.
 
 ### Failure shape
 
@@ -114,9 +129,13 @@ When a `pydantic_model:` references a non-importable model:
 
 > **FAIL**: `kitty-specs/<mission>/contracts/<file>.md` (codeblock #N) declared `pydantic_model: <bad.path.Model>` but the module is not importable: `<ImportError text>`.
 
+When a non-legacy codeblock carries neither frontmatter nor a skip marker (the per-block strictness, `block-N-MISSING_FRONTMATTER`):
+
+> **FAIL**: Contract block `<file>.md::block-N` carries neither `# pydantic_model:` frontmatter nor a `# round-trip: skip: <reason>` marker. Add frontmatter to round-trip the block, add a skip marker if it is non-executable, or (pre-Slice-F only) add the file to the legacy allowlist.
+
 ### Legacy allowlist behaviour
 
-For files in the legacy allowlist, FAIL conditions become WARN conditions and the test passes — but the legacy file's path is reported in a pytest warning so the operator sees the unwound work.
+For files in the legacy allowlist, FAIL conditions become WARN conditions and the test passes — but the legacy file's path is reported in a pytest warning so the operator sees the unwound work. Legacy files keep **file-level** leniency (untagged blocks are tolerated); the per-block strictness above applies only to non-legacy contracts.
 
 ---
 
@@ -126,7 +145,8 @@ For files in the legacy allowlist, FAIL conditions become WARN conditions and th
 |---|---|---|
 | A new contract's `expect: valid` example doesn't actually parse | `test_example_round_trip` FAIL | "Contract `<file>` codeblock #N declares `expect: valid` but `model_validate` raised: `<exc>`. Fix the example OR the model" |
 | A new contract's `expect: invalid` example DOES parse | `test_example_round_trip` FAIL | "Contract `<file>` codeblock #N declares `expect: invalid` but `model_validate` succeeded. Either the example was meant to be valid OR the model lost a validator" |
-| A contract file in `kitty-specs/<mission>/contracts/` has YAML codeblocks but none carry frontmatter | If the contract is post-Slice-F (not in legacy allowlist) — `test_example_round_trip` FAIL | "Contract `<file>` has unfronted YAML codeblocks. Add `# pydantic_model:` and `# expect:` frontmatter or move the file to the legacy allowlist (`_baselines.yaml:test_example_round_trip.legacy_contract_allowlist`)" |
+| A non-legacy contract has a YAML codeblock with neither `# pydantic_model:` frontmatter nor a `# round-trip: skip: <reason>` marker | `test_example_round_trip` FAIL (per block, `block-N-MISSING_FRONTMATTER`) | "Block `<file>::block-N` carries neither frontmatter nor a skip marker. Tag it, skip-mark it, or (pre-Slice-F only) add the file to the legacy allowlist" |
+| A new `# round-trip: skip:` marker is added in a non-legacy contract without bumping the baseline | `test_ratchet_baselines` FAIL (growth) | "skip_marker_blocks grew above baseline. Bump `_baselines.yaml:test_example_round_trip.skip_marker_blocks` with a one-line rationale naming the new block" |
 | A contract is in the legacy allowlist but no longer exists | `test_ratchet_baselines` FAIL with stale-allowlist message | "Stale legacy contract `<file>` in allowlist. Remove from `_baselines.yaml`" |
 
 ---

--- a/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/org-drg-schema.md
+++ b/kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/org-drg-schema.md
@@ -15,6 +15,7 @@ The organisation-tier DRG fragment is one configured layer of doctrine-reference
 The operator configures one or more org packs:
 
 ```yaml
+# round-trip: skip: operator .kittify/config.yaml shape sketch (organisation_packs list), not a single Pydantic payload — the executable OrgDRGFragment examples are below
 organisation_packs:
   - name: acme-compliance
     source: local_path

--- a/kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md
+++ b/kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md
@@ -46,6 +46,7 @@
 Tasks-phase WP F3 wires this into `.github/workflows/ci-quality.yml` (or the current equivalent) as:
 
 ```yaml
+# round-trip: skip: GitHub Actions CI step (not a Pydantic model payload) — migrated from the legacy allowlist to an explicit non-executable marker (#2255)
 - name: Docs freshness
   run: |
     SPEC_KITTY_ENABLE_SAAS_SYNC=1 SPEC_KITTY_NO_UPGRADE_CHECK=1 \

--- a/kitty-specs/specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md
+++ b/kitty-specs/specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md
@@ -6,6 +6,7 @@ A new top-level `protection:` block in `.kittify/config.yaml`. Backward compatib
 current default behavior.
 
 ```yaml
+# round-trip: skip: operator-config shape sketch — resolved by the frozen ProtectionPolicy dataclass + raw-YAML protection_policy.resolve (fail-closes via ProtectionConfigError), no Pydantic model_validate payload (#2255)
 # .kittify/config.yaml
 protection:
   # Branches the safe-commit guard refuses direct commits to.

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -113,10 +113,15 @@ test_example_round_trip:
   # predating the Slice F frontmatter convention. These are allowlisted
   # per FR-141 so they warn instead of failing. +1 for T031 (#1301):
   # spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md carries a
-  # CI-wiring YAML snippet (not a Pydantic model payload). The baseline
-  # participates in the burn-down policy (C-004): it MUST shrink as legacy
-  # missions backfill the ``# pydantic_model:`` / ``# expect:`` frontmatter.
-  legacy_contract_allowlist: 152
+  # CI-wiring YAML snippet (not a Pydantic model payload). +1 for #2255:
+  # specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md
+  # carries the ``.kittify/config.yaml`` ``protection:`` operator-config shape
+  # sketch, whose resolved artefact is the frozen ``ProtectionPolicy`` dataclass
+  # + ``protection_policy.resolve`` raw-YAML resolver (no Pydantic ``model_validate``
+  # target), so the FR-140 round-trip does not apply. The baseline participates in
+  # the burn-down policy (C-004): it MUST shrink as legacy missions backfill the
+  # ``# pydantic_model:`` / ``# expect:`` frontmatter.
+  legacy_contract_allowlist: 153
 
 # tests/architectural/test_all_declarations_required.py
 # Populated by WP02 after the charter/kernel __all__ sweep. WP01

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -122,6 +122,17 @@ test_example_round_trip:
   # migration moved check_docs_freshness.md (the former T031 +1) out of this set,
   # so the count drops 152 -> 151.
   legacy_contract_allowlist: 151
+  # justification: count of permanently-non-executable ``# round-trip: skip:``
+  # blocks in NON-legacy contracts (#2255). Unlike the legacy allowlist above,
+  # these are legitimate permanent exemptions (shape sketches, CI snippets,
+  # non-Pydantic operator config) with NO shrink mandate — this baseline exists
+  # so that ADDING a new skip is explicit and reviewable: a new marker grows the
+  # count above this baseline and fails test_ratchet_baselines until the value is
+  # bumped here with a one-line rationale naming the new block. The 5 seed entries
+  # are config-schema-delta.md, protection-config.md, check_docs_freshness.md, and
+  # the two Slice F convention contracts (contract-round-trip-frontmatter.md,
+  # org-drg-schema.md).
+  skip_marker_blocks: 5
 
 # tests/architectural/test_all_declarations_required.py
 # Populated by WP02 after the charter/kernel __all__ sweep. WP01

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -109,19 +109,19 @@ test_compat_shims:
 # sweep. WP01 pins this at 0 so the meta-test can run; WP03 edits
 # upward only if the sweep finds legitimately-excluded contracts.
 test_example_round_trip:
-  # justification: WP03 discovery sweep found 151 contracts from missions
-  # predating the Slice F frontmatter convention. These are allowlisted
-  # per FR-141 so they warn instead of failing. +1 for T031 (#1301):
-  # spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md carries a
-  # CI-wiring YAML snippet (not a Pydantic model payload). +1 for #2255:
-  # specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md
-  # carries the ``.kittify/config.yaml`` ``protection:`` operator-config shape
-  # sketch, whose resolved artefact is the frozen ``ProtectionPolicy`` dataclass
-  # + ``protection_policy.resolve`` raw-YAML resolver (no Pydantic ``model_validate``
-  # target), so the FR-140 round-trip does not apply. The baseline participates in
-  # the burn-down policy (C-004): it MUST shrink as legacy missions backfill the
+  # justification: 151 contracts from missions PREDATING the Slice F frontmatter
+  # convention. These are allowlisted file-level per FR-141 so they warn instead
+  # of failing. This set is *only* pre-Slice-F legacy debt and participates in the
+  # burn-down policy (C-004): it MUST shrink as legacy missions backfill the
   # ``# pydantic_model:`` / ``# expect:`` frontmatter.
-  legacy_contract_allowlist: 153
+  #
+  # Post-Slice-F files that are simply non-executable (CI-wiring snippets,
+  # ``.kittify/config.yaml`` shape sketches, non-Pydantic operator config) do NOT
+  # belong here. Per #2255 they carry a per-block ``# round-trip: skip: <reason>``
+  # marker instead (block-level discovery in test_example_round_trip.py). That
+  # migration moved check_docs_freshness.md (the former T031 +1) out of this set,
+  # so the count drops 152 -> 151.
+  legacy_contract_allowlist: 151
 
 # tests/architectural/test_all_declarations_required.py
 # Populated by WP02 after the charter/kernel __all__ sweep. WP01

--- a/tests/architectural/test_ratchet_baselines.py
+++ b/tests/architectural/test_ratchet_baselines.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import importlib
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -64,7 +64,7 @@ class _PerCategorySection(BaseModel):
     model_config = {"extra": "allow"}
 
     @classmethod
-    def model_validate(cls, obj: Any, **kwargs: Any) -> _PerCategorySection:  # type: ignore[override]
+    def model_validate(cls, obj: Any, **kwargs: Any) -> _PerCategorySection:
         if isinstance(obj, dict):
             for k, v in obj.items():
                 if not isinstance(v, int) or v < 0:
@@ -161,7 +161,7 @@ def _import_module_attr(module_dotted: str, attr_name: str) -> frozenset[Any]:
             f"module scope so the ratchet baseline meta-test can introspect "
             f"its size."
         )
-    return getattr(module, attr_name)
+    return cast("frozenset[Any]", getattr(module, attr_name))
 
 
 def test_baseline_file_exists_with_required_keys() -> None:

--- a/tests/architectural/test_ratchet_baselines.py
+++ b/tests/architectural/test_ratchet_baselines.py
@@ -265,6 +265,15 @@ def test_growing_an_allowlist_above_baseline_fails() -> None:
             "_LEGACY_CONTRACT_ALLOWLIST",
             data["test_example_round_trip"]["legacy_contract_allowlist"],
         ),
+        # #2255: permanently-non-executable ``# round-trip: skip:`` blocks. Growth
+        # is visible (a new skip fails the ratchet until the baseline is bumped);
+        # unlike the legacy allowlist these are permanent (no shrink mandate).
+        (
+            "test_example_round_trip",
+            "tests.contract.test_example_round_trip",
+            "_SKIP_MARKED_BLOCKS",
+            data["test_example_round_trip"]["skip_marker_blocks"],
+        ),
     ]
     for label, module_dotted, attr_name, baseline in single_baselines:
         current = len(_import_module_attr(module_dotted, attr_name))
@@ -350,6 +359,15 @@ def test_growth_fails_shrinkage_warns() -> None:
             "tests.contract.test_example_round_trip",
             "_LEGACY_CONTRACT_ALLOWLIST",
             data["test_example_round_trip"]["legacy_contract_allowlist"],
+        ),
+        # #2255: permanently-non-executable ``# round-trip: skip:`` blocks. Growth
+        # is visible (a new skip fails the ratchet until the baseline is bumped);
+        # unlike the legacy allowlist these are permanent (no shrink mandate).
+        (
+            "test_example_round_trip",
+            "tests.contract.test_example_round_trip",
+            "_SKIP_MARKED_BLOCKS",
+            data["test_example_round_trip"]["skip_marker_blocks"],
         ),
     ]
     for label, module_dotted, attr_name, baseline in single_baselines:

--- a/tests/contract/snapshots/spec-kitty-events-6.1.0.json
+++ b/tests/contract/snapshots/spec-kitty-events-6.1.0.json
@@ -1,0 +1,160 @@
+{
+  "envelope_class": "spec_kitty_events.models.Event",
+  "field_names": [
+    "aggregate_id",
+    "build_id",
+    "causation_id",
+    "correlation_id",
+    "data_tier",
+    "event_id",
+    "event_type",
+    "lamport_clock",
+    "node_id",
+    "payload",
+    "project_slug",
+    "project_uuid",
+    "schema_version",
+    "timestamp"
+  ],
+  "package": "spec-kitty-events",
+  "required_fields": [
+    "aggregate_id",
+    "build_id",
+    "correlation_id",
+    "event_id",
+    "event_type",
+    "lamport_clock",
+    "node_id",
+    "project_uuid",
+    "timestamp"
+  ],
+  "resolved_version": "6.1.0",
+  "schema": {
+    "description": "Immutable event with causal metadata for distributed conflict detection.\n\nTimestamp semantics\n-------------------\n\nThe ``timestamp`` field is the producer-assigned wall-clock occurrence time\nof the modelled event. Consumers (SaaS ingestion, dashboards, audit, sync\ndrains, projections, scorecards) MUST preserve this value end-to-end and\nMUST NOT substitute server-receipt, import, drain, or replay time for it.\nConsumer-side receipt/import time, if persisted, MUST be stored under a\ndistinct field name \u2014 the recommended name is ``received_at``.\n\nSee ``kitty-specs/teamspace-event-contract-foundation-01KQHDE4/data-model.md``\n(Timestamp Semantics: Rules R-T-01, R-T-02, R-T-03) for the authoritative\nrules, and ``spec_kitty_events.conformance.assert_producer_occurrence_preserved``\nfor an executable consumer-side conformance helper.",
+    "properties": {
+      "aggregate_id": {
+        "description": "Identifier of the entity this event modifies",
+        "minLength": 1,
+        "title": "Aggregate Id",
+        "type": "string"
+      },
+      "build_id": {
+        "description": "Canonical checkout or worktree identity that produced this event",
+        "minLength": 1,
+        "title": "Build Id",
+        "type": "string"
+      },
+      "causation_id": {
+        "anyOf": [
+          {
+            "maxLength": 36,
+            "minLength": 26,
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Event ID of the parent event (26-char ULID or UUID accepted, None for root events)",
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Causation Id"
+      },
+      "correlation_id": {
+        "description": "Correlation identifier (26-char ULID or UUID accepted)",
+        "maxLength": 36,
+        "minLength": 26,
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Correlation Id",
+        "type": "string"
+      },
+      "data_tier": {
+        "default": 0,
+        "description": "Progressive data sharing tier (0=local, 4=telemetry)",
+        "maximum": 4,
+        "minimum": 0,
+        "title": "Data Tier",
+        "type": "integer"
+      },
+      "event_id": {
+        "description": "Unique event identifier (26-char ULID or UUID accepted)",
+        "maxLength": 36,
+        "minLength": 26,
+        "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$|^[0-9a-fA-F]{32}$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        "title": "Event Id",
+        "type": "string"
+      },
+      "event_type": {
+        "description": "Event type identifier (e.g., 'WPStatusChanged', 'TagAdded')",
+        "minLength": 1,
+        "title": "Event Type",
+        "type": "string"
+      },
+      "lamport_clock": {
+        "description": "Lamport logical clock value (monotonically increasing)",
+        "minimum": 0,
+        "title": "Lamport Clock",
+        "type": "integer"
+      },
+      "node_id": {
+        "description": "Required causal emitter identity used for Lamport ordering and deterministic tie-breaking",
+        "minLength": 1,
+        "title": "Node Id",
+        "type": "string"
+      },
+      "payload": {
+        "additionalProperties": true,
+        "description": "Event-specific data (opaque to library)",
+        "title": "Payload",
+        "type": "object"
+      },
+      "project_slug": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Human-readable project identifier (optional)",
+        "title": "Project Slug"
+      },
+      "project_uuid": {
+        "description": "UUID of the project this event belongs to",
+        "format": "uuid",
+        "title": "Project Uuid",
+        "type": "string"
+      },
+      "schema_version": {
+        "default": "3.0.0",
+        "description": "Envelope schema version (semver)",
+        "pattern": "^\\d+\\.\\d+\\.\\d+$",
+        "title": "Schema Version",
+        "type": "string"
+      },
+      "timestamp": {
+        "description": "Producer-assigned wall-clock occurrence time (ISO-8601 UTC). Records when the modelled event actually happened on the producing system (CLI machine, runtime worker, tracker subsystem). Consumers MUST preserve this value through ingestion, persistence, projection, reduction, and serialization, and MUST NOT substitute receipt/import/server time for this field. Consumer receipt time, if persisted, MUST be stored under a distinct field (recommended: 'received_at'). Not used for ordering \u2014 Lamport clock and node_id own ordering.",
+        "format": "date-time",
+        "title": "Timestamp",
+        "type": "string"
+      }
+    },
+    "required": [
+      "event_id",
+      "event_type",
+      "aggregate_id",
+      "timestamp",
+      "build_id",
+      "node_id",
+      "lamport_clock",
+      "project_uuid",
+      "correlation_id"
+    ],
+    "title": "Event",
+    "type": "object"
+  },
+  "schema_title": "Event",
+  "version_source": "uv.lock"
+}

--- a/tests/contract/test_example_round_trip.py
+++ b/tests/contract/test_example_round_trip.py
@@ -518,11 +518,44 @@ def _discover_examples() -> list[tuple[str, str, str, str, str | None]]:
     return examples
 
 
+def _discover_skip_marked_blocks() -> frozenset[str]:
+    """Return the ``rel::block-N`` labels of every ``# round-trip: skip:`` block.
+
+    Restricted to NON-legacy contracts, where the skip marker is load-bearing
+    (legacy contracts keep file-level leniency and do not need markers). The set
+    is ratcheted in ``tests/architectural/_baselines.yaml`` so that adding a new
+    permanently-non-executable block is an explicit, reviewable event — a new
+    skip grows the count above its baseline and fails the ratchet until the
+    baseline is bumped with a justification. Unlike the legacy allowlist, skip
+    markers are permanent legitimate exemptions (no shrink mandate); the ratchet
+    exists purely for growth VISIBILITY, not burn-down.
+    """
+    labels: set[str] = set()
+    if not _KITTY_SPECS_ROOT.exists():
+        return frozenset(labels)
+    for contract_md in sorted(_KITTY_SPECS_ROOT.glob("*/contracts/*.md")):
+        if _is_legacy(contract_md):
+            continue
+        rel = _relative_path(contract_md)
+        blocks = _extract_yaml_blocks(contract_md.read_text(encoding="utf-8"))
+        for block_idx, block_body in enumerate(blocks, start=1):
+            kind, _ = _classify_yaml_block(block_body)
+            if kind == "skip":
+                labels.add(f"{rel}::block-{block_idx}")
+    return frozenset(labels)
+
+
 # ---------------------------------------------------------------------------
 # Collect parametrize cases at module-import time (pytest requires this)
 # ---------------------------------------------------------------------------
 _DISCOVERED: list[tuple[str, str, str, str, str | None]] = _discover_examples()
 _ALL_CASES: list[tuple[str, str, str, str, str | None]] = _DISCOVERED + _INLINE_NEGATIVE_FIXTURES
+
+# Ratcheted set of permanently-non-executable (``# round-trip: skip:``) blocks in
+# non-legacy contracts. Introspected by ``tests.architectural.test_ratchet_baselines``
+# against ``_baselines.yaml::test_example_round_trip.skip_marker_blocks`` so skip
+# growth is explicit (see ``_discover_skip_marked_blocks``).
+_SKIP_MARKED_BLOCKS: frozenset[str] = _discover_skip_marked_blocks()
 
 # ---------------------------------------------------------------------------
 # The parametrised gate (AC-10)
@@ -724,3 +757,26 @@ def test_legacy_collection_warns_and_does_not_fail_when_untagged() -> None:
         _collect_legacy_blocks("x/contracts/y.md", ["a: 1\n"], out)
     # Legacy files never emit a MISSING_FRONTMATTER failure case.
     assert out == []
+
+
+def test_skip_marked_blocks_invariants() -> None:
+    """The ratcheted skip set holds only non-legacy, genuinely skip-marked blocks.
+
+    Guards the two promises of ``_discover_skip_marked_blocks`` without pinning a
+    hardcoded count (the baseline in ``_baselines.yaml`` owns the count). It stays
+    green when a future PR legitimately adds a marker and bumps the baseline.
+    """
+    assert isinstance(_SKIP_MARKED_BLOCKS, frozenset)
+    for label in _SKIP_MARKED_BLOCKS:
+        rel, _, suffix = label.partition("::block-")
+        assert suffix, f"malformed skip label: {label!r}"
+        # Invariant 1: skip markers are only ratcheted for NON-legacy contracts.
+        assert rel not in _LEGACY_CONTRACT_ALLOWLIST, (
+            f"{rel} is legacy-allowlisted; its blocks must not be counted as skips"
+        )
+        # Invariant 2: the referenced block actually classifies as a skip.
+        block_idx = int(suffix)
+        blocks = _extract_yaml_blocks((_REPO_ROOT / rel).read_text(encoding="utf-8"))
+        kind, info = _classify_yaml_block(blocks[block_idx - 1])
+        assert kind == "skip"
+        assert info["reason"], f"skip marker in {label} must carry a reason"

--- a/tests/contract/test_example_round_trip.py
+++ b/tests/contract/test_example_round_trip.py
@@ -18,17 +18,34 @@ Optionally::
 
     # expect_message: <substring>   (only meaningful with ``expect: invalid``)
 
-Codeblocks without ``# pydantic_model:`` are silently skipped (they are
-documentation prose or shape sketches).
+Block-level discovery (non-legacy contracts)
+--------------------------------------------
+For a contract NOT in the legacy allowlist, discovery is **block-level**: EVERY
+parseable YAML codeblock must be either tagged with ``# pydantic_model:``
+frontmatter (executed against the model) OR carry an explicit non-executable
+marker::
+
+    # round-trip: skip: <reason>
+
+A block carrying neither is a gate failure for that specific block — a tagged
+sibling no longer masks a forgotten tag. The ``# round-trip: skip:`` marker is
+the explicit home for illustrations, shape sketches, CI-wiring snippets, and
+non-Pydantic operator config (e.g. a ``.kittify/config.yaml`` block whose
+resolver reads raw YAML rather than a Pydantic model). The reason is mandatory.
+This is a permanent, per-block exemption taxonomy — distinct from the legacy
+burn-down allowlist below.
 
 Legacy allowlist (FR-141)
 -------------------------
-Contracts from missions predating this convention are tracked in
-``_LEGACY_CONTRACT_ALLOWLIST``.  Files in the allowlist emit a
-``warnings.warn`` instead of failing when their YAML codeblocks lack
-frontmatter.  The allowlist count is pinned in
+Contracts from missions **predating** this convention are tracked file-level in
+``_LEGACY_CONTRACT_ALLOWLIST``.  Files in the allowlist emit a ``warnings.warn``
+instead of failing when their YAML codeblocks lack frontmatter, and keep
+file-level leniency (a tagged block does not force the rest to be tagged). The
+allowlist count is pinned in
 ``tests/architectural/_baselines.yaml::test_example_round_trip.legacy_contract_allowlist``
-so it can shrink over time as legacy contracts are backfilled.
+and MUST shrink over time as legacy contracts are backfilled (C-004 burn-down).
+Post-convention files that are simply non-executable belong in a
+``# round-trip: skip:`` marker, NOT this allowlist.
 
 ATDD anchors
 ------------
@@ -227,14 +244,11 @@ _LEGACY_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         "kitty-specs/wp-prompt-governance-payload-01KRR8HS/contracts/charter-context-resolver.md",
         "kitty-specs/wp-prompt-governance-payload-01KRR8HS/contracts/charter-sync-cross-link.md",
         "kitty-specs/wp-prompt-governance-payload-01KRR8HS/contracts/runtime-template-governance-payload-contract.md",
-        # CI-wiring YAML snippet (not a Pydantic model payload); added per T031 (#1301)
-        "kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md",
-        # `.kittify/config.yaml` ``protection:`` operator-config shape sketch
-        # (not a Pydantic model payload); the resolved artefact is the frozen
-        # ``ProtectionPolicy`` dataclass + ``protection_policy.resolve`` raw-YAML
-        # resolver, which fail-closes via ``ProtectionConfigError`` rather than
-        # ``model_validate`` — so the FR-140 round-trip does not apply. Added per #2255.
-        "kitty-specs/specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md",
+        # NOTE: post-Slice-F files that are simply non-executable (CI-wiring
+        # snippets, ``.kittify/config.yaml`` shape sketches, non-Pydantic config)
+        # do NOT belong here — they carry a per-block ``# round-trip: skip: <reason>``
+        # marker instead. This allowlist is *only* for pre-Slice-F legacy contracts
+        # that still need backfilling (C-004 burn-down). See #2255.
     }
 )
 
@@ -269,6 +283,21 @@ _FRONTMATTER_RE: re.Pattern[str] = re.compile(
 )
 _EXPECT_MESSAGE_RE: re.Pattern[str] = re.compile(
     r"^# expect_message: (?P<msg>.+)$", re.MULTILINE
+)
+
+# Explicit per-block "this YAML block is intentionally non-executable" marker.
+# In a NON-legacy contract every YAML codeblock must be either tagged with
+# ``# pydantic_model:`` frontmatter (executed against that model) OR carry this
+# marker with a mandatory reason. A block with neither fails the gate per-block
+# (FR-140 block-level discovery). The marker is the explicit home for shape
+# sketches, illustrations, CI-wiring snippets, and non-Pydantic operator config
+# — distinct from the legacy burn-down allowlist (which is file-level and
+# tracked in ``_baselines.yaml``). The reason is required: ``# round-trip: skip:``
+# with no text does not match and the block is treated as missing frontmatter.
+_SKIP_MARKER_RE: re.Pattern[str] = re.compile(
+    # ``[ \t]*`` (not ``\s*``) so the reason cannot run onto the next line and a
+    # bare ``# round-trip: skip:`` with no reason fails to match (forcing a reason).
+    r"^# round-trip: skip:[ \t]*(?P<reason>\S.*)$", re.MULTILINE
 )
 
 # Fenced yaml codeblock (triple backtick, NOT preceded on the same line by a
@@ -346,16 +375,126 @@ def _parse_expect_message(raw: str) -> str:
     return stripped
 
 
+def _classify_yaml_block(block_body: str) -> tuple[str, dict[str, Any]]:
+    """Classify a single YAML codeblock for the round-trip gate.
+
+    Returns ``(kind, info)`` where *kind* is one of:
+
+    * ``"execute"`` — the block carries ``# pydantic_model:`` frontmatter; *info*
+      holds ``model`` / ``expect`` / ``expect_message`` / ``payload``.
+    * ``"skip"`` — the block carries a ``# round-trip: skip: <reason>`` marker;
+      *info* holds ``reason``. The block is intentionally non-executable.
+    * ``"missing"`` — the block carries neither; *info* is empty. For a
+      non-legacy contract this is a gate failure (a forgotten tag).
+
+    Frontmatter takes precedence over a skip marker when both are present, so a
+    real example can never be silently disabled by a stray marker.
+    """
+    fm = _FRONTMATTER_RE.search(block_body)
+    if fm is not None:
+        msg_match = _EXPECT_MESSAGE_RE.search(block_body)
+        return "execute", {
+            "model": fm.group("model"),
+            "expect": fm.group("expect"),
+            "expect_message": (
+                _parse_expect_message(msg_match.group("msg")) if msg_match else None
+            ),
+            "payload": _strip_frontmatter_comments(block_body),
+        }
+    skip = _SKIP_MARKER_RE.search(block_body)
+    if skip is not None:
+        return "skip", {"reason": skip.group("reason").strip()}
+    return "missing", {}
+
+
+def _collect_legacy_blocks(
+    rel: str,
+    yaml_blocks: list[str],
+    examples: list[tuple[str, str, str, str, str | None]],
+) -> None:
+    """Collect executable cases from a legacy (pre-Slice-F) contract.
+
+    Legacy contracts keep file-level burn-down leniency: tagged blocks still
+    execute, but untagged blocks are tolerated. A warning fires only when the
+    file carries NO frontmatter at all, nudging backfill. Block-level strictness
+    is deferred until the file is backfilled out of ``_LEGACY_CONTRACT_ALLOWLIST``.
+    """
+    found_any_frontmatter = False
+    for block_idx, block_body in enumerate(yaml_blocks, start=1):
+        kind, info = _classify_yaml_block(block_body)
+        if kind != "execute":
+            continue
+        found_any_frontmatter = True
+        examples.append(
+            (
+                f"{rel}::block-{block_idx}",
+                info["model"],
+                info["expect"],
+                info["payload"],
+                info["expect_message"],
+            )
+        )
+    if not found_any_frontmatter:
+        warnings.warn(
+            f"Legacy contract '{rel}' has {len(yaml_blocks)} YAML codeblock(s) "
+            f"but none carry ``# pydantic_model:`` frontmatter. "
+            f"Consider backfilling the convention to shrink the legacy allowlist "
+            f"(tests/architectural/_baselines.yaml::test_example_round_trip"
+            f".legacy_contract_allowlist).",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def _collect_strict_blocks(
+    rel: str,
+    yaml_blocks: list[str],
+    examples: list[tuple[str, str, str, str, str | None]],
+) -> None:
+    """Collect cases from a non-legacy contract under block-level strictness (FR-140).
+
+    Every YAML block must be either tagged (executed against its model) or carry
+    an explicit ``# round-trip: skip: <reason>`` marker. A block with neither is
+    emitted as ``<MISSING_FRONTMATTER>`` so the parametrised gate fails on that
+    specific block — a tagged sibling can no longer mask a forgotten tag.
+    """
+    for block_idx, block_body in enumerate(yaml_blocks, start=1):
+        kind, info = _classify_yaml_block(block_body)
+        if kind == "execute":
+            examples.append(
+                (
+                    f"{rel}::block-{block_idx}",
+                    info["model"],
+                    info["expect"],
+                    info["payload"],
+                    info["expect_message"],
+                )
+            )
+        elif kind == "missing":
+            examples.append(
+                (
+                    f"{rel}::block-{block_idx}-MISSING_FRONTMATTER",
+                    "<MISSING_FRONTMATTER>",
+                    "valid",
+                    "{}",
+                    None,
+                )
+            )
+        # kind == "skip": intentionally non-executable; nothing to add.
+
+
 def _discover_examples() -> list[tuple[str, str, str, str, str | None]]:
-    """Walk every ``kitty-specs/*/contracts/*.md`` and yield tagged examples.
+    """Walk every ``kitty-specs/*/contracts/*.md`` and yield round-trip cases.
 
     Yields tuples of:
         (contract_label, model_dotted_path, expect, yaml_payload, expect_message_or_None)
 
-    Codeblocks without ``# pydantic_model:`` are silently skipped.
-    Legacy contracts with YAML codeblocks but no frontmatter emit a warning.
-    Non-legacy contracts with YAML codeblocks but no frontmatter -> included
-    with model_path="<MISSING_FRONTMATTER>" so the parametrised test fails.
+    Discovery is **block-level** for non-legacy contracts: each YAML block must
+    be tagged with ``# pydantic_model:`` frontmatter (executed) or carry a
+    ``# round-trip: skip: <reason>`` marker (intentionally non-executable);
+    otherwise the block is emitted as ``<MISSING_FRONTMATTER>`` and the gate
+    fails on it. Legacy contracts (``_LEGACY_CONTRACT_ALLOWLIST``) keep
+    file-level burn-down leniency and warn instead of failing.
     """
     examples: list[tuple[str, str, str, str, str | None]] = []
 
@@ -365,54 +504,16 @@ def _discover_examples() -> list[tuple[str, str, str, str, str | None]]:
     for contract_md in sorted(_KITTY_SPECS_ROOT.glob("*/contracts/*.md")):
         text = contract_md.read_text(encoding="utf-8")
         rel = _relative_path(contract_md)
-        is_legacy = _is_legacy(contract_md)
 
         yaml_blocks = _extract_yaml_blocks(text)
         if not yaml_blocks:
             # No YAML codeblocks at all — just a prose contract. Skip quietly.
             continue
 
-        found_any_frontmatter = False
-        for block_idx, block_body in enumerate(yaml_blocks, start=1):
-            fm = _FRONTMATTER_RE.search(block_body)
-            if fm is None:
-                continue
-            found_any_frontmatter = True
-            model_path = fm.group("model")
-            expect = fm.group("expect")
-            msg_match = _EXPECT_MESSAGE_RE.search(block_body)
-            expect_message: str | None = (
-                _parse_expect_message(msg_match.group("msg")) if msg_match else None
-            )
-
-            payload = _strip_frontmatter_comments(block_body)
-
-            label = f"{rel}::block-{block_idx}"
-            examples.append((label, model_path, expect, payload, expect_message))
-
-        # Warn if a legacy contract has YAML blocks but none had frontmatter.
-        if not found_any_frontmatter and is_legacy:
-            warnings.warn(
-                f"Legacy contract '{rel}' has {len(yaml_blocks)} YAML codeblock(s) "
-                f"but none carry ``# pydantic_model:`` frontmatter. "
-                f"Consider backfilling the convention to shrink the legacy allowlist "
-                f"(tests/architectural/_baselines.yaml::test_example_round_trip"
-                f".legacy_contract_allowlist).",
-                UserWarning,
-                stacklevel=2,
-            )
-        elif not found_any_frontmatter and not is_legacy:
-            # Non-legacy contract with YAML blocks but no frontmatter -> gate failure.
-            label = f"{rel}::block-MISSING_FRONTMATTER"
-            examples.append(
-                (
-                    label,
-                    "<MISSING_FRONTMATTER>",
-                    "valid",
-                    "{}",
-                    None,
-                )
-            )
+        if _is_legacy(contract_md):
+            _collect_legacy_blocks(rel, yaml_blocks, examples)
+        else:
+            _collect_strict_blocks(rel, yaml_blocks, examples)
 
     return examples
 
@@ -450,13 +551,16 @@ def test_contract_example_round_trip(
     ``kitty-specs/slice-f-multi-context-extensibility-01KRX5C8/contracts/
     contract-round-trip-frontmatter.md``.
     """
-    # --- Guard: missing frontmatter on a non-legacy contract ---
+    # --- Guard: a non-legacy YAML block carries neither frontmatter nor a skip marker ---
     if model_path == "<MISSING_FRONTMATTER>":
         pytest.fail(
-            f"Contract '{contract_label}' has YAML codeblock(s) but none carry "
-            f"``# pydantic_model:`` frontmatter. Add frontmatter per the Slice F "
-            f"convention OR move the file to ``_LEGACY_CONTRACT_ALLOWLIST`` in "
-            f"``tests/contract/test_example_round_trip.py`` and update "
+            f"Contract block '{contract_label}' carries neither "
+            f"``# pydantic_model:`` frontmatter nor a ``# round-trip: skip: <reason>`` "
+            f"marker. Pick one: (1) add frontmatter to round-trip the block against "
+            f"a Pydantic model; (2) add ``# round-trip: skip: <reason>`` if the block "
+            f"is an illustration / shape sketch / non-Pydantic config or CI snippet; "
+            f"or (3) for a pre-Slice-F file, add it to ``_LEGACY_CONTRACT_ALLOWLIST`` "
+            f"in ``tests/contract/test_example_round_trip.py`` and bump "
             f"``tests/architectural/_baselines.yaml``."
         )
 
@@ -523,3 +627,100 @@ def test_contract_example_round_trip(
                 f"but the ValidationError text does not contain it.\n"
                 f"Actual error:\n{error_text}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Unit coverage for block-level discovery (FR-140 block-level + skip marker, #2255)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_block_executes_on_frontmatter() -> None:
+    kind, info = _classify_yaml_block(
+        "# pydantic_model: a.b.C\n# expect: invalid\n"
+        "# expect_message: boom\nkey: value\n"
+    )
+    assert kind == "execute"
+    assert info["model"] == "a.b.C"
+    assert info["expect"] == "invalid"
+    assert info["expect_message"] == "boom"
+    # Frontmatter comment lines are stripped from the executable payload.
+    assert info["payload"] == "key: value\n"
+
+
+def test_classify_block_skips_on_marker_with_reason() -> None:
+    kind, info = _classify_yaml_block(
+        "# round-trip: skip: illustration only\nkey: value\n"
+    )
+    assert kind == "skip"
+    assert info["reason"] == "illustration only"
+
+
+def test_classify_block_missing_when_neither_present() -> None:
+    kind, info = _classify_yaml_block("key: value\nother: 1\n")
+    assert kind == "missing"
+    assert info == {}
+
+
+def test_classify_block_skip_marker_requires_a_reason() -> None:
+    # An empty reason must NOT count as a skip — the block falls through to
+    # ``missing`` so the gate forces an explicit rationale.
+    kind, _ = _classify_yaml_block("# round-trip: skip:\nkey: value\n")
+    assert kind == "missing"
+
+
+def test_classify_block_frontmatter_wins_over_skip_marker() -> None:
+    # A real example can never be silently disabled by a stray skip marker.
+    kind, info = _classify_yaml_block(
+        "# pydantic_model: a.b.C\n# expect: valid\n# round-trip: skip: nope\nk: v\n"
+    )
+    assert kind == "execute"
+    assert info["model"] == "a.b.C"
+
+
+def test_strict_collection_fails_untagged_block_per_block() -> None:
+    out: list[tuple[str, str, str, str, str | None]] = []
+    _collect_strict_blocks("x/contracts/y.md", ["a: 1\n", "b: 2\n"], out)
+    # Both untagged blocks fail, each labelled with its own block index.
+    assert [c[1] for c in out] == ["<MISSING_FRONTMATTER>", "<MISSING_FRONTMATTER>"]
+    assert out[0][0] == "x/contracts/y.md::block-1-MISSING_FRONTMATTER"
+    assert out[1][0] == "x/contracts/y.md::block-2-MISSING_FRONTMATTER"
+
+
+def test_strict_collection_skips_marked_block() -> None:
+    out: list[tuple[str, str, str, str, str | None]] = []
+    _collect_strict_blocks(
+        "x/contracts/y.md", ["# round-trip: skip: shape sketch\na: 1\n"], out
+    )
+    assert out == []
+
+
+def test_strict_collection_executes_tagged_block() -> None:
+    out: list[tuple[str, str, str, str, str | None]] = []
+    _collect_strict_blocks(
+        "x/contracts/y.md", ["# pydantic_model: a.b.C\n# expect: valid\nk: v\n"], out
+    )
+    assert len(out) == 1
+    assert out[0][0] == "x/contracts/y.md::block-1"
+    assert out[0][1] == "a.b.C"
+
+
+def test_strict_collection_tagged_sibling_does_not_mask_untagged() -> None:
+    # The core P1 regression (#2255): a tagged block in the same file must NOT
+    # absorb an untagged sibling. The untagged block still fails.
+    out: list[tuple[str, str, str, str, str | None]] = []
+    _collect_strict_blocks(
+        "x/contracts/y.md",
+        ["# pydantic_model: a.b.C\n# expect: valid\nk: v\n", "untagged: true\n"],
+        out,
+    )
+    kinds = {c[1] for c in out}
+    assert "<MISSING_FRONTMATTER>" in kinds
+    assert "a.b.C" in kinds
+
+
+def test_legacy_collection_warns_and_does_not_fail_when_untagged() -> None:
+    out: list[tuple[str, str, str, str, str | None]] = []
+    with pytest.warns(UserWarning, match="Legacy contract"):
+        _collect_legacy_blocks("x/contracts/y.md", ["a: 1\n"], out)
+    # Legacy files never emit a MISSING_FRONTMATTER failure case.
+    assert out == []

--- a/tests/contract/test_example_round_trip.py
+++ b/tests/contract/test_example_round_trip.py
@@ -229,6 +229,12 @@ _LEGACY_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         "kitty-specs/wp-prompt-governance-payload-01KRR8HS/contracts/runtime-template-governance-payload-contract.md",
         # CI-wiring YAML snippet (not a Pydantic model payload); added per T031 (#1301)
         "kitty-specs/spec-kitty-3-2-docs-01KS4KSZ/contracts/check_docs_freshness.md",
+        # `.kittify/config.yaml` ``protection:`` operator-config shape sketch
+        # (not a Pydantic model payload); the resolved artefact is the frozen
+        # ``ProtectionPolicy`` dataclass + ``protection_policy.resolve`` raw-YAML
+        # resolver, which fail-closes via ``ProtectionConfigError`` rather than
+        # ``model_validate`` — so the FR-140 round-trip does not apply. Added per #2255.
+        "kitty-specs/specify-protected-primary-coherence-01KVMBD6/contracts/protection-config.md",
     }
 )
 


### PR DESCRIPTION
## Summary

Closes #2255. `tests/contract/` was red on `main` for two repo-level reasons unrelated to any PR under test, so the contract CI gate showed red on every open PR. This makes the gate green and hardens the round-trip discovery contract.

### 1. Missing `spec-kitty-events-6.1.0` envelope snapshot — 3 failures (primary)
The repo resolves `spec-kitty-events==6.1.0` (uv.lock), but `tests/contract/snapshots/` only carried through `6.0.0`. Regenerated `tests/contract/snapshots/spec-kitty-events-6.1.0.json` with the **canonical generator** (`scripts/snapshot_events_envelope.py --force`) — not hand-authored. The `6.0.0`→`6.1.0` envelope field/required sets are **identical** (verified), so no envelope drift is masked.

Fixes the 3 `test_events_envelope_matches_resolved_version` failures.

### 2. Two missions' contract files missing round-trip frontmatter — 2 failures (secondary)
Both missions (`01KV…`) **postdate** the Slice F frontmatter convention (`01KRX5C8`), so they are genuine convention violations (not legacy):

- **`config-schema-delta.md`** → added `# pydantic_model:` frontmatter binding the example to the real `OrgPackConfig` model, with a `valid` case (the new `subdir` field) and an `invalid` case (the documented `..`-escape rejection).
- **`protection-config.md`** → it is an operator-config shape sketch with **no Pydantic payload model** (frozen `ProtectionPolicy` dataclass + raw-YAML `protection_policy.resolve`). It carries a per-block `# round-trip: skip: <reason>` marker (see below).

### 3. Hardened discovery contract (addresses PR review P1 + P2)
Review found the gate's frontmatter detection was **file-level**: one tagged block made the walker silently skip every untagged sibling, so a forgotten tag was invisible (a blast-radius probe showed it affected the Slice F convention's own contracts too).

- **Block-level discovery** for non-legacy contracts: every YAML block must carry `# pydantic_model:` frontmatter (executed) **or** an explicit `# round-trip: skip: <reason>` marker (reason mandatory). A block with neither fails the gate on that specific block.
- **Explicit exemption taxonomy:** the `# round-trip: skip:` marker is the permanent home for illustrations / shape sketches / CI-wiring snippets / non-Pydantic config. `_LEGACY_CONTRACT_ALLOWLIST` is now **only** pre-Slice-F legacy debt (burn-down). `protection-config.md` and the conflated, pre-existing `check_docs_freshness.md` leave the allowlist (**152 → 151**, a burn-down shrink) for skip markers.
- New unit tests cover the classifier and both collectors, including the `tagged-sibling-does-not-mask-untagged` regression.

## Verification
- 5 originally-failing contract tests pass; round-trip gate + ratchet (`allowlist 151 == baseline 151`) + envelope + 10 new unit tests all green.
- `ruff` ✅, `mypy` ✅, terminology guard ✅ on touched files.

## Pre-existing, out-of-scope failure (reported per the Pre-existing Failure Reporting Rule)
`tests/contract/test_charter_compact_includes_section_anchors.py::…[minimal.md|multidirective.md]` fail **only under the `-n auto` parallel run** and **pass in isolation/serially**. Proven pre-existing on clean `main` (changes stashed). A parallel test-isolation flake unrelated to this PR — not fixed here to preserve change locality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)