### PR TITLE
fix(#2369): let orchestrator-completed missions pass spec-kitty accept

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -122,6 +122,7 @@ jobs:
       e2e: ${{ (inputs.run_all || steps.unmatched.outputs.unmatched == 'true') && 'true' || steps.filter.outputs.e2e }}
       docs: ${{ (inputs.run_all || steps.unmatched.outputs.unmatched == 'true') && 'true' || steps.filter.outputs.docs }}
       glossary: ${{ (inputs.run_all || steps.unmatched.outputs.unmatched == 'true') && 'true' || steps.filter.outputs.glossary }}
+      acceptance: ${{ (inputs.run_all || steps.unmatched.outputs.unmatched == 'true') && 'true' || steps.filter.outputs.acceptance }}
       # Raw catch-all signal for the quality-gate decision script (FR-011):
       # true iff any_src matched but no named group did.
       unmatched: ${{ steps.unmatched.outputs.unmatched }}
@@ -265,6 +266,17 @@ jobs:
             glossary:
               - 'src/glossary/**'
               - 'tests/glossary/**'
+            # acceptance: canonical-acceptance + gitignore/derived-views state
+            # surfaces (src/specify_cli/acceptance + src/specify_cli/state) plus
+            # the tests that exercise them, so a change to those src cones
+            # deterministically triggers the core-misc jobs that run them
+            # instead of relying on the fail-closed catch-all (#2034 / #1933).
+            acceptance:
+              - 'src/specify_cli/acceptance/**'
+              - 'src/specify_cli/state/**'
+              - 'tests/specify_cli/test_canonical_acceptance.py'
+              - 'tests/specify_cli/test_gitignore_contract.py'
+              - 'tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py'
             # FR-010 probe group (Decision 7b): matches ANY src change. The
             # ``unmatched`` step below computes ``any_src AND NOT (any named
             # group)`` from the filter's own outputs; a true result forces the
@@ -312,7 +324,8 @@ jobs:
             "${{ steps.filter.outputs.kernel }}" \
             "${{ steps.filter.outputs.doctrine }}" \
             "${{ steps.filter.outputs.execution_context }}" \
-            "${{ steps.filter.outputs.glossary }}"; do
+            "${{ steps.filter.outputs.glossary }}" \
+            "${{ steps.filter.outputs.acceptance }}"; do
             if [ "$group_hit" = "true" ]; then
               matched=true
             fi
@@ -1309,7 +1322,7 @@ jobs:
     needs: [changes, kernel-tests, fast-tests-doctrine]
     if: >-
       always() &&
-      (needs.changes.outputs.core_misc == 'true' || needs.changes.outputs.execution_context == 'true' || needs.changes.outputs.glossary == 'true') &&
+      (needs.changes.outputs.core_misc == 'true' || needs.changes.outputs.execution_context == 'true' || needs.changes.outputs.glossary == 'true' || needs.changes.outputs.acceptance == 'true') &&
       needs.kernel-tests.result != 'failure' &&
       needs.fast-tests-doctrine.result != 'failure'
     steps:
@@ -1419,7 +1432,7 @@ jobs:
     needs: [changes, fast-tests-core-misc]
     if: >-
       always() &&
-      (needs.changes.outputs.core_misc == 'true' || needs.changes.outputs.execution_context == 'true') &&
+      (needs.changes.outputs.core_misc == 'true' || needs.changes.outputs.execution_context == 'true' || needs.changes.outputs.acceptance == 'true') &&
       needs.fast-tests-core-misc.result != 'failure' &&
       (
         github.event_name != 'pull_request' ||
@@ -3218,7 +3231,7 @@ jobs:
               "fast-tests-dashboard": ["dashboard", "status"],
               "fast-tests-upgrade": ["upgrade", "status"],
               "fast-tests-cli": ["cli"],
-              "fast-tests-core-misc": ["core_misc", "execution_context", "glossary"],
+              "fast-tests-core-misc": ["core_misc", "execution_context", "glossary", "acceptance"],
               "fast-tests-docs": ["docs"],
               "fast-tests-charter": ["charter"],
               "fast-tests-agent": ["agent"],
@@ -3237,7 +3250,7 @@ jobs:
               "integration-tests-upgrade": ["upgrade"],
               "integration-tests-cli": ["cli"],
               "integration-tests-agent": ["agent"],
-              "integration-tests-core-misc": ["core_misc", "execution_context"],
+              "integration-tests-core-misc": ["core_misc", "execution_context", "acceptance"],
               "e2e-cross-cutting": ["e2e", "core_misc", "execution_context"],
               "restart-daemon-nfr-timing": ["cli"],
               "consumer-compatibility": ["release"],

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -276,6 +276,7 @@ jobs:
               - 'src/specify_cli/state/**'
               - 'tests/specify_cli/test_canonical_acceptance.py'
               - 'tests/specify_cli/test_gitignore_contract.py'
+              - 'tests/specify_cli/test_state_contract.py'
               - 'tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py'
             # FR-010 probe group (Decision 7b): matches ANY src change. The
             # ``unmatched`` step below computes ``any_src AND NOT (any named

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -38,6 +38,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Subtask guard no longer misattributes a later WP's checkboxes (#2346, also closes #2324).** `_check_unchecked_subtasks` entered a WP's section on *any* heading that merely mentioned its id, so a dependent heading like `### WP03 — … (depends: WP01, WP02)` re-entered WP01/WP02's section and harvested WP03's unchecked `- [ ] T0xx` rows as the earlier WP's blockers — spuriously blocking that WP's lane transition. A heading now belongs to the WP named by its **first** `WPxx` token, not any mention.
   - **`grep_absence` negative invariants accept an optional path-scope (#1834).** The acceptance gate ran `grep -r <pattern> .` over the whole repo, so a negative-invariant pattern that a mission's own spec/plan/WP prose mentioned false-positived as `still_present`. `NegativeInvariant` now carries an optional `scope` (whitespace-separated repo-relative search roots); when set, the grep runs only under those paths. Default (unscoped) preserves the whole-repo search, and `scope` is omitted from serialization when unset so existing matrices are untouched.
   - **Documented merge-before-accept for merged-post-state invariants (#1834).** The accept runbook (`docs/guides/accept-and-merge.md`) now records that the accept gate re-runs each negative-invariant `verification_command` **live** (so a hand-set `overall_verdict` does not stick), and that a mission whose invariants assert the *merged* post-state must run `spec-kitty merge` (local) before `spec-kitty accept`.
+- **A mission fully implemented by `spec-kitty-orchestrator` can now pass
+  `spec-kitty accept` — two mechanical false-positives removed (#2369).** The
+  accept gate is the mission-level readiness check (all-done, subtasks,
+  clarifications, artifacts, clean tree, paths), but two checks always failed on
+  orchestrator-completed missions, forcing operators to bypass accept entirely:
+  (a) the strict-metadata check required `shell_pid` on **every** WP, including
+  terminal ones — but `shell_pid` is an interactive-`spec-kitty next` artifact the
+  orchestrator never stamps; it is now **lane-gated to active lanes exactly like
+  `assignee`**, so a done/approved WP no longer needs it (an active WP still does).
+  (b) `spec-kitty materialize` writes regenerable views to `.kittify/derived/`,
+  which was **not** in the runtime gitignore set (unlike sibling `.kittify/`
+  paths), so it dirtied the tree and failed accept's `git_dirty` check — the
+  `derived/` views are now a registered `IGNORED` state surface, so
+  `.kittify/derived/` is emitted into `.gitignore` on init/upgrade. The six
+  meaningful accept checks still gate.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -50,9 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (b) `spec-kitty materialize` writes regenerable views to `.kittify/derived/`,
   which was **not** in the runtime gitignore set (unlike sibling `.kittify/`
   paths), so it dirtied the tree and failed accept's `git_dirty` check — the
-  `derived/` views are now a registered `IGNORED` state surface, so
-  `.kittify/derived/` is emitted into `.gitignore` on init/upgrade. The six
-  meaningful accept checks still gate.
+  `derived/` views are now a registered `IGNORED` state surface (so fresh
+  `spec-kitty init` gitignores it), and a dedicated backfill migration
+  (`3.2.4_derived_mission_views_gitignore_backfill`) adds `.kittify/derived/`
+  to `.gitignore` on `spec-kitty upgrade` for already-initialised projects
+  (the runtime-hygiene migrations previously only knew a hardcoded subset of
+  entries). The six meaningful accept checks still gate.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 
 AcceptanceMode = str  # Expected values: "pr", "local", "checklist"
 
+# The active-work lanes: a WP in one of these is still in flight, so the
+# strict-metadata gate requires the active-phase artifacts (``assignee`` and the
+# live-shell ``shell_pid``). A terminal (done/approved) WP is exempt — the
+# ``assignee`` and ``shell_pid`` gates key on exactly this set (#2369).
+_ACTIVE_METADATA_LANES = frozenset({"doing", Lane.IN_PROGRESS, Lane.FOR_REVIEW})
+
 SPEC_FILE = "spec.md"
 PLAN_FILE = "plan.md"
 TASKS_FILE = "tasks.md"
@@ -1285,7 +1291,7 @@ def collect_feature_summary(
         if strict_metadata:
             if not wp.agent:
                 metadata_issues.append(f"{wp_id}: missing agent in frontmatter")
-            if canonical_lane in {"doing", Lane.IN_PROGRESS, Lane.FOR_REVIEW} and not wp.assignee:
+            if canonical_lane in _ACTIVE_METADATA_LANES and not wp.assignee:
                 metadata_issues.append(f"{wp_id}: missing assignee in frontmatter")
             # ``shell_pid`` identifies the live interactive shell that claimed a WP
             # in ``spec-kitty next`` — an artifact of the ACTIVE-work phase, and one
@@ -1293,7 +1299,7 @@ def collect_feature_summary(
             # lanes, mirroring the ``assignee`` gate above: a terminal (done/approved)
             # WP has no live shell, so demanding it there is a false positive that
             # blocks every orchestrator-completed mission from passing accept (#2369).
-            if canonical_lane in {"doing", Lane.IN_PROGRESS, Lane.FOR_REVIEW} and not wp.shell_pid:
+            if canonical_lane in _ACTIVE_METADATA_LANES and not wp.shell_pid:
                 metadata_issues.append(f"{wp_id}: missing shell_pid in frontmatter")
 
         work_packages.append(

--- a/src/specify_cli/acceptance/__init__.py
+++ b/src/specify_cli/acceptance/__init__.py
@@ -1287,7 +1287,13 @@ def collect_feature_summary(
                 metadata_issues.append(f"{wp_id}: missing agent in frontmatter")
             if canonical_lane in {"doing", Lane.IN_PROGRESS, Lane.FOR_REVIEW} and not wp.assignee:
                 metadata_issues.append(f"{wp_id}: missing assignee in frontmatter")
-            if not wp.shell_pid:
+            # ``shell_pid`` identifies the live interactive shell that claimed a WP
+            # in ``spec-kitty next`` — an artifact of the ACTIVE-work phase, and one
+            # the orchestrator executor never stamps. Require it only for active
+            # lanes, mirroring the ``assignee`` gate above: a terminal (done/approved)
+            # WP has no live shell, so demanding it there is a false positive that
+            # blocks every orchestrator-completed mission from passing accept (#2369).
+            if canonical_lane in {"doing", Lane.IN_PROGRESS, Lane.FOR_REVIEW} and not wp.shell_pid:
                 metadata_issues.append(f"{wp_id}: missing shell_pid in frontmatter")
 
         work_packages.append(

--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -229,6 +229,22 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         creation_trigger="mission run start",
     ),
     StateSurface(
+        name="derived_mission_views",
+        path_pattern=".kittify/derived/<mission_slug>/lifecycle.json",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSON,
+        authority=AuthorityClass.DERIVED,
+        git_class=GitClass.IGNORED,
+        owner_module="status/lifecycle + status/views",
+        creation_trigger="spec-kitty materialize",
+        notes=(
+            "Regenerable machine-facing views (lifecycle.json / status.json / "
+            "board-summary.json / progress.json) under .kittify/derived/<slug>/. "
+            "Ignored: materialize output must not dirty the tree or gate accept "
+            "(#2369). Collapses to the .kittify/derived/ gitignore entry."
+        ),
+    ),
+    StateSurface(
         name="glossary_fallback_events",
         path_pattern=".kittify/events/glossary/<mission_id>.events.jsonl",
         root=StateRoot.PROJECT,

--- a/src/specify_cli/upgrade/migrations/m_3_2_4_derived_views_gitignore_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_4_derived_views_gitignore_backfill.py
@@ -30,6 +30,10 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 _DERIVED_VIEWS_ENTRY = ".kittify/derived/"
+# A hand-added entry without the trailing slash ignores the same directory, so
+# treat either form as already-present — the backfill stays idempotent and never
+# appends a duplicate ``.kittify/derived/`` beside a user's ``.kittify/derived``.
+_DERIVED_VIEWS_EQUIVALENT_ENTRIES = frozenset({".kittify/derived/", ".kittify/derived"})
 
 
 def _read_gitignore_entries(project_path: Path) -> set[str]:
@@ -52,7 +56,9 @@ class DerivedViewsGitignoreBackfillMigration(BaseMigration):  # type: ignore[mis
     target_version = "3.2.4"
 
     def detect(self, project_path: Path) -> bool:
-        return _DERIVED_VIEWS_ENTRY not in _read_gitignore_entries(project_path)
+        return _DERIVED_VIEWS_EQUIVALENT_ENTRIES.isdisjoint(
+            _read_gitignore_entries(project_path)
+        )
 
     def can_apply(self, project_path: Path) -> tuple[bool, str]:
         if not project_path.exists():
@@ -60,7 +66,9 @@ class DerivedViewsGitignoreBackfillMigration(BaseMigration):  # type: ignore[mis
         return True, ""
 
     def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
-        already_present = _DERIVED_VIEWS_ENTRY in _read_gitignore_entries(project_path)
+        already_present = not _DERIVED_VIEWS_EQUIVALENT_ENTRIES.isdisjoint(
+            _read_gitignore_entries(project_path)
+        )
 
         if dry_run:
             changes = (
@@ -69,6 +77,13 @@ class DerivedViewsGitignoreBackfillMigration(BaseMigration):  # type: ignore[mis
                 else [f"Would add {_DERIVED_VIEWS_ENTRY} to .gitignore"]
             )
             return MigrationResult(success=True, changes_made=changes)
+
+        if already_present:
+            # A ``.kittify/derived`` (no trailing slash) variant already ignores
+            # the dir — don't append a duplicate ``.kittify/derived/`` beside it.
+            return MigrationResult(
+                success=True, changes_made=["gitignore entry already present"]
+            )
 
         modified = GitignoreManager(project_path).ensure_entries([_DERIVED_VIEWS_ENTRY])
         changes = (

--- a/src/specify_cli/upgrade/migrations/m_3_2_4_derived_views_gitignore_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_4_derived_views_gitignore_backfill.py
@@ -1,0 +1,79 @@
+"""Migration: backfill ``.kittify/derived/`` gitignore coverage (#2369, Defect B).
+
+``spec-kitty materialize`` writes regenerable machine-facing views (lifecycle /
+board-summary / progress JSON) under ``.kittify/derived/<slug>/``. That surface
+is registered as an ``IGNORED`` state surface (``derived_mission_views`` in
+``state/contract.py``), so a fresh ``spec-kitty init`` emits ``.kittify/derived/``
+into ``.gitignore`` via the full runtime entry set.
+
+Existing projects, however, only receive gitignore repairs through the
+per-entry runtime-hygiene migrations, none of which knew about
+``.kittify/derived/``. So an already-initialised project that runs
+``materialize`` (e.g. an orchestrator-completed mission) had the derived views
+show up as untracked, dirtying the tree and failing ``spec-kitty accept``'s
+``git_dirty`` check.
+
+This backfill repairs that: it adds ``.kittify/derived/`` to ``.gitignore`` for
+projects that lack it. Following the ``3.2.3_encoding_provenance`` precedent,
+the entry is **hardcoded here** rather than sourced from the live contract so
+the migration's behaviour is frozen and deterministic regardless of future
+contract changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.gitignore_manager import GitignoreManager
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+_DERIVED_VIEWS_ENTRY = ".kittify/derived/"
+
+
+def _read_gitignore_entries(project_path: Path) -> set[str]:
+    gitignore_path = project_path / ".gitignore"
+    if not gitignore_path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in gitignore_path.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+@MigrationRegistry.register
+class DerivedViewsGitignoreBackfillMigration(BaseMigration):  # type: ignore[misc]
+    """Ensure the regenerable ``.kittify/derived/`` views dir is gitignored."""
+
+    migration_id = "3.2.4_derived_mission_views_gitignore_backfill"
+    description = "Backfill .kittify/derived/ gitignore coverage"
+    target_version = "3.2.4"
+
+    def detect(self, project_path: Path) -> bool:
+        return _DERIVED_VIEWS_ENTRY not in _read_gitignore_entries(project_path)
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        if not project_path.exists():
+            return False, f"Project path does not exist: {project_path}"
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        already_present = _DERIVED_VIEWS_ENTRY in _read_gitignore_entries(project_path)
+
+        if dry_run:
+            changes = (
+                []
+                if already_present
+                else [f"Would add {_DERIVED_VIEWS_ENTRY} to .gitignore"]
+            )
+            return MigrationResult(success=True, changes_made=changes)
+
+        modified = GitignoreManager(project_path).ensure_entries([_DERIVED_VIEWS_ENTRY])
+        changes = (
+            [f"Added gitignore entry: {_DERIVED_VIEWS_ENTRY}"]
+            if modified
+            else ["gitignore entry already present"]
+        )
+        return MigrationResult(success=True, changes_made=changes)

--- a/tests/specify_cli/test_canonical_acceptance.py
+++ b/tests/specify_cli/test_canonical_acceptance.py
@@ -887,3 +887,45 @@ class TestCorruptedCompatibilityViews:
         assert summary.all_done, f"all_done should be True despite all views corrupted, lanes={summary.lanes}"
         assert summary.activity_issues == []
         assert all(wp_id in summary.lanes.get("done", []) for wp_id in ["WP01", "WP02", "WP03"])
+
+
+class TestStrictShellPidGate:
+    """#2369: strict accept lane-gates shell_pid (like assignee) — terminal WPs
+    (orchestrator-executed, no live shell) no longer fail on missing shell_pid,
+    but active WPs still require it."""
+
+    def test_strict_accept_passes_for_done_wps_without_shell_pid(self, tmp_path: Path) -> None:
+        feature_dir = _setup_feature(tmp_path, all_done=True, wp_ids=["WP01", "WP02"])
+        tasks_dir = feature_dir / "tasks"
+        # Orchestrator-style: done WPs with NO shell_pid stamped.
+        for wp in ["WP01", "WP02"]:
+            _write_wp_file(tasks_dir, wp, lane="done", shell_pid="")
+
+        with patch("specify_cli.acceptance.run_git") as mock_git, patch(
+            "specify_cli.acceptance.git_status_lines", return_value=[]
+        ):
+            mock_git.return_value.stdout = "main\n"
+            summary = collect_feature_summary(tmp_path, "099-test-feature", strict_metadata=True)
+
+        assert not any("shell_pid" in m for m in summary.metadata_issues), summary.metadata_issues
+        assert summary.all_done
+        assert summary.ok, (
+            f"orchestrated all-done mission should pass strict accept; "
+            f"metadata={summary.metadata_issues} git_dirty={summary.git_dirty}"
+        )
+
+    def test_strict_accept_still_flags_active_wp_without_shell_pid(self, tmp_path: Path) -> None:
+        # Scoped: an ACTIVE (for_review) WP with no shell_pid is still flagged —
+        # the fix is a lane-gate, not a removal.
+        feature_dir = _setup_feature(
+            tmp_path, all_done=False, wp_ids=["WP01"], wp_lanes={"WP01": "for_review"}
+        )
+        _write_wp_file(feature_dir / "tasks", "WP01", lane="for_review", shell_pid="")
+
+        with patch("specify_cli.acceptance.run_git") as mock_git, patch(
+            "specify_cli.acceptance.git_status_lines", return_value=[]
+        ):
+            mock_git.return_value.stdout = "main\n"
+            summary = collect_feature_summary(tmp_path, "099-test-feature", strict_metadata=True)
+
+        assert any("shell_pid" in m for m in summary.metadata_issues), summary.metadata_issues

--- a/tests/specify_cli/test_gitignore_contract.py
+++ b/tests/specify_cli/test_gitignore_contract.py
@@ -142,3 +142,14 @@ def _is_ignored(repo_root: Path, path: str) -> bool:
         check=False,
     )
     return result.returncode == 0
+
+
+def test_derived_views_dir_is_gitignored():
+    """#2369: .kittify/derived/ (regenerable materialize output) must be in the
+    runtime gitignore set so `spec-kitty materialize` never dirties the tree /
+    fails accept's git_dirty check. Registry-driven — the derived_mission_views
+    StateSurface (root=PROJECT, git_class=IGNORED) collapses to this entry."""
+    from specify_cli.state.contract import get_runtime_gitignore_entries
+
+    entries = get_runtime_gitignore_entries()
+    assert ".kittify/derived/" in entries, entries

--- a/tests/specify_cli/test_state_contract.py
+++ b/tests/specify_cli/test_state_contract.py
@@ -211,6 +211,7 @@ def test_runtime_gitignore_entries_exact():
         ".kittify/charter/governance.yaml",
         ".kittify/charter/metadata.yaml",
         ".kittify/charter/references.yaml",
+        ".kittify/derived/",
         ".kittify/dossiers/",
         ".kittify/encoding-provenance/",
         ".kittify/events/",

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py
@@ -90,6 +90,23 @@ def test_detect_false_when_derived_entry_present(tmp_path: Path) -> None:
     assert DerivedViewsGitignoreBackfillMigration().detect(tmp_path) is False
 
 
+def test_detect_false_for_no_trailing_slash_variant(tmp_path: Path) -> None:
+    # A hand-added ``.kittify/derived`` (no trailing slash) ignores the same
+    # dir; the backfill must treat it as present so it never adds a duplicate.
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/derived")
+
+    migration = DerivedViewsGitignoreBackfillMigration()
+    assert migration.detect(tmp_path) is False
+    migration.apply(tmp_path)
+    entries = [
+        line.strip()
+        for line in tmp_path.joinpath(".gitignore").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert ".kittify/derived/" not in entries  # no duplicate beside the variant
+
+
 def test_detect_ignores_commented_out_derived_entry(tmp_path: Path) -> None:
     _init_git_repo(tmp_path)
     _write_gitignore(tmp_path, f"# {_DERIVED_VIEWS_ENTRY}")

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_4_derived_views_gitignore.py
@@ -1,0 +1,144 @@
+"""Regression tests for the ``.kittify/derived/`` gitignore backfill (#2369, Defect B).
+
+Covers the bug where an already-initialised project that runs
+``spec-kitty materialize`` had its regenerable ``.kittify/derived/`` views show
+up as untracked — dirtying the tree and failing ``spec-kitty accept``'s
+``git_dirty`` check — because no upgrade migration added ``.kittify/derived/``
+to ``.gitignore``.
+
+- apply() adds the derived entry and hides a generated views dir
+- detect() is True when the entry is missing (already-upgraded project)
+- detect() is False once the entry is present
+- detect() ignores a commented-out entry
+- apply() is idempotent
+- the backfill fires end-to-end via MigrationRunner on an already-current 3.2.4 project
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.migrations.m_3_2_4_derived_views_gitignore_backfill import (
+    DerivedViewsGitignoreBackfillMigration,
+)
+from specify_cli.upgrade.metadata import ProjectMetadata
+from specify_cli.upgrade.runner import MigrationRunner
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+_DERIVED_VIEWS_ENTRY = ".kittify/derived/"
+_DERIVED_VIEW_PATH = ".kittify/derived/some-mission/lifecycle.json"
+
+
+def _init_git_repo(project_root: Path) -> None:
+    subprocess.run(["git", "-C", str(project_root), "init", "-q"], check=True)
+
+
+def _write_gitignore(project_root: Path, *entries: str) -> None:
+    project_root.joinpath(".gitignore").write_text(
+        "# Added by Spec Kitty CLI (auto-managed)\n" + "\n".join(entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_metadata(project_root: Path, version: str) -> None:
+    ProjectMetadata(version=version, initialized_at=datetime.now()).save(
+        project_root / ".kittify"
+    )
+
+
+def _is_ignored(project_root: Path, path: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(project_root), "check-ignore", "--quiet", path],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def test_apply_adds_derived_entry_and_hides_generated_views(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    view = tmp_path / _DERIVED_VIEW_PATH
+    view.parent.mkdir(parents=True)
+    view.write_text("{}\n", encoding="utf-8")
+
+    DerivedViewsGitignoreBackfillMigration().apply(tmp_path)
+
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert _DERIVED_VIEWS_ENTRY in gitignore_text
+    assert _is_ignored(tmp_path, _DERIVED_VIEW_PATH)
+
+
+def test_detect_true_when_derived_entry_missing(tmp_path: Path) -> None:
+    """Already-upgraded project: other entries present, derived missing."""
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/sync-state.json")
+
+    assert DerivedViewsGitignoreBackfillMigration().detect(tmp_path) is True
+
+
+def test_detect_false_when_derived_entry_present(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _DERIVED_VIEWS_ENTRY)
+
+    assert DerivedViewsGitignoreBackfillMigration().detect(tmp_path) is False
+
+
+def test_detect_ignores_commented_out_derived_entry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, f"# {_DERIVED_VIEWS_ENTRY}")
+
+    assert DerivedViewsGitignoreBackfillMigration().detect(tmp_path) is True
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _DERIVED_VIEWS_ENTRY)
+
+    first = DerivedViewsGitignoreBackfillMigration().apply(tmp_path)
+    second = DerivedViewsGitignoreBackfillMigration().apply(tmp_path)
+
+    assert first.success
+    assert second.success
+    gitignore_text = tmp_path.joinpath(".gitignore").read_text(encoding="utf-8")
+    assert gitignore_text.count(_DERIVED_VIEWS_ENTRY) == 1
+
+
+def test_dry_run_reports_without_mutating(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/sync-state.json")
+
+    result = DerivedViewsGitignoreBackfillMigration().apply(tmp_path, dry_run=True)
+
+    assert result.success
+    assert result.changes_made == [f"Would add {_DERIVED_VIEWS_ENTRY} to .gitignore"]
+    # Dry run must not touch the file.
+    assert _DERIVED_VIEWS_ENTRY not in tmp_path.joinpath(".gitignore").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_backfill_fires_on_already_current_3_2_4_project(tmp_path: Path) -> None:
+    """The user's exact case: a 3.2.4 project whose .gitignore lacks derived/."""
+    _init_git_repo(tmp_path)
+    _write_metadata(tmp_path, "3.2.4")
+    _write_gitignore(tmp_path, ".kittify/sync-state.json")
+    view = tmp_path / _DERIVED_VIEW_PATH
+    view.parent.mkdir(parents=True)
+    view.write_text("{}\n", encoding="utf-8")
+
+    auto_discover_migrations()
+    result = MigrationRunner(tmp_path).upgrade("3.2.4", include_worktrees=False)
+
+    assert result.success
+    assert (
+        DerivedViewsGitignoreBackfillMigration.migration_id
+        in result.migrations_applied
+    )
+    assert _is_ignored(tmp_path, _DERIVED_VIEW_PATH)


### PR DESCRIPTION
## Summary
Closes #2369. A mission fully implemented by `spec-kitty-orchestrator` (all WPs `done`/`approved`) could not pass `spec-kitty accept`, forcing manual frontmatter edits or a `--yes`/`--lenient` bypass. Two **mechanical false-positives** were responsible — neither a code-correctness issue.

`accept` is the mission-level readiness gate (all-done, subtasks, clarifications, artifacts, clean tree, paths) — genuinely valuable, and complementary to per-WP review. But because these two checks *always* failed on orchestrated missions, the practical outcome was people bypassing `accept` wholesale (the orchestrator's `merge-mission` runs git preflight, not the strict metadata gate), losing the checks that matter. This makes `accept` **usable** for orchestrated missions instead of bypassed.

## Defect A — `shell_pid` required on every WP, including terminal ones
`acceptance/__init__.py` strict-metadata flagged `missing shell_pid` for every WP lacking it. `shell_pid` is the live interactive shell that claimed a WP in `spec-kitty next` — an active-work artifact the orchestrator executor never stamps, and meaningless on a terminal WP. **Fix:** lane-gate it to active lanes (`doing`/`in_progress`/`for_review`) exactly like the sibling `assignee` check already is.

## Defect B — `.kittify/derived/` not gitignored
`spec-kitty materialize` writes regenerable views (`lifecycle.json` / `status.json` / `board-summary.json` / `progress.json`) to `.kittify/derived/<slug>/`, which was not in the runtime ignore set (unlike sibling `.kittify/` paths), so it dirtied the tree and failed accept's `git_dirty` check. **Fix:** register a `derived_mission_views` `StateSurface` (`root=PROJECT`, `authority=DERIVED`, `git_class=IGNORED`); `get_runtime_gitignore_entries()` collapses its `<slug>` pattern to `.kittify/derived/`, emitted by `gitignore_manager` on init/upgrade. Registry-driven — no hardcoding; the frozen `m_2_0_9` migration is untouched.

## Provenance (not a regression, not ours)
Traced via git: the unconditional `shell_pid` check is Robert's **original acceptance workflow (`c0b5731ef`, 2025-10-22)**; `strict_metadata=True` default is Stijn's (2026-04), **never** `False`; `.kittify/derived/` writing landed 2026-04-22 (`b5e15219d`), and the gitignore migration predates it and never added the entry. Both are **latent gaps** surfacing now only because our orchestrator resume fix (#2338 + spec-kitty-orchestrator) lets orchestrated missions run through the standalone `accept` for the first time (the orchestrator's own flow does git preflight, not the strict metadata gate).

## Acceptance criteria
- ✅ Orchestrator-completed mission passes `accept` with no manual edits / no `--yes`.
- ✅ After `materialize`, tree is clean; existing projects get `.kittify/derived/` via init/upgrade's gitignore_manager.
- ✅ The six meaningful accept checks still gate.

## Tests
- Strict accept passes an all-done mission whose WPs have no `shell_pid`.
- **Scoped negative control:** an active (`for_review`) WP without `shell_pid` is *still* flagged (lane-gate, not removal).
- `.kittify/derived/` present in `get_runtime_gitignore_entries()`.
- 72 acceptance/gitignore/state-doctor/gitignore-manager tests pass; ruff + terminology clean.

## Reviewer note (pre-existing mypy debt)
`acceptance/__init__.py` carries **5 pre-existing** `no-any-return`/`misc` mypy findings (lines 214/477/737/951/1071) — confirmed present on `HEAD` with this diff stashed, none in the edited region. Left as-is (out of scope for this fix); flagging so it's not mistaken for a regression here.