### PR TITLE
docs(cluster-2): surface changelog/roadmap/release-goals in nav, author the maintainer PR-landing guide, split docs CI, bump Pages actions

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'src/**'
       - 'docs/**'
+      - 'scripts/docs/**'
       - '.kittify/doctrine/overlays/**'
       - 'tests/**'
       - 'pyproject.toml'
@@ -31,6 +32,7 @@ on:
     paths:
       - 'src/**'
       - 'docs/**'
+      - 'scripts/docs/**'
       - '.kittify/doctrine/overlays/**'
       - 'tests/**'
       - 'pyproject.toml'
@@ -101,6 +103,7 @@ jobs:
       doctrine: ${{ inputs.run_all && 'true' || steps.filter.outputs.doctrine }}
       execution_context: ${{ inputs.run_all && 'true' || steps.filter.outputs.execution_context }}
       e2e: ${{ inputs.run_all && 'true' || steps.filter.outputs.e2e }}
+      docs: ${{ inputs.run_all && 'true' || steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -183,7 +186,6 @@ jobs:
               - 'src/specify_cli/saas/**'
               - 'src/specify_cli/status/**'
               - 'src/specify_cli/tool_surface/**'
-              - 'docs/**'
               - 'tests/architectural/**'
               - 'tests/specify_cli/tool_surface/**'
               - 'tests/kernel/**'
@@ -203,6 +205,17 @@ jobs:
               - '.github/workflows/ci-quality.yml'
               - 'tests/e2e/**'
               - 'tests/cross_cutting/**'
+            # docs: docs-only changes run a dedicated CHEAP job (fast-tests-docs)
+            # instead of the full core-misc code cone. Docs prose, the docs test
+            # suite, and the docs tooling under scripts/docs all map here. This
+            # class ONLY narrows the docs->code direction; every non-docs path
+            # keeps triggering exactly what it triggered before (docs/** was
+            # removed from core_misc, but tests/docs stays selected by the
+            # core-misc jobs so a src change still over-covers docs). See #2359.
+            docs:
+              - 'docs/**'
+              - 'tests/docs/**'
+              - 'scripts/docs/**'
             charter:
               - 'src/charter/**'
               - 'src/specify_cli/charter_runtime/**'
@@ -1250,6 +1263,47 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: fast-test-core-misc-reports
+          path: out/reports/
+
+  # ---------------------------------------------------------------------------
+  # fast-tests-docs: dedicated CHEAP job for docs-only changes (#2359). A
+  # docs/**, tests/docs/**, or scripts/docs/** change sets docs=true and runs
+  # ONLY this job instead of the ~17-minute core-misc code cone. It runs the
+  # full docs test surface (tests/docs) plus the two docs-scanning architectural
+  # guards that must still trigger on docs prose changes (terminology canon and
+  # CLI-reference parity). Marker is `not windows_ci` (NOT `fast`): tests/docs
+  # and both arch guards carry architectural/git_repo/unit markers, so a `fast`
+  # selector would silently deselect them. tests/docs stays ALSO selected by
+  # fast-tests-core-misc + integration-tests-core-misc, so orphan coverage is
+  # unchanged and a src change still over-covers docs (fail-safe).
+  # ---------------------------------------------------------------------------
+  fast-tests-docs:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: always() && needs.changes.outputs.docs == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: '3.12'
+      - run: uv sync --frozen --all-extras
+      - run: mkdir -p out/reports/coverage
+      - name: "Run fast tests — docs"
+        run: |
+          uv run python -m pytest \
+            tests/docs \
+            tests/architectural/test_no_legacy_terminology.py \
+            tests/architectural/test_docs_cli_reference_parity.py \
+            -m "not windows_ci" -q --tb=short \
+            -n auto --dist loadfile \
+            --durations=50 \
+            --cov=scripts/docs \
+            --cov-report=xml:out/reports/coverage/coverage-fast-docs.xml
+      - name: "Upload fast-docs coverage"
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fast-test-docs-reports
           path: out/reports/
 
   # ---------------------------------------------------------------------------
@@ -2932,6 +2986,7 @@ jobs:
       - fast-tests-upgrade
       - fast-tests-cli
       - fast-tests-core-misc
+      - fast-tests-docs
       - fast-tests-charter
       - fast-tests-agent
       - integration-tests-doctrine
@@ -2982,6 +3037,7 @@ jobs:
             "${{ needs.fast-tests-upgrade.result }}" \
             "${{ needs.fast-tests-cli.result }}" \
             "${{ needs.fast-tests-core-misc.result }}" \
+            "${{ needs.fast-tests-docs.result }}" \
             "${{ needs.fast-tests-charter.result }}" \
             "${{ needs.fast-tests-agent.result }}" \
             "${{ needs.integration-tests-doctrine.result }}" \

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -66,10 +66,10 @@ jobs:
         run: python3 scripts/docs/redirect_stub_generator.py coverage --site-dir docs/_site
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 
@@ -83,4 +83,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,6 +366,10 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Test your changes with the Spec-Driven Development workflow to ensure compatibility.
 
+## Maintainer guides
+
+- [Landing contributor PRs](docs/guides/pr-landing.md) — the maintainer runbook for taking a contributor PR from "open with red CI" to "merge-ready, evidence posted, operator merges": claim, isolated worktree, rebase, red classification, folds, red-first verification, push discipline, and hand-off.
+
 ## Development workflow
 
 When working on spec-kitty:

--- a/docs/adr/3.x/2026-06-27-1-common-docs-reconciliation.md
+++ b/docs/adr/3.x/2026-06-27-1-common-docs-reconciliation.md
@@ -117,6 +117,8 @@ history only*. The **living architectural design collapses into a single unversi
 `docs/architecture/`** — era belongs to history, not to the current design. All ADRs are
 converted to YAML frontmatter (today 0 use it → invisible to DocFX).
 
+**Amendment (2026-07-04, [#2353](https://github.com/Priivacy-ai/spec-kitty/issues/2353)):** `release-goals/` is promoted to a published fourteenth section (declared release-line intent) — a further justified deviation from the standard 13-section tree.
+
 ### D4 — Redirect mechanism: generated `<meta http-equiv="refresh">` stub pages per old path
 
 **Decision:** Because DocFX on GitHub Pages has **no native redirect/alias mechanism**, every

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog
-description: 'Changelog landing page: points to the canonical docs/changelog/CHANGELOG.md and explains the byte-for-byte root CHANGELOG.md alias kept in sync for release tooling.'
+description: 'Changelog landing page: points to the canonical docs/changelog/CHANGELOG.md and explains the root CHANGELOG.md symlink that release tooling reads.'
 doc_status: active
 updated: '2026-07-04'
 related:
@@ -13,12 +13,12 @@ related:
 The canonical Spec Kitty changelog lives in this section as
 [`CHANGELOG.md`](CHANGELOG.md) (Mission B, FR-009).
 
-The repository-root `CHANGELOG.md` **persists as an alias** kept byte-for-byte
-in sync with this canonical copy: release tooling (`scripts/release/`,
-`pyproject.toml`, `.github/release-readiness.yml`) reads the root path and is
-out of relocate scope. Root is the alias; `docs/changelog/CHANGELOG.md` is
-canonical.
+The repository-root `CHANGELOG.md` is a **symlink to this canonical copy**:
+release tooling (`scripts/release/`, `pyproject.toml`,
+`.github/release-readiness.yml`) reads the root path and is out of relocate
+scope. Root is the symlink; `docs/changelog/CHANGELOG.md` is canonical.
 
 For where the project is going next, see the
 [release goals](../release-goals/index.md) and the
-[3.2.x milestone roadmap](../plans/3-2-x-milestone-roadmap.md).
+[3.2.x milestone roadmap](../plans/3-2-x-milestone-roadmap.md) (a plans/
+working document under the distil-then-retire lifecycle).

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -2,9 +2,11 @@
 title: Changelog
 description: 'Changelog landing page: points to the canonical docs/changelog/CHANGELOG.md and explains the byte-for-byte root CHANGELOG.md alias kept in sync for release tooling.'
 doc_status: active
-updated: '2026-06-27'
+updated: '2026-07-04'
 related:
 - docs/changelog/CHANGELOG.md
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/release-goals/index.md
 ---
 # Changelog
 
@@ -16,3 +18,7 @@ in sync with this canonical copy: release tooling (`scripts/release/`,
 `pyproject.toml`, `.github/release-readiness.yml`) reads the root path and is
 out of relocate scope. Root is the alias; `docs/changelog/CHANGELOG.md` is
 canonical.
+
+For where the project is going next, see the
+[release goals](../release-goals/index.md) and the
+[3.2.x milestone roadmap](../plans/3-2-x-milestone-roadmap.md).

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1934,6 +1934,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/guides/pr-landing.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/guides/recover-from-implementation-crash.md
   tag: current
   divio_type: none

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -16,7 +16,8 @@
           "guides/**.md",
           "operations/**.md",
           "migrations/**.md",
-          "changelog/**.md"
+          "changelog/**.md",
+          "release-goals/**.md"
         ],
         "exclude": [
           "**/_*.md"

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -31,6 +31,9 @@ pages that outlive any single mission. For effort-scoped working notes
 
 ## Maintainer guides
 
+The split rule: guides are repo-workflow how-tos regardless of audience;
+run-the-system runbooks live in [operations](../operations/index.md).
+
 - [Landing contributor PRs](pr-landing.md) — the claim → isolate → rebase → classify → fold → squad → hand-off runbook, with field-tested gotchas.
 
 ## See also

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,12 +1,13 @@
 ---
 title: Guides
-description: 'Durable contributor how-to guides for Spec Kitty: testing workflows, review gates, contract pinning, and cross-package local development.'
+description: 'Durable how-to guides for Spec Kitty: testing workflows, review gates, contract pinning, cross-package local development, and maintainer runbooks.'
 doc_status: active
-updated: '2026-06-27'
+updated: '2026-07-04'
 related:
 - docs/configuration/index.md
 - docs/guides/contract-pinning.md
 - docs/guides/local-overrides.md
+- docs/guides/pr-landing.md
 - docs/guides/review-gates.md
 - docs/guides/testing-flakiness.md
 - docs/guides/testing-parallel.md
@@ -16,17 +17,21 @@ related:
 ---
 # Guides
 
-Durable contributor how-tos and workflow guides — task-oriented pages that
-outlive any single mission. For effort-scoped working notes (audits, debriefs,
-investigations) see [`../plans/`](../plans/index.md).
+Durable contributor and maintainer how-tos and workflow guides — task-oriented
+pages that outlive any single mission. For effort-scoped working notes
+(audits, debriefs, investigations) see [`../plans/`](../plans/index.md).
 
-## Pages
+## Contributor guides
 
 - [Test-flakiness handling policy](testing-flakiness.md) — detection tiers and the never-retry-to-green rule.
 - [Running the test suite in parallel](testing-parallel.md) — the parallel-run workflow and volume gates.
 - [Contract pinning workflow](contract-pinning.md) — pinning observable contracts in tests.
 - [Review gates](review-gates.md) — the pre-PR / pre-review checklist.
 - [Local overrides for cross-package development](local-overrides.md) — dev-only editable installs that must never be committed.
+
+## Maintainer guides
+
+- [Landing contributor PRs](pr-landing.md) — the claim → isolate → rebase → classify → fold → squad → hand-off runbook, with field-tested gotchas.
 
 ## See also
 

--- a/docs/guides/pr-landing.md
+++ b/docs/guides/pr-landing.md
@@ -1,0 +1,295 @@
+---
+title: 'Landing Contributor PRs: The Maintainer Runbook'
+description: 'The maintainer workflow for landing contributor PRs: claim, isolated worktree, rebase, red classification, folds, red-first verification, squad review, push discipline, and hand-off.'
+doc_status: active
+updated: '2026-07-04'
+related:
+- docs/guides/index.md
+- docs/guides/review-gates.md
+- docs/guides/testing-flakiness.md
+- docs/changelog/index.md
+---
+# Landing Contributor PRs: The Maintainer Runbook
+
+**Audience**: Maintainers taking contributor PRs from "open with red CI" to
+"merge-ready, evidence posted, operator merges".
+**Issue**: [Priivacy-ai/spec-kitty#2341](https://github.com/Priivacy-ai/spec-kitty/issues/2341)
+**Origin**: The 2026-07-04 landing pass (#2332, #2336, #2338, #2239, #2238),
+where this workflow was run end-to-end and its friction points were logged.
+
+The deliverable of a landing pass is never a merge. It is a PR that is green,
+un-drafted, carries a full evidence trail in its comment thread, and states
+any landing-order constraints — so the operator can merge it without
+re-deriving the adjudication. The maintainer never merges
+(see [step 11](#11-hand-off--the-operator-merges)).
+
+## The workflow at a glance
+
+1. [Claim before touching](#1-claim-before-touching)
+2. [One isolated worktree per PR](#2-one-isolated-worktree-per-pr)
+3. [Rebase onto current upstream/main first](#3-rebase-onto-current-upstreammain-first)
+4. [Classify every red check](#4-classify-every-red-check)
+5. [Folds: remediation commits on the contributor branch](#5-folds-remediation-commits-on-the-contributor-branch)
+6. [Red-first verification for bugfix PRs](#6-red-first-verification-for-bugfix-prs)
+7. [Review focus areas beyond CI](#7-review-focus-areas-beyond-ci)
+8. [Adversarial squad for architectural or API-surface PRs](#8-adversarial-squad-for-architectural-or-api-surface-prs)
+9. [Push discipline](#9-push-discipline)
+10. [Post the remediation summary](#10-post-the-remediation-summary)
+11. [Hand-off — the operator merges](#11-hand-off--the-operator-merges)
+12. [Follow-up hygiene](#12-follow-up-hygiene)
+
+## 1. Claim before touching
+
+Post a claim comment on the PR **before** any rebase or review work: what you
+are picking up, in which landing queue, and what you plan to do. One claim per
+PR in the pass, posted first.
+
+```bash
+unset GITHUB_TOKEN   # keyring auth has full repo scope; a limited env token may not
+gh pr comment <N> --repo Priivacy-ai/spec-kitty \
+  --body "Claiming this PR for today's landing pass: rebase onto upstream/main, adjudicate red checks, fold fixes as needed. Evidence to follow."
+```
+
+Why: it prevents duplicated maintainer effort when several PRs are being
+landed in parallel, and it means the contributor is never surprised by
+maintainer commits appearing on their branch.
+
+## 2. One isolated worktree per PR
+
+Never touch the primary checkout — a mission session may own it. Give every
+PR its own worktree:
+
+```bash
+git fetch upstream pull/<N>/head:pr-<N>-local
+git worktree add .worktrees/pr-<N>-landing pr-<N>-local
+cd .worktrees/pr-<N>-landing
+```
+
+Each worktree builds its own `uv` virtualenv on the first `uv run` — expect
+roughly 40 seconds and some disk on that first command. That is normal, not a
+hang.
+
+## 3. Rebase onto current upstream/main first
+
+Contributor branches are routinely 100+ commits behind. Every adjudication —
+tests, gates, review — happens on the rebased tip, not the stale base:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+Changelog conflicts resolve in `docs/changelog/CHANGELOG.md`, which is the
+canonical changelog. The root `CHANGELOG.md` is a symlink to it (since the
+symlink cutover that rode #2338), so both paths reach the same file — resolve
+the conflict once, in the canonical location.
+
+## 4. Classify every red check
+
+This is the core reviewer decision point. Diagnose each red check on the
+rebased tip and classify it into exactly one of four bins:
+
+| Classification | What it looks like | Action |
+|---|---|---|
+| **PR defect** | The PR's own change breaks a test or gate | Fix it on the branch (a "fold", [step 5](#5-folds-remediation-commits-on-the-contributor-branch)) |
+| **Contract the PR legitimately crosses** | A seam move-set completeness gate, a census tolerance band | Re-pin the contract **in the same PR**, with a dated rationale in the pin |
+| **Pre-existing main breakage** | The same red reproduces on an unrelated main-based branch | Prove it cross-branch, file an upstream issue (campsite-cleaning standing order); do **not** fix it inside the contributor PR and do **not** retry-to-green |
+| **Perf-budget flake** | A budget gate trips without a correctness signal | Note it, watch for recurrence, tune the budget at the root if it repeats — never retry-to-green |
+
+The cross-branch reproduction for the third bin is cheap and decisive:
+
+```bash
+git worktree add /tmp/repro-main upstream/main
+cd /tmp/repro-main && PWHEADLESS=1 uv run pytest <failing test> -q
+```
+
+If it is red there too, the PR does not wear the failure — the filed issue
+does. See the
+[test-flakiness handling policy](testing-flakiness.md) for the
+never-retry-to-green rule behind the fourth bin.
+
+## 5. Folds: remediation commits on the contributor branch
+
+Folds are maintainer commits pushed directly to the contributor branch. This
+relies on `maintainerCanModify`, which is true by default on PRs from forks.
+
+- Keep each fold small and single-purpose.
+- Label the commit subject `landing fold: ...`.
+- Explain every fold in the remediation summary comment ([step 10](#10-post-the-remediation-summary)).
+
+Typical folds: canonical-source fixes (the changelog lives in
+`docs/changelog/`), seam re-pins with dated rationale, retired-shim API
+migrations, and doc/contract artifact sync.
+
+## 6. Red-first verification for bugfix PRs
+
+A fix whose test is green before and after the fix captures nothing. Prove
+the PR's test actually witnesses the bug by swapping the pre-fix product file
+back in:
+
+```bash
+git checkout upstream/main -- <product-file>
+PWHEADLESS=1 uv run pytest <the PR's test> -q     # MUST FAIL
+git checkout HEAD -- <product-file>
+PWHEADLESS=1 uv run pytest <the PR's test> -q     # must pass again
+```
+
+Post the result on the PR. If the test never goes red, the fold is a better
+test — not a green checkmark.
+
+## 7. Review focus areas beyond CI
+
+What the maintainer reads the diff for, beyond the checks:
+
+- **Canonical sources** — does the change edit the source of truth, or a
+  generated mirror/agent copy? (Agent directories under `.claude/`,
+  `.amazonq/`, etc. are generated; sources live under `src/doctrine/`.)
+- **SSOT / duplication** — does new code near-copy an existing canonical seam
+  or resolver? Justified divergence must be adjudicated explicitly (name the
+  contract difference), never assumed.
+- **Contract artifacts** — a new command or field on a versioned surface must
+  land in the machine contract (`upstream_contract.json`), the version
+  ledger, and the human docs together, in the same PR.
+- **Scope-vs-spec** — an apparent scope surprise may be required by the
+  mission spec; check the FRs and constraints before flagging creep.
+- **Error-handling nets** — best-effort helpers must catch the *actual*
+  exception types their callees raise, not a guessed superset.
+- **Terminology canon** — on any prose or doctrine touch, run the guard
+  locally: `PWHEADLESS=1 uv run pytest tests/architectural/test_no_legacy_terminology.py -q`.
+
+## 8. Adversarial squad for architectural or API-surface PRs
+
+For changes to versioned contracts or shared seams, dispatch profile-loaded
+review lenses in parallel — for example `architect-alphonso` for design and
+contract adherence, `paula-patterns` for SSOT and duplication — with
+read-only access to the landing worktree.
+
+- Fold their MAJOR findings ([step 5](#5-folds-remediation-commits-on-the-contributor-branch)).
+- File their MINORs and NOTEs as **one** follow-up issue, parented under the
+  relevant functional epic.
+
+## 9. Push discipline
+
+Before any force-push to a fork branch, check for commits you have not seen —
+Copilot-review commits and parallel-session commits get cherry-picked, never
+clobbered:
+
+```bash
+git fetch <fork-remote> <branch>
+git log <old-head>..FETCH_HEAD --oneline   # anything here? cherry-pick it first
+LEASE_SHA=$(git rev-parse FETCH_HEAD)
+git push <fork-remote> HEAD:refs/heads/<branch> --force-with-lease=<branch>:"$LEASE_SHA"
+```
+
+Two lease lessons from the 2026-07-04 pass, both worth internalizing:
+
+1. **A bare `--force-with-lease` fails with `(stale info)` on fork branches
+   you have never fetched** — the lease has no remote-tracking ref to compare
+   against locally. The explicit `<branch>:<sha>` form above is the standard
+   flow, not a workaround.
+2. **The lease sha must come from `git rev-parse`, never retyped from a
+   display.** Two pushes in the pass were rejected because a lease sha was
+   retyped from a 9-character abbreviated prefix.
+
+## 10. Post the remediation summary
+
+After pushing folds, post one structured comment on the PR:
+
+- the review verdict;
+- each fold, with its why;
+- squad verdicts, if a squad ran;
+- local test evidence — counts, plus `ruff` / `mypy` results;
+- pre-existing failures called out **with the filed issue number**;
+- the state: e.g. "watching CI; merge-ready on green".
+
+Contributor-education notes (for example, which file is the canonical
+changelog) go in this comment too, addressed to the author.
+
+## 11. Hand-off — the operator merges
+
+The operator merges; the maintainer never runs `gh pr merge`. The hand-off
+deliverable is:
+
+- green CI;
+- the PR un-drafted;
+- the evidence trail on the PR;
+- landing-order constraints stated explicitly — for example, a structural
+  cutover riding one PR forces an order on the rest of the pass.
+
+## 12. Follow-up hygiene
+
+Everything discovered but out of scope gets a tracked home **the same day**:
+filed, labeled, and parented under a functional epic (never a meta rollup).
+New issues get processed by a triage pass immediately, so the next landing
+pass starts from a clean queue.
+
+## Gotchas
+
+Field notes from the 2026-07-04 landing pass. Where the friction has since
+been fixed, the end-state is stated instead of the trap.
+
+- **The changelog has one canonical home.** `docs/changelog/CHANGELOG.md` is
+  the canonical changelog; the root `CHANGELOG.md` is a symlink to it. Edits
+  and conflict resolutions land in the canonical file either way — there is
+  no longer a generated root mirror to trip docs-freshness.
+- **`--force-with-lease` on never-fetched fork branches.** See
+  [step 9](#9-push-discipline): use the explicit `<branch>:<sha>` lease form,
+  and take the sha from `git rev-parse` — never retype it from an
+  abbreviated display.
+- **Pre-existing main breakage surfaces mid-pass.** One broken contract on
+  main (#2339: dotted `migration_id` vs the dry-run JSON contract) turned
+  local runs red on *every* rebased branch in the pass. Adjudication cost one
+  cross-branch reproduction per PR until the issue was filed — file early;
+  the filed issue is what lets subsequent PRs skip the reproduction.
+- **Saturated tolerance bands trip on the next legitimate change.** The CLI
+  visible-count census sat at the top of its band, so the next legitimate
+  command (#2338) tripped it. A saturated band needs a re-pin with a dated
+  rationale — the band was re-pinned 2026-07-04 at 236 visible (tolerance
+  212–259) in `tests/docs/test_check_cli_reference_freshness.py`. That
+  re-pin-in-the-same-PR pattern is the model for the second bin of
+  [step 4](#4-classify-every-red-check).
+- **Seam completeness gates are invisible to contributors.** Adding a `def`
+  to `src/specify_cli/cli/commands/agent/tasks_move_task.py` also requires
+  joining the `_MOVE_SET` pin in
+  `tests/specify_cli/cli/commands/agent/test_tasks_move_task_seam.py` and the
+  re-export block in `agent/tasks.py`. Expect this as a fold on PRs that
+  touch decomposed command modules.
+- **CI-only architectural gates land late.** Repo-wide gates (terminology,
+  shim retirement, seam boundaries) run in the
+  `integration-tests-core-misc (architectural)` shard — a PR can pass every
+  fast shard and fail ~40 minutes later. Run `tests/architectural/` locally
+  on the rebased tip before declaring a branch green.
+- **Shard path-filters mask pre-existing failures.** The `changes` filter
+  skips shards like `fast-tests-cli` on PRs that do not touch those paths, so
+  a pre-existing red only surfaces on the first PR that does — the innocent
+  PR wears the failure. Classify it as pre-existing (bin three of
+  [step 4](#4-classify-every-red-check)), not as the PR's defect.
+- **`scripts/` invocations need `PYTHONPATH=.`.** The docs scripts import
+  `scripts.docs.*` as a package; without it they crash with
+  `ModuleNotFoundError: scripts`:
+
+  ```bash
+  PYTHONPATH=. uv run python scripts/docs/check_docs_freshness.py --ci
+  ```
+
+- **`build_cli_reference.py` defaults to the wrong output path.** Its
+  defaults write `docs/reference/`, while the live canonical reference is
+  `docs/api/cli-commands.md`. Always pass the outputs explicitly:
+
+  ```bash
+  PYTHONPATH=. uv run python scripts/docs/build_cli_reference.py \
+    --output docs/api/cli-commands.md \
+    --agent-output docs/api/agent-subcommands.md
+  ```
+
+- **Per-worktree venv rebuild.** The first `uv run` in a fresh landing
+  worktree rebuilds the virtualenv (~40 s + disk). Budget for it; do not
+  debug it.
+
+## See also
+
+- [Review gates: pre-PR / pre-review checklist](review-gates.md) — the
+  contributor-side hygiene this runbook assumes.
+- [Test-flakiness handling policy](testing-flakiness.md) — the
+  never-retry-to-green rule and budget-gate tuning.
+- [Guides index](index.md)

--- a/docs/guides/pr-landing.md
+++ b/docs/guides/pr-landing.md
@@ -1,6 +1,6 @@
 ---
 title: 'Landing Contributor PRs: The Maintainer Runbook'
-description: 'The maintainer workflow for landing contributor PRs: claim, isolated worktree, rebase, red classification, folds, red-first verification, squad review, push discipline, and hand-off.'
+description: 'The maintainer workflow for landing contributor PRs: claim, worktree isolation, rebase, red classification, folds, red-first verification, push discipline, and hand-off.'
 doc_status: active
 updated: '2026-07-04'
 related:
@@ -244,10 +244,10 @@ been fixed, the end-state is stated instead of the trap.
 - **Saturated tolerance bands trip on the next legitimate change.** The CLI
   visible-count census sat at the top of its band, so the next legitimate
   command (#2338) tripped it. A saturated band needs a re-pin with a dated
-  rationale — the band was re-pinned 2026-07-04 at 236 visible (tolerance
-  212–259) in `tests/docs/test_check_cli_reference_freshness.py`. That
-  re-pin-in-the-same-PR pattern is the model for the second bin of
-  [step 4](#4-classify-every-red-check).
+  rationale — e.g. the 2026-07-04 re-pin at 236 visible (tolerance 212–259)
+  in `tests/docs/test_check_cli_reference_freshness.py`; the current values
+  live in that test, not here. That re-pin-in-the-same-PR pattern is the
+  model for the second bin of [step 4](#4-classify-every-red-check).
 - **Seam completeness gates are invisible to contributors.** Adding a `def`
   to `src/specify_cli/cli/commands/agent/tasks_move_task.py` also requires
   joining the `_MOVE_SET` pin in

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,11 @@
 title: Spec Kitty 3.2 Documentation
 description: Current Spec Kitty 3.2 documentation for new adopters, upgrade operators, harness users, and CLI integrators.
 doc_status: active
-updated: '2026-06-03'
+updated: '2026-07-04'
 related:
+- docs/changelog/index.md
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/release-goals/index.md
 - docs/migrations/from-charter-2x.md
 - docs/migrations/index.md
 - docs/migrations/upgrade-to-0-12-0.md
@@ -28,6 +31,12 @@ Spec Kitty documentation is organized as a single 13-section Common Docs structu
 - Current governance source: `.kittify/charter/charter.md`.
 - Current mission loop: `spec-kitty next --agent <name> --mission <slug>`.
 - Upgrade path: start at [Migrations](migrations/index.md), then follow the current guides.
+
+## What's new and roadmap
+
+- [Changelog](changelog/index.md) — release history (canonical `CHANGELOG.md`).
+- [Release goals](release-goals/index.md) — declared intent of each release line (3.2.x, 3.3.x).
+- [3.2.x milestone roadmap](plans/3-2-x-milestone-roadmap.md) — execution roadmap for the current milestone.
 
 ## Sections
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,6 @@ doc_status: active
 updated: '2026-07-04'
 related:
 - docs/changelog/index.md
-- docs/plans/3-2-x-milestone-roadmap.md
 - docs/release-goals/index.md
 - docs/migrations/from-charter-2x.md
 - docs/migrations/index.md
@@ -23,7 +22,7 @@ related:
   </nav>
 </section>
 
-Spec Kitty documentation is organized as a single 13-section Common Docs structure under this one entry point. Use it when you are installing Spec Kitty for the first time, upgrading an existing project, running missions through an AI harness, or checking exact CLI behavior.
+Spec Kitty documentation is organized as a single 14-section Common Docs structure (the standard 13 sections plus a published release-goals section) under this one entry point. Use it when you are installing Spec Kitty for the first time, upgrading an existing project, running missions through an AI harness, or checking exact CLI behavior.
 
 ## Answer summary
 
@@ -35,8 +34,7 @@ Spec Kitty documentation is organized as a single 13-section Common Docs structu
 ## What's new and roadmap
 
 - [Changelog](changelog/index.md) — release history (canonical `CHANGELOG.md`).
-- [Release goals](release-goals/index.md) — declared intent of each release line (3.2.x, 3.3.x).
-- [3.2.x milestone roadmap](plans/3-2-x-milestone-roadmap.md) — execution roadmap for the current milestone.
+- [Release goals](release-goals/index.md) — declared intent of each release line (3.2.x, 3.3.x); each line's execution roadmap is linked from there and from [Plans](plans/index.md).
 
 ## Sections
 
@@ -103,6 +101,11 @@ Every section has its own `index.md` landing page. This page is the single entry
     <strong>Changelog</strong>
     <span>Release history.</span>
   </a>
+  <a class="sk-doc-card" href="release-goals/index.md">
+    <span class="sk-card-kicker">Release Goals</span>
+    <strong>Release goals</strong>
+    <span>Declared intent of each release line.</span>
+  </a>
 </div>
 
 ## Section index
@@ -121,6 +124,7 @@ Every section has its own `index.md` landing page. This page is the single entry
 | Operations | [operations/index.md](operations/index.md) |
 | Migrations | [migrations/index.md](migrations/index.md) |
 | Changelog | [changelog/index.md](changelog/index.md) |
+| Release Goals | [release-goals/index.md](release-goals/index.md) |
 
 ## Migration and archive
 

--- a/docs/plans/3-2-x-milestone-roadmap.md
+++ b/docs/plans/3-2-x-milestone-roadmap.md
@@ -3,6 +3,10 @@ title: 3.2.x Milestone — Roadmap
 description: 'Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items.'
 doc_status: active
 updated: '2026-07-04'
+related:
+- docs/changelog/index.md
+- docs/plans/index.md
+- docs/release-goals/index.md
 ---
 # 3.2.x Milestone — Roadmap
 

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -2,7 +2,10 @@
 title: Plans
 description: 'Plans landing page: the distil-then-retire working surface for investigations, research, initiatives, user journeys, and design notes (Mission B, FR-009).'
 doc_status: draft
-updated: '2026-06-27'
+updated: '2026-07-04'
+related:
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/release-goals/index.md
 ---
 # Plans
 
@@ -19,3 +22,10 @@ home for the `architecture/`-rooted plans content:
 - **`notes/`** — legacy (1.x) design notes.
 - Loose investigation/trace docs (e.g. the Windows-compatibility mission review
   and the test-suite-acceleration plan).
+
+## Current milestone roadmap
+
+The [3.2.x milestone roadmap](3-2-x-milestone-roadmap.md) is the operator-facing
+execution roadmap for the current milestone. The durable declarations of intent
+it executes live in [release goals](../release-goals/index.md); as a plans/
+document, the roadmap itself follows the distil-then-retire lifecycle.

--- a/docs/release-goals/index.md
+++ b/docs/release-goals/index.md
@@ -1,6 +1,6 @@
 ---
 title: Release goals
-description: Internal release-goal declarations for Spec Kitty milestones, tracking the focus and intended scope of the 3.2.x and 3.3.x release lines.
+description: Published release-goal declarations for Spec Kitty milestones, recording the focus and intended scope of the 3.2.x and 3.3.x release lines.
 doc_status: active
 updated: '2026-07-04'
 related:
@@ -13,8 +13,10 @@ related:
 ---
 # Release goals
 
-Internal release-goal declarations that record the intended focus of each release line.
-These are planning artifacts for maintainers, not user-facing release notes.
+Release-goal declarations that record the intended focus of each release line.
+They remain intent/planning documents — published so the declared direction of
+each release line is public — not release notes; for what actually shipped,
+see the [changelog](../changelog/index.md).
 
 ## In this section
 

--- a/docs/release-goals/index.md
+++ b/docs/release-goals/index.md
@@ -2,10 +2,11 @@
 title: Release goals
 description: Internal release-goal declarations for Spec Kitty milestones, tracking the focus and intended scope of the 3.2.x and 3.3.x release lines.
 doc_status: active
-updated: '2026-06-27'
+updated: '2026-07-04'
 related:
 - docs/development/index.md
 - docs/index.md
+- docs/plans/3-2-x-milestone-roadmap.md
 - docs/release-goals/3.2.x.md
 - docs/release-goals/3.3.x.md
 - docs/release-goals/README.md
@@ -23,5 +24,8 @@ These are planning artifacts for maintainers, not user-facing release notes.
 
 ## See also
 
+- [3.2.x milestone roadmap](../plans/3-2-x-milestone-roadmap.md) — operator-facing
+  execution roadmap for the 3.2.x goals (a plans/ working document under the
+  distil-then-retire lifecycle).
 - [Documentation home](../index.md)
 - [Development notes](../development/index.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -24,6 +24,8 @@
   href: migrations/index.md
 - name: Changelog
   href: changelog/index.md
+- name: Release Goals
+  href: release-goals/index.md
 - name: Mission Runs
   href: kitty-specs/index.html
 - name: Historical Archive


### PR DESCRIPTION
## Summary

DOCOPS cluster 2 — a docsite navigation + maintainer-docs + CI-hygiene slice. Closes #2353, closes #2341, closes #2359; advances #2354 (its guides-navigation slice).

Five commits:

1. **`dd1cff329` — nav/IA (#2353).** Surfaces the "what's new / where is it going" pair on the docsite: Release Goals added to `toc.yml` (after Changelog) and — per the IA review, see below — properly **published** (added to `docfx.json` content + the `docs/index.md` section grid, with a dated D3 amendment note to the Common-Docs reconciliation ADR); the milestone roadmap linked from `plans/index.md`; a compact durable pointer block on the root index. Also heals a pre-existing 404 (the roadmap's link to `release-goals/3.2.x.md`).
2. **`84ccd4c10` — maintainer PR-landing guide (#2341 / #2354 slice).** New `docs/guides/pr-landing.md`: the 12-step landing approach + gotchas, authored from the 2026-07-04 landing pass, every command/path verified against the tree. `docs/guides/index.md` gains a Contributor/Maintainer split (the #2354 finding that the guides index carried only using-spec-kitty content); linked from CONTRIBUTING.md.
3. **`44a4d07d8` — squad folds.** See review section.
4. **`29d5a156d` — Pages actions to node24 (deploy hygiene).** deploy-pages v4→v5, upload-pages-artifact v3→v5, configure-pages v5→v6 — clears the Node-20-forced-to-24 deprecation surfaced on the deploy run. (The deploy itself recovered on rerun; the original failure was a transient GitHub Pages "try again later.")
5. **`66837022e` — docs-only CI split (#2359).** New `fast-tests-docs` job (~1.5m) runs `tests/docs` + the terminology-canon and CLI-parity guards; `docs/**` removed from the `core_misc` trigger so a docs-only PR no longer pays the ~17m code cone. **Fail-safe invariant verified** by a before/after trigger matrix: only the docs→code direction narrows; non-docs paths trigger exactly what they do today. Full `tests/architectural/` green (640 passed), gate-coverage orphan set unchanged, no conformance re-pins.

## Adversarial squad (3 docops lenses)

- **debbie (live evidence): APPROVE** — every command/path in the guide executed or falsified against the tree (the `PYTHONPATH` crash reproduces as documented; census band + seam paths match verbatim); all nav targets resolve; gates green.
- **alphonso (IA): REQUEST-CHANGES → resolved.** BLOCKER F1: Release Goals was added to nav but sat outside the DocFX publish set — a half-reversal of ADR D3 that would ship a 404ing nav entry. **Folded (Option A):** release-goals is now a published section (docfx globs + index grid + D3 amendment). Follow-up **#2360** filed (no gate validates toc hrefs against the publish manifest — the defect class).
- **daphne (Common Docs content): REQUEST-CHANGES → resolved.** BLOCKER: the guide's frontmatter description was 182 chars (CI band max 180); folded to her 169-char text. Plus the symlink-wording refresh (changelog index still said "kept byte-for-byte in sync" pre-cutover) and roadmap back-edges.

## Rebase interplay — for the ci-suite-map mission session (tidy/ci-suite-map-2034, #2034)

Commit `66837022e` touches `ci-quality.yml` blocks that mission also owns. On whichever lands second, reconcile: the new `docs:` dorny filter class (~line 215) + `docs` output (~line 104); `docs/**` removed from `core_misc:`; new `fast-tests-docs` job (~line 1280, marker `-m "not windows_ci"`); `quality-gate` needs+result-loop additions (~lines 2989/3040). `_gate_coverage_baseline.json` is **unchanged** (orphan set identical; only the report-only duplicate count rises); `_MIN_EXPECTED_GATES=40` floor now has one gate of headroom. `tests/docs` stays selected by the core-misc jobs too (over-cover fail-safe) — a core-misc reshard must keep it.

## Gates (final tip)

tests/docs 514 passed · tests/architectural 640 passed · check_docs_freshness --ci exit 0 · description_length_check --strict 0 violations · inventory_lockfile --strict 550/550 · relative_link_fixer 0 dead · related_validator --strict 0 dangling · terminology canon green · YAML valid.

## Trail

Multi-agent op: curator-carla (nav + guide authoring), python-pedro (CI split + deploy hygiene), reviewer folds; adversarial squad debbie/alphonso/daphne. Follow-ups filed: #2360 (nav↔publish-manifest gate), #2361 (post-deploy smoketest), #2362 (nightly clickthrough). Sibling docsite-health work merged today: #2313/#2348/#2349 (PR #2350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112a9agVvMYqgTaJD2HXttg