### PR TITLE
fix: clean up stale lint suppressions

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -2077,7 +2077,7 @@ def _count_legacy_body_uploads_for_mission(mission_slug: str | None) -> int:
         conn.close()
 
 
-def _build_boundary_check_failures(  # noqa: C901
+def _build_boundary_check_failures(
     *,
     failure_set: Any = None,
     daemon_mismatched_fields: list[str] | None = None,
@@ -2302,7 +2302,7 @@ def _emit_status_check_json() -> None:
     # the singleton fails ``--check`` even when on-disk state is clean.
     try:
         live_orphan_report = scan_sync_daemons()
-    except Exception:  # noqa: BLE001
+    except Exception:
         live_orphan_report = None
     live_orphan_count = (
         int(live_orphan_report.orphan_count) if live_orphan_report is not None else 0
@@ -2321,7 +2321,7 @@ def _emit_status_check_json() -> None:
     active_event_count = 0
     try:
         active_event_count = int(queue.size())
-    except Exception:  # noqa: BLE001
+    except Exception:
         active_event_count = 0
     active_body_count = 0
     try:
@@ -2338,7 +2338,7 @@ def _emit_status_check_json() -> None:
             )
         finally:
             _conn.close()
-    except Exception:  # noqa: BLE001
+    except Exception:
         active_body_count = 0
 
     ok = (
@@ -2595,7 +2595,7 @@ def status(  # noqa: C901
         # having to grep ``ps`` themselves.
         try:
             orphan_report = scan_sync_daemons()
-        except Exception:  # noqa: BLE001
+        except Exception:
             orphan_report = None
         if orphan_report is not None:
             if orphan_report.orphan_count == 0:
@@ -2703,7 +2703,7 @@ def status(  # noqa: C901
         finally:
             _conn.close()
     # Read-only diagnostic: never let status rendering fail on queue inspection.
-    except Exception:  # noqa: BLE001
+    except Exception:
         body_queue_count = 0
 
     # Legacy body-upload count (read-only).
@@ -3221,7 +3221,7 @@ def doctor() -> None:  # noqa: C901
 
     try:
         singleton_report = scan_sync_daemons()
-    except Exception:  # noqa: BLE001
+    except Exception:
         singleton_report = None
 
     if singleton_report is not None:

--- a/src/specify_cli/compat/_adapters/uv_receipt.py
+++ b/src/specify_cli/compat/_adapters/uv_receipt.py
@@ -110,7 +110,7 @@ def _receipt_path_for_executable(executable: str) -> Path | None:
 def _default_uv_tool_dir() -> Path:
     """Return the default uv tool directory for the current platform."""
     try:
-        from platformdirs import user_data_dir  # type: ignore[import-not-found]
+        from platformdirs import user_data_dir
 
         return Path(user_data_dir("uv")) / "tools"
     except ImportError:
@@ -122,7 +122,7 @@ def _default_uv_tool_dir() -> Path:
 def _default_uv_bin_dir() -> Path:
     """Return the default uv tool bin directory for the current platform."""
     try:
-        from platformdirs import user_data_dir  # noqa: PLC0415  (same import, ignore comment omitted)
+        from platformdirs import user_data_dir
 
         return Path(user_data_dir("uv")) / "bin"
     except ImportError:
@@ -243,7 +243,7 @@ class UvReceiptReader:
         Never raises (NFR-003 / CHK032). Returns a result with all fields
         None/empty on any error.
         """
-        try:  # noqa: BLE001
+        try:
             receipt_path = _receipt_path_for_executable(executable)
             if receipt_path is None:
                 return _empty_result()
@@ -251,7 +251,7 @@ class UvReceiptReader:
             try:
                 content = receipt_path.read_text(encoding="utf-8")
                 receipt = tomllib.loads(content)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 return _empty_result()
 
             if not isinstance(receipt, dict):
@@ -264,7 +264,7 @@ class UvReceiptReader:
             default_tool_dir = _default_uv_tool_dir()
             try:
                 is_default_tool_dir: bool | None = tool_dir.resolve() == default_tool_dir.resolve()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 is_default_tool_dir = tool_dir == default_tool_dir
 
             bin_dir = _parse_bin_dir(receipt)
@@ -272,7 +272,7 @@ class UvReceiptReader:
                 default_bin_dir = _default_uv_bin_dir()
                 try:
                     is_default_bin_dir: bool | None = bin_dir.resolve() == default_bin_dir.resolve()
-                except Exception:  # noqa: BLE001
+                except Exception:
                     is_default_bin_dir = bin_dir == default_bin_dir
             else:
                 is_default_bin_dir = None
@@ -297,7 +297,7 @@ class UvReceiptReader:
                 requirements=requirements,
                 package_source=package_source,
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             return _empty_result()
 
     @staticmethod
@@ -307,7 +307,7 @@ class UvReceiptReader:
         Used by the detect_runtime() detection chain as a light probe
         (does not parse the full receipt). Never raises (CHK032).
         """
-        try:  # noqa: BLE001
+        try:
             executable_parent = exe_path.parent
             if executable_parent.name.lower() not in {"bin", "scripts"}:
                 return False
@@ -324,5 +324,5 @@ class UvReceiptReader:
                     if isinstance(req, dict) and req.get("name") == _PACKAGE_NAME:
                         return True
             return False
-        except Exception:  # noqa: BLE001
+        except Exception:
             return False

--- a/src/specify_cli/compat/history.py
+++ b/src/specify_cli/compat/history.py
@@ -126,7 +126,7 @@ def default_history_db_path() -> Path:
         return Path(env_override)
 
     try:
-        from platformdirs import user_cache_dir  # type: ignore[import-not-found]
+        from platformdirs import user_cache_dir
 
         return Path(user_cache_dir("spec-kitty")) / "upgrade-history.db"
     except ImportError:
@@ -196,7 +196,7 @@ class UpgradeAttemptStore:
         Uses INSERT OR IGNORE — duplicate ``attempt_id`` is a silent no-op.
         Runs retention trim after each successful write (both in one transaction).
         """
-        try:  # noqa: BLE001
+        try:
             ts = record.timestamp
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=UTC)
@@ -224,7 +224,7 @@ class UpgradeAttemptStore:
                     ),
                 )
                 conn.execute(_RETENTION_SQL, (install_method_str, install_method_str))
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
     def is_idempotent(self, attempt: UpgradeAttemptRecord) -> bool:
@@ -237,7 +237,7 @@ class UpgradeAttemptStore:
         """
         if attempt.target_version is None:
             return False
-        try:  # noqa: BLE001
+        try:
             with contextlib.closing(self._connect()) as conn:
                 cursor = conn.execute(
                     """\
@@ -251,7 +251,7 @@ class UpgradeAttemptStore:
                 )
                 row = cursor.fetchone()
             return row is not None
-        except Exception:  # noqa: BLE001
+        except Exception:
             return False
 
     def consecutive_failure_count(
@@ -268,7 +268,7 @@ class UpgradeAttemptStore:
         for ``install_method`` within ``window_seconds`` of now, counting from the
         tail until the first non-failure record (contracts/history-store-query.md).
         """
-        try:  # noqa: BLE001
+        try:
             import time
 
             cutoff = time.time() - window_seconds
@@ -292,7 +292,7 @@ class UpgradeAttemptStore:
                 else:
                     break
             return count
-        except Exception:  # noqa: BLE001
+        except Exception:
             return 0
 
     def last_success_timestamp(
@@ -303,7 +303,7 @@ class UpgradeAttemptStore:
 
         Fail-open: returns None on any store error.
         """
-        try:  # noqa: BLE001
+        try:
             with contextlib.closing(self._connect()) as conn:
                 cursor = conn.execute(
                     """\
@@ -323,5 +323,5 @@ class UpgradeAttemptStore:
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=UTC)
             return dt.astimezone(UTC)
-        except Exception:  # noqa: BLE001
+        except Exception:
             return None

--- a/src/specify_cli/readiness/upgrade_ux.py
+++ b/src/specify_cli/readiness/upgrade_ux.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess  # noqa: S404 — required to invoke the existing `spec-kitty upgrade` binary
+import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -240,7 +240,7 @@ def _derive_confidence(exit_code: int | None, entrypoint_match: bool) -> Verific
     - MEDIUM: exit_code == 0 AND entrypoint_match == False
     - LOW:    exit_code != 0
     """
-    from specify_cli.compat.install_events import VerificationConfidence as _VC  # noqa: PLC0415
+    from specify_cli.compat.install_events import VerificationConfidence as _VC
 
     if exit_code == 0 and entrypoint_match:
         return _VC.HIGH
@@ -264,7 +264,7 @@ def _emit_install_verified_event(event: UvToolInstallationVerified) -> None:
 
     NFR-007: swallows all errors; never logs or transmits receipt_path.
     """
-    import contextlib  # noqa: PLC0415
+    import contextlib
 
     with contextlib.suppress(Exception):
         _emitted_install_events.append(event)
@@ -282,9 +282,9 @@ def _append_upgrade_attempt_record(
     target_version: str | None,
 ) -> None:
     """Best-effort append to UpgradeAttemptStore.  Swallows all errors (NFR-008)."""
-    try:  # noqa: BLE001
-        import ulid  # type: ignore[import-not-found]  # python-ulid has no stubs  # noqa: PLC0415
-        from specify_cli.compat.history import (  # noqa: PLC0415
+    try:
+        import ulid
+        from specify_cli.compat.history import (
             UpgradeAttemptOutcome,
             UpgradeAttemptRecord,
             UpgradeAttemptStore,
@@ -305,7 +305,7 @@ def _append_upgrade_attempt_record(
             target_version=target_version,
         )
         UpgradeAttemptStore().append(record)
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
 
 
@@ -339,7 +339,7 @@ def _default_upgrade_runner(
     - UV_TOOL installs: emits ``UvToolInstallationVerified`` event (FR-014).
     - All install methods: appends ``UpgradeAttemptRecord`` to history store (FR-012).
     """
-    from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
+    from specify_cli.compat._detect.install_method import InstallMethod
 
     if cmd.argv is None:
         return subprocess.CompletedProcess(args=[], returncode=1)
@@ -348,7 +348,7 @@ def _default_upgrade_runner(
     merged_env: dict[str, str] | None = {**os.environ, **cmd.env} if cmd.env else None
 
     try:
-        completed: subprocess.CompletedProcess[bytes] = subprocess.run(  # noqa: S603,S607 — fixed argv; PATH lookup is intentional
+        completed: subprocess.CompletedProcess[bytes] = subprocess.run(
             argv,
             check=False,
             env=merged_env,
@@ -359,9 +359,9 @@ def _default_upgrade_runner(
 
     # T025: Emit UvToolInstallationVerified (UV_TOOL only, best-effort, NFR-007)
     if runtime.install_method == InstallMethod.UV_TOOL:
-        try:  # noqa: BLE001
-            from specify_cli.compat._adapters.uv_receipt import UvReceiptReader  # noqa: PLC0415
-            from specify_cli.compat.install_events import UvToolInstallationVerified  # noqa: PLC0415
+        try:
+            from specify_cli.compat._adapters.uv_receipt import UvReceiptReader
+            from specify_cli.compat.install_events import UvToolInstallationVerified
 
             post_receipt = UvReceiptReader.read_for_executable(sys.executable)
             entrypoint_match = _check_entrypoint_present(post_receipt)
@@ -373,7 +373,7 @@ def _default_upgrade_runner(
                 confidence=confidence,
             )
             _emit_install_verified_event(event)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
     # T026: Append UpgradeAttemptRecord (all install methods, best-effort)
@@ -454,7 +454,7 @@ def _default_prompt() -> UpgradeChoice:
     response as "Upgrade now".
     """
     # Local imports to keep module-load cost low.
-    from rich.console import Console  # noqa: PLC0415
+    from rich.console import Console
 
     out = Console(stderr=True)
     out.print()
@@ -479,7 +479,7 @@ def _default_prompt() -> UpgradeChoice:
 
 def _print_unsafe_installer_guidance(method_name: str) -> None:
     """Emit guidance for installers that are not auto-upgrade-safe."""
-    from rich.console import Console  # noqa: PLC0415
+    from rich.console import Console
 
     out = Console(stderr=True)
     out.print(
@@ -572,11 +572,11 @@ def _run_auto_upgrade_if_safe(
 ) -> tuple[bool, int | None, bool]:
     if safe:
         if upgrade_runner is None:
-            from dataclasses import replace as _replace  # noqa: PLC0415
+            from dataclasses import replace as _replace
 
-            from specify_cli.compat._detect.install_method import InstallMethod  # noqa: PLC0415
-            from specify_cli.compat._detect.runtime import detect_runtime as _detect_runtime  # noqa: PLC0415
-            from specify_cli.compat.remediation import RemediationIntent, plan_remediation  # noqa: PLC0415
+            from specify_cli.compat._detect.install_method import InstallMethod
+            from specify_cli.compat._detect.runtime import detect_runtime as _detect_runtime
+            from specify_cli.compat.remediation import RemediationIntent, plan_remediation
 
             raw_runtime = _detect_runtime()
             # Override install_method with what installer_detector() returned —
@@ -651,7 +651,7 @@ def _handle_prompt_choice(
     )
 
 
-def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrator with many short-circuit branches
+def run_upgrade_ux(
     ctx: typer.Context | None,
     *,
     suppressed: bool,
@@ -697,17 +697,17 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
         prompt = _default_prompt
     try:
         # Deferred imports.
-        from specify_cli.compat import (  # noqa: PLC0415
+        from specify_cli.compat import (
             Decision,
             Invocation,
             NagCache,
         )
-        from specify_cli.compat import plan as compat_plan  # noqa: PLC0415
-        from specify_cli.compat._detect.install_method import (  # noqa: PLC0415
+        from specify_cli.compat import plan as compat_plan
+        from specify_cli.compat._detect.install_method import (
             InstallMethod,
             is_safe_for_auto_upgrade,
         )
-        from specify_cli.compat._detect.runtime import detect_runtime  # noqa: PLC0415
+        from specify_cli.compat._detect.runtime import detect_runtime
 
         if installer_detector is None:
             def _default_installer_detector() -> object:
@@ -785,7 +785,7 @@ def run_upgrade_ux(  # noqa: C901,PLR0911,PLR0912,PLR0913,PLR0915 — orchestrat
             method=method,
             upgrade_runner=upgrade_runner,
         )
-    except Exception:  # noqa: BLE001 — UX path must never raise out of the CLI.
+    except Exception:
         return _inactive_outcome()
 
 
@@ -795,7 +795,7 @@ def _persist(cache: _NagCacheLike, kwargs: dict[str, object]) -> None:
     Swallows any exception — cache mutation failure must not block the CLI.
     """
     try:
-        from specify_cli.compat import NagCacheRecord  # noqa: PLC0415
+        from specify_cli.compat import NagCacheRecord
 
         cli_version_key = kwargs["cli_version_key"]
         latest_source = kwargs["latest_source"]
@@ -830,7 +830,7 @@ def _persist(cache: _NagCacheLike, kwargs: dict[str, object]) -> None:
             never_ask=bool(kwargs.get("never_ask", False)),
         )
         cache.write(record)
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
 
 

--- a/src/specify_cli/saas/readiness.py
+++ b/src/specify_cli/saas/readiness.py
@@ -126,7 +126,7 @@ def _probe_rollout() -> bool:
 
     try:
         return bool(is_saas_sync_enabled())
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 
@@ -146,7 +146,7 @@ def _probe_auth(repo_root: Path) -> bool:
         from specify_cli.auth import get_token_manager  # local import — auth may not be in path
 
         return bool(get_token_manager().is_authenticated)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 
@@ -188,7 +188,7 @@ def _probe_host_config() -> str | None:
         from specify_cli.sync.target_authority import resolve_sync_target
 
         return str(resolve_sync_target().resolved_server_url)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return None
 
 
@@ -201,9 +201,9 @@ def _probe_reachability(server_url: str, timeout_s: float = 2.0) -> bool:
     """
     try:
         req = urllib.request.Request(server_url, method="HEAD")
-        with urllib.request.urlopen(req, timeout=timeout_s):  # noqa: S310  # nosec B310
+        with urllib.request.urlopen(req, timeout=timeout_s):  # nosec B310
             return True
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 
@@ -219,7 +219,7 @@ def _probe_mission_binding(repo_root: Path) -> bool:
 
         config = load_tracker_config(repo_root)
         return bool(config.is_configured)
-    except Exception:  # noqa: BLE001
+    except Exception:
         return False
 
 
@@ -295,7 +295,7 @@ def evaluate_readiness(
         # All applicable checks passed.
         return _build_result(ReadinessState.READY)
 
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         return ReadinessResult(
             state=ReadinessState.HOST_UNREACHABLE,
             message=_WORDING[ReadinessState.HOST_UNREACHABLE][0],

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -856,7 +856,7 @@ class EventEmitter:
                 get_token_manager(),
                 endpoint="/api/v1/events/batch/",
             )
-        except Exception as exc:  # noqa: BLE001 — explicit "log and skip" boundary
+        except Exception as exc:
             import logging
 
             logging.getLogger(__name__).warning("emitter._get_team_slug: ingress resolver raised: %s", exc)
@@ -1638,7 +1638,7 @@ class EventEmitter:
                 event_type,
                 self._enrich_proof_subject(payload),
             )
-        except Exception as exc:  # noqa: BLE001 - producer contract preserves None-on-invalid
+        except Exception as exc:
             _console.print(f"[yellow]Warning: {event_type} payload validation failed: {exc}[/yellow]")
             return None
 

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -423,7 +423,7 @@ def _read_scope_identity_local_only() -> tuple[str, str] | None:
     try:
         token_manager = get_token_manager()
         session = token_manager.get_current_session()
-    except Exception:  # noqa: BLE001 — never fail preflight on auth storage errors
+    except Exception:
         session = None
 
     if session is not None and session.email:
@@ -650,7 +650,7 @@ def _count_legacy_rows_for_scope(
     try:
         counts = detect_legacy_rows_for_scope(scope)
     # Defensive: never block preflight on a legacy-row query error.
-    except Exception:  # noqa: BLE001
+    except Exception:
         return (0, 0)
 
     # Preferred path: the structured ``LegacyRowCounts`` exposes the

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -487,7 +487,7 @@ def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None
     try:
         from specify_cli.auth import get_token_manager
         from specify_cli.auth.session import require_private_team_id
-    except Exception as exc:  # noqa: BLE001 — explicit "log and skip" boundary
+    except Exception as exc:
         import logging
 
         logging.getLogger(__name__).warning(

--- a/src/specify_cli/sync/runtime.py
+++ b/src/specify_cli/sync/runtime.py
@@ -242,7 +242,7 @@ class SyncRuntime:
             from .config import SyncConfig
 
             return SyncConfig().resolve_runtime_target()
-        except Exception as exc:  # noqa: BLE001 — never fail runtime on resolution
+        except Exception as exc:
             logger.debug("Could not resolve canonical sync target: %s", exc)
             return None
 

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -307,8 +307,8 @@ _CATEGORY_B_GRANDFATHERED_LEGACY: frozenset[str] = frozenset(
         "specify_cli.scripts.tasks.acceptance_support::perform_acceptance",
         # ``task_helpers`` is a script-style sibling of ``acceptance_support``:
         # its sole runtime caller (``scripts/tasks/tasks_cli.py``) imports it via
-        # a bare ``from task_helpers import ...`` (sys.path-relative, ``# noqa:
-        # E402``), which the qualified-import AST scanner cannot resolve — the
+        # a bare ``from task_helpers import ...`` (sys.path-relative E402
+        # suppression), which the qualified-import AST scanner cannot resolve — the
         # same blind-spot already grandfathered for ``acceptance_support`` above.
         # Pre-existing on upstream/main (predates this mission; ``task_helpers``
         # ``__all__`` and this gate were both byte-identical at the merge base).


### PR DESCRIPTION
Follow-up to #2131.\n\nThis is intentionally lint-only:\n- remove stale Ruff noqa/type-ignore suppressions surfaced in #2131-adjacent files\n- rewrite one prose comment that Ruff parsed as an invalid noqa directive\n- no behavior changes\n\nVerification:\n- .venv/bin/ruff check . --output-format=concise\n- git diff --name-only -- '*.py' | xargs .venv/bin/ruff check --extend-select RUF100 --output-format=concise\n- .venv/bin/ruff check src tests --select TID251 --output-format=concise\n- .venv/bin/python -m mypy --strict src/specify_cli src/charter src/doctrine\n- .venv/bin/python scripts/generate_contextive_glossaries.py check\n- .venv/bin/python scripts/check_patch_targets.py\n- .venv/bin/python -m pytest tests/agent/test_json_group_typer_surface.py -q\n- npx --yes @commitlint/cli@19.8.1 --config commitlint.config.cjs --from HEAD~1 --to HEAD --verbose