### PR TITLE
docs: fix stale docs/development/ testing-doc links (post-consolidation)

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2055,7 +2055,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # quarantine-visibility: runs `-m quarantine` for real (SPEC_KITTY_RUN_QUARANTINE=1)
   # so irreducible environmental flakes stay VISIBLE — never silently retried to
-  # green. Per docs/development/testing-flakiness.md this job is intentionally
+  # green. Per docs/guides/testing-flakiness.md this job is intentionally
   # NON-BLOCKING: it MUST NOT be added to the `quality-gate` aggregation below
   # or to branch-protection required checks, so a quarantined flake can never turn
   # main red or block an unrelated PR. Tolerates pytest exit code 5 (no tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,11 +208,11 @@ Rules:
   protected by per-worker HOME isolation, so run them in their own `-n0` pass.
 
 Full rationale, the volume env gates, and the stability ratchet:
-[docs/development/testing-parallel.md](docs/development/testing-parallel.md).
+[docs/guides/testing-parallel.md](docs/guides/testing-parallel.md).
 
 When a test goes red on CI unrelated to your diff, follow the flakiness policy —
 **tune budget gates, fix correctness flakes at the root, never retry-to-green:**
-[docs/development/testing-flakiness.md](docs/development/testing-flakiness.md).
+[docs/guides/testing-flakiness.md](docs/guides/testing-flakiness.md).
 
 ## Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@ CI test coverage, and decomposes the `agent/tasks.py` god-module.
   one-way-import seam modules with a byte-identical CLI surface; the three planning-commit tails
   are centralized through `commit_for_mission` (#2058 / #2114; follow-up body-thinning + FR-007
   consolidation tracked in #2116).
-- **Test-flakiness handling policy (#2038):** a suite-wide policy (`docs/development/testing-flakiness.md`)
+- **Test-flakiness handling policy (#2038):** a suite-wide policy (`docs/guides/testing-flakiness.md`)
   — never retry-to-green; three tiers (budget / correctness / environmental), each with one sanctioned
   response — plus an env-gated, **non-blocking** `quarantine` pytest marker (held out of every normal/
   blocking run unless `SPEC_KITTY_RUN_QUARANTINE=1`), distinct from the mutmut-deselection `flaky` marker.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ pytest tests/integration/test_version_isolation.py  # Isolation tests
 
 To run the suite in parallel (typically ≥2× faster on a ≥4-core machine), plus
 the serial daemon pass and the coverage-neutrality gates, see
-[Running the test suite in parallel](docs/development/testing-parallel.md).
+[Running the test suite in parallel](docs/guides/testing-parallel.md).
 
 ### Testing Unreleased Main or a Pull Request
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -248,7 +248,7 @@ CI test coverage, and decomposes the `agent/tasks.py` god-module.
   one-way-import seam modules with a byte-identical CLI surface; the three planning-commit tails
   are centralized through `commit_for_mission` (#2058 / #2114; follow-up body-thinning + FR-007
   consolidation tracked in #2116).
-- **Test-flakiness handling policy (#2038):** a suite-wide policy (`docs/development/testing-flakiness.md`)
+- **Test-flakiness handling policy (#2038):** a suite-wide policy (`docs/guides/testing-flakiness.md`)
   — never retry-to-green; three tiers (budget / correctness / environmental), each with one sanctioned
   response — plus an env-gated, **non-blocking** `quarantine` pytest marker (held out of every normal/
   blocking run unless `SPEC_KITTY_RUN_QUARANTINE=1`), distinct from the mutmut-deselection `flaky` marker.

--- a/tests/_support/quarantine.py
+++ b/tests/_support/quarantine.py
@@ -11,7 +11,7 @@ The actual deselection happens in ``tests/conftest.py``'s
 ``pytest_collection_modifyitems`` — this module holds the pure, unit-testable
 decision so the policy can be verified without driving a full pytest session.
 
-See ``docs/development/testing-flakiness.md``.
+See ``docs/guides/testing-flakiness.md``.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ QUARANTINE_MARKER = "quarantine"
 _SKIP_REASON = (
     "quarantine: environmental flake under tracking — held out of normal runs. "
     f"Set {RUN_QUARANTINE_ENV_VAR}=1 to run it. "
-    "See docs/development/testing-flakiness.md"
+    "See docs/guides/testing-flakiness.md"
 )
 
 

--- a/tests/architectural/test_quarantine_marker.py
+++ b/tests/architectural/test_quarantine_marker.py
@@ -13,7 +13,7 @@ rot:
 3. CI runs ``-m quarantine`` in a job that is **non-blocking** (absent from the
    ``quality-gate`` aggregation) and tolerates an empty quarantine set.
 
-See ``docs/development/testing-flakiness.md``.
+See ``docs/guides/testing-flakiness.md``.
 """
 
 from __future__ import annotations
@@ -54,7 +54,7 @@ def test_quarantine_marker_is_registered() -> None:
     assert QUARANTINE_MARKER in names, (
         "The `quarantine` marker must be registered in pytest.ini's `markers` "
         "block (the single source of truth, #2034) — see "
-        "docs/development/testing-flakiness.md"
+        "docs/guides/testing-flakiness.md"
     )
 
 

--- a/tests/specify_cli/shims/test_registry.py
+++ b/tests/specify_cli/shims/test_registry.py
@@ -6,7 +6,7 @@ order is randomised per process by ``PYTHONHASHSEED``. Parametrising over a bare
 ``pytest-xdist`` worker process, which trips xdist's collection-equivalence guard
 ("Different tests were collected between gw0 and gwN"). Always wrap the set in
 ``sorted(...)`` so the parametrised case order is deterministic across workers.
-See docs/development/testing-flakiness.md (Tier: parallel-collection nondeterminism).
+See docs/guides/testing-flakiness.md (Tier: parallel-collection nondeterminism).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
**Draft** — small doc-hygiene fix surfaced by the codebase-health review.

The docs-consolidation mission moved `testing-parallel.md` and `testing-flakiness.md` from `docs/development/` to `docs/guides/`, but its reference-sweep missed 8 live files still linking the old paths (now broken links):

- `AGENTS.md` (×2) — the real file; `CLAUDE.md` is a symlink to it (left untouched)
- `CONTRIBUTING.md`, `CHANGELOG.md`, `docs/changelog/CHANGELOG.md`
- `tests/_support/quarantine.py` (×2), `tests/specify_cli/shims/test_registry.py`, `tests/architectural/test_quarantine_marker.py` (×2) — paths appear only in assertion/docstring messages
- `.github/workflows/ci-quality.yml` (comment)

All re-pointed to `docs/guides/`. Historical `kitty-specs/` snapshots left as immutable. Quarantine + registry tests pass (113). No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)