### PR TITLE
test(#2357,#2360): PR-time docsite publish-integrity gates — close the deploy-outage class by construction

### DIFF
--- a/tests/docs/_publish_manifest_helpers.py
+++ b/tests/docs/_publish_manifest_helpers.py
@@ -1,0 +1,125 @@
+"""Shared primitives for the PR-time docsite publish-integrity gates.
+
+Both gates in ``test_publish_manifest_coherence.py`` (#2357, #2360) reduce to
+the same question, asked of two different inputs (a committed baseline URL, a
+``docs/toc.yml`` href): *is this site-relative published-URL path resolvable
+WITHOUT a DocFX build?* "Resolvable" means one of:
+
+* **DERIVED** — the page still exists in the source tree, so
+  ``capture_baseline_urls.derive_urls_from_source`` would (re-)produce it, or
+* **REDIRECT-COVERED** — the URL is a key in the committed
+  ``redirect_map.yaml``, so a ``<meta refresh>`` stub will preserve it
+  (``redirect_stub_generator.check_coverage``'s real, build-time invariant).
+
+This is a **static-tree approximation** of ``check_coverage``: the real gate
+checks file presence inside an emitted ``_site``; DocFX/.NET is CI-only (see
+``redirect_stub_generator`` module docstring), so PR-time cannot build one.
+The approximation trades that live-build fidelity for running in every PR.
+
+Known model limit (documented in ``derive_urls_from_source``'s own docstring):
+pages generated at build time from a non-static source — today, exactly
+``kitty-specs/**/*.html``, emitted by ``generate_kitty_specs_docs.py`` from the
+top-level ``kitty-specs/`` mission-spec tree, per the ``resource`` block in
+``docs/docfx.json`` — are absent from a plain source-tree walk. Both gates
+allowlist *only* that one documented shape (:func:`is_generated_at_build`);
+anything else that is neither derived nor redirect-covered is a real gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Mirrors capture_baseline_urls.SITE_URL / redirect_stub_generator.SITE_URL —
+# duplicated here (both source modules already duplicate the same literal)
+# rather than importing a private constant across an internal/test boundary.
+SITE_URL = "https://docs.spec-kitty.ai/"
+
+MD_SUFFIX = ".md"
+HTML_SUFFIX = ".html"
+
+# The ONLY documented build-time generator whose output is absent from a
+# static source-tree walk (see module docstring above). Narrow by
+# construction: matches exactly the resource-block shape docfx.json declares
+# (``kitty-specs/**/*.html``) — a prefix-and-suffix pair, nothing broader (no
+# bare-prefix or bare-suffix match that could swallow an unrelated real gap).
+_GENERATED_AT_BUILD_PREFIX = "kitty-specs/"
+
+
+def is_generated_at_build(url_path: str) -> bool:
+    """True only for the one documented non-static generator output.
+
+    ``url_path`` is site-relative (no ``SITE_URL`` prefix), e.g.
+    ``"kitty-specs/index.html"``.
+    """
+    return url_path.startswith(_GENERATED_AT_BUILD_PREFIX) and url_path.endswith(
+        HTML_SUFFIX
+    )
+
+
+def strip_site(url: str, site_url: str = SITE_URL) -> str:
+    """Strip the site-URL prefix, mirroring ``redirect_stub_generator._strip_site``."""
+    return url[len(site_url) :] if url.startswith(site_url) else url
+
+
+def uncovered_urls(
+    candidate_paths: list[str],
+    derived_paths: set[str],
+    redirect_map: dict[str, str],
+) -> list[str]:
+    """Return the ``candidate_paths`` that are neither DERIVED nor REDIRECT-COVERED.
+
+    Shared by both gates: gate 1 passes the committed baseline URLs as
+    ``candidate_paths``; gate 2 passes the resolved ``docs/toc.yml`` href
+    targets. ``derived_paths`` and ``redirect_map`` keys must already be
+    site-relative (no ``SITE_URL`` prefix). The one documented build-time
+    generator shape (:func:`is_generated_at_build`) is excluded narrowly —
+    every other miss is a real, reportable gap.
+    """
+    uncovered: list[str] = []
+    for path in candidate_paths:
+        if is_generated_at_build(path):
+            continue
+        if path in derived_paths or path in redirect_map:
+            continue
+        uncovered.append(path)
+    return sorted(uncovered)
+
+
+def iter_toc_hrefs(toc_path: Path) -> list[str]:
+    """Flatten every ``href`` in a DocFX ``toc.yml``, including nested ``items``."""
+    data: Any = yaml.safe_load(toc_path.read_text(encoding="utf-8")) or []
+    hrefs: list[str] = []
+
+    def _walk(nodes: Any) -> None:
+        for node in nodes or []:
+            href = node.get("href")
+            if href:
+                hrefs.append(str(href))
+            _walk(node.get("items"))
+
+    _walk(data)
+    return hrefs
+
+
+def href_to_url_path(href: str) -> str | None:
+    """Resolve a root ``toc.yml`` href to its site-relative published-URL path.
+
+    ``docs/toc.yml`` hrefs are relative to the docs root for the top-level nav
+    this gate covers. A directory reference (trailing ``/``) resolves to that
+    directory's ``index.html`` (DocFX's own convention, also relied on by
+    ``redirect_map.yaml``'s ``archive/1x/index.html`` etc. entries); a
+    ``*.md`` reference resolves like DocFX's content mapping (``*.html``);
+    anything else (already ``*.html``) passes through unchanged. External
+    links (``http://``/``https://``) are out of scope for publish-coherence
+    and resolve to ``None`` so callers can skip them.
+    """
+    if href.startswith(("http://", "https://")):
+        return None
+    if href.endswith("/"):
+        return f"{href}index.html"
+    if href.endswith(MD_SUFFIX):
+        return f"{href[: -len(MD_SUFFIX)]}{HTML_SUFFIX}"
+    return href

--- a/tests/docs/_publish_manifest_helpers.py
+++ b/tests/docs/_publish_manifest_helpers.py
@@ -8,13 +8,23 @@ WITHOUT a DocFX build?* "Resolvable" means one of:
 * **DERIVED** — the page still exists in the source tree, so
   ``capture_baseline_urls.derive_urls_from_source`` would (re-)produce it, or
 * **REDIRECT-COVERED** — the URL is a key in the committed
-  ``redirect_map.yaml``, so a ``<meta refresh>`` stub will preserve it
-  (``redirect_stub_generator.check_coverage``'s real, build-time invariant).
+  ``redirect_map.yaml`` **and** its redirect TARGET itself resolves (is
+  DERIVED or a documented build-time-generated shape). This mirrors
+  ``redirect_stub_generator.check_coverage``'s real, build-time invariant
+  exactly: a stub is only real coverage when ``target_live`` holds —
+  ``generate()`` refuses to emit a stub pointing at a 404 (the no-404
+  invariant) and reports it as a ``dead_targets`` entry instead. A redirect
+  whose target does not resolve is NOT coverage; the source path is reported
+  uncovered, same as ``check_coverage`` would (post-build) via a missing
+  stub.
 
 This is a **static-tree approximation** of ``check_coverage``: the real gate
 checks file presence inside an emitted ``_site``; DocFX/.NET is CI-only (see
 ``redirect_stub_generator`` module docstring), so PR-time cannot build one.
 The approximation trades that live-build fidelity for running in every PR.
+There is no known divergence left between this approximation's notion of
+"covered" and ``check_coverage``'s: both require the redirect target to
+resolve, not merely that the source is a mapped key.
 
 Known model limit (documented in ``derive_urls_from_source``'s own docstring):
 pages generated at build time from a non-static source — today, exactly
@@ -23,6 +33,16 @@ top-level ``kitty-specs/`` mission-spec tree, per the ``resource`` block in
 ``docs/docfx.json`` — are absent from a plain source-tree walk. Both gates
 allowlist *only* that one documented shape (:func:`is_generated_at_build`);
 anything else that is neither derived nor redirect-covered is a real gap.
+This allowlist also applies when resolving a redirect TARGET (a redirect
+could in principle point at a kitty-specs generated page), keeping the two
+checks symmetric.
+
+Separately documented known-limit (not a divergence from ``check_coverage``,
+since ``docfx.json``'s ``overwrite`` block is not a publish source at all):
+the ``overwrite`` block (``apidoc/**.md``) is not modeled by
+``derive_urls_from_source`` and therefore not by this approximation either,
+because ``docs/apidoc/`` is currently empty/inert — a future apidoc
+population would need this revisited.
 """
 
 from __future__ import annotations
@@ -73,16 +93,28 @@ def uncovered_urls(
 
     Shared by both gates: gate 1 passes the committed baseline URLs as
     ``candidate_paths``; gate 2 passes the resolved ``docs/toc.yml`` href
-    targets. ``derived_paths`` and ``redirect_map`` keys must already be
-    site-relative (no ``SITE_URL`` prefix). The one documented build-time
+    targets. ``derived_paths`` and ``redirect_map`` keys/values must already
+    be site-relative (no ``SITE_URL`` prefix). The one documented build-time
     generator shape (:func:`is_generated_at_build`) is excluded narrowly —
     every other miss is a real, reportable gap.
+
+    REDIRECT-COVERED requires the redirect's TARGET to resolve too (mirrors
+    ``redirect_stub_generator.check_coverage``'s ``target_live`` requirement):
+    a path that is merely a ``redirect_map`` key is not sufficient — if its
+    target is not itself DERIVED (or the documented generated-at-build shape),
+    the stub would point at a 404 and ``generate()`` would refuse to emit it
+    (a ``dead_targets`` entry), so the source path is reported uncovered.
     """
     uncovered: list[str] = []
     for path in candidate_paths:
         if is_generated_at_build(path):
             continue
-        if path in derived_paths or path in redirect_map:
+        if path in derived_paths:
+            continue
+        target = redirect_map.get(path)
+        if target is not None and (
+            target in derived_paths or is_generated_at_build(target)
+        ):
             continue
         uncovered.append(path)
     return sorted(uncovered)

--- a/tests/docs/test_publish_manifest_coherence.py
+++ b/tests/docs/test_publish_manifest_coherence.py
@@ -1,0 +1,290 @@
+"""PR-time docsite publish-integrity gates (#2357, #2360).
+
+Two "no PR-time gate saw it" defect classes, closed by construction
+(DIRECTIVE_043):
+
+* **Gate 1 (#2357)** — a moved-away page can leave a committed baseline URL
+  with neither a live page nor a redirect stub. The real NFR-002 invariant
+  (``redirect_stub_generator.check_coverage``) only runs post-build in CI
+  (DocFX is CI-only); this is its PR-time, build-free approximation: every
+  baseline URL must be DERIVED (still resolvable from the source tree, see
+  ``capture_baseline_urls.derive_urls_from_source``) or REDIRECT-COVERED (a
+  key in the committed ``redirect_map.yaml``). This is exactly the class that
+  broke the docsite deploy for a week on 2026-07-04 — an incomplete
+  migration-runbook move left a baseline URL uncovered, caught only
+  post-merge by the build-time gate.
+
+* **Gate 2 (#2360)** — a ``docs/toc.yml`` nav entry can point at an
+  unpublished path and ship a 404. In cluster 2, a "Release Goals" nav entry
+  pointing at an unpublished path was caught only by adversarial review, not
+  by any PR-time gate. This asserts every toc href resolves to a DERIVED or
+  REDIRECT-COVERED published URL — the same "covered" test as gate 1, applied
+  to the nav instead of the baseline.
+
+Both gates share the static-tree "covered" primitive in
+``tests/docs/_publish_manifest_helpers.py`` (``uncovered_urls`` +
+``is_generated_at_build``'s narrow allowlist for the one documented
+build-time-only generator, ``kitty-specs/**/*.html``).
+
+Scope (intentionally tight): toc **href** coherence only — the witnessed
+defect shape. Body-link publish-coverage (asserting every in-page markdown
+link that targets another *published* page actually resolves) is a plausible
+follow-on but is NOT covered here: distinguishing "link to a published page"
+from "intentional cross-reference to an unpublished file" (e.g. a link to
+this repo's own ``CONTRIBUTING.md``, a kitty-specs mission doc, or an
+``architecture/adr`` symlink target) needs scoping work to avoid false
+positives on the current tree, and that scoping was not attempted here. Left
+as an explicit follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.docs.capture_baseline_urls import derive_urls_from_source
+from scripts.docs.redirect_stub_generator import (
+    DEFAULT_BASELINE,
+    DEFAULT_REDIRECT_MAP,
+    load_baseline,
+    load_redirect_map,
+)
+from tests.docs._publish_manifest_helpers import (
+    SITE_URL,
+    href_to_url_path,
+    is_generated_at_build,
+    iter_toc_hrefs,
+    strip_site,
+    uncovered_urls,
+)
+
+# tests/docs runs in the dedicated `fast-tests-docs` CI job under
+# `-m "not windows_ci"` (no `fast` marker required there — see
+# .github/workflows/ci-quality.yml's fast-tests-docs job comment). No special
+# marker needed to be collected by that job; `fast` is added anyway so this
+# file also participates in the broader fast-tests-core-misc sweep like its
+# siblings (test_capture_baseline_urls.py, test_redirect_stub_generator.py).
+pytestmark = pytest.mark.fast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DOCS_DIR = _REPO_ROOT / "docs"
+DEFAULT_DOCFX_JSON = DEFAULT_DOCS_DIR / "docfx.json"
+DEFAULT_TOC = DEFAULT_DOCS_DIR / "toc.yml"
+
+
+def _write(path: Path, text: str = "x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _stage_docs_tree(root: Path) -> tuple[Path, Path]:
+    """Stage a tiny published docs tree: two live pages, one content block."""
+    docs = root / "docs"
+    _write(docs / "index.md")
+    _write(docs / "how-to" / "create-plan.md")
+    docfx = docs / "docfx.json"
+    docfx.write_text(
+        json.dumps(
+            {
+                "build": {
+                    "content": [{"files": ["index.md", "how-to/*.md"]}],
+                    "resource": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return docs, docfx
+
+
+def _derived_paths(docs: Path, docfx: Path) -> set[str]:
+    return {
+        strip_site(u, SITE_URL)
+        for u in derive_urls_from_source(docs, docfx, site_url=SITE_URL)
+    }
+
+
+# --- Gate 1 (#2357): baseline coverage ---------------------------------------
+
+
+def test_gate1_fixture_has_teeth_on_moved_away_page(tmp_path: Path) -> None:
+    """A baseline URL for a page that moved away with no stub is reported.
+
+    This is the exact pre-#2313 defect shape: the migration-runbook page moved,
+    its old baseline URL was neither still-derivable nor redirect-covered, and
+    nothing caught it until the post-build NFR-002 gate — a week after the
+    docsite had already been broken. Pinned here as a permanent regression
+    test (mirrors ``test_redirect_stub_generator.test_coverage_red_when_
+    redirect_removed``'s pattern of asserting the exact uncovered output).
+    """
+    docs, docfx = _stage_docs_tree(tmp_path)
+    derived = _derived_paths(docs, docfx)
+    baseline_paths = sorted(derived | {"how-to/retired-runbook.html"})
+
+    uncovered = uncovered_urls(baseline_paths, derived, redirect_map={})
+
+    assert uncovered == ["how-to/retired-runbook.html"]
+
+
+def test_gate1_fixture_green_once_redirect_covers_the_move(tmp_path: Path) -> None:
+    """The same moved-away page is covered once a redirect stub maps it forward."""
+    docs, docfx = _stage_docs_tree(tmp_path)
+    derived = _derived_paths(docs, docfx)
+    baseline_paths = sorted(derived | {"how-to/retired-runbook.html"})
+    redirect_map = {"how-to/retired-runbook.html": "how-to/create-plan.html"}
+
+    uncovered = uncovered_urls(baseline_paths, derived, redirect_map)
+
+    assert uncovered == []
+
+
+def test_gate1_fixture_excludes_only_the_documented_generated_shape(
+    tmp_path: Path,
+) -> None:
+    """The kitty-specs build-time allowlist is narrow — it must not mask a real gap.
+
+    ``kitty-specs/index.html`` is absent from the static source tree (it is
+    generated by ``generate_kitty_specs_docs.py`` at build time) and must be
+    excluded rather than flagged. A same-shaped-looking but genuinely missing
+    page OUTSIDE ``kitty-specs/`` must still be reported — proving the
+    allowlist matches by the documented prefix, not by "absent from source"
+    in general (which would silently swallow the very defect class #2357
+    exists to catch).
+    """
+    docs, docfx = _stage_docs_tree(tmp_path)
+    derived = _derived_paths(docs, docfx)
+    baseline_paths = sorted(
+        derived | {"kitty-specs/index.html", "how-to/also-missing.html"}
+    )
+
+    uncovered = uncovered_urls(baseline_paths, derived, redirect_map={})
+
+    assert uncovered == ["how-to/also-missing.html"]
+    assert "kitty-specs/index.html" not in uncovered
+
+
+def test_gate1_live_baseline_is_fully_covered() -> None:
+    """The real gate: every committed baseline URL is derived or redirect-covered.
+
+    No live DocFX ``_site`` build (CI-only) — this is the static-tree
+    approximation described in the module docstring. A RED here on the current
+    tree is a real, reportable NFR-002-adjacent gap, not a test to loosen.
+    """
+    _, baseline_paths = load_baseline(DEFAULT_BASELINE)
+    derived = _derived_paths(DEFAULT_DOCS_DIR, DEFAULT_DOCFX_JSON)
+    redirect_map = load_redirect_map(DEFAULT_REDIRECT_MAP)
+
+    uncovered = uncovered_urls(baseline_paths, derived, redirect_map)
+
+    assert uncovered == []
+
+
+# --- Gate 2 (#2360): nav <-> publish-manifest coherence ----------------------
+
+
+def test_gate2_fixture_has_teeth_on_unpublished_toc_href(tmp_path: Path) -> None:
+    """A toc.yml href pointing at an unpublished page is reported.
+
+    This is the exact cluster-2 "Release Goals" shape: a nav entry added
+    pointing at a path that was never in the published set — it would have
+    shipped a 404 and was only caught by adversarial review. Pinned as a
+    permanent regression test.
+    """
+    docs, docfx = _stage_docs_tree(tmp_path)
+    toc = docs / "toc.yml"
+    toc.write_text(
+        "- name: Home\n  href: index.md\n"
+        "- name: Release Goals\n  href: release-goals/index.md\n",
+        encoding="utf-8",
+    )
+    derived = _derived_paths(docs, docfx)
+    hrefs = iter_toc_hrefs(toc)
+    resolved = [p for h in hrefs if (p := href_to_url_path(h)) is not None]
+
+    uncovered = uncovered_urls(resolved, derived, redirect_map={})
+
+    assert uncovered == ["release-goals/index.html"]
+
+
+def test_gate2_fixture_green_once_toc_href_targets_a_published_page(
+    tmp_path: Path,
+) -> None:
+    docs, docfx = _stage_docs_tree(tmp_path)
+    toc = docs / "toc.yml"
+    toc.write_text(
+        "- name: Home\n  href: index.md\n"
+        "- name: How-To\n  href: how-to/create-plan.md\n",
+        encoding="utf-8",
+    )
+    derived = _derived_paths(docs, docfx)
+    hrefs = iter_toc_hrefs(toc)
+    resolved = [p for h in hrefs if (p := href_to_url_path(h)) is not None]
+
+    uncovered = uncovered_urls(resolved, derived, redirect_map={})
+
+    assert uncovered == []
+
+
+def test_gate2_fixture_excludes_only_the_documented_generated_shape(
+    tmp_path: Path,
+) -> None:
+    """A ``kitty-specs/*.html`` nav href is allowlisted narrowly, like gate 1."""
+    docs, docfx = _stage_docs_tree(tmp_path)
+    toc = docs / "toc.yml"
+    toc.write_text(
+        "- name: Home\n  href: index.md\n"
+        "- name: Mission Runs\n  href: kitty-specs/index.html\n"
+        "- name: Ghost\n  href: how-to/ghost.md\n",
+        encoding="utf-8",
+    )
+    derived = _derived_paths(docs, docfx)
+    hrefs = iter_toc_hrefs(toc)
+    resolved = [p for h in hrefs if (p := href_to_url_path(h)) is not None]
+
+    uncovered = uncovered_urls(resolved, derived, redirect_map={})
+
+    assert uncovered == ["how-to/ghost.html"]
+    assert "kitty-specs/index.html" not in uncovered
+
+
+def test_gate2_href_resolution_handles_directories_and_external_links() -> None:
+    """Directory hrefs resolve to their index; external links are out of scope."""
+    assert href_to_url_path("archive/") == "archive/index.html"
+    assert href_to_url_path("archive/2x/") == "archive/2x/index.html"
+    assert href_to_url_path("guides/index.md") == "guides/index.html"
+    assert href_to_url_path("kitty-specs/index.html") == "kitty-specs/index.html"
+    assert href_to_url_path("https://example.com/") is None
+    assert href_to_url_path("http://example.com/") is None
+
+
+def test_gate2_live_toc_hrefs_all_resolve_to_published_or_redirected_urls() -> None:
+    """The real gate: every ``docs/toc.yml`` href targets a published/covered path.
+
+    This is the check that would have caught the cluster-2 "Release Goals"
+    404 pre-fix. A RED here means a live nav entry currently 404s and must be
+    reported, not suppressed.
+    """
+    derived = _derived_paths(DEFAULT_DOCS_DIR, DEFAULT_DOCFX_JSON)
+    redirect_map = load_redirect_map(DEFAULT_REDIRECT_MAP)
+    hrefs = iter_toc_hrefs(DEFAULT_TOC)
+    resolved = [p for h in hrefs if (p := href_to_url_path(h)) is not None]
+
+    uncovered = uncovered_urls(resolved, derived, redirect_map)
+
+    assert uncovered == []
+
+
+# --- Shared allowlist narrowness -----------------------------------------
+
+
+def test_generated_at_build_allowlist_matches_only_kitty_specs_html() -> None:
+    """``is_generated_at_build`` must not over-match beyond the documented shape."""
+    assert is_generated_at_build("kitty-specs/index.html")
+    assert is_generated_at_build("kitty-specs/nested/mission.html")
+    # Same prefix, wrong suffix (not an html page) -> not excluded.
+    assert not is_generated_at_build("kitty-specs/toc.yml")
+    # Same suffix, wrong/no prefix -> not excluded (a real page, or a real gap).
+    assert not is_generated_at_build("how-to/kitty-specs-guide.html")
+    assert not is_generated_at_build("index.html")

--- a/tests/docs/test_publish_manifest_coherence.py
+++ b/tests/docs/test_publish_manifest_coherence.py
@@ -165,6 +165,27 @@ def test_gate1_fixture_excludes_only_the_documented_generated_shape(
     assert "kitty-specs/index.html" not in uncovered
 
 
+def test_gate1_fixture_red_when_redirect_target_is_dead(tmp_path: Path) -> None:
+    """A redirect whose TARGET does not resolve is not real coverage.
+
+    Mirrors ``redirect_stub_generator.check_coverage``'s ``target_live``
+    requirement (a stub is only real coverage when ``new_path`` resolves to a
+    live page — ``generate()``'s no-404 invariant refuses to emit a stub
+    pointing at a 404 and reports it as a ``dead_targets`` entry instead).
+    Treating "path is a redirect_map key" as sufficient (the pre-fold
+    behaviour) is false confidence: a redirect to a dead page is NOT real
+    coverage, and the SOURCE must still be reported uncovered.
+    """
+    docs, docfx = _stage_docs_tree(tmp_path)
+    derived = _derived_paths(docs, docfx)
+    baseline_paths = sorted(derived | {"how-to/retired-runbook.html"})
+    redirect_map = {"how-to/retired-runbook.html": "how-to/nonexistent-target.html"}
+
+    uncovered = uncovered_urls(baseline_paths, derived, redirect_map)
+
+    assert uncovered == ["how-to/retired-runbook.html"]
+
+
 def test_gate1_live_baseline_is_fully_covered() -> None:
     """The real gate: every committed baseline URL is derived or redirect-covered.
 


### PR DESCRIPTION
## Summary

Closes #2357, closes #2360. Two PR-time static gates in the `fast-tests-docs` job that close, by construction (DIRECTIVE_043), the two failure classes from the 2026-07-04 docsite incident — both of which previously escaped every PR-time gate:

1. **#2357 — baseline coverage approximation.** Statically re-derives the NFR-002 invariant (every committed baseline URL is DERIVED or REDIRECT-COVERED) without a DocFX build. Would have redded Mission B's incomplete migration-runbook move *at PR time* instead of leaving the deploy broken for a week.
2. **#2360 — nav↔publish-manifest coherence.** Every `docs/toc.yml` href must target a published/covered path. Would have caught cluster 2's Release Goals 404 mechanically instead of via adversarial review.

Both compose the existing canonical seams (`derive_urls_from_source`, `load_redirect_map`, `load_baseline`) — no new plumbing, no `ci-quality.yml` change (they land in the `fast-tests-docs` job from #2359). Two files: `tests/docs/test_publish_manifest_coherence.py` + `tests/docs/_publish_manifest_helpers.py`.

## Red-first (both gates have real teeth)

Each gate's regression assertion was proven RED against an injected defect before being pinned:
- Gate 1: an uncovered baseline URL (`how-to/retired-runbook.html` — the pre-#2313 shape) → flagged.
- Gate 2: an unpublished toc href (`release-goals/index.html` — the cluster-2 shape) → flagged.
- Gate 1 (dead-target, added in review): a redirect whose *target* is missing → flagged.

Live tree (post-#2350/#2363, healthy): both gates GREEN with no suppression; the only allowlist needed is `kitty-specs/*.html` (build-generated, absent from a static tree — proven narrow: disabling it reds exactly **4** tests).

## Fidelity — the crux for a static approximation of a CI-only gate

A focused adversarial-verification lens probed both divergence directions against the authoritative build-time `check_coverage`:
- **False confidence (BLOCKER-class):** found one real (dormant) gap — the initial gate treated redirect-map *membership* as coverage without verifying the redirect *target* resolves, unlike `check_coverage` (which requires `target_live`). **Folded** (`87df8e885`): coverage now requires the redirect target itself be a published page; red-first dead-target test added; live tree confirmed 0/136 dead targets so gates stay green. No remaining divergence from `check_coverage`.
- **False block:** cleared — `derive_urls_from_source` models every *live* docfx.json content+resource block; the `overwrite` (`apidoc/**`) block is inert (`docs/apidoc/` doesn't exist), documented as a known-limit to revisit if populated.

## Where this sits in the deploy-integrity defense (epic #2314, buckets A/B)

- **PR-time static (this PR):** #2357 baseline coverage · #2360 nav↔publish coherence.
- **Runtime follow-on (filed, not here):** #2361 post-deploy smoketest · #2362 nightly clickthrough.
Layered: static catches it before merge; runtime catches what only the live DocFX build/serve can reveal.

## Gates

tests/docs 525 passed · check_docs_freshness --ci exit 0 · ruff + mypy clean on both new files · inventory strict no-op (no new pages).

## Trail

Implementer python-pedro (sonnet — model discipline per #2364, moderate implementation tier); focused fidelity-verification lens (debugger-debbie); one review fold. Scaled to the work: a 2-file test-only slice got one adversarial lens on its real risk (static/CI fidelity), not a full squad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112a9agVvMYqgTaJD2HXttg