### PR TITLE
fix(#2335): move-task --to for_review commits uncommitted lane deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the coordination surface. `lifecycle.json` now also carries `mission_id`. No
   change for merged/idle missions.
 
+- **`move-task --to for_review` recovers a killed implementer's uncommitted lane
+  deliverables instead of dead-ending (#2335).** When an implementer finished its
+  files but was interrupted before committing, moving the work package to
+  `for_review` failed with a message demanding a manual `git add`/`git commit`
+  *inside the lane worktree* — violating the "spec-kitty drives commits" rule. On
+  the `for_review` transition, when the auto-commit policy is enabled (the
+  default), spec-kitty now commits the finished lane deliverables via the tool
+  (`safe_commit` on the lane branch) before the readiness guard runs, so recovery
+  completes without touching lane git by hand. Scoped to `for_review` only
+  (`approved`/`done` deliverables are already committed); `--force` still
+  bypasses, and `--no-auto-commit` defers to the existing guard.
+
 - **`mission close` / `spec-kitty merge` now commit the retrospective they
   auto-generate, instead of leaving the durable event log dirty.** Closing a
   mission that was merged via the legacy plain-git/GitHub path (so merge-time

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the coordination surface. `lifecycle.json` now also carries `mission_id`. No
   change for merged/idle missions.
 
+- **`move-task --to for_review` recovers a killed implementer's uncommitted lane
+  deliverables instead of dead-ending (#2335).** When an implementer finished its
+  files but was interrupted before committing, moving the work package to
+  `for_review` failed with a message demanding a manual `git add`/`git commit`
+  *inside the lane worktree* — violating the "spec-kitty drives commits" rule. On
+  the `for_review` transition, when the auto-commit policy is enabled (the
+  default), spec-kitty now commits the finished lane deliverables via the tool
+  (`safe_commit` on the lane branch) before the readiness guard runs, so recovery
+  completes without touching lane git by hand. Scoped to `for_review` only
+  (`approved`/`done` deliverables are already committed); `--force` still
+  bypasses, and `--no-auto-commit` defers to the existing guard.
+
 - **`mission close` / `spec-kitty merge` now commit the retrospective they
   auto-generate, instead of leaving the durable event log dirty.** Closing a
   mission that was merged via the legacy plain-git/GitHub path (so merge-time

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -392,8 +392,12 @@ from specify_cli.cli.commands.agent.tasks_move_task import (
     _detect_arbiter_override as _detect_arbiter_override,
     _detect_reviewer_name as _detect_reviewer_name,
     _do_move_task as _do_move_task,
+    # #2335: the for_review deliverable-recovery pair (lane porcelain parser +
+    # pre-guard auto-commit) joins the family surface like every other def.
+    _lane_deliverable_paths as _lane_deliverable_paths,
     _mt_approval_facts as _mt_approval_facts,
     _mt_build_request as _mt_build_request,
+    _mt_commit_lane_deliverables as _mt_commit_lane_deliverables,
     _mt_commit_wp_file as _mt_commit_wp_file,
     _mt_current_event_lane as _mt_current_event_lane,
     _mt_done_ancestry_facts as _mt_done_ancestry_facts,

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -366,6 +366,91 @@ def _mt_build_request(
     )
 
 
+def _lane_deliverable_paths(worktree_path: Path, porcelain: str) -> tuple[Path, ...]:
+    """Parse ``git status --porcelain`` lines into absolute deliverable paths."""
+    paths: list[Path] = []
+    for line in porcelain.splitlines():
+        if len(line) < 4:
+            continue
+        entry = line[3:]
+        if " -> " in entry:  # rename/copy — the destination is the live path
+            entry = entry.split(" -> ", 1)[1]
+        entry = entry.strip().strip('"')
+        if entry:
+            paths.append(worktree_path / entry)
+    return tuple(paths)
+
+
+def _mt_commit_lane_deliverables(st: _MoveTaskState) -> None:
+    """Commit finished lane deliverables before a review transition (#2335).
+
+    A killed implementer can leave its deliverables uncommitted in the lane
+    worktree; without this, ``move-task --to for_review`` dead-ends demanding a
+    manual in-worktree ``git commit`` — violating the tool-drives-commits rule.
+    When auto-commit is enabled, stage + commit the finished deliverables via the
+    tool (``safe_commit`` on the lane branch) so the readiness guard sees a clean
+    tree. Best-effort: any failure leaves the tree untouched and the existing
+    ``_validate_ready_for_review`` guard explains the situation.
+    """
+    from specify_cli.cli.commands.agent import tasks as _tasks
+
+    try:
+        workspace = _tasks.resolve_workspace_for_wp(
+            st.main_repo_root, st.mission_slug, st.task_id
+        )
+    except (ValueError, FileNotFoundError):
+        return
+    # Only a real lane worktree carries deliverables to commit; a planning-artifact
+    # / repo-root WP has no lane branch (branch_name is None) — nothing to do.
+    if workspace.resolution_kind != "lane_workspace" or workspace.branch_name is None:
+        return
+    worktree_path = workspace.worktree_path
+    if not worktree_path.exists():
+        return
+
+    status = _tasks.subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if status.returncode != 0:
+        return
+    # Reuse the guard's runtime-state filter so we only commit genuine deliverables
+    # (never spec-kitty's own review-lock / .kittify bookkeeping).
+    filtered = _tasks._filter_runtime_state_paths(status.stdout.strip())
+    if not filtered:
+        return
+    paths = _lane_deliverable_paths(worktree_path, filtered)
+    if not paths:
+        return
+
+    try:
+        from specify_cli.git import safe_commit
+
+        safe_commit(
+            repo_root=st.main_repo_root,
+            worktree_root=worktree_path,
+            destination_ref=workspace.branch_name,
+            message=f"chore({st.task_id}): commit lane deliverables for review",
+            paths=paths,
+        )
+        if not st.json_output:
+            _tasks.console.print(
+                f"[cyan]Committed lane deliverables for {st.task_id} on "
+                f"{workspace.branch_name} before review.[/cyan]"
+            )
+    except Exception as exc:  # noqa: BLE001 — best-effort; the guard explains on failure
+        if not st.json_output:
+            _tasks.console.print(
+                f"[yellow]Warning:[/yellow] could not auto-commit lane deliverables "
+                f"for {st.task_id}: {exc}"
+            )
+
+
 def _mt_gather_review_facts(st: _MoveTaskState) -> None:
     """Gather the early (guard-gating) facts and build the pass-1 request."""
     from specify_cli.cli.commands.agent import tasks as _tasks
@@ -393,6 +478,15 @@ def _mt_gather_review_facts(st: _MoveTaskState) -> None:
     review_ready = True
     review_guidance: tuple[str, ...] = ()
     if st.target_lane in (Lane.FOR_REVIEW, Lane.APPROVED, Lane.DONE):
+        # #2335: on the implement→review handoff, recover a killed implementer's
+        # uncommitted deliverables by committing them via the tool (auto-commit
+        # policy) BEFORE the readiness guard runs — so recovery never dead-ends
+        # demanding a manual worktree commit. Scoped to for_review ONLY:
+        # approved/done deliverables are already committed (they passed review),
+        # so a dirty tree there is a real signal the guard should still surface.
+        # --force still bypasses; auto-commit-off defers to the guard.
+        if st.target_lane == Lane.FOR_REVIEW and st.resolved_auto_commit and not st.force:
+            _mt_commit_lane_deliverables(st)
         is_valid, guidance = _tasks._validate_ready_for_review(
             st.repo_root,
             st.mission_slug,

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -393,12 +393,15 @@ def _mt_commit_lane_deliverables(st: _MoveTaskState) -> None:
     ``_validate_ready_for_review`` guard explains the situation.
     """
     from specify_cli.cli.commands.agent import tasks as _tasks
+    from specify_cli.lanes.persistence import CorruptLanesError, MissingLanesError
 
     try:
         workspace = _tasks.resolve_workspace_for_wp(
             st.main_repo_root, st.mission_slug, st.task_id
         )
-    except (ValueError, FileNotFoundError):
+    except (ValueError, FileNotFoundError, MissingLanesError, CorruptLanesError):
+        # No resolvable lane workspace (missions without lanes.json included) —
+        # nothing to recover; the readiness guard stays authoritative.
         return
     # Only a real lane worktree carries deliverables to commit; a planning-artifact
     # / repo-root WP has no lane branch (branch_name is None) — nothing to do.

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -432,12 +432,14 @@ def _mt_commit_lane_deliverables(st: _MoveTaskState) -> None:
         return
 
     try:
+        from mission_runtime import CommitTarget
+
         from specify_cli.git import safe_commit
 
         safe_commit(
             repo_root=st.main_repo_root,
             worktree_root=worktree_path,
-            destination_ref=workspace.branch_name,
+            target=CommitTarget(ref=workspace.branch_name),
             message=f"chore({st.task_id}): commit lane deliverables for review",
             paths=paths,
         )

--- a/tests/specify_cli/cli/commands/agent/test_tasks_move_task_seam.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_move_task_seam.py
@@ -48,6 +48,10 @@ _MOVE_SET: tuple[str, ...] = (
     "_mt_resolve_targets",
     "_mt_resolve_feedback",
     "_mt_build_request",
+    # #2335: for_review deliverable-recovery pair (porcelain parser + pre-guard
+    # auto-commit), re-exported through ``tasks`` like the rest of the family.
+    "_lane_deliverable_paths",
+    "_mt_commit_lane_deliverables",
     "_mt_gather_review_facts",
     "_mt_fire_override_persist",
     "_mt_done_ancestry_facts",

--- a/tests/tasks/test_move_task_git_validation_unit.py
+++ b/tests/tasks/test_move_task_git_validation_unit.py
@@ -373,7 +373,9 @@ class TestMoveTaskGitValidation:
     def test_move_to_for_review_still_validates(
         self, mock_slug: Mock, mock_root: Mock, git_repo_with_worktree: tuple[Path, Path]
     ):
-        """Should still validate when moving to for_review (existing behavior)."""
+        """With auto-commit OFF, moving to for_review still validates and blocks on
+        uncommitted work (#2335: the guard defers to the operator only when
+        auto-commit is disabled; with it on, deliverables are committed instead)."""
         repo_root, worktree = git_repo_with_worktree
         mock_root.return_value = repo_root
         mock_slug.return_value = "017-test-feature"
@@ -381,10 +383,12 @@ class TestMoveTaskGitValidation:
         # Create uncommitted file in worktree
         (worktree / "uncommitted.txt").write_text("Uncommitted work\n")
 
-        # Try to move to for_review (should fail)
-        result = runner.invoke(app, ["move-task", "WP01", "--to", "for_review", "--json"])
+        # With --no-auto-commit, the recovery commit is skipped and the guard fires.
+        result = runner.invoke(
+            app, ["move-task", "WP01", "--to", "for_review", "--no-auto-commit", "--json"]
+        )
 
-        # Verify failure (existing behavior preserved)
+        # Verify failure (guard still validates when auto-commit is off)
         assert result.exit_code == 1
         # Parse only the first JSON object (CLI may output multiple)
         first_line = result.stdout.strip().split("\n")[0]
@@ -573,3 +577,63 @@ class TestMoveTaskGitValidation:
         worktree_events = read_events(worktree / "kitty-specs" / "017-test-feature")
         assert any(event.wp_id == "WP01" and event.to_lane == Lane.FOR_REVIEW for event in main_events)
         assert not any(event.wp_id == "WP01" and event.to_lane == Lane.FOR_REVIEW for event in worktree_events)
+
+
+class TestMoveTaskCommitsLaneDeliverables:
+    """#2335 — move-task --to for_review commits uncommitted lane deliverables
+    (killed-implementer recovery) instead of dead-ending on a manual commit."""
+
+    @patch("specify_cli.cli.commands.agent.tasks.locate_project_root")
+    @patch("specify_cli.cli.commands.agent.tasks._find_mission_slug")
+    def test_for_review_auto_commits_uncommitted_deliverables(
+        self, mock_slug: Mock, mock_root: Mock, git_repo_with_worktree: tuple[Path, Path]
+    ):
+        repo_root, worktree = git_repo_with_worktree
+        mock_root.return_value = repo_root
+        mock_slug.return_value = "017-test-feature"
+
+        # A killed implementer left a finished deliverable uncommitted in the lane.
+        (worktree / "deliverable.py").write_text("print('done')\n")
+        assert (
+            subprocess.run(
+                ["git", "status", "--porcelain"], cwd=worktree, capture_output=True, text=True, check=True
+            ).stdout.strip()
+            != ""
+        )
+
+        # Recovery: move to for_review WITHOUT --force. Auto-commit is on by default.
+        result = runner.invoke(app, ["move-task", "WP01", "--to", "for_review", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        # The deliverable was committed via the tool — worktree is clean, no manual git.
+        assert (
+            subprocess.run(
+                ["git", "status", "--porcelain"], cwd=worktree, capture_output=True, text=True, check=True
+            ).stdout.strip()
+            == ""
+        )
+        # It landed on the lane branch as a real commit.
+        head_files = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=worktree, capture_output=True, text=True, check=True,
+        ).stdout
+        assert "deliverable.py" in head_files
+        # And the transition actually happened.
+        main_events = read_events(repo_root / "kitty-specs" / "017-test-feature")
+        assert any(e.wp_id == "WP01" and e.to_lane == Lane.FOR_REVIEW for e in main_events)
+
+
+def test_lane_deliverable_paths_parses_porcelain(tmp_path: Path):
+    """The porcelain parser extracts modified/untracked/renamed paths, dropping shape noise."""
+    from specify_cli.cli.commands.agent.tasks_move_task import _lane_deliverable_paths
+
+    porcelain = "\n".join([
+        " M src/app.py",       # modified
+        "?? new_file.txt",     # untracked
+        'R  old.py -> new.py',  # rename → destination
+        "x",                    # too short — ignored
+    ])
+    paths = _lane_deliverable_paths(tmp_path, porcelain)
+    names = {p.name for p in paths}
+    assert names == {"app.py", "new_file.txt", "new.py"}
+    assert all(p.parent == tmp_path or p.is_relative_to(tmp_path) for p in paths)


### PR DESCRIPTION
## Summary
Closes #2335. Recovering a stale WP with `spec-kitty agent tasks move-task <WP> --to for_review` **dead-ended** when the lane worktree had uncommitted deliverables (the implementer finished the files but was killed before committing): the readiness guard demanded a manual `git add`/`git commit` **inside the lane worktree**, violating the "spec-kitty drives commits, don't touch worktree git by hand" rule. The only escape was `--force`, which bypasses the guard and commits nothing.

## Fix
On the `for_review` transition, when the auto-commit policy is enabled (the default), `_mt_gather_review_facts` now commits the finished lane deliverables via `safe_commit` on the lane branch **before** `_validate_ready_for_review` runs — so the guard sees a clean tree and recovery completes without hand-git. It reuses the guard's own `_filter_runtime_state_paths` (commit only genuine deliverables, never spec-kitty's own review-lock / `.kittify` bookkeeping) and resolves the lane worktree/branch via `resolve_workspace_for_wp` (planning-artifact WPs with no lane worktree are skipped). **Best-effort:** a commit failure leaves the tree untouched and the existing guard explains the situation.

## Scope decision
- **`for_review` only.** `approved`/`done` deliverables are already committed (they passed review), so a dirty tree there stays a real signal the guard should surface — behavior unchanged.
- `--force` still bypasses the guard; `--no-auto-commit` defers to the existing guard.

## Acceptance criteria
- ✅ `move-task <WP> --to for_review` on a WP whose lane worktree has uncommitted deliverables commits them (auto-commit on) and completes — no manual `git add`/`git commit`.
- ✅ No behavior change when nothing is uncommitted, when auto-commit is off, for `approved`/`done`, or for planning-artifact WPs with no lane worktree.
- ✅ Regression test: uncommitted lane deliverable → move-task to for_review → deliverable committed on the lane branch + transition succeeds.

## Tests
- `for_review` with an uncommitted deliverable → auto-commits + transitions (asserts clean worktree, deliverable present on the lane branch HEAD, and the `for_review` event).
- `--no-auto-commit` → guard still blocks (the prior "for_review still validates" test re-pinned to this path, documenting the new gating).
- Pure unit test for the porcelain path parser (modified / untracked / rename→destination / shape-noise).
- 137 tasks-family + `for_review` regression tests pass; `test_resolution_authority_gates` / `test_untrusted_path_containment` / terminology guard green; ruff + mypy clean. No version bump (no `__init__.py` change); CHANGELOG under `[Unreleased] - 3.2.4`.

## Relationship to the larger mission-resume bug
This is **Defect 2** of the report. **Defects 1 & 3** — the orchestrator's resumable scheduler (dispatch a reviewer for `for_review` WPs on resume; quarantine-not-infinite-loop on `LANE_ALLOCATION_FAILED`) and idempotent lane re-allocation — live in `spec-kitty-orchestrator` and are tracked separately. Note this fix **partially mitigates Defect 1**: leaving the lane clean after a `for_review` transition removes the `DirtyWorktreeError` (`worktree_allocator._validate_worktree_clean`) that surfaces as `LANE_ALLOCATION_FAILED` on lane reuse. The dashboard-orphan sibling is already fixed (#2331 → #2332).