### PR TITLE
fix(#2331): resolve dashboard mission identity from the primary surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shows under its real title and canonical ULID; status/board display still uses
   the coordination surface. `lifecycle.json` now also carries `mission_id`. No
   change for merged/idle missions.
+
 - **`mission close` / `spec-kitty merge` now commit the retrospective they
   auto-generate, instead of leaving the durable event log dirty.** Closing a
   mission that was merged via the legacy plain-git/GitHub path (so merge-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **The dashboard no longer orphans a valid in-flight (mid-orchestration)
+  mission (#2331).** While a coordination-topology mission had live worktrees
+  checked out, `spec-kitty dashboard` registered it under a synthetic
+  `orphan:<slug>` key — hiding it from the mission dropdown — because the
+  registry read mission identity (`meta.json`) from the coordination worktree,
+  which lacks it (`meta.json` is a PRIMARY-partition artifact that lives on the
+  primary checkout). Identity now resolves through the kind-aware
+  `resolve_planning_read_dir(..., PRIMARY_METADATA)` seam, so a mission mid-run
+  shows under its real title and canonical ULID; status/board display still uses
+  the coordination surface. `lifecycle.json` now also carries `mission_id`. No
+  change for merged/idle missions.
 - **`mission close` / `spec-kitty merge` now commit the retrospective they
   auto-generate, instead of leaving the durable event log dirty.** Closing a
   mission that was merged via the legacy plain-git/GitHub path (so merge-time

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **The dashboard no longer orphans a valid in-flight (mid-orchestration)
+  mission (#2331).** While a coordination-topology mission had live worktrees
+  checked out, `spec-kitty dashboard` registered it under a synthetic
+  `orphan:<slug>` key — hiding it from the mission dropdown — because the
+  registry read mission identity (`meta.json`) from the coordination worktree,
+  which lacks it (`meta.json` is a PRIMARY-partition artifact that lives on the
+  primary checkout). Identity now resolves through the kind-aware
+  `resolve_planning_read_dir(..., PRIMARY_METADATA)` seam, so a mission mid-run
+  shows under its real title and canonical ULID; status/board display still uses
+  the coordination surface. `lifecycle.json` now also carries `mission_id`. No
+  change for merged/idle missions.
+
 - **`mission close` / `spec-kitty merge` now commit the retrospective they
   auto-generate, instead of leaving the durable event log dirty.** Closing a
   mission that was merged via the legacy plain-git/GitHub path (so merge-time

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -13,6 +13,10 @@ from typing import Any
 
 from specify_cli.dashboard.charter_path import resolve_project_charter_path
 from specify_cli.lanes.branch_naming import resolve_mid8
+from specify_cli.missions._read_path_resolver import (
+    MissionSelectorAmbiguous,
+    resolve_planning_read_dir,
+)
 from specify_cli.upgrade.legacy_detector import is_legacy_format
 from specify_cli.status import wp_state_for
 from specify_cli.status import Lane
@@ -394,6 +398,41 @@ def _read_mission_identity(feature_dir: Path) -> tuple[str | None, int | None]:
     return mission_id, mission_number
 
 
+def _resolve_identity_primary_first(
+    project_dir: Path, feature_dir: Path
+) -> tuple[str | None, int | None]:
+    """Resolve ``(mission_id, mission_number)`` from the PRIMARY surface (#2331).
+
+    Mission identity (``meta.json``) is a PRIMARY-partition artifact: it lives on
+    the primary checkout, never the coordination worktree. But
+    :func:`gather_feature_paths` prefers the coord worktree copy (it holds live
+    *status*), and that copy has no ``meta.json`` mid-orchestration — so reading
+    identity off the scanned ``feature_dir`` orphaned a valid in-flight mission.
+
+    Read identity through the kind-aware read seam
+    (:func:`resolve_planning_read_dir` with ``PRIMARY_METADATA``, the same seam the
+    coord-read fixes use to anchor primary artifacts), and only fall back to the
+    scanned ``feature_dir`` when the primary copy is absent/identity-less (e.g.
+    lane-only or pre-3.1 layouts) so no merged/idle mission regresses.
+    """
+    from mission_runtime import MissionArtifactKind  # noqa: PLC0415 — late import, cold-start cost
+
+    slug = feature_dir.name
+    try:
+        primary_dir = resolve_planning_read_dir(
+            project_dir, slug, kind=MissionArtifactKind.PRIMARY_METADATA
+        )
+    except (ValueError, MissionSelectorAmbiguous):
+        # Unsafe slug segment (traversal guard) or an ambiguous handle — the
+        # dashboard scan must never crash, so keep the scanned dir.
+        return _read_mission_identity(feature_dir)
+
+    mission_id, mission_number = _read_mission_identity(primary_dir)
+    if mission_id is None and mission_number is None and primary_dir != feature_dir:
+        return _read_mission_identity(feature_dir)
+    return mission_id, mission_number
+
+
 def _mission_record_key(feature_dir: Path, mission_id: str | None, mission_number: int | None) -> str:
     """Compute the canonical registry key for a mission.
 
@@ -433,7 +472,9 @@ def build_mission_registry(project_dir: Path) -> dict[str, dict[str, Any]]:
     feature_paths = gather_feature_paths(project_dir)
 
     for _feature_id, feature_dir in feature_paths.items():
-        mission_id, mission_number = _read_mission_identity(feature_dir)
+        # Identity is PRIMARY-anchored (#2331); status/display keep the scanned
+        # (possibly coord) feature_dir below.
+        mission_id, mission_number = _resolve_identity_primary_first(project_dir, feature_dir)
         key = _mission_record_key(feature_dir, mission_id, mission_number)
 
         # mid8 is meaningful only when key is an actual mission_id (ULID).

--- a/src/specify_cli/status/lifecycle.py
+++ b/src/specify_cli/status/lifecycle.py
@@ -65,6 +65,11 @@ class MissionLifecycleResult:
     review_wp_count: int
     terminal_wp_count: int
     has_event_log: bool
+    # Canonical mission identity (#2331). Surfaced in ``lifecycle.json`` so the
+    # derived view carries the ULID, not only the slug — letting a consumer (e.g.
+    # the dashboard registry) re-link a mission to its canonical id from a
+    # materialized view. ``None`` only for pre-3.1.1 missions without a mission_id.
+    mission_id: str | None = None
     # Post-mission lifecycle facts (WP01 / FR-002). ``post_mission_events`` holds
     # the ``MissionReopened`` + ``FollowUpRecorded`` envelopes sorted by
     # ``(timestamp, event_id)`` so ``lifecycle.json`` stays byte-stable; rendered
@@ -78,6 +83,7 @@ class MissionLifecycleResult:
     def to_dict(self) -> dict[str, Any]:
         return {
             "mission_slug": self.mission_slug,
+            "mission_id": self.mission_id,
             "mission_number": self.mission_number,
             "mission_type": self.mission_type,
             "state": self.state,
@@ -394,6 +400,7 @@ def derive_mission_lifecycle(
 
     return MissionLifecycleResult(
         mission_slug=snapshot.mission_slug or identity.mission_slug or feature_dir.name,
+        mission_id=identity.mission_id,
         mission_number=identity.mission_number,
         mission_type=identity.mission_type,
         state=mission_state,

--- a/tests/specify_cli/status/test_lifecycle.py
+++ b/tests/specify_cli/status/test_lifecycle.py
@@ -243,3 +243,26 @@ def test_is_mission_completed_false_for_recoverable_no_events(tmp_path: Path) ->
     assert is_mission_completed(
         feature_dir, now=datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
     ) is False
+
+
+def test_lifecycle_carries_mission_id(tmp_path: Path) -> None:
+    """#2331: the derived lifecycle + lifecycle.json expose the canonical ULID,
+    so a consumer can re-link a mission to its identity from a materialized view."""
+    ulid = "01KWN9D0MJ79NK1T90RWYY2Y7R"
+    feature_dir = tmp_path / "kitty-specs" / "054-carries-id"
+    _write_meta(feature_dir, mission_id=ulid)
+
+    result = derive_mission_lifecycle(
+        feature_dir, now=datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    )
+    assert result.mission_id == ulid
+    assert result.to_dict()["mission_id"] == ulid
+
+    derived_dir = tmp_path / ".kittify" / "derived"
+    generate_lifecycle_json(
+        feature_dir, derived_dir, now=datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+    )
+    written = json.loads(
+        (derived_dir / "054-carries-id" / "lifecycle.json").read_text(encoding="utf-8")
+    )
+    assert written["mission_id"] == ulid

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -515,6 +515,52 @@ def test_dashboard_scans_prefer_coord_worktree_over_root_checkout(tmp_path):
     assert lanes["approved"][0]["id"] == "WP01"
 
 
+def test_registry_resolves_canonical_id_for_inflight_coord_mission(tmp_path):
+    """#2331: a mid-orchestration mission (registered coord worktree, meta.json
+    absent from the coord tree) must resolve to its canonical ULID in the
+    registry — never ``orphan:<slug>`` — because identity is a PRIMARY artifact.
+
+    Reproduces the reported split-brain: ``gather_feature_paths`` prefers the
+    coord worktree (live status), but ``meta.json`` lives only on the primary
+    checkout, so identity resolution must read the primary surface.
+    """
+    slug = "spec-kitty-moov-integration-01KWN9D0"
+    ulid = "01KWN9D0MJ79NK1T90RWYY2Y7R"
+
+    _git(["init", "--initial-branch=main"], tmp_path)
+    _git(["config", "user.email", "scanner@example.com"], tmp_path)
+    _git(["config", "user.name", "Scanner Test"], tmp_path)
+    _git(["config", "commit.gpgsign", "false"], tmp_path)
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(["add", "README.md"], tmp_path)
+    _git(["commit", "-q", "-m", "seed"], tmp_path)
+    coord_worktree = tmp_path / ".worktrees" / f"{slug}-coord"
+    _git(
+        ["worktree", "add", "-q", "-b", f"kitty/mission-{slug}", str(coord_worktree)],
+        tmp_path,
+    )
+
+    # PRIMARY checkout: feature + canonical meta.json (the identity source).
+    primary_dir = _create_feature(tmp_path, slug, lane="in_progress")
+    (primary_dir / "meta.json").write_text(
+        json.dumps({"mission_id": ulid, "mission_slug": slug}), encoding="utf-8"
+    )
+
+    # COORD worktree: live feature artifacts but NO meta.json (mid-orchestration).
+    coord_feature_dir = coord_worktree / "kitty-specs" / slug
+    _create_feature_at(coord_feature_dir, lane="in_progress")
+    assert not (coord_feature_dir / "meta.json").exists()
+
+    registry = scanner.build_mission_registry(tmp_path)
+
+    assert ulid in registry, f"expected canonical ULID key; got {list(registry)}"
+    assert not any(k.startswith("orphan:") for k in registry), f"unexpected orphan: {list(registry)}"
+    assert registry[ulid]["mission_slug"] == slug
+    assert registry[ulid]["mid8"] == ulid[:8]
+    # And it is listed for display (not filtered as a pseudo-key).
+    assert ulid in scanner.sort_missions_for_display(registry)
+
+
 @pytest.mark.fast
 def test_dashboard_husk_coord_dir_does_not_shadow_primary(tmp_path):
     """F-005 adversarial: a ``-coord``-NAMED directory that git does NOT

--- a/tests/test_dashboard/test_scanner_mission_id.py
+++ b/tests/test_dashboard/test_scanner_mission_id.py
@@ -198,6 +198,49 @@ class TestPrimaryFirstIdentity:
 
         assert mission_id == self._ULID
 
+    def test_traversal_guard_valueerror_falls_back_to_scanned_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # resolve_planning_read_dir raises ValueError on a traversal-unsafe
+        # segment — the dashboard scan must fall back, never crash (#2331).
+        scanned = tmp_path / "kitty-specs" / self._SLUG
+        _write_meta(scanned, mission_id=self._ULID)
+
+        def _raise(*_args: object, **_kwargs: object) -> Path:
+            raise ValueError("unsafe path segment")
+
+        monkeypatch.setattr(
+            "specify_cli.dashboard.scanner.resolve_planning_read_dir", _raise
+        )
+
+        mission_id, _mission_number = _resolve_identity_primary_first(tmp_path, scanned)
+
+        assert mission_id == self._ULID
+
+    def test_ambiguous_selector_falls_back_to_scanned_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MissionSelectorAmbiguous (two same-slug missions across surfaces) must
+        # keep the scan alive on the scanned copy, not crash the dashboard.
+        from specify_cli.missions._read_path_resolver import MissionSelectorAmbiguous
+
+        scanned = tmp_path / "kitty-specs" / self._SLUG
+        _write_meta(scanned, mission_id=self._ULID)
+
+        def _raise(*_args: object, **_kwargs: object) -> Path:
+            raise MissionSelectorAmbiguous(
+                handle=self._SLUG,
+                candidates=[self._SLUG, f"{self._SLUG}-copy"],
+            )
+
+        monkeypatch.setattr(
+            "specify_cli.dashboard.scanner.resolve_planning_read_dir", _raise
+        )
+
+        mission_id, _mission_number = _resolve_identity_primary_first(tmp_path, scanned)
+
+        assert mission_id == self._ULID
+
 
 # ---------------------------------------------------------------------------
 # T047 — Display ordering

--- a/tests/test_dashboard/test_scanner_mission_id.py
+++ b/tests/test_dashboard/test_scanner_mission_id.py
@@ -16,6 +16,7 @@ import pytest
 
 from specify_cli.dashboard.scanner import (
     _read_mission_identity,
+    _resolve_identity_primary_first,
     build_mission_registry,
     sort_missions_for_display,
 )
@@ -161,6 +162,41 @@ class TestBuildMissionRegistry:
         (feature_dir / "meta.json").write_text("{bad json", encoding="utf-8")
 
         assert _read_mission_identity(feature_dir) == (None, None)
+
+
+class TestPrimaryFirstIdentity:
+    """#2331 — identity resolves from the PRIMARY surface, never the coord worktree.
+
+    During active orchestration the scanned ``feature_dir`` is the coordination
+    worktree copy, which has no ``meta.json`` (identity is a PRIMARY-partition
+    artifact). Reading identity there orphaned a valid live mission.
+    """
+
+    _ULID = "01KWN9D0MJ79NK1T90RWYY2Y7R"
+    _SLUG = "spec-kitty-moov-integration-01KWN9D0"
+
+    def test_resolves_from_primary_when_scanned_dir_lacks_meta(self, tmp_path: Path) -> None:
+        # Canonical identity lives on the primary surface (repo-root kitty-specs/).
+        _create_mission_dir(tmp_path / "kitty-specs", self._SLUG, mission_id=self._ULID)
+        # The scanned dir is a coord-worktree copy WITHOUT meta.json.
+        coord_dir = tmp_path / ".worktrees" / f"{self._SLUG}-coord" / "kitty-specs" / self._SLUG
+        coord_dir.mkdir(parents=True)
+        assert not (coord_dir / "meta.json").exists()
+
+        mission_id, _mission_number = _resolve_identity_primary_first(tmp_path, coord_dir)
+
+        assert mission_id == self._ULID, "identity must resolve from the primary surface, not orphan"
+
+    def test_falls_back_to_scanned_dir_when_primary_absent(self, tmp_path: Path) -> None:
+        # No primary copy at repo-root/kitty-specs/<slug>; identity only on the
+        # scanned dir. Must NOT regress (e.g. lane-only / pre-3.1 layouts).
+        scanned = tmp_path / "elsewhere" / self._SLUG
+        _write_meta(scanned, mission_id=self._ULID)
+        assert not (tmp_path / "kitty-specs" / self._SLUG / "meta.json").exists()
+
+        mission_id, _mission_number = _resolve_identity_primary_first(tmp_path, scanned)
+
+        assert mission_id == self._ULID
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #2331. A mid-orchestration coordination-topology mission was registered under a synthetic `orphan:<slug>` key and filtered out of the `spec-kitty dashboard` dropdown. `build_mission_registry` (`dashboard/scanner.py`) read mission identity from the scanned `feature_dir`, which `gather_feature_paths` deliberately points at the **coordination worktree** (it holds live status) — but `meta.json` is a **PRIMARY-partition artifact** that lives only on the primary checkout, so identity resolved to `(None, None)` and `_mission_record_key` emitted `orphan:<slug>`. Same class as the coord-read work (#2115/#2118/#2185): a PRIMARY artifact read off the coordination surface.

## Fix
- `build_mission_registry` now resolves identity via `_resolve_identity_primary_first`, which reads `meta.json` through the kind-aware **`resolve_planning_read_dir(..., PRIMARY_METADATA)`** seam (the canonical read fold), falling back to the scanned dir when the primary copy is absent (lane-only / pre-3.1 layouts) so merged/idle missions never regress. The record keeps the scanned (possibly coord) `feature_dir` for live status/board display.
- `lifecycle.json` now carries `mission_id` — `MissionLifecycleResult` already resolved it via `resolve_mission_identity`, but it was dropped from `to_dict()`.

## Design note (resolution-authority gate)
Chose the `resolve_planning_read_dir` seam over a direct `primary_feature_dir_for_mission` call specifically to stay gate-clean. The resolution-authority gate (the one that reworked #2149) flags direct `primary_feature_dir_for_mission` calls, and its allowlist is shrink-only — routing through the sanctioned kind-aware seam needs no allowlist entry and no baseline bump. The dashboard scan is kept resilient: `ValueError` (traversal guard) / `MissionSelectorAmbiguous` fall back to the scanned dir rather than crash.

## Acceptance criteria
- ✅ An in-flight (unmerged, mid-orchestration, valid `meta.json`) mission appears under its real title and canonical ULID in `dashboard --json` — never `orphan:<slug>`.
- ✅ No regression for merged/idle missions (primary dir == scanned dir for those; fallback preserves any edge layout).
- ✅ `lifecycle.json` carries `mission_id`.

## Tests
- Unit (`test_scanner_mission_id.py`): primary-first identity resolution when the scanned dir is a coord copy without `meta.json`; fallback to the scanned dir when the primary copy is absent.
- End-to-end (`test_scanner.py`): a **registered** git coord worktree whose tree lacks `meta.json` → `build_mission_registry` resolves the canonical ULID (no orphan) and lists it for display.
- Lifecycle (`test_lifecycle.py`): `mission_id` present on the result and in the written `lifecycle.json`.
- 155 tests pass incl. `test_resolution_authority_gates` / `test_untrusted_path_containment` / `test_gate_read_literal_ban`; ruff + mypy + terminology guard clean. No version bump (no `__init__.py` change); CHANGELOG under `[Unreleased] - 3.2.4`.

## Notes
Cosmetic (does not affect orchestration or mission data). Sibling: #2280 — same class of mid-run state-management rough edges.