### PR TITLE
fix: guard/gate friction hotfix batch (#2346/#2324 subtask guard, #1834 accept-gate)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **Guard/gate friction hotfixes (#2346 / #2324, #1834).**
+  - **Subtask guard no longer misattributes a later WP's checkboxes (#2346, also closes #2324).** `_check_unchecked_subtasks` entered a WP's section on *any* heading that merely mentioned its id, so a dependent heading like `### WP03 — … (depends: WP01, WP02)` re-entered WP01/WP02's section and harvested WP03's unchecked `- [ ] T0xx` rows as the earlier WP's blockers — spuriously blocking that WP's lane transition. A heading now belongs to the WP named by its **first** `WPxx` token, not any mention.
+  - **`grep_absence` negative invariants accept an optional path-scope (#1834).** The acceptance gate ran `grep -r <pattern> .` over the whole repo, so a negative-invariant pattern that a mission's own spec/plan/WP prose mentioned false-positived as `still_present`. `NegativeInvariant` now carries an optional `scope` (whitespace-separated repo-relative search roots); when set, the grep runs only under those paths. Default (unscoped) preserves the whole-repo search, and `scope` is omitted from serialization when unset so existing matrices are untouched.
+  - **Documented merge-before-accept for merged-post-state invariants (#1834).** The accept runbook (`docs/guides/accept-and-merge.md`) now records that the accept gate re-runs each negative-invariant `verification_command` **live** (so a hand-set `overall_verdict` does not stick), and that a mission whose invariants assert the *merged* post-state must run `spec-kitty merge` (local) before `spec-kitty accept`.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/docs/guides/accept-and-merge.md
+++ b/docs/guides/accept-and-merge.md
@@ -2,7 +2,7 @@
 title: How to Accept and Merge a Mission
 description: "How to accept and merge a mission with Spec Kitty 3.2: Use this guide to validate mission readiness and merge to the mission's target branch."
 doc_status: active
-updated: '2026-06-03'
+updated: '2026-07-04'
 related:
 - docs/guides/install-and-upgrade.md
 - docs/guides/keep-main-clean.md
@@ -50,6 +50,38 @@ To run a read-only checklist (in your terminal):
 ```bash
 spec-kitty accept --mode checklist
 ```
+
+### Negative Invariants That Assert the Merged Post-State
+
+The accept gate **re-runs each acceptance negative-invariant `verification_command`
+live** against the working tree at accept time — it does not trust a stored
+`result` or a hand-set `overall_verdict`. Two consequences follow:
+
+- **Hand-editing a verdict does not stick.** Setting `overall_verdict` (or a
+  negative invariant's `result`) by hand in `acceptance-matrix.json` is
+  overwritten the moment accept runs; the invariant's `verification_command` is
+  the single source of truth, and it must actually pass in the checkout accept
+  runs from.
+- **Merged-post-state invariants must be verified after merge.** If an invariant
+  asserts a state that only exists **once the mission is merged** — for example,
+  "`shell: bash` is present in `ci-quality.yml`" when that line is added by the
+  merge — it cannot pass while the mission still lives on its lane branch. For
+  such missions, run `spec-kitty merge` (into **local** `main`) **before**
+  `spec-kitty accept`, so the working tree accept inspects already carries the
+  merged post-state:
+
+  ```bash
+  spec-kitty merge          # land into LOCAL main first
+  spec-kitty accept         # now the post-state invariants can verify live
+  ```
+
+  This inverts the usual accept-then-merge order and is only needed for missions
+  whose negative invariants assert the post-merge result. Missions whose
+  invariants describe the lane's own diff verify fine in the normal order.
+
+  If you prefer not to re-order, scope the invariant to a path that exists on the
+  lane branch (see `NegativeInvariant.scope`) or express it as a `custom_command`
+  that is meaningful pre-merge.
 
 ## Merge to the Target Branch
 

--- a/src/specify_cli/acceptance/matrix.py
+++ b/src/specify_cli/acceptance/matrix.py
@@ -77,6 +77,12 @@ class NegativeInvariant:
     verification_command: str | None = None
     result: str = "pending"  # "confirmed_absent" | "still_present" | "pending" | "verification_error"
     evidence: str | None = None
+    # Optional path-scope for ``grep_absence``: whitespace-separated repo-relative
+    # search root(s). When set, the grep runs only under these paths instead of
+    # the whole repo, so a pattern that a mission's OWN spec/plan/WP prose
+    # mentions does not false-positive as "still_present" (#1834). Default
+    # (``None``) preserves the whole-repo search (unchanged behaviour).
+    scope: str | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -87,6 +93,10 @@ class NegativeInvariant:
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
         extras = data.pop("extras", {}) or {}
+        # Omit an unset ``scope`` so existing matrices are not rewritten with a
+        # ``scope: null`` key on their next serialization.
+        if data.get("scope") is None:
+            data.pop("scope", None)
         data.update(extras)
         return data
 
@@ -360,8 +370,13 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="pending",
             evidence="No grep pattern specified in verification_command",
+            scope=ni.scope,
             extras=ni.extras,
         )
+
+    # A scoped invariant restricts the grep to its declared repo-relative
+    # search root(s); an unscoped one searches the whole repo (``.``), as before.
+    search_roots = ni.scope.split() if ni.scope else ["."]
 
     try:
         result = subprocess.run(
@@ -372,7 +387,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
                 "--exclude-dir=.git",
                 "--",
                 ni.verification_command,
-                ".",
+                *search_roots,
             ],
             cwd=str(repo_root),
             capture_output=True,
@@ -386,6 +401,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="verification_error",
             evidence=f"grep failed to start: {exc}",
+            scope=ni.scope,
             extras=ni.extras,
         )
     if result.returncode == 1:
@@ -397,6 +413,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="confirmed_absent",
             evidence="grep found zero matches",
+            scope=ni.scope,
             extras=ni.extras,
         )
     if result.returncode == 0:
@@ -408,6 +425,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
             verification_command=ni.verification_command,
             result="still_present",
             evidence=f"grep found matches: {'; '.join(matches)}",
+            scope=ni.scope,
             extras=ni.extras,
         )
     details = (result.stderr or result.stdout).strip()[:500]
