### PR TITLE
feat(docs): one-command ADR index + inventory-lockfile freshener

### DIFF
--- a/docs/adr/3.x/README.md
+++ b/docs/adr/3.x/README.md
@@ -6,6 +6,9 @@ Architectural Decision Records for the 3.x track (starting 3.0.0, released 2026-
 
 - `YYYY-MM-DD-N-descriptive-title-with-dashes.md` where `N` is `1, 2, 3, …` per ADR landed on a given date.
 
+After adding an ADR file, run `python scripts/docs/freshen_adr_inventory.py docs/adr/3.x/<your-adr>.md`
+to update the page-inventory lockfile and add the row to the index table below.
+
 ## Source of Truth
 
 This folder is canonical for 3.x decisions. The `architecture/` tree was removed

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,6 +22,20 @@ system is navigable across major versions.
 - [2.x ADRs](2.x/README.md) — decisions from the 2.x lineage.
 - [3.x ADRs](3.x/README.md) — current (3.x) decisions.
 
+## Adding an ADR
+
+After adding an ADR file under `docs/adr/<era>/`, run:
+
+```bash
+python scripts/docs/freshen_adr_inventory.py docs/adr/<era>/<your-adr>.md
+```
+
+This freshens **both** indexes the `docs-freshness` CI gate enforces — the
+generated page-inventory lockfile (`docs/development/3-2-page-inventory.yaml`)
+and the era `README.md` index table — in one idempotent, date-ordered pass.
+Use `--all` to back-fill every missing row, or `--check` to verify without
+writing.
+
 ## See also
 
 - [Documentation home](../index.md)

--- a/scripts/docs/freshen_adr_inventory.py
+++ b/scripts/docs/freshen_adr_inventory.py
@@ -1,0 +1,481 @@
+"""One-command ADR index + inventory-lockfile freshener.
+
+Adding an ADR under ``docs/adr/<era>/`` (era = ``1.x`` | ``2.x`` | ``3.x``)
+requires two index updates the ``docs-freshness`` CI gate enforces:
+
+1. A :class:`~scripts.docs._inventory.PageInventoryEntry` row in
+   ``docs/development/3-2-page-inventory.yaml`` — a **generated lockfile**,
+   regenerated from every page's frontmatter.
+2. A table row ``| YYYY-MM-DD | [Title](filename.md) |`` in the era's
+   ``docs/adr/<era>/README.md`` index.
+
+Agents repeatedly trip the gate (``LEAK-MISSING-INVENTORY``,
+``INVENTORY-INCOMPLETE``, ``INVENTORY-LOCKFILE-DRIFT``) by forgetting one of
+these. This tool freshens **both** in one command, reusing the canonical
+machinery in :mod:`scripts.docs.inventory_lockfile` and
+:mod:`scripts.docs._inventory` — it never forks the inventory schema.
+
+Usage::
+
+    python scripts/docs/freshen_adr_inventory.py docs/adr/3.x/my-adr.md
+    python scripts/docs/freshen_adr_inventory.py --all
+    python scripts/docs/freshen_adr_inventory.py --check docs/adr/3.x/my-adr.md
+
+* **Inventory:** the page inventory is regenerated wholesale from frontmatter
+  (``render_lockfile(generate_inventory(...))``), so it auto-picks up every new
+  doc — including new ADRs. On a clean tree this is a no-op.
+* **ADR README rows:** for each target ADR the era README's index table gets a
+  new row, inserted date-ascending, idempotently (a basename already linked is
+  skipped).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from scripts.docs._inventory import parse_frontmatter
+from scripts.docs.inventory_lockfile import (
+    DEFAULT_INVENTORY_PATH,
+    generate_inventory,
+    render_lockfile,
+)
+
+__all__ = [
+    "AdrMeta",
+    "FreshenResult",
+    "build_parser",
+    "detect_missing_adrs",
+    "freshen",
+    "main",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+_ADR_SUBDIR: Final[str] = "adr"
+_README_NAME: Final[str] = "README.md"
+_ERA_RE: Final[re.Pattern[str]] = re.compile(r"^\d+\.x$")
+_TITLE_PREFIX: Final[str] = "ADR: "
+_WHITESPACE_RE: Final[re.Pattern[str]] = re.compile(r"\s+")
+
+# ADR index table detection. The header carries both "Date" and "Title"; the
+# next line is the markdown separator; data rows follow until the first
+# non-pipe line.
+_TABLE_HEADER_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*\|.*\bdate\b.*\|.*\btitle\b.*\|\s*$", re.IGNORECASE
+)
+_TABLE_SEP_RE: Final[re.Pattern[str]] = re.compile(r"^\s*\|[\s:|-]*-[\s:|-]*\|\s*$")
+_TABLE_ROW_RE: Final[re.Pattern[str]] = re.compile(r"^\s*\|.*\|\s*$")
+
+
+class FreshenError(Exception):
+    """Raised for an unrecoverable target/era-README problem."""
+
+
+@dataclass(slots=True, frozen=True)
+class AdrMeta:
+    """Frontmatter-derived facts about one ADR needed for its README row."""
+
+    basename: str
+    title: str
+    date: str
+
+    def row(self) -> str:
+        """Render the canonical era-README index row for this ADR."""
+        return f"| {self.date} | [{self.title}]({self.basename}) |"
+
+
+@dataclass(slots=True, frozen=True)
+class FreshenResult:
+    """Outcome of a freshen/check run (what changed, what's still stale)."""
+
+    inventory_written: bool
+    readme_rows_added: tuple[str, ...]
+    missing_rows: tuple[str, ...]
+    inventory_stale: bool
+
+    @property
+    def is_clean(self) -> bool:
+        """True iff nothing is stale (safe ``--check`` exit)."""
+        return not self.missing_rows and not self.inventory_stale
+
+
+# --------------------------------------------------------------------------- #
+# Era README resolution
+# --------------------------------------------------------------------------- #
+
+
+def _era_readme_for(adr_path: Path, docs_root: Path) -> Path:
+    """Resolve the era ``README.md`` for an ADR at ``docs/adr/<era>/<name>.md``.
+
+    Validates the ADR lives directly under ``<docs_root>/adr/<era>/`` where
+    ``<era>`` matches ``N.x`` — a mislocated path is a hard error, not a silent
+    guess.
+    """
+    era_dir = adr_path.parent
+    if era_dir.parent.name != _ADR_SUBDIR or not _ERA_RE.match(era_dir.name):
+        raise FreshenError(
+            f"{adr_path} is not under {docs_root.name}/{_ADR_SUBDIR}/<era>/ "
+            f"(era must match N.x)"
+        )
+    return era_dir / _README_NAME
+
+
+# --------------------------------------------------------------------------- #
+# ADR frontmatter -> row facts
+# --------------------------------------------------------------------------- #
+
+
+def _clean_title(raw: object) -> str:
+    """Collapse whitespace and strip a leading ``ADR: `` prefix from a title."""
+    text = str(raw) if raw is not None else ""
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if text.startswith(_TITLE_PREFIX):
+        text = text[len(_TITLE_PREFIX) :].strip()
+    return text
+
+
+def _read_adr_meta(adr_path: Path) -> AdrMeta:
+    """Parse an ADR's frontmatter into the facts its README row needs."""
+    try:
+        text = adr_path.read_text(encoding="utf-8")
+    except OSError as exc:  # unreadable target — surface, don't guess
+        raise FreshenError(f"cannot read ADR {adr_path}: {exc}") from exc
+    frontmatter = parse_frontmatter(text)
+    title = _clean_title(frontmatter.get("title"))
+    date = str(frontmatter.get("date", "")).strip()
+    if not title or not date:
+        raise FreshenError(
+            f"{adr_path} frontmatter is missing a title and/or date "
+            f"(title={title!r}, date={date!r})"
+        )
+    return AdrMeta(basename=adr_path.name, title=title, date=date)
+
+
+# --------------------------------------------------------------------------- #
+# README table editing
+# --------------------------------------------------------------------------- #
+
+
+def _find_adr_table(lines: list[str]) -> tuple[int, int]:
+    """Return ``(data_start, data_end)`` for the ADR index table's data rows.
+
+    ``data_start`` is the first data-row index (after the header + separator);
+    ``data_end`` is one past the last contiguous data row. Raises if no
+    ``| Date | Title |`` table exists.
+    """
+    for index in range(len(lines) - 1):
+        if _TABLE_HEADER_RE.match(lines[index]) and _TABLE_SEP_RE.match(
+            lines[index + 1]
+        ):
+            data_start = index + 2
+            data_end = data_start
+            while data_end < len(lines) and _TABLE_ROW_RE.match(lines[data_end]):
+                data_end += 1
+            return data_start, data_end
+    raise FreshenError("no ADR index table (`| Date | Title |`) found")
+
+
+def _row_date(row: str) -> str:
+    """Extract the first (date) cell from a markdown table row."""
+    cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+    return cells[0] if cells else ""
+
+
+def _insertion_index(rows: list[str], date: str) -> int:
+    """Index at which a new row for ``date`` keeps the table date-ascending.
+
+    Inserts after every existing row whose date is ``<= date`` (so a new row
+    lands after same-date neighbours), preserving ascending order.
+    """
+    position = len(rows)
+    for offset, row in enumerate(rows):
+        if _row_date(row) > date:
+            position = offset
+            break
+    return position
+
+
+def _insert_readme_row(readme_text: str, meta: AdrMeta) -> tuple[str, bool]:
+    """Insert ``meta``'s row into the ADR table, idempotent + date-ordered.
+
+    Returns ``(new_text, changed)``. ``changed`` is ``False`` when the ADR's
+    basename is already linked in the table (no duplicate row).
+    """
+    if f"]({meta.basename})" in readme_text:
+        return readme_text, False
+
+    trailing_newline = readme_text.endswith("\n")
+    lines = readme_text.splitlines()
+    data_start, data_end = _find_adr_table(lines)
+    rows = lines[data_start:data_end]
+
+    offset = _insertion_index(rows, meta.date)
+    lines.insert(data_start + offset, meta.row())
+
+    new_text = "\n".join(lines)
+    if trailing_newline:
+        new_text += "\n"
+    return new_text, True
+
+
+def _freshen_readme_row(adr_path: Path, docs_root: Path) -> str | None:
+    """Add ``adr_path``'s row to its era README. Return basename if changed."""
+    meta = _read_adr_meta(adr_path)
+    readme = _era_readme_for(adr_path, docs_root)
+    if not readme.exists():
+        raise FreshenError(f"era README not found: {readme}")
+    original = readme.read_text(encoding="utf-8")
+    updated, changed = _insert_readme_row(original, meta)
+    if changed:
+        readme.write_text(updated, encoding="utf-8")
+        return meta.basename
+    return None
+
+
+def _readme_has_row(adr_path: Path, docs_root: Path) -> bool:
+    """True iff ``adr_path``'s basename is already linked in its era README."""
+    readme = _era_readme_for(adr_path, docs_root)
+    if not readme.exists():
+        return False
+    return f"]({adr_path.name})" in readme.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Inventory regeneration
+# --------------------------------------------------------------------------- #
+
+
+def _inventory_path(repo_root: Path) -> Path:
+    """Resolve the committed inventory lockfile under ``repo_root``."""
+    return repo_root / DEFAULT_INVENTORY_PATH
+
+
+def _rendered_inventory(docs_root: Path, repo_root: Path) -> str:
+    """Render the fresh inventory lockfile string from frontmatter."""
+    entries = generate_inventory(docs_root, repo_root=repo_root)
+    return render_lockfile(entries)
+
+
+def _regenerate_inventory(docs_root: Path, repo_root: Path) -> bool:
+    """Rewrite the committed inventory from frontmatter. Return True if changed."""
+    target = _inventory_path(repo_root)
+    fresh = _rendered_inventory(docs_root, repo_root)
+    current = target.read_text(encoding="utf-8") if target.exists() else None
+    if current == fresh:
+        return False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(fresh, encoding="utf-8")
+    return True
+
+
+def _inventory_is_stale(docs_root: Path, repo_root: Path) -> bool:
+    """True iff the committed inventory diverges from a fresh generation."""
+    target = _inventory_path(repo_root)
+    if not target.exists():
+        return True
+    return target.read_text(encoding="utf-8") != _rendered_inventory(
+        docs_root, repo_root
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Target discovery
+# --------------------------------------------------------------------------- #
+
+
+def _era_has_table(readme: Path) -> bool:
+    """True iff ``readme`` exists and contains an ADR index table."""
+    if not readme.exists():
+        return False
+    try:
+        _find_adr_table(readme.read_text(encoding="utf-8").splitlines())
+    except FreshenError:
+        return False
+    return True
+
+
+def detect_missing_adrs(docs_root: Path) -> list[Path]:
+    """Every ADR under ``docs/adr/<era>/`` missing from its era README table.
+
+    Only eras whose README actually maintains an index table are considered —
+    legacy eras without a table (e.g. 1.x/2.x) are intentionally skipped rather
+    than back-filled with a table they never carried.
+    """
+    adr_root = docs_root / _ADR_SUBDIR
+    if not adr_root.is_dir():
+        return []
+    missing: list[Path] = []
+    for era_dir in sorted(p for p in adr_root.iterdir() if p.is_dir()):
+        if not _ERA_RE.match(era_dir.name):
+            continue
+        if not _era_has_table(era_dir / _README_NAME):
+            continue
+        for adr_path in sorted(era_dir.glob("*.md")):
+            if adr_path.name == _README_NAME:
+                continue
+            if not _readme_has_row(adr_path, docs_root):
+                missing.append(adr_path)
+    return missing
+
+
+def _targets_missing_rows(adr_paths: list[Path], docs_root: Path) -> list[str]:
+    """Basenames of ``adr_paths`` that lack their era README row."""
+    return [p.name for p in adr_paths if not _readme_has_row(p, docs_root)]
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def freshen(
+    adr_paths: list[Path],
+    *,
+    docs_root: Path,
+    repo_root: Path,
+    check: bool,
+) -> FreshenResult:
+    """Freshen (or, in ``check`` mode, verify) both indexes.
+
+    In write mode: add each ADR's README row, then regenerate the inventory.
+    In check mode: never write — report which targeted ADRs miss their row and
+    whether the committed inventory is stale.
+    """
+    if check:
+        return FreshenResult(
+            inventory_written=False,
+            readme_rows_added=(),
+            missing_rows=tuple(_targets_missing_rows(adr_paths, docs_root)),
+            inventory_stale=_inventory_is_stale(docs_root, repo_root),
+        )
+
+    added: list[str] = []
+    for adr_path in adr_paths:
+        basename = _freshen_readme_row(adr_path, docs_root)
+        if basename is not None:
+            added.append(basename)
+    inventory_written = _regenerate_inventory(docs_root, repo_root)
+    return FreshenResult(
+        inventory_written=inventory_written,
+        readme_rows_added=tuple(added),
+        missing_rows=(),
+        inventory_stale=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``freshen_adr_inventory`` CLI parser."""
+    parser = argparse.ArgumentParser(
+        prog="freshen_adr_inventory",
+        description=(
+            "Freshen BOTH ADR indexes in one command: regenerate the "
+            "page-inventory lockfile from frontmatter AND add each ADR's row "
+            "to its era README table. Idempotent and date-ordered."
+        ),
+    )
+    parser.add_argument(
+        "adr_paths",
+        nargs="*",
+        type=Path,
+        help="Explicit ADR .md paths under docs/adr/<era>/.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Auto-detect every ADR missing from its era README table.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Verify only (no writes): exit non-zero if the inventory is stale "
+            "or any targeted ADR is missing its README row."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repo root (default: current working directory).",
+    )
+    parser.add_argument(
+        "--docs-root",
+        type=Path,
+        default=None,
+        help="Docs root (default: <repo-root>/docs).",
+    )
+    return parser
+
+
+def _resolve_targets(args: argparse.Namespace, docs_root: Path) -> list[Path]:
+    """Resolve the ADR targets from explicit paths and/or ``--all``."""
+    targets: list[Path] = list(args.adr_paths)
+    if args.all:
+        known = {p.resolve() for p in targets}
+        for detected in detect_missing_adrs(docs_root):
+            if detected.resolve() not in known:
+                targets.append(detected)
+    return targets
+
+
+def _emit_check(result: FreshenResult) -> int:
+    """Print the check-mode summary and return the exit code."""
+    for basename in result.missing_rows:
+        sys.stdout.write(f"ADR-README-ROW-MISSING {basename}\n")
+    if result.inventory_stale:
+        sys.stdout.write("INVENTORY-LOCKFILE-DRIFT (committed inventory is stale)\n")
+    status = "clean" if result.is_clean else "STALE"
+    sys.stdout.write(
+        f"freshen_adr_inventory --check: {status} "
+        f"(missing_rows={len(result.missing_rows)} "
+        f"inventory_stale={result.inventory_stale})\n"
+    )
+    return 0 if result.is_clean else 1
+
+
+def _emit_write(result: FreshenResult) -> int:
+    """Print the write-mode summary and return the exit code."""
+    for basename in result.readme_rows_added:
+        sys.stdout.write(f"README-ROW-ADDED {basename}\n")
+    inv = "regenerated" if result.inventory_written else "unchanged"
+    sys.stdout.write(
+        f"freshen_adr_inventory: rows_added={len(result.readme_rows_added)} "
+        f"inventory={inv}\n"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    args = build_parser().parse_args(argv)
+    repo_root: Path = args.repo_root
+    docs_root: Path = args.docs_root if args.docs_root is not None else repo_root / "docs"
+
+    targets = _resolve_targets(args, docs_root)
+
+    try:
+        result = freshen(
+            targets, docs_root=docs_root, repo_root=repo_root, check=args.check
+        )
+    except FreshenError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 2
+
+    return _emit_check(result) if args.check else _emit_write(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - module-level CLI guard
+    raise SystemExit(main())

--- a/scripts/docs/freshen_adr_inventory.py
+++ b/scripts/docs/freshen_adr_inventory.py
@@ -25,8 +25,8 @@ Usage::
   (``render_lockfile(generate_inventory(...))``), so it auto-picks up every new
   doc — including new ADRs. On a clean tree this is a no-op.
 * **ADR README rows:** for each target ADR the era README's index table gets a
-  new row, inserted date-ascending, idempotently (a basename already linked is
-  skipped).
+  new row, inserted date-ascending, idempotently (a basename already linked
+  **within the index table** is skipped; a prose link elsewhere does not count).
 """
 
 from __future__ import annotations
@@ -115,17 +115,27 @@ class FreshenResult:
 def _era_readme_for(adr_path: Path, docs_root: Path) -> Path:
     """Resolve the era ``README.md`` for an ADR at ``docs/adr/<era>/<name>.md``.
 
-    Validates the ADR lives directly under ``<docs_root>/adr/<era>/`` where
-    ``<era>`` matches ``N.x`` — a mislocated path is a hard error, not a silent
-    guess.
+    Validates the ADR lives **inside** ``docs_root`` at exactly
+    ``adr/<era>/<file>.md`` (``<era>`` matching ``N.x``). Checking the directory
+    *names* alone is not enough — an out-of-tree path like ``/tmp/adr/3.x/foo.md``
+    would otherwise be accepted and the tool would edit ``/tmp/adr/3.x/README.md``.
+    A path that escapes the docs root, or does not match the exact shape, is a
+    hard error rather than a destructive guess.
     """
-    era_dir = adr_path.parent
-    if era_dir.parent.name != _ADR_SUBDIR or not _ERA_RE.match(era_dir.name):
+    try:
+        rel_parts = adr_path.resolve().relative_to(docs_root.resolve()).parts
+    except ValueError:  # adr_path is not inside docs_root
+        rel_parts = ()
+    if (
+        len(rel_parts) != 3
+        or rel_parts[0] != _ADR_SUBDIR
+        or not _ERA_RE.match(rel_parts[1])
+    ):
         raise FreshenError(
-            f"{adr_path} is not under {docs_root.name}/{_ADR_SUBDIR}/<era>/ "
-            f"(era must match N.x)"
+            f"{adr_path} is not under {docs_root.name}/{_ADR_SUBDIR}/<era>/<file>.md "
+            f"(era must match N.x and the path must live inside the docs root)"
         )
-    return era_dir / _README_NAME
+    return adr_path.parent / _README_NAME
 
 
 # --------------------------------------------------------------------------- #
@@ -203,19 +213,32 @@ def _insertion_index(rows: list[str], date: str) -> int:
     return position
 
 
+def _rows_link_basename(rows: list[str], basename: str) -> bool:
+    """True iff any ADR-table *data row* links ``basename``.
+
+    Table-scoped on purpose: a link to the ADR in README prose (outside the
+    index table) must NOT count as "already in the table", or the index row
+    would be wrongly skipped. Shared by write-mode (:func:`_insert_readme_row`)
+    and check-mode (:func:`_readme_has_row`) so both agree.
+    """
+    needle = f"]({basename})"
+    return any(needle in row for row in rows)
+
+
 def _insert_readme_row(readme_text: str, meta: AdrMeta) -> tuple[str, bool]:
     """Insert ``meta``'s row into the ADR table, idempotent + date-ordered.
 
-    Returns ``(new_text, changed)``. ``changed`` is ``False`` when the ADR's
-    basename is already linked in the table (no duplicate row).
+    Returns ``(new_text, changed)``. ``changed`` is ``False`` only when the
+    ADR's basename is already linked **within the index table** (a prose link
+    elsewhere does not count — see :func:`_rows_link_basename`).
     """
-    if f"]({meta.basename})" in readme_text:
-        return readme_text, False
-
     trailing_newline = readme_text.endswith("\n")
     lines = readme_text.splitlines()
     data_start, data_end = _find_adr_table(lines)
     rows = lines[data_start:data_end]
+
+    if _rows_link_basename(rows, meta.basename):
+        return readme_text, False
 
     offset = _insertion_index(rows, meta.date)
     lines.insert(data_start + offset, meta.row())
@@ -241,11 +264,21 @@ def _freshen_readme_row(adr_path: Path, docs_root: Path) -> str | None:
 
 
 def _readme_has_row(adr_path: Path, docs_root: Path) -> bool:
-    """True iff ``adr_path``'s basename is already linked in its era README."""
+    """True iff ``adr_path``'s basename is linked in its era README index table.
+
+    Table-aware (reuses :func:`_find_adr_table` + :func:`_rows_link_basename`) so
+    ``--check`` agrees with write-mode: a prose link outside the table is not a
+    row, and a README without a table has no row.
+    """
     readme = _era_readme_for(adr_path, docs_root)
     if not readme.exists():
         return False
-    return f"]({adr_path.name})" in readme.read_text(encoding="utf-8")
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    try:
+        data_start, data_end = _find_adr_table(lines)
+    except FreshenError:
+        return False
+    return _rows_link_basename(lines[data_start:data_end], adr_path.name)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/docs/test_freshen_adr_inventory.py
+++ b/tests/docs/test_freshen_adr_inventory.py
@@ -335,3 +335,108 @@ def test_midrange_date_inserts_between_neighbours(tmp_path: Path) -> None:
     idx = dates.index("2026-05-20")
     assert dates[idx - 1] == "2026-05-16"
     assert dates[idx + 1] == "2026-06-26"
+
+
+# --------------------------------------------------------------------------- #
+# 7. Path-escape safety (Copilot review: _era_readme_for must validate that the
+#    ADR lives INSIDE docs_root, not merely that dir names read `adr/<era>`).
+# --------------------------------------------------------------------------- #
+
+
+def test_out_of_tree_adr_is_rejected_and_edits_nothing(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    # A decoy `adr/3.x/` tree OUTSIDE docs_root — the `/tmp/adr/3.x/foo.md` shape
+    # the review flagged as destructively editable.
+    outside = repo_root / "outside" / "adr" / "3.x"
+    outside.mkdir(parents=True)
+    outside_readme = outside / "README.md"
+    outside_readme.write_text(_README_TEMPLATE, encoding="utf-8")
+    decoy = outside / "2026-06-30-1-decoy.md"
+    decoy.write_text(_adr("Decoy", "2026-06-30"), encoding="utf-8")
+    before = outside_readme.read_text(encoding="utf-8")
+
+    exit_code = main(
+        [str(decoy), "--repo-root", str(repo_root), "--docs-root", str(docs_root)]
+    )
+
+    assert exit_code == 2  # FreshenError: path escapes docs_root
+    assert outside_readme.read_text(encoding="utf-8") == before  # untouched
+
+
+# --------------------------------------------------------------------------- #
+# 8. Prose-link false-positive (Copilot review: the idempotency check must be
+#    table-scoped — a link in README prose must not count as "already in the
+#    table" for either write-mode or --check).
+# --------------------------------------------------------------------------- #
+
+
+def _readme_prose_links(basename: str) -> str:
+    """The full index table, plus a prose link to ``basename`` ABOVE it.
+
+    The table itself does NOT contain a row for ``basename`` — only prose links
+    it. A basename-anywhere check would wrongly treat it as already present.
+    """
+    return dedent(
+        f"""\
+        # 3.x ADRs
+
+        Architectural Decision Records for the 3.x track. Background for the new
+        work lives in [the brand new thing]({basename}).
+
+        ## Index
+
+        | Date | Title |
+        |---|---|
+        | 2026-04-03 | [Execution lanes own worktrees](2026-04-03-1-execution-lanes.md) |
+        | 2026-05-16 | [Doctrine layer merge semantics](2026-05-16-1-doctrine-merge.md) |
+        | 2026-06-26 | [Single-authority seam](2026-06-26-1-single-authority-seam.md) |
+        """
+    )
+
+
+def test_prose_link_does_not_block_table_row_insert(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    basename = "2026-06-30-1-new-thing.md"
+    (docs_root / "adr" / "3.x" / "README.md").write_text(
+        _readme_prose_links(basename), encoding="utf-8"
+    )
+    new_adr = docs_root / "adr" / "3.x" / basename
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+
+    result = freshen(
+        [new_adr], docs_root=docs_root, repo_root=repo_root, check=False
+    )
+
+    # The prose link must NOT suppress the table-row insert.
+    assert basename in result.readme_rows_added
+    rows = _table_rows(_read_readme(docs_root))
+    assert any(f"]({basename})" in row for row in rows)
+
+
+def test_check_reports_missing_when_only_prose_links_adr(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    basename = "2026-06-30-1-new-thing.md"
+    (docs_root / "adr" / "3.x" / "README.md").write_text(
+        _readme_prose_links(basename), encoding="utf-8"
+    )
+    new_adr = docs_root / "adr" / "3.x" / basename
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+    _write_inventory(repo_root, docs_root)  # isolate: only the README row is at issue
+
+    # Table-aware detection must still see it as missing (not prose-fooled) — and
+    # --check must agree with write-mode.
+    assert new_adr in detect_missing_adrs(docs_root)
+    exit_code = main(
+        [
+            str(new_adr),
+            "--check",
+            "--repo-root",
+            str(repo_root),
+            "--docs-root",
+            str(docs_root),
+        ]
+    )
+    assert exit_code == 1

--- a/tests/docs/test_freshen_adr_inventory.py
+++ b/tests/docs/test_freshen_adr_inventory.py
@@ -1,0 +1,337 @@
+"""Tests for ``scripts/docs/freshen_adr_inventory.py``.
+
+The tool freshens BOTH ADR indexes the docs-freshness gate enforces:
+1. the generated page-inventory lockfile (regenerated from frontmatter), and
+2. the era ``README.md`` ADR table (a date-ordered, idempotent row insert).
+
+Fixtures are production-shaped: a real ``docs/adr/3.x/`` tree with genuine
+ADR frontmatter, a real era README carrying a ``| Date | Title |`` index
+table, and a real committed inventory lockfile rendered by the canonical
+generator — so a run exercises the same code path CI does.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.docs.freshen_adr_inventory import (  # noqa: E402
+    DEFAULT_INVENTORY_PATH,
+    detect_missing_adrs,
+    freshen,
+    main,
+)
+from scripts.docs.inventory_lockfile import (  # noqa: E402
+    generate_inventory,
+    render_lockfile,
+)
+
+pytestmark = [pytest.mark.fast]
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builders
+# --------------------------------------------------------------------------- #
+
+_README_TEMPLATE = dedent(
+    """\
+    # 3.x ADRs
+
+    Architectural Decision Records for the 3.x track.
+
+    ## Index
+
+    | Date | Title |
+    |---|---|
+    | 2026-04-03 | [Execution lanes own worktrees](2026-04-03-1-execution-lanes.md) |
+    | 2026-05-16 | [Doctrine layer merge semantics](2026-05-16-1-doctrine-merge.md) |
+    | 2026-06-26 | [Single-authority seam](2026-06-26-1-single-authority-seam.md) |
+    """
+)
+
+
+def _adr(title: str, date: str, *, body: str = "Decision body.") -> str:
+    return dedent(
+        f"""\
+        ---
+        title: {title}
+        status: Accepted
+        date: '{date}'
+        ---
+
+        ## Context
+
+        {body}
+        """
+    )
+
+
+def _write_docs_tree(repo_root: Path) -> Path:
+    """Stage a realistic docs tree; return the docs root."""
+    docs_root = repo_root / "docs"
+    era = docs_root / "adr" / "3.x"
+    era.mkdir(parents=True)
+
+    (era / "README.md").write_text(_README_TEMPLATE, encoding="utf-8")
+
+    # Pre-existing ADRs that already have README rows.
+    (era / "2026-04-03-1-execution-lanes.md").write_text(
+        _adr("Execution lanes own worktrees", "2026-04-03"), encoding="utf-8"
+    )
+    (era / "2026-05-16-1-doctrine-merge.md").write_text(
+        _adr("Doctrine layer merge semantics", "2026-05-16"), encoding="utf-8"
+    )
+    (era / "2026-06-26-1-single-authority-seam.md").write_text(
+        _adr("Single-authority seam", "2026-06-26"), encoding="utf-8"
+    )
+
+    # A non-ADR doc so the inventory has more than ADRs in it.
+    (docs_root / "index.md").write_text(
+        _adr("Docs home", "2026-01-01"), encoding="utf-8"
+    )
+
+    _write_inventory(repo_root, docs_root)
+    return docs_root
+
+
+def _write_inventory(repo_root: Path, docs_root: Path) -> None:
+    """Render + commit an inventory matching the current tree (no drift)."""
+    inv = repo_root / DEFAULT_INVENTORY_PATH
+    inv.parent.mkdir(parents=True, exist_ok=True)
+    inv.write_text(
+        render_lockfile(generate_inventory(docs_root, repo_root=repo_root)),
+        encoding="utf-8",
+    )
+
+
+def _read_readme(docs_root: Path) -> str:
+    return (docs_root / "adr" / "3.x" / "README.md").read_text(encoding="utf-8")
+
+
+def _table_rows(readme_text: str) -> list[str]:
+    """Return the ADR table's data rows (between separator and blank/EOF)."""
+    rows: list[str] = []
+    in_table = False
+    for line in readme_text.splitlines():
+        if line.startswith("|---"):
+            in_table = True
+            continue
+        if in_table:
+            if line.startswith("|"):
+                rows.append(line)
+            else:
+                break
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# 1. Adding a new ADR surfaces both rows
+# --------------------------------------------------------------------------- #
+
+
+def test_new_adr_gets_inventory_and_readme_rows(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    new_adr = docs_root / "adr" / "3.x" / "2026-06-30-1-new-thing.md"
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+
+    result = freshen(
+        [new_adr], docs_root=docs_root, repo_root=repo_root, check=False
+    )
+
+    # README row present with the right date/title/link.
+    readme = _read_readme(docs_root)
+    assert (
+        "| 2026-06-30 | [A Brand New Thing](2026-06-30-1-new-thing.md) |" in readme
+    )
+    assert "2026-06-30-1-new-thing.md" in result.readme_rows_added
+
+    # Inventory row present (path appears in the regenerated lockfile).
+    inv = (repo_root / DEFAULT_INVENTORY_PATH).read_text(encoding="utf-8")
+    assert "docs/adr/3.x/2026-06-30-1-new-thing.md" in inv
+    assert result.inventory_written is True
+
+
+# --------------------------------------------------------------------------- #
+# 2. Idempotency
+# --------------------------------------------------------------------------- #
+
+
+def test_running_twice_is_idempotent(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    new_adr = docs_root / "adr" / "3.x" / "2026-06-30-1-new-thing.md"
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+
+    freshen([new_adr], docs_root=docs_root, repo_root=repo_root, check=False)
+    first = _read_readme(docs_root)
+
+    second_result = freshen(
+        [new_adr], docs_root=docs_root, repo_root=repo_root, check=False
+    )
+    second = _read_readme(docs_root)
+
+    assert first == second  # no duplicate row / no second change
+    assert second_result.readme_rows_added == ()
+    assert second_result.inventory_written is False
+    # Exactly one row references the basename.
+    assert second.count("](2026-06-30-1-new-thing.md)") == 1
+
+
+# --------------------------------------------------------------------------- #
+# 3. --check exit codes
+# --------------------------------------------------------------------------- #
+
+
+def test_check_nonzero_when_readme_row_missing(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    new_adr = docs_root / "adr" / "3.x" / "2026-06-30-1-new-thing.md"
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+    # Regenerate inventory so ONLY the README row is missing (isolate the cause).
+    _write_inventory(repo_root, docs_root)
+
+    exit_code = main(
+        [
+            str(new_adr),
+            "--check",
+            "--repo-root",
+            str(repo_root),
+            "--docs-root",
+            str(docs_root),
+        ]
+    )
+    assert exit_code == 1
+
+
+def test_check_nonzero_when_inventory_stale(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    # Add an ADR + its README row but leave the inventory stale.
+    new_adr = docs_root / "adr" / "3.x" / "2026-06-30-1-new-thing.md"
+    new_adr.write_text(_adr("A Brand New Thing", "2026-06-30"), encoding="utf-8")
+    freshen([new_adr], docs_root=docs_root, repo_root=repo_root, check=False)
+    # Now dirty the tree with another doc so the committed inventory is stale.
+    (docs_root / "extra.md").write_text(_adr("Extra", "2026-02-02"), encoding="utf-8")
+
+    exit_code = main(
+        [
+            str(new_adr),
+            "--check",
+            "--repo-root",
+            str(repo_root),
+            "--docs-root",
+            str(docs_root),
+        ]
+    )
+    assert exit_code == 1
+
+
+def test_check_zero_when_clean(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+
+    exit_code = main(
+        [
+            "--check",
+            "--repo-root",
+            str(repo_root),
+            "--docs-root",
+            str(docs_root),
+        ]
+    )
+    assert exit_code == 0
+
+
+# --------------------------------------------------------------------------- #
+# 4. --all auto-detects README-missing ADRs
+# --------------------------------------------------------------------------- #
+
+
+def test_all_detects_and_adds_missing_row(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    orphan = docs_root / "adr" / "3.x" / "2026-06-29-1-orphan.md"
+    orphan.write_text(_adr("Orphan ADR", "2026-06-29"), encoding="utf-8")
+
+    assert orphan in detect_missing_adrs(docs_root)
+
+    exit_code = main(
+        ["--all", "--repo-root", str(repo_root), "--docs-root", str(docs_root)]
+    )
+    assert exit_code == 0
+
+    readme = _read_readme(docs_root)
+    assert "| 2026-06-29 | [Orphan ADR](2026-06-29-1-orphan.md) |" in readme
+    assert detect_missing_adrs(docs_root) == []
+
+
+# --------------------------------------------------------------------------- #
+# 5. Title normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_adr_prefix_stripped_from_title(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    adr = docs_root / "adr" / "3.x" / "2026-06-30-1-prefixed.md"
+    adr.write_text(_adr("'ADR: Foo Bar'", "2026-06-30"), encoding="utf-8")
+
+    freshen([adr], docs_root=docs_root, repo_root=repo_root, check=False)
+
+    readme = _read_readme(docs_root)
+    assert "| 2026-06-30 | [Foo Bar](2026-06-30-1-prefixed.md) |" in readme
+    assert "ADR: Foo Bar" not in readme
+
+
+def test_folded_multiline_title_collapses(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    adr = docs_root / "adr" / "3.x" / "2026-06-30-1-folded.md"
+    # A single-quoted YAML scalar folded across two lines (real ADR shape).
+    adr.write_text(
+        "---\n"
+        "title: 'ADR: Single-Authority Seam + Call-Site Gate for Resolution\n"
+        "  Boundaries (Phase 1)'\n"
+        "status: Accepted\n"
+        "date: '2026-06-30'\n"
+        "---\n\n## Context\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    freshen([adr], docs_root=docs_root, repo_root=repo_root, check=False)
+
+    readme = _read_readme(docs_root)
+    assert (
+        "| 2026-06-30 | [Single-Authority Seam + Call-Site Gate for "
+        "Resolution Boundaries (Phase 1)](2026-06-30-1-folded.md) |" in readme
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 6. Date-ordered insertion
+# --------------------------------------------------------------------------- #
+
+
+def test_midrange_date_inserts_between_neighbours(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    docs_root = _write_docs_tree(repo_root)
+    # Existing dates: 2026-04-03, 2026-05-16, 2026-06-26. Insert 2026-05-20.
+    adr = docs_root / "adr" / "3.x" / "2026-05-20-1-midrange.md"
+    adr.write_text(_adr("Midrange Decision", "2026-05-20"), encoding="utf-8")
+
+    freshen([adr], docs_root=docs_root, repo_root=repo_root, check=False)
+
+    rows = _table_rows(_read_readme(docs_root))
+    dates = [row.split("|")[1].strip() for row in rows]
+    assert dates == sorted(dates)  # table stays ascending
+    idx = dates.index("2026-05-20")
+    assert dates[idx - 1] == "2026-05-16"
+    assert dates[idx + 1] == "2026-06-26"

--- a/tests/specify_cli/identity/test_identity_build_id_determinism.py
+++ b/tests/specify_cli/identity/test_identity_build_id_determinism.py
@@ -22,7 +22,7 @@ from specify_cli.identity.project import (
     resolve_identity,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 _NODE_ID = "abc123def456"
 _OTHER_NODE_ID = "ffffffffffff"

--- a/tests/specify_cli/sync/test_worktree_clean_invariant.py
+++ b/tests/specify_cli/sync/test_worktree_clean_invariant.py
@@ -70,6 +70,10 @@ from mission_runtime.artifacts import (
 from specify_cli.identity.project import load_identity
 from specify_cli.sync.events import emit_wp_status_changed, reset_emitter
 
+# Gate-selected markers so this file is actually run in CI (was a zero-gate #2034
+# orphan): it drives real git via ``subprocess`` (git_repo) and is integration-level.
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
 _CONFIG_RELPATH = ".kittify/config.yaml"
 _MISSION_SLUG = "worktree-clean-invariant-01KWC9Y0"
 

--- a/tests/specify_cli/tracker/test_binding_report_only.py
+++ b/tests/specify_cli/tracker/test_binding_report_only.py
@@ -25,7 +25,7 @@ from specify_cli.tracker.config import (
 )
 from specify_cli.tracker.saas_service import SaaSTrackerService
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 @pytest.fixture()


### PR DESCRIPTION
**Draft** — dev-tooling QoL. Removes a recurring `docs-freshness` failure agents hit when adding an ADR.

## Motivation
Adding an ADR under `docs/adr/<era>/` requires two index updates the `docs-freshness` gate enforces, and they're easy to forget (`LEAK-MISSING-INVENTORY` / `INVENTORY-LOCKFILE-DRIFT`):
1. a `PageInventoryEntry` row in `docs/development/3-2-page-inventory.yaml` (a **generated** lockfile — regenerated from frontmatter, not hand-maintained), and
2. a `| date | [title](file) |` row in the era README table.

The first is already a library operation (`inventory_lockfile.generate_inventory` + `render_lockfile`, verified byte-stable) but **undiscoverable** — agents hand-edit the YAML instead. The second is genuinely un-automated. This wraps both into one command and documents it where the next author will look.

## `scripts/docs/freshen_adr_inventory.py`
```
freshen_adr_inventory [-h] [--all] [--check] [--repo-root R] [--docs-root D] [adr_paths ...]
```
- **Inventory:** regenerates `3-2-page-inventory.yaml` from frontmatter (reuses the canonical `inventory_lockfile` machinery — no schema fork; a no-op on a clean tree).
- **ADR README row:** parses each ADR's frontmatter `title`/`date`, strips a leading `ADR: `, collapses folded titles, derives the era README from the path, inserts the row — **idempotent** + **date-ascending**.
- `--all` auto-detects ADRs missing from their era README; `--check` is a verify-only gate (non-zero on stale inventory or missing rows).

## Tests / quality
- `tests/docs/test_freshen_adr_inventory.py` — **9 passed** (both-rows add, idempotency, `--check` stale/missing→non-zero & clean→zero, `--all` detect, `ADR:` strip, folded-title collapse, date-ordered insertion). Full `tests/docs/`: **519 passed**. ruff + mypy clean.
- Dogfood: throwaway ADR → tool → `check_docs_freshness --ci` exit 0 → reverted to a clean tree.

## Reviewer notes
- New README rows use the ADR's frontmatter `title` verbatim (prefix-stripped) — canonical SSOT. Existing hand-authored rows have divergent casing; not retroactively reconciled (out of scope).
- Discoverability note added to `docs/adr/index.md` + the 3.x README.
- Legacy eras (1.x/2.x) have no ADR table and the gate is green without one, so `--all` skips table-less eras rather than back-filling a table; an explicit path into a table-less era errors clearly. **This is the one behavior worth a reviewer's eye.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)