### PR TITLE
test(campsite): reconcile no-dead-modules allowlist for m_3_2_3 backfill migration

### DIFF
--- a/tests/architectural/test_no_dead_modules.py
+++ b/tests/architectural/test_no_dead_modules.py
@@ -197,12 +197,10 @@ _CATEGORY_1_AUTO_DISCOVERED_MIGRATIONS: frozenset[str] = frozenset(
         "specify_cli.upgrade.migrations.m_3_2_0rc35_activate_builtin_mission_types",
         # WP05 (charter-pack-activation-layer-01KSYE4V) migration added here.
         "specify_cli.upgrade.migrations.m_3_2_0rc35_default_charter_pack",
-        # org-doctrine-profile-integrity-closeout WP04: upstream rebase added
-        # this auto-discovered migration (loaded via pkgutil.iter_modules in
-        # migrations/__init__.py, never statically imported -> always an
-        # allowlisted Cat-1 orphan by design). Test-exercised by
-        # tests/specify_cli/test_sync_state_gitignore_migration.py.
-        "specify_cli.upgrade.migrations.m_3_2_0rc35_sync_state_gitignore",
+        # NOTE: m_3_2_0rc35_sync_state_gitignore was removed from this allowlist
+        # (2026-07-04 campsite) — it is now statically imported by
+        # m_3_2_3_encoding_provenance_gitignore_backfill (below), so it has a
+        # real src/ caller and is no longer an orphan.
         # pi-and-letta-agent-support-01KT4Q26 WP01: backfill migration for
         # .pi/ and .letta/ gitignore entries and skill-pack repair.
         # Auto-discovered via pkgutil.iter_modules; never statically imported.
@@ -233,6 +231,12 @@ _CATEGORY_1_AUTO_DISCOVERED_MIGRATIONS: frozenset[str] = frozenset(
         # 3.2.0rc45 standalone governance skill retirement migration:
         # auto-discovered via pkgutil.iter_modules in migrations/__init__.py.
         "specify_cli.upgrade.migrations.m_3_2_0rc45_retire_standalone_skill_surface",
+        # 3.2.3 encoding-provenance/gitignore backfill migration: auto-discovered
+        # via pkgutil.iter_modules + @MigrationRegistry.register; never statically
+        # imported by runtime code. (It statically imports
+        # m_3_2_0rc35_sync_state_gitignore, which is why that module is no longer
+        # an orphan and was removed from this allowlist.)
+        "specify_cli.upgrade.migrations.m_3_2_3_encoding_provenance_gitignore_backfill",
     }
 )
 


### PR DESCRIPTION
## Summary

Standalone campsite fix for a **pre-existing base-red** on `main`: `tests/architectural/test_no_dead_modules.py::test_no_new_dead_modules_under_src` was failing on `upstream/main` itself (surfaced while landing #2365/#2364; cross-base confirmed, unrelated to either mission).

Two drifted allowlist entries, reconciled:

- **Added** `m_3_2_3_encoding_provenance_gitignore_backfill` — a recently-landed migration (auto-discovered via `pkgutil.iter_modules` + `@MigrationRegistry.register`, never statically imported) that was a new orphan missing from the Cat-1 allowlist.
- **Removed** `m_3_2_0rc35_sync_state_gitignore` — the new migration above **statically imports** it, giving it a real `src/` caller, so its allowlist entry became stale ("the wiring landed").

The two are causally linked: the same new migration both needs allowlisting *and* supplies the caller that de-orphans the old one.

## Verification

`tests/architectural/test_no_dead_modules.py` — **2 passed** (was 1 failed on `main`); ruff clean; allowlist-only change (no production code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)