@@ -418,6 +436,7 @@ def _check_grep_absence(repo_root: Path, ni: NegativeInvariant) -> NegativeInvar
         verification_command=ni.verification_command,
         result="verification_error",
         evidence=f"grep verification failed (exit {result.returncode}): {details}",
+        scope=ni.scope,
         extras=ni.extras,
     )
 

--- a/src/specify_cli/cli/commands/agent/tasks_shared.py
+++ b/src/specify_cli/cli/commands/agent/tasks_shared.py
@@ -485,14 +485,18 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
         if in_code_fence:
             continue
 
-        # Check if we entered this WP's section
-        if re.search(rf"^#{{2,4}}[^#].*{wp_id}\b", line):
+        # A heading belongs to the WP named by its FIRST ``WPxx`` token (the
+        # section's own id), NOT any mention — so ``### WP03 ... (depends: WP01,
+        # WP02)`` does not re-enter WP01/WP02's section (#2346 / #2324).
+        heading_wp: str | None = None
+        if re.match(r"^#{2,4}[^#]", line):
+            wp_tokens = re.findall(r"\bWP\d{2,}\b", line)
+            heading_wp = wp_tokens[0] if wp_tokens else None
+        if heading_wp == wp_id:
             in_wp_section = True
             continue
-
-        # Check if we entered a different WP section
-        if in_wp_section and re.search(r"^#{2,4}[^#].*WP\d{2}\b", line):
-            break  # Left this WP's section
+        if in_wp_section and heading_wp is not None and heading_wp != wp_id:
+            break  # entered a different WP's section
 
         # Look for unchecked canonical task rows in this WP's section
         if in_wp_section:

