### PR TITLE
fix(gitignore): ignore kitty-ops/ops-index.jsonl Op-index cache (#2341)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **The Op-index performance cache is now gitignored (#2341).**
+  `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
+  `spec-kitty invocations list` — was never added to `.gitignore`, so a
+  freshly-generated index showed up in `git status` indefinitely (and could be
+  accidentally committed). It is now registered as an `IGNORED` `LOCAL_RUNTIME`
+  surface in the state contract (`op_invocation_index`), which flows into fresh
+  `spec-kitty init` protection automatically. Existing projects are repaired by
+  the runtime git-hygiene migration, which also `git rm --cached`s a
+  previously-committed index. Durable per-Op audit records
+  (`kitty-ops/<op_id>.jsonl`, the new `op_invocation_record` surface) stay
+  **tracked** — only the index is ignored.
 - **The dashboard no longer orphans a valid in-flight (mid-orchestration)
   mission (#2331).** While a coordination-topology mission had live worktrees
   checked out, `spec-kitty dashboard` registered it under a synthetic

--- a/src/mission_runtime/artifacts.py
+++ b/src/mission_runtime/artifacts.py
@@ -161,8 +161,11 @@ _SELF_BOOKKEEPING_SUFFIXES: tuple[str, ...] = (
 # own invocation audit trail — NOT mission planning artifacts.  A stale record
 # left from a previous ``spec-kitty dispatch`` session must not block dirty-tree
 # gates.  The match is TIGHT: exactly ``kitty-ops/`` segment + 26-char Crockford
-# base32 ULID + ``.jsonl``.  A non-ULID basename (e.g. ``notes.txt``,
-# ``ops-index.jsonl``) is NOT matched — they remain real dirt (G-5 invariant).
+# base32 ULID + ``.jsonl``.  A non-ULID basename (e.g. ``notes.txt``) is NOT
+# matched — it remains real dirt (G-5 invariant).  Note: ``ops-index.jsonl``
+# is a non-ULID basename too, but as of #2341 it is a gitignored LOCAL_RUNTIME
+# cache (``op_invocation_index`` surface), so it never reaches this classifier
+# in a correctly-migrated project — it is not "real dirt" here.
 # Crockford base32 alphabet: digits 0–9 plus uppercase A–Z MINUS I, L, O, U.
 _KITTY_OPS_OP_RECORD_RE: re.Pattern[str] = re.compile(
     r"(?:^|/)kitty-ops/[0-9A-HJKMNP-TV-Z]{26}\.jsonl$"

--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -177,6 +177,17 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         notes="Machine-local SaaS sync relay queue; never commit.",
     ),
     StateSurface(
+        name="encoding_provenance_global_log",
+        path_pattern=".kittify/encoding-provenance/global.jsonl",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSONL,
+        authority=AuthorityClass.LOCAL_RUNTIME,
+        git_class=GitClass.IGNORED,
+        owner_module="charter/_io",
+        creation_trigger="charter file decoding outside kitty-specs/<mission>/",
+        notes="Machine-local encoding audit log; never commit.",
+    ),
+    StateSurface(
         name="runtime_feature_index",
         path_pattern=".kittify/runtime/feature-runs.json",
         root=StateRoot.PROJECT,

--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -269,6 +269,39 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         owner_module="dossier drift detector",
         creation_trigger="dossier parity baseline accept",
     ),
+    StateSurface(
+        name="op_invocation_record",
+        path_pattern="kitty-ops/<op_id>.jsonl",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSONL,
+        authority=AuthorityClass.AUTHORITATIVE,
+        git_class=GitClass.TRACKED,
+        owner_module="invocation/writer",
+        creation_trigger="profile-invocation start/complete",
+        notes=(
+            "Durable per-Op audit record; committed for traceability. "
+            "kitty-ops/ never collapses to a fully-ignored top dir in "
+            "get_runtime_gitignore_entries() because both kitty-ops surfaces "
+            "are 2-segment paths (the collapse guard requires >=3 segments) -- "
+            "not because this TRACKED sibling exists. A future 3-segment "
+            "IGNORED surface under kitty-ops/ would rely on the mixed-git_class "
+            "exclusion instead; see test_contract_runtime_entries_include_ops_index."
+        ),
+    ),
+    StateSurface(
+        name="op_invocation_index",
+        path_pattern="kitty-ops/ops-index.jsonl",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSONL,
+        authority=AuthorityClass.LOCAL_RUNTIME,
+        git_class=GitClass.IGNORED,
+        owner_module="invocation/writer",
+        creation_trigger="profile-invocation start (index append)",
+        notes=(
+            "Machine-local reverse-scan performance cache; never commit. "
+            "Durable records live in kitty-ops/<op_id>.jsonl."
+        ),
+    ),
     # -----------------------------------------------------------------------
     # Section B -- Charter State (.kittify/charter/)
     # -----------------------------------------------------------------------

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
@@ -11,11 +11,12 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
-_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
-_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+_PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
+_PROVENANCE_TRACKED_PATH = ".kittify/encoding-provenance/global.jsonl"
+_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
 _LOCAL_RUNTIME_TRACKED_PATHS = (
     ".kittify/charter/context-state.json",
-    _PROVENANCE_ENTRY,
+    _PROVENANCE_TRACKED_PATH,
 )
 
 
@@ -51,8 +52,19 @@ def _untrack(project_path: Path, relative_path: str) -> bool:
     return result.returncode == 0
 
 
+def _read_gitignore_entries(project_path: Path) -> set[str]:
+    gitignore_path = project_path / ".gitignore"
+    if not gitignore_path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in gitignore_path.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
 @MigrationRegistry.register
-class KittifyRuntimeGitHygieneMigration(BaseMigration):
+class KittifyRuntimeGitHygieneMigration(BaseMigration):  # type: ignore[misc]
     """Ignore sync state and untrack known local-runtime files."""
 
     migration_id = "3.2.0rc35_kittify_runtime_git_hygiene"
@@ -60,11 +72,8 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
     target_version = "3.2.0rc35"
 
     def detect(self, project_path: Path) -> bool:
-        gitignore_path = project_path / ".gitignore"
-        gitignore_text = (
-            gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
-        )
-        entry_missing = any(entry not in gitignore_text for entry in _GITIGNORE_ENTRIES)
+        gitignore_entries = _read_gitignore_entries(project_path)
+        entry_missing = any(entry not in gitignore_entries for entry in _GITIGNORE_ENTRIES)
         tracked_runtime = any(
             _is_tracked(project_path, path)
             for path in _LOCAL_RUNTIME_TRACKED_PATHS
@@ -78,6 +87,10 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
 
     def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
         if dry_run:
+            gitignore_entries = _read_gitignore_entries(project_path)
+            missing_entries = [
+                entry for entry in _GITIGNORE_ENTRIES if entry not in gitignore_entries
+            ]
             tracked = [
                 path
                 for path in _LOCAL_RUNTIME_TRACKED_PATHS
@@ -85,19 +98,23 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
             ]
             return MigrationResult(
                 success=True,
-                changes_made=[
-                    f"Would add {entry} to .gitignore" for entry in _GITIGNORE_ENTRIES
-                ]
+                changes_made=[f"Would add {entry} to .gitignore" for entry in missing_entries]
                 + [f"Would untrack local runtime file: {path}" for path in tracked],
             )
 
         changes: list[str] = []
         errors: list[str] = []
 
+        gitignore_entries = _read_gitignore_entries(project_path)
+        missing_entries = [
+            entry for entry in _GITIGNORE_ENTRIES if entry not in gitignore_entries
+        ]
         manager = GitignoreManager(project_path)
         modified = manager.ensure_entries(list(_GITIGNORE_ENTRIES))
-        if modified:
-            changes.append(f"Added gitignore entries: {', '.join(_GITIGNORE_ENTRIES)}")
+        if modified and missing_entries:
+            changes.append(f"Added gitignore entries: {', '.join(missing_entries)}")
+        elif modified:
+            changes.append("Updated .gitignore")
         else:
             changes.append("gitignore entries already present")
 

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
@@ -13,10 +13,14 @@ from .base import BaseMigration, MigrationResult
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
 _PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
 _PROVENANCE_TRACKED_PATH = ".kittify/encoding-provenance/global.jsonl"
-_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+# Machine-local Op-index performance cache (durable Op records live in
+# kitty-ops/<op_id>.jsonl and stay tracked -- only the index is ignored).
+_OPS_INDEX_ENTRY = "kitty-ops/ops-index.jsonl"
+_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY, _OPS_INDEX_ENTRY)
 _LOCAL_RUNTIME_TRACKED_PATHS = (
     ".kittify/charter/context-state.json",
     _PROVENANCE_TRACKED_PATH,
+    _OPS_INDEX_ENTRY,
 )
 
 

--- a/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0rc35_sync_state_gitignore.py
@@ -11,9 +11,11 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
+_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_GITIGNORE_ENTRIES = (_SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
 _LOCAL_RUNTIME_TRACKED_PATHS = (
     ".kittify/charter/context-state.json",
-    ".kittify/encoding-provenance/global.jsonl",
+    _PROVENANCE_ENTRY,
 )
 
 
@@ -59,15 +61,15 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
 
     def detect(self, project_path: Path) -> bool:
         gitignore_path = project_path / ".gitignore"
-        sync_entry_missing = (
-            not gitignore_path.exists()
-            or _SYNC_STATE_ENTRY not in gitignore_path.read_text(encoding="utf-8")
+        gitignore_text = (
+            gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
         )
+        entry_missing = any(entry not in gitignore_text for entry in _GITIGNORE_ENTRIES)
         tracked_runtime = any(
             _is_tracked(project_path, path)
             for path in _LOCAL_RUNTIME_TRACKED_PATHS
         )
-        return sync_entry_missing or tracked_runtime
+        return entry_missing or tracked_runtime
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:
         if not project_path.exists():
@@ -84,20 +86,20 @@ class KittifyRuntimeGitHygieneMigration(BaseMigration):
             return MigrationResult(
                 success=True,
                 changes_made=[
-                    f"Would add {_SYNC_STATE_ENTRY} to .gitignore",
-                    *[f"Would untrack local runtime file: {path}" for path in tracked],
-                ],
+                    f"Would add {entry} to .gitignore" for entry in _GITIGNORE_ENTRIES
+                ]
+                + [f"Would untrack local runtime file: {path}" for path in tracked],
             )
 
         changes: list[str] = []
         errors: list[str] = []
 
         manager = GitignoreManager(project_path)
-        modified = manager.ensure_entries([_SYNC_STATE_ENTRY])
+        modified = manager.ensure_entries(list(_GITIGNORE_ENTRIES))
         if modified:
-            changes.append(f"Added {_SYNC_STATE_ENTRY} to .gitignore")
+            changes.append(f"Added gitignore entries: {', '.join(_GITIGNORE_ENTRIES)}")
         else:
-            changes.append(f"{_SYNC_STATE_ENTRY} already present in .gitignore")
+            changes.append("gitignore entries already present")
 
         for path in _LOCAL_RUNTIME_TRACKED_PATHS:
             if not _is_tracked(project_path, path):

--- a/src/specify_cli/upgrade/migrations/m_3_2_3_encoding_provenance_gitignore_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_3_encoding_provenance_gitignore_backfill.py
@@ -1,0 +1,38 @@
+"""Migration: backfill encoding-provenance gitignore coverage for 3.2.x projects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+
+@MigrationRegistry.register
+class EncodingProvenanceGitignoreBackfillMigration(BaseMigration):  # type: ignore[misc]
+    """Re-run the runtime git hygiene repair for already-shipped 3.2.x installs."""
+
+    migration_id = "3.2.3_encoding_provenance_gitignore_backfill"
+    description = "Backfill encoding-provenance gitignore coverage"
+    target_version = "3.2.3"
+
+    def detect(self, project_path: Path) -> bool:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().detect(project_path)
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().can_apply(project_path)
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        from .m_3_2_0rc35_sync_state_gitignore import (
+            KittifyRuntimeGitHygieneMigration,
+        )
+
+        return KittifyRuntimeGitHygieneMigration().apply(project_path, dry_run=dry_run)

--- a/tests/specify_cli/test_gitignore_contract.py
+++ b/tests/specify_cli/test_gitignore_contract.py
@@ -70,9 +70,21 @@ def test_contract_runtime_entries_complete():
     assert len(entries) >= 4, f"Expected at least 4 runtime entries, got {len(entries)}"  # noqa: PLR2004
     assert ".kittify/.dashboard" in entries
     assert ".kittify/merge-state.json" in entries
+    assert ".kittify/encoding-provenance/" in entries
     assert ".kittify/runtime/" in entries
     assert ".kittify/events/" in entries
     assert ".kittify/dossiers/" in entries
+
+
+def test_gitignore_manager_protects_encoding_provenance(tmp_path: Path) -> None:
+    """Fresh init protection hides the global encoding provenance log."""
+    from specify_cli.gitignore_manager import GitignoreManager
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    result = GitignoreManager(tmp_path).protect_all_agents()
+
+    assert result.success
+    assert _is_ignored(tmp_path, ".kittify/encoding-provenance/global.jsonl")
 
 
 def test_research_evidence_logs_are_trackable():

--- a/tests/specify_cli/test_gitignore_contract.py
+++ b/tests/specify_cli/test_gitignore_contract.py
@@ -87,6 +87,30 @@ def test_gitignore_manager_protects_encoding_provenance(tmp_path: Path) -> None:
     assert _is_ignored(tmp_path, ".kittify/encoding-provenance/global.jsonl")
 
 
+def test_contract_runtime_entries_include_ops_index():
+    """The Op-index performance cache is a runtime-ignored contract entry."""
+    from specify_cli.state.contract import get_runtime_gitignore_entries
+
+    entries = get_runtime_gitignore_entries()
+    # File-level entry -- NOT collapsed to kitty-ops/, because the durable
+    # per-Op records under kitty-ops/ are tracked.
+    assert "kitty-ops/ops-index.jsonl" in entries
+    assert "kitty-ops/" not in entries
+
+
+def test_gitignore_manager_protects_ops_index(tmp_path: Path) -> None:
+    """Fresh init protection hides the Op-index cache but not durable records."""
+    from specify_cli.gitignore_manager import GitignoreManager
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    result = GitignoreManager(tmp_path).protect_all_agents()
+
+    assert result.success
+    assert _is_ignored(tmp_path, "kitty-ops/ops-index.jsonl")
+    # Durable per-Op audit records stay trackable.
+    assert not _is_ignored(tmp_path, "kitty-ops/01HXYZ.jsonl")
+
+
 def test_research_evidence_logs_are_trackable():
     """Investigation evidence logs under research/ are not masked by *.log."""
 

--- a/tests/specify_cli/test_state_contract.py
+++ b/tests/specify_cli/test_state_contract.py
@@ -212,6 +212,7 @@ def test_runtime_gitignore_entries_exact():
         ".kittify/charter/metadata.yaml",
         ".kittify/charter/references.yaml",
         ".kittify/dossiers/",
+        ".kittify/encoding-provenance/",
         ".kittify/events/",
         ".kittify/merge-state.json",
         ".kittify/missions/__pycache__/",

--- a/tests/specify_cli/test_state_contract.py
+++ b/tests/specify_cli/test_state_contract.py
@@ -219,6 +219,7 @@ def test_runtime_gitignore_entries_exact():
         ".kittify/runtime/",
         ".kittify/sync-state.json",
         ".kittify/workspaces/",
+        "kitty-ops/ops-index.jsonl",
     ]
     assert entries == expected
 

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
@@ -1,0 +1,78 @@
+"""Regression tests for the encoding-provenance gitignore repair.
+
+Covers the bug where ``.kittify/encoding-provenance/global.jsonl`` was listed
+for untracking but never added to ``.gitignore``, so a freshly-generated
+(untracked) provenance log showed up in ``git status`` forever.
+
+- apply() adds the provenance entry to .gitignore
+- detect() returns True when the provenance entry is missing even though
+  sync-state is already present (the already-upgraded-project case)
+- detect() returns False once both entries are present and nothing is tracked
+- apply() is idempotent when both entries are already present
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations.m_3_2_0rc35_sync_state_gitignore import (
+    KittifyRuntimeGitHygieneMigration,
+)
+
+pytestmark = [pytest.mark.unit]
+
+_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_SYNC_STATE_ENTRY = ".kittify/sync-state.json"
+
+
+def _init_git_repo(project_root: Path) -> None:
+    subprocess.run(["git", "-C", str(project_root), "init", "-q"], check=True)
+
+
+def _write_gitignore(project_root: Path, *entries: str) -> None:
+    project_root.joinpath(".gitignore").write_text(
+        "# Added by Spec Kitty CLI (auto-managed)\n" + "\n".join(entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_apply_adds_provenance_entry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    migration = KittifyRuntimeGitHygieneMigration()
+
+    migration.apply(tmp_path)
+
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert _PROVENANCE_ENTRY in gitignore_text
+    assert _SYNC_STATE_ENTRY in gitignore_text
+
+
+def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
+    """Already-upgraded project: sync-state present, provenance entry missing."""
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
+
+
+def test_detect_false_when_both_entries_present(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is False
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+
+    result = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    assert result.success
+    assert result.errors == []
+    # Entry must appear exactly once — no duplication on re-apply.
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert gitignore_text.count(_PROVENANCE_ENTRY) == 1

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
@@ -34,6 +34,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 _PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
 _PROVENANCE_LOG_PATH = ".kittify/encoding-provenance/global.jsonl"
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
+_OPS_INDEX_ENTRY = "kitty-ops/ops-index.jsonl"
 
 
 def _init_git_repo(project_root: Path) -> None:
@@ -86,9 +87,11 @@ def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
     assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
 
 
-def test_detect_false_when_both_entries_present(tmp_path: Path) -> None:
+def test_detect_false_when_all_entries_present(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+    _write_gitignore(
+        tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY, _OPS_INDEX_ENTRY
+    )
 
     assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is False
 
@@ -102,7 +105,7 @@ def test_detect_ignores_commented_out_provenance_entry(tmp_path: Path) -> None:
 
 def test_apply_reports_only_missing_gitignore_entries(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _OPS_INDEX_ENTRY)
 
     result = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
 
@@ -113,7 +116,9 @@ def test_apply_reports_only_missing_gitignore_entries(tmp_path: Path) -> None:
 
 def test_apply_is_idempotent(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+    _write_gitignore(
+        tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY, _OPS_INDEX_ENTRY
+    )
 
     first = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
     second = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
@@ -124,6 +129,66 @@ def test_apply_is_idempotent(tmp_path: Path) -> None:
     # Entry must appear exactly once; no duplication on re-apply.
     gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
     assert gitignore_text.count(_PROVENANCE_GITIGNORE_ENTRY) == 1
+
+
+def _is_tracked(project_root: Path, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(project_root), "ls-files", "--error-unmatch", path],
+            check=False,
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def test_apply_adds_ops_index_entry_and_hides_index(tmp_path: Path) -> None:
+    """The Op-index performance cache must be gitignored by the repair."""
+    _init_git_repo(tmp_path)
+    index = tmp_path / _OPS_INDEX_ENTRY
+    index.parent.mkdir(parents=True)
+    index.write_text("{}\n", encoding="utf-8")
+
+    KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert _OPS_INDEX_ENTRY in gitignore_text
+    assert _is_ignored(tmp_path, _OPS_INDEX_ENTRY)
+
+
+def test_detect_true_when_only_ops_index_entry_missing(tmp_path: Path) -> None:
+    """Project already carrying the other entries but missing ops-index."""
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
+
+
+def test_apply_untracks_committed_ops_index(tmp_path: Path) -> None:
+    """A previously-committed ops-index is untracked but durable records are not."""
+    _init_git_repo(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "t@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True
+    )
+    ops_dir = tmp_path / "kitty-ops"
+    ops_dir.mkdir()
+    (ops_dir / "ops-index.jsonl").write_text("{}\n", encoding="utf-8")
+    durable = ops_dir / "01HXYZ.jsonl"
+    durable.write_text("{}\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "-m", "seed"], check=True
+    )
+
+    KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    assert not _is_tracked(tmp_path, _OPS_INDEX_ENTRY)
+    # Durable per-Op records must remain tracked.
+    assert _is_tracked(tmp_path, "kitty-ops/01HXYZ.jsonl")
 
 
 @pytest.mark.parametrize("from_version", ["3.2.1", "3.2.2", "3.2.3"])
@@ -138,6 +203,10 @@ def test_backfill_migration_repairs_already_current_3_2_x_project(
     provenance_log.parent.mkdir(parents=True)
     provenance_log.write_text("{}\n", encoding="utf-8")
 
+    index = tmp_path / _OPS_INDEX_ENTRY
+    index.parent.mkdir(parents=True)
+    index.write_text("{}\n", encoding="utf-8")
+
     auto_discover_migrations()
     result = MigrationRunner(tmp_path).upgrade("3.2.3", include_worktrees=False)
 
@@ -147,3 +216,5 @@ def test_backfill_migration_repairs_already_current_3_2_x_project(
         in result.migrations_applied
     )
     assert _is_ignored(tmp_path, _PROVENANCE_LOG_PATH)
+    # The backfill path (re-running rc35 hygiene) also repairs the Op-index.
+    assert _is_ignored(tmp_path, _OPS_INDEX_ENTRY)

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
@@ -14,6 +14,7 @@ for untracking but never added to ``.gitignore``, so a freshly-generated
 from __future__ import annotations
 
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -21,10 +22,17 @@ import pytest
 from specify_cli.upgrade.migrations.m_3_2_0rc35_sync_state_gitignore import (
     KittifyRuntimeGitHygieneMigration,
 )
+from specify_cli.upgrade.migrations.m_3_2_3_encoding_provenance_gitignore_backfill import (
+    EncodingProvenanceGitignoreBackfillMigration,
+)
+from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.metadata import ProjectMetadata
+from specify_cli.upgrade.runner import MigrationRunner
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
-_PROVENANCE_ENTRY = ".kittify/encoding-provenance/global.jsonl"
+_PROVENANCE_GITIGNORE_ENTRY = ".kittify/encoding-provenance/"
+_PROVENANCE_LOG_PATH = ".kittify/encoding-provenance/global.jsonl"
 _SYNC_STATE_ENTRY = ".kittify/sync-state.json"
 
 
@@ -39,15 +47,35 @@ def _write_gitignore(project_root: Path, *entries: str) -> None:
     )
 
 
-def test_apply_adds_provenance_entry(tmp_path: Path) -> None:
+def _write_metadata(project_root: Path, version: str) -> None:
+    ProjectMetadata(version=version, initialized_at=datetime.now()).save(
+        project_root / ".kittify"
+    )
+
+
+def _is_ignored(project_root: Path, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(project_root), "check-ignore", "--quiet", path],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def test_apply_adds_provenance_entry_and_hides_generated_log(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     migration = KittifyRuntimeGitHygieneMigration()
+    provenance_log = tmp_path / _PROVENANCE_LOG_PATH
+    provenance_log.parent.mkdir(parents=True)
+    provenance_log.write_text("{}\n", encoding="utf-8")
 
     migration.apply(tmp_path)
 
     gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
-    assert _PROVENANCE_ENTRY in gitignore_text
+    assert _PROVENANCE_GITIGNORE_ENTRY in gitignore_text
     assert _SYNC_STATE_ENTRY in gitignore_text
+    assert _is_ignored(tmp_path, _PROVENANCE_LOG_PATH)
 
 
 def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
@@ -60,19 +88,62 @@ def test_detect_true_when_only_provenance_entry_missing(tmp_path: Path) -> None:
 
 def test_detect_false_when_both_entries_present(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
 
     assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is False
 
 
-def test_apply_is_idempotent(tmp_path: Path) -> None:
+def test_detect_ignores_commented_out_provenance_entry(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
-    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_ENTRY)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, f"# {_PROVENANCE_GITIGNORE_ENTRY}")
+
+    assert KittifyRuntimeGitHygieneMigration().detect(tmp_path) is True
+
+
+def test_apply_reports_only_missing_gitignore_entries(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
 
     result = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
 
-    assert result.success
-    assert result.errors == []
-    # Entry must appear exactly once — no duplication on re-apply.
+    assert result.changes_made[0] == (
+        f"Added gitignore entries: {_PROVENANCE_GITIGNORE_ENTRY}"
+    )
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY, _PROVENANCE_GITIGNORE_ENTRY)
+
+    first = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+    second = KittifyRuntimeGitHygieneMigration().apply(tmp_path)
+
+    assert first.success
+    assert second.success
+    assert second.errors == []
+    # Entry must appear exactly once; no duplication on re-apply.
     gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
-    assert gitignore_text.count(_PROVENANCE_ENTRY) == 1
+    assert gitignore_text.count(_PROVENANCE_GITIGNORE_ENTRY) == 1
+
+
+@pytest.mark.parametrize("from_version", ["3.2.1", "3.2.2", "3.2.3"])
+def test_backfill_migration_repairs_already_current_3_2_x_project(
+    tmp_path: Path,
+    from_version: str,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_metadata(tmp_path, from_version)
+    _write_gitignore(tmp_path, _SYNC_STATE_ENTRY)
+    provenance_log = tmp_path / _PROVENANCE_LOG_PATH
+    provenance_log.parent.mkdir(parents=True)
+    provenance_log.write_text("{}\n", encoding="utf-8")
+
+    auto_discover_migrations()
+    result = MigrationRunner(tmp_path).upgrade("3.2.3", include_worktrees=False)
+
+    assert result.success
+    assert (
+        EncodingProvenanceGitignoreBackfillMigration.migration_id
+        in result.migrations_applied
+    )
+    assert _is_ignored(tmp_path, _PROVENANCE_LOG_PATH)


### PR DESCRIPTION
## What

`kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers `spec-kitty invocations list` — was never added to `.gitignore`. A freshly-generated index showed up in `git status` indefinitely and could be accidentally committed. This registers it as an ignored runtime surface so both fresh `init` and the upgrade path cover it, while keeping the durable per-Op audit records tracked.

Closes #2341. Supersedes #2151 (this branch is the rebased encoding-provenance fix from #2151 **plus** the ops-index fix; see "Relationship to #2151" below).

## Changes

- **State contract (`src/specify_cli/state/contract.py`)** — two new `StateSurface`s:
  - `op_invocation_record` (`kitty-ops/<op_id>.jsonl`, **TRACKED / AUTHORITATIVE**) — durable per-Op audit records, committed for traceability.
  - `op_invocation_index` (`kitty-ops/ops-index.jsonl`, **IGNORED / LOCAL_RUNTIME**) — the performance cache, never committed.
- **Fresh `init`** picks the index up automatically: `get_runtime_gitignore_entries()` derives from the contract and `GitignoreManager.protect_all_agents()` consumes it. The emitter yields the **file-level** entry (not a collapsed `kitty-ops/`) because both surfaces are 2-segment paths and the top-dir collapse guard requires ≥3 segments — durable records stay committed.
- **Existing projects** — the rc35 git-hygiene migration (`m_3_2_0rc35_sync_state_gitignore.py`) adds the entry and `git rm --cached`s a previously-committed index. The untrack is surgical (exact literal path only, never a `<op_id>` record). Re-run for already-current 3.2.x installs by the `m_3_2_3` backfill.
- **Doc clarity** — corrected the now-stale `ops-index.jsonl` rationale comment in `mission_runtime/artifacts.py` (it is a gitignored cache, so it never reaches the dirty-tree classifier).

## Verification

**Red-first (bugfix discipline):** stashed the two production files; all 4 new tests FAIL without the change, pass with it.

```
ruff check   → All checks passed
mypy         → Success: no issues found
tests/specify_cli/test_state_contract.py
tests/specify_cli/test_gitignore_contract.py
tests/specify_cli/upgrade/migrations/test_m_3_2_0rc35_provenance_gitignore.py
             → 56 passed
tests/specify_cli/{docs,invocation} + host-surface inventory  → 370 passed
tests/docs/{check_docs_freshness,inventory_lockfile,inventory_path_stable}  → 58 passed
tests/mission_runtime/test_self_bookkeeping_allowlist.py  → 12 passed
terminology guard  → 3 passed
```

## Adversarial squad (pre-merge)

Two profile-loaded lenses (architect-alphonso, paula-patterns), read-only. **Both: APPROVE, no MAJORs.** MINORs folded into this PR:
- Corrected the imprecise "tracked-record surface prevents collapse" rationale → the real guard is path depth; documented on the surface + in the commit.
- Updated the stale `artifacts.py` dirty-tree rationale comment.

One MINOR deferred as a tracked follow-up (see below).

## Follow-up (out of scope — will file)

**Contract↔migration literal duplication.** `kitty-ops/ops-index.jsonl` (and, pre-existing, `sync-state.json` + `encoding-provenance/`) live in both the state contract and the migration's hardcoded tuples. The squad's decisive finding: the migration is **version-pinned and deliberately re-run by the backfill**, so deriving it from the live contract would be a *regression* (a frozen migration silently picking up future entries). The hardcoded tuple is correct; the duplication is a documented, bounded trade-off. Filing a tracked issue rather than "fixing" it here.

## Relationship to #2151

#2151 is the encoding-provenance fix (issue #2150), ~199 commits behind `main`. This branch is that work **rebased onto current main** (2 commits) with the ops-index fix added on top — one cohesive "register a runtime cache as an ignored StateSurface" change set. Recommend closing #2151 in favor of this once merged.

## Hand-off

Draft. Green CI + operator merges — I have not merged. No Sonar UI work outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
