### PR TITLE
fix(#2280): commit auto-captured retrospective + event-log append at close/merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **`mission close` / `spec-kitty merge` now commit the retrospective they
+  auto-generate, instead of leaving the durable event log dirty.** Closing a
+  mission that was merged via the legacy plain-git/GitHub path (so merge-time
+  teardown never ran) auto-captured `retrospective.yaml` and appended a
+  `RetrospectiveCaptured` event to `status.events.jsonl`, but left both
+  uncommitted with no notice — violating the atomic-event-log discipline
+  (FR-016), since an uncommitted append can be lost. The shared post-merge
+  retrospective postcondition now commits the captured record + its event-log
+  append via the merge-bookkeeping commit path, so `merge` and `mission close`
+  behave identically and the working tree is left clean. If the commit cannot be
+  made (detached HEAD / not a worktree), it fails open but reports the
+  uncommitted artifacts and the exact command to commit them. `mission close
+  --help` no longer describes the non-`--discard` path as a pure "no-op".
 - **`map-requirements` now explains *why* a WP `requirement_refs` entry is stale
   instead of looking like data corruption (#2066).** When the stale/invalid-refs
   gate trips, the `--json` payload (and console output) now surface the FR-ID set

--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -525,10 +525,14 @@ def close_cmd(
 ) -> None:
     """Close a mission. Wraps FR-016 lifecycle teardown.
 
-    Without ``--discard``: tear down the coordination worktree only.
-    This is a safe no-op after a successful ``spec-kitty merge`` (the
-    merge command already runs the same teardown); useful when the
-    teardown was skipped (e.g. legacy merge path) or interrupted.
+    Without ``--discard``: run the merge-completion teardown — persist the
+    mission retrospective to its durable home and tear down the coordination
+    worktree. Idempotent after a successful ``spec-kitty merge`` (which already
+    ran the same teardown); useful when the teardown was skipped (e.g. the legacy
+    plain-git/GitHub merge path) or interrupted. NOTE: on a mission that was
+    merged without a retrospective, this generates one
+    (``kitty-specs/<slug>/retrospective.yaml``) plus a ``RetrospectiveCaptured``
+    event and commits both — it is not a pure no-op in that case.
 
     With ``--discard``: abandon the mission mid-flight. Deletes the
     coordination branch and every lane branch named in

--- a/src/specify_cli/post_merge/retrospective_terminus.py
+++ b/src/specify_cli/post_merge/retrospective_terminus.py
@@ -24,6 +24,10 @@ from specify_cli.core.constants import RETROSPECTIVE_FILENAME
 
 logger = logging.getLogger(__name__)
 
+# The durable mission event log. Kept local (not imported from the migration-only
+# module) so the post-merge terminus owns its own literal.
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+
 FailureCategory = Literal[
     "missing_artifacts",
     "generator_exception",
@@ -106,6 +110,19 @@ def run_retrospective_postcondition(
             exc=exc,
         )
 
+    # #2119 follow-up: commit whatever the capture wrote — the RetrospectiveCaptured
+    # event + retrospective.yaml on success, or the capture_failed event append on
+    # failure. Both merge and `mission close` funnel through here, so committing at
+    # this single seam keeps the two paths consistent and honours the atomic
+    # event-log discipline (FR-016): a merged/closed mission must never be left with
+    # an uncommitted append in its durable status.events.jsonl. Fail-open-but-loud —
+    # a commit failure is reported, never raised (must not abort merge/close).
+    _commit_captured_retrospective(
+        mission_slug=mission_slug,
+        feature_dir=feature_dir,
+        repo_root=repo_root,
+    )
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -152,6 +169,117 @@ def _invoke_capture(
         repo_root=repo_root,
         block_on_failure=False,
     )
+
+
+def _resolve_commit_branch(repo_root: Path) -> str | None:
+    """Return the short branch name at ``repo_root`` HEAD, or ``None``.
+
+    Matches ``safe_commit``'s HEAD assertion (which reads ``symbolic-ref HEAD``),
+    so the resolved name is a valid ``destination_ref``. Returns ``None`` when the
+    path is not a git worktree or HEAD is detached — the caller then skips the
+    commit rather than guessing a destination.
+    """
+    from specify_cli.core.git_ops import run_command  # noqa: PLC0415
+
+    inside_ret, inside_out, _ = run_command(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    if inside_ret != 0 or inside_out.strip() != "true":
+        return None
+    branch_ret, branch_out, _ = run_command(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        capture=True,
+        check_return=False,
+        cwd=repo_root,
+    )
+    if branch_ret != 0:
+        return None
+    return branch_out.strip() or None
+
+
+def _paths_with_uncommitted_changes(repo_root: Path, paths: list[Path]) -> tuple[Path, ...]:
+    """Return the subset of ``paths`` that differ from HEAD or are untracked."""
+    from specify_cli.core.git_ops import run_command  # noqa: PLC0415
+
+    dirty: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            continue
+        rel = str(path.relative_to(repo_root)) if path.is_absolute() else str(path)
+        ret, out, _ = run_command(
+            ["git", "status", "--porcelain", "--", rel],
+            capture=True,
+            check_return=False,
+            cwd=repo_root,
+        )
+        if ret == 0 and out.strip():
+            dirty.append(path)
+    return tuple(dirty)
+
+
+def _commit_captured_retrospective(
+    *,
+    mission_slug: str,
+    feature_dir: Path,
+    repo_root: Path,
+) -> None:
+    """Commit the just-captured retrospective + its event-log append.
+
+    Mirrors ``spec-kitty merge``'s bookkeeping commit so the auto-capture path
+    (merge OR ``mission close``) never leaves the durable event log with an
+    uncommitted append. Uses ``MERGE_BOOKKEEPING`` — this IS the post-merge /
+    close bookkeeping flow (FR-007 retrospective postcondition) — so the guard
+    authorizes landing it on a protected target branch.
+
+    Fail-open-but-loud: any failure is reported via a WARNING (surfaced by the CLI
+    logging bootstrap) with the exact remediation command, and NEVER raised — the
+    caller must not abort the merge/close.
+    """
+    candidates = [feature_dir / RETROSPECTIVE_FILENAME, feature_dir / _STATUS_EVENTS_FILENAME]
+    paths = _paths_with_uncommitted_changes(repo_root, candidates)
+    if not paths:
+        return  # nothing the capture wrote is dirty — already committed or absent
+
+    branch = _resolve_commit_branch(repo_root)
+    if branch is None:
+        logger.warning(
+            "retrospective for mission %s was captured but NOT committed: %s is not on a "
+            "branch (detached HEAD or not a git worktree). Commit it manually so the "
+            "durable event log is not left with an uncommitted append.",
+            mission_slug,
+            repo_root,
+        )
+        return
+
+    from specify_cli.core.commit_guard import GuardCapability  # noqa: PLC0415
+    from specify_cli.git import safe_commit  # noqa: PLC0415
+
+    try:
+        safe_commit(
+            repo_root=repo_root,
+            worktree_root=repo_root,
+            destination_ref=branch,
+            message=f"chore({mission_slug}): capture mission retrospective",
+            paths=paths,
+            capability=GuardCapability.MERGE_BOOKKEEPING,
+        )
+        logger.debug("committed retrospective bookkeeping for mission %s onto %s", mission_slug, branch)
+    except Exception as exc:  # noqa: BLE001 — fail-open: report but never abort merge/close
+        joined = " ".join(str(p) for p in paths)
+        logger.warning(
+            "retrospective for mission %s was captured but could NOT be committed: %s. "
+            "The durable event log has an uncommitted append. Commit it manually: "
+            "git -C %s add %s && git -C %s commit -m 'chore(%s): capture mission retrospective'",
+            mission_slug,
+            exc,
+            repo_root,
+            joined,
+            repo_root,
+            mission_slug,
+        )
 
 
 def _emit_capture_failed(

--- a/tests/specify_cli/post_merge/test_retrospective_triggering.py
+++ b/tests/specify_cli/post_merge/test_retrospective_triggering.py
@@ -16,13 +16,17 @@ fast, hermetic, and free of git-subprocess overhead.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from specify_cli.post_merge.retrospective_terminus import run_retrospective_postcondition
+from specify_cli.post_merge.retrospective_terminus import (
+    _commit_captured_retrospective,
+    run_retrospective_postcondition,
+)
 
 pytestmark = [pytest.mark.unit]
 
@@ -216,3 +220,134 @@ class TestRunRetrospectivePostcondition:
 
         assert _classify_exc(ValueError("bad value")) == "generator_exception"
         assert _classify_exc(RuntimeError("boom")) == "generator_exception"
+
+
+# ---------------------------------------------------------------------------
+# #2119 follow-up — the auto-captured retrospective must be COMMITTED, so a
+# merged/closed mission is never left with an uncommitted event-log append.
+# ---------------------------------------------------------------------------
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    """Init a git repo on ``main`` with one seed commit so HEAD is on a branch."""
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / ".gitkeep").write_text("", encoding="utf-8")
+    _git(root, "add", ".gitkeep")
+    _git(root, "commit", "-m", "seed")
+
+
+def _porcelain(root: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+
+
+class TestRetrospectiveCommit:
+    """The captured retrospective + its event-log append are committed (FR-016)."""
+
+    def test_captured_retrospective_is_committed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Success path: retrospective.yaml + status.events.jsonl are committed →
+        the working tree is clean after the postcondition (no dirty append)."""
+        monkeypatch.setenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", "1")
+        _init_repo(tmp_path)
+        feature_dir = _make_feature_dir(tmp_path)
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "seed mission dir")
+        assert _porcelain(tmp_path) == ""  # pre-condition: clean
+
+        def _fake_capture(**_kwargs: Any) -> None:
+            (feature_dir / "retrospective.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+            (feature_dir / "status.events.jsonl").write_text(
+                '{"event": "RetrospectiveCaptured"}\n', encoding="utf-8"
+            )
+
+        with _patch_resolver(feature_dir), _patch_invoke(side_effect=_fake_capture):
+            run_retrospective_postcondition(mission_slug=MISSION_SLUG, repo_root=tmp_path)
+
+        assert (feature_dir / "retrospective.yaml").exists()
+        # The retrospective artifacts specifically must be committed (absent from
+        # porcelain) — unrelated runtime scratch (e.g. .kittify/) is not our concern.
+        dirty = _porcelain(tmp_path)
+        assert "retrospective.yaml" not in dirty, dirty
+        assert "status.events.jsonl" not in dirty, dirty
+        last_msg = _git(tmp_path, "log", "-1", "--format=%s").stdout.strip()
+        assert "capture mission retrospective" in last_msg
+
+    def test_capture_failed_event_is_committed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Failure path: the capture_failed event append is also committed — the
+        durable event log is never left dirty even when capture fails."""
+        monkeypatch.setenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", "1")
+        _init_repo(tmp_path)
+        feature_dir = _make_feature_dir(tmp_path)
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "seed mission dir")
+
+        def _emit(**_kwargs: Any) -> None:
+            (feature_dir / "status.events.jsonl").write_text(
+                '{"event": "retrospective.capture_failed"}\n', encoding="utf-8"
+            )
+
+        with (
+            _patch_resolver(feature_dir),
+            _patch_invoke(side_effect=RuntimeError("boom")),
+            patch(
+                "specify_cli.post_merge.retrospective_terminus._emit_capture_failed",
+                side_effect=_emit,
+            ),
+        ):
+            run_retrospective_postcondition(mission_slug=MISSION_SLUG, repo_root=tmp_path)
+
+        assert "status.events.jsonl" not in _porcelain(tmp_path), "capture_failed append must be committed"
+
+    def test_noop_when_not_a_git_repo(self, tmp_path: Path) -> None:
+        """Fail-open: a non-git tree does not raise; the file is left in place."""
+        feature_dir = _make_feature_dir(tmp_path)
+        (feature_dir / "retrospective.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+        # Must not raise even though tmp_path is not a git worktree.
+        _commit_captured_retrospective(
+            mission_slug=MISSION_SLUG, feature_dir=feature_dir, repo_root=tmp_path
+        )
+        assert (feature_dir / "retrospective.yaml").exists()
+
+    def test_detached_head_reports_and_skips(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Detached HEAD: cannot resolve a destination → warn + skip (leave dirty),
+        never raise. The warning surfaces the uncommitted append to the operator."""
+        _init_repo(tmp_path)
+        feature_dir = _make_feature_dir(tmp_path)
+        _git(tmp_path, "add", "-A")
+        _git(tmp_path, "commit", "-m", "seed mission dir")
+        head_sha = _git(tmp_path, "rev-parse", "HEAD").stdout.strip()
+        _git(tmp_path, "checkout", head_sha)  # detach HEAD
+        (feature_dir / "retrospective.yaml").write_text("schema_version: 1\n", encoding="utf-8")
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _commit_captured_retrospective(
+                mission_slug=MISSION_SLUG, feature_dir=feature_dir, repo_root=tmp_path
+            )
+
+        assert any("NOT committed" in rec.message for rec in caplog.records)
+        # File remains uncommitted (skipped), but the operator was told.
+        assert "retrospective.yaml" in _porcelain(tmp_path)


### PR DESCRIPTION
## Summary
Closes #2280. `spec-kitty mission close` (non-`--discard`) and `spec-kitty merge` share `run_retrospective_postcondition`, which auto-generates `retrospective.yaml` and appends a `RetrospectiveCaptured` event to `status.events.jsonl` — but never commits either. On a mission merged via the legacy plain-git/GitHub path (so merge-time teardown never ran), `mission close` left the durable event log with an **uncommitted append** on the target branch, with no notice in its output.

## Why it's a defect (verified against the specs, not just the report)
- **Violates the atomic-event-log invariant (FR-016, `mission-coordination-branch-atomic-event-log-01KSPTVW`):** *"No workflow mutation may occur unless the corresponding git mutation is permitted"*; FR-005: `status.events.jsonl` **"MUST be committed."** An uncommitted append can be lost.
- **Not merge/close-consistent:** both paths share the same postcondition, which generates-but-doesn't-commit. `merge` only *appears* clean because retrospectives are normally authored+committed during mission-review *before* merge (hitting the idempotent no-op branch). The auto-capture path was uncommitted in **both**.
- **Docs disagreed:** `mission close --help` called the non-`--discard` path *"a safe no-op"* while it wrote two files.

## Fix (one shared seam → merge and close behave identically)
- `run_retrospective_postcondition` now commits `retrospective.yaml` + the `status.events.jsonl` append via `safe_commit` (`MERGE_BOOKKEEPING` capability — this *is* the post-merge/close bookkeeping flow), on **both** the success and `capture_failed` branches, so the event log is never left dirty.
- **Fail-open-but-loud:** if the commit can't be made (detached HEAD / not a worktree), it logs a WARNING with the exact remediation command rather than aborting — the postcondition is contractually fail-open (must never abort merge/close).
- `mission close --help` no longer describes the non-`--discard` path as a pure "no-op".
- The commit helper uses self-contained `core.git_ops` probes, keeping `post_merge` decoupled from `merge/git_probes.py`.

## Alternative ruled out
Leaving `retrospective.yaml` as an uncommitted human-review draft: the `retrospective-durable-home` ADR (`2026-06-25-1-terminal-artifact-durable-home-teardown.md`) states *"the retrospective is a reviewable artifact, not transient state"* and homes it in the **tracked** `kitty-specs/<slug>/`. Human-authored retros pre-exist and hit the idempotent no-op branch, so they are never clobbered.

## Scope note for reviewers (FR-016 fidelity)
FR-016's strict model is *pre-flight-gate → write → surgical-rollback-on-commit-failure*. This fix is *write → commit, fail-open-but-loud* — a deliberate, proportionate choice because the retrospective postcondition is contractually fail-open; full pre-flight-gated rollback for this path would be a much larger change. Flagging so it's seen as a scoped decision, not an oversight.

## Adjacency note
Draft PR #2277 (coord/gate papercut sweep) touches the same *neighborhood* (`merge/git_probes.py`, `coordination/surface_resolver.py`) but **not** any file in this PR; the commit helper here is intentionally self-contained, so there's no collision if #2277 lands first.

## Tests
- `commit-on-success`, `commit-of-capture_failed`, `non-git no-op`, `detached-HEAD warn+skip` (git-backed).
- Verification: postcondition **14 passed**; teardown-seam + terminus-wiring + mission-close integration **40 passed**; merge tests through the postcondition **61 passed**; `ruff` + `mypy` clean; terminology guard green. No version bump (no `__init__.py` change); CHANGELOG under `[Unreleased] - 3.2.4`.