--- a/tests/agent/cli/commands/test_tasks_helpers.py
+++ b/tests/agent/cli/commands/test_tasks_helpers.py
@@ -457,6 +457,53 @@ def test_check_unchecked_subtasks_only_target_wp(tmp_path: Path) -> None:
     assert "T002" not in result
 
 
+# A realistic mission tail: WP02 is fully CHECKED, and the NEXT section is a
+# dependent WP whose heading MENTIONS WP01/WP02 in a ``(depends: ...)`` clause.
+_TASKS_MD_DEPENDS_MENTION = """\
+## Work Packages
+
+### WP02 — Init Surgery
+
+- [x] T004 Remove flags (WP02)
+- [x] T005 Remove stages (WP02)
+
+### WP03 — Wire-up (depends: WP01, WP02)
+
+- [ ] T006 Wire the new surface (WP03)
+- [ ] T007 Backfill the regression test (WP03)
+"""
+
+
+def test_check_unchecked_subtasks_next_wp_depends_mention_not_misattributed(
+    tmp_path: Path,
+) -> None:
+    """#2346 / #2324 regression: a later ``### WP03 ... (depends: WP01, WP02)``
+    heading must NOT re-enter WP02's section and harvest WP03's unchecked rows
+    as WP02's. A heading belongs to its FIRST WPxx token, not any mention.
+
+    Pre-fix (``^#{2,4}[^#].*{wp_id}\\b`` entry regex): scanning ``WP02`` matches
+    the WP03 heading (it mentions ``WP02``), ``continue``s past the exit check,
+    and wrongly returns WP03's ``T007`` as a WP02 blocker.
+    """
+    feature_dir = tmp_path / "kitty-specs" / "010-test"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "tasks.md").write_text(
+        _TASKS_MD_DEPENDS_MENTION, encoding="utf-8"
+    )
+
+    with patch(
+        "specify_cli.cli.commands.agent.tasks.get_main_repo_root", return_value=tmp_path
+    ):
+        wp02 = _check_unchecked_subtasks(tmp_path, "010-test", "WP02", False)
+        wp03 = _check_unchecked_subtasks(tmp_path, "010-test", "WP03", False)
+
+    # WP02 is fully checked; the dependent WP03 heading must not pull T006/T007
+    # into WP02's blocker list.
+    assert wp02 == [], f"WP02's subtasks are all checked; got {wp02!r}"
+    # WP03 still reports its OWN unchecked rows correctly.
+    assert wp03 == ["T006", "T007"]
+
+
 # ---------------------------------------------------------------------------
 # _behind_commits_touch_only_planning_artifacts
 # ---------------------------------------------------------------------------

--- a/tests/lanes/test_acceptance_matrix.py
+++ b/tests/lanes/test_acceptance_matrix.py
@@ -350,6 +350,65 @@ class TestNegativeInvariants:
 
         assert results[0].result == "confirmed_absent"
 
+    def test_grep_absence_scope_excludes_prose_false_positive(self, tmp_path):
+        """#1834(c): a pattern present ONLY in a mission's own prose (docs/spec)
+        must NOT false-positive as still_present when the invariant is scoped to
+        a code dir. Whole-repo would find the prose mention; the scope excludes
+        it -> confirmed_absent.
+        """
+        pattern = "old_legacy_route"
+        # Prose path that mentions the pattern (the mission's own WP/spec text).
+        (tmp_path / "kitty-specs" / "m").mkdir(parents=True)
+        (tmp_path / "kitty-specs" / "m" / "spec.md").write_text(
+            f"We removed the {pattern} surface entirely.\n", encoding="utf-8"
+        )
+        # Code dir that is genuinely clean of the pattern.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("def main(): pass\n")
+
+        scoped = NegativeInvariant(
+            "NI-01", "No legacy route in code",
+            "grep_absence",
+            verification_command=pattern,
+            scope="src",
+        )
+        assert enforce_negative_invariants(tmp_path, [scoped])[0].result == (
+            "confirmed_absent"
+        )
+
+        # Sanity: the SAME invariant without a scope finds the prose mention and
+        # (wrongly, for the mission's purpose) reports still_present — proving the
+        # scope is what excludes the false positive.
+        unscoped = NegativeInvariant(
+            "NI-02", "No legacy route anywhere",
+            "grep_absence",
+            verification_command=pattern,
+        )
+        assert enforce_negative_invariants(tmp_path, [unscoped])[0].result == (
+            "still_present"
+        )
+
+    def test_grep_absence_scope_still_catches_offender_in_scope(self, tmp_path):
+        """A scoped invariant still reports still_present when the pattern IS
+        present inside the scoped code path — scoping narrows, it does not
+        blind the check."""
+        pattern = "old_legacy_route"
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text(f"{pattern} = '/old'\n")
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "guide.md").write_text("nothing here\n")
+
+        scoped = NegativeInvariant(
+            "NI-01", "No legacy route in code",
+            "grep_absence",
+            verification_command=pattern,
+            scope="src",
+        )
+        result = enforce_negative_invariants(tmp_path, [scoped])[0]
+        assert result.result == "still_present"
+        # Scope survives enforcement (round-trips on re-serialization).
+        assert result.scope == "src"
+
     def test_custom_command_pass(self, tmp_path):
         invariants = [
             NegativeInvariant(


### PR DESCRIPTION
## What

A small P0 **friction-hotfix batch** — guard/gate bugs that repeatedly cost time in the mission workflow (surfaced across ~6 recent missions; recommended as the next pickup by the #2017 friction investigation, as targeted fixes rather than a broad #2017 mission).

Closes #2346
Closes #2324

### Fixes

- **#2346 / #2324 — subtask-guard misattributes the NEXT WP's checkboxes.** `_check_unchecked_subtasks` identified a heading's section by *any* `WPxx` mention, so `### WP03 … (depends: WP01, WP02)` re-entered WP02's section and the scan harvested WP03's unchecked rows as WP02's — blocking `move-task WP02` with a bogus "unchecked subtasks" error. Now a heading belongs to the WP named by its **first** `WPxx` token. Regression-tested with the exact `(depends: …)` heading shape (red-first).
- **#1834 (a) — merge-before-accept documented.** The `accept` gate re-runs each acceptance negative-invariant `verification_command` live against the working tree, so invariants that assert the *merged* post-state can't verify pre-merge. Documented in the accept/merge runbook (`docs/guides/accept-and-merge.md`).
- **#1834 (c) — `grep_absence` path-scope.** Acceptance `grep_absence` invariants scanned the whole repo, so a pattern a mission's own spec/WP prose mentions false-positived as "still_present". Added an optional `NegativeInvariant.scope` (default unchanged = whole-repo); scoped invariants grep only the given path(s). Backward-compatible (omitted from serialization when unset).

### Not in this batch (tracked)

- **#2367 (Mechanism A)** — refined during this work and **descoped**: the VCS lock is already committed on the default `auto_commit=True` path, and deliberately not on `--no-auto-commit` (#2222 decision). The real gap is the **merge/coord-resync guard** needing `_is_vcs_lock_only_meta_diff` parity — a coord-authority change wanting its own reviewer, not a hotfix. See the [refined diagnosis](https://github.com/Priivacy-ai/spec-kitty/issues/2367#issuecomment-4883178290). #2367 Mechanism B and **#1834 (b)** (resolve the matrix against the merged tree) also remain open.

### Notes
- No `src/specify_cli/__init__.py` change → no version bump. CHANGELOG entry added to the canonical `docs/changelog/CHANGELOG.md`.
- Coordinates cleanly with open PR #2370 (edits `acceptance/__init__.py`; this batch edits `acceptance/matrix.py` — different files; both add to the Unreleased CHANGELOG list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
