### PR TITLE
chore(status): re-materialize two stale mission status.json snapshots (TeamSpace SNAPSHOT_DRIFT)

### DIFF
--- a/kitty-specs/decompose-merge-god-module-01KVXHDK/status.json
+++ b/kitty-specs/decompose-merge-god-module-01KVXHDK/status.json
@@ -1,7 +1,7 @@
 {
-  "event_count": 11,
-  "last_event_id": "01KVXKAEBPCNRK5967724VQYJV",
-  "materialized_at": "2026-06-24T19:57:09.878488+00:00",
+  "event_count": 88,
+  "last_event_id": "01KVY1PDFA7G7XPB6N8NKHYNW7",
+  "materialized_at": "2026-06-25T00:08:22.250873+00:00",
   "mission_number": "",
   "mission_slug": "decompose-merge-god-module-01KVXHDK",
   "mission_type": "software-dev",
@@ -10,89 +10,89 @@
     "blocked": 0,
     "canceled": 0,
     "claimed": 0,
-    "done": 0,
+    "done": 11,
     "for_review": 0,
     "in_progress": 0,
     "in_review": 0,
-    "planned": 11
+    "planned": 0
   },
   "work_packages": {
     "WP01": {
-      "actor": "finalize-tasks",
+      "actor": "merge",
       "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKA61KY2JHDJ5C4YQJT32F",
-      "last_transition_at": "2026-06-24T19:57:01.363095+00:00"
+      "lane": "done",
+      "last_event_id": "01KVY1P4GYX4E8GMG3B33S8DSB",
+      "last_transition_at": "2026-06-25T00:08:13.086308+00:00"
     },
     "WP02": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKA7J6P1N1A7KTT2QZN648",
-      "last_transition_at": "2026-06-24T19:57:02.918262+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1P5F7V9TBJN78MVNY5TW5",
+      "last_transition_at": "2026-06-25T00:08:14.055736+00:00"
     },
     "WP03": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKA8BFYMFZB2NT7DTG8GBR",
-      "last_transition_at": "2026-06-24T19:57:03.727552+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1P6CFHMMAPS95AZT166A7",
+      "last_transition_at": "2026-06-25T00:08:14.991145+00:00"
     },
     "WP04": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKA960Z7857N5APPZ1TFDP",
-      "last_transition_at": "2026-06-24T19:57:04.576296+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1P7999GDY2EJ1TYM6C0FT",
+      "last_transition_at": "2026-06-25T00:08:15.913784+00:00"
     },
     "WP05": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKA9V4PEG56Y7J0WD4H1JX",
-      "last_transition_at": "2026-06-24T19:57:05.252151+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1P86WC5ZKT2KZ61FKV1Y3",
+      "last_transition_at": "2026-06-25T00:08:16.860514+00:00"
     },
     "WP06": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKAANJC2W2HQ9XY0TK9Z0R",
-      "last_transition_at": "2026-06-24T19:57:06.098246+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1P94JDZY2MG4X6M7VK5YM",
+      "last_transition_at": "2026-06-25T00:08:17.811016+00:00"
     },
     "WP07": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKABEXC9MR6FEWPW4RPWH1",
-      "last_transition_at": "2026-06-24T19:57:06.909066+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1PA113MK1XVNMJ8JB7D7E",
+      "last_transition_at": "2026-06-25T00:08:18.721315+00:00"
     },
     "WP08": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKAC7G8QSZ068N6VKJZYZX",
-      "last_transition_at": "2026-06-24T19:57:07.696734+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1PAXPXS3BY4QZ8HK4JRNQ",
+      "last_transition_at": "2026-06-25T00:08:19.638040+00:00"
     },
     "WP09": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKAD1B5SFTAAV4VQE4D3GC",
-      "last_transition_at": "2026-06-24T19:57:08.523374+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1PBVBPNGT9QG0QWN08F4Y",
+      "last_transition_at": "2026-06-25T00:08:20.587969+00:00"
     },
     "WP10": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKADPB806E5C1JKZTCA90S",
-      "last_transition_at": "2026-06-24T19:57:09.195924+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1PCNZZDTKSWT8QJ3BZDKT",
+      "last_transition_at": "2026-06-25T00:08:21.439548+00:00"
     },
     "WP11": {
-      "actor": "finalize-tasks",
-      "force_count": 0,
-      "lane": "planned",
-      "last_event_id": "01KVXKAEBPCNRK5967724VQYJV",
-      "last_transition_at": "2026-06-24T19:57:09.878488+00:00"
+      "actor": "merge",
+      "force_count": 2,
+      "lane": "done",
+      "last_event_id": "01KVY1PDFA7G7XPB6N8NKHYNW7",
+      "last_transition_at": "2026-06-25T00:08:22.250873+00:00"
     }
   }
 }

--- a/kitty-specs/decompose-mission-god-module-01KVXHF8/status.json
+++ b/kitty-specs/decompose-mission-god-module-01KVXHF8/status.json
@@ -2,7 +2,7 @@
   "event_count": 47,
   "last_event_id": "01KVY0ECP12P524KBWG4HVXNMZ",
   "materialized_at": "2026-06-24T23:46:30.721180+00:00",
-  "mission_number": "",
+  "mission_number": "148",
   "mission_slug": "decompose-mission-god-module-01KVXHF8",
   "mission_type": "software-dev",
   "summary": {


### PR DESCRIPTION
## What

Re-materializes `status.json` from `status.events.jsonl` (via `specify_cli.status.reducer.materialize`) for the two missions `spec-kitty doctor mission-state --audit` flagged as TeamSpace `SNAPSHOT_DRIFT` **error** blockers:

- `decompose-merge-god-module-01KVXHDK` — snapshot frozen at event 11 of 88: reported all 11 WPs `planned` while the event log has them `done`.
- `decompose-mission-god-module-01KVXHF8` — missing the merge-time `mission_number: 148`.

After: audit reports **0 errors / 0 TeamSpace blockers** across 236 missions.

## Why now

Surfaced while verifying the repo catfoods its own main (editable install @ cf2e91e17). The upgrade path itself recommends `doctor mission-state --fix`, but that fixer does **not** repair the SNAPSHOT_DRIFT blockers it flags — tooling gap filed separately.

## Notes

- Pure planning-artifact diff (2 × `status.json`), zero code changes.
- `--fix` also wrote uncommitted repairs into several *stale coordination worktrees* of long-merged missions; not included here, called out in the gap issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YC7W2g1xJHQdBB7eBGu748