### PR TITLE
fix(#2376): mission-state repair preserves canonical lifecycle events (stop emptying status.events.jsonl)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -56,6 +56,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `.gitignore` on `spec-kitty upgrade` for already-initialised projects
   (the runtime-hygiene migrations previously only knew a hardcoded subset of
   entries). The six meaningful accept checks still gate.
+- **Mission-state repair no longer empties `status.events.jsonl` of a healthy
+  mission (#2376).** The repair (run by `spec-kitty upgrade` via the TeamSpace
+  mission-state gate, and by `doctor mission-state --fix`) quarantined *every*
+  `event_type` row except retrospective ones — including the canonical lifecycle
+  events (`MissionCreated`, `SpecifyStarted`, `WPCreated`, …) that
+  `status/lifecycle_events.py` writes and whose **only** per-mission home is
+  `status.events.jsonl`. A completed mission whose log was all lifecycle events
+  was emptied to 0 bytes. Repair now **preserves** canonical lifecycle events
+  (those in `LIFECYCLE_EVENT_TYPES`) and retrospective rows in place — matching
+  the runtime reader and the lifecycle writer's "safe target for repair tooling"
+  contract — and a backstop refuses to write a 0-byte log when the source was
+  non-empty. Decision-Moment (`DecisionPoint*`) rows are still pruned: their
+  canonical store is `decisions/index.json` / `DM-*.md`, so the copy here is a
+  mirror (unchanged, tested behavior). Rows preserved verbatim in the quarantine
+  dir remain recoverable.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -86,7 +86,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     possibly-stale coordination worktree. Repair now re-anchors to the canonical
     primary main-checkout via the single worktree-pointer parser
     (`resolve_canonical_root`), so it always targets the primary
-    `kitty-specs/<slug>` (drift converges) and never dirties `.worktrees/`.
+    `kitty-specs/<slug>` (drift converges) and never dirties `.worktrees/`. The
+    read-only `--audit` path is now anchored on the **same** authority at the
+    `run_mission_state` dispatch seam, so audit and fix resolve to the identical
+    canonical root from any cwd (a worktree-invoked `--audit` reads the primary,
+    matching `--fix`) instead of diverging onto a stale worktree.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -63,14 +63,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   events (`MissionCreated`, `SpecifyStarted`, `WPCreated`, …) that
   `status/lifecycle_events.py` writes and whose **only** per-mission home is
   `status.events.jsonl`. A completed mission whose log was all lifecycle events
-  was emptied to 0 bytes. Repair now **preserves** canonical lifecycle events
-  (those in `LIFECYCLE_EVENT_TYPES`) and retrospective rows in place — matching
-  the runtime reader and the lifecycle writer's "safe target for repair tooling"
-  contract — and a backstop refuses to write a 0-byte log when the source was
-  non-empty. Decision-Moment (`DecisionPoint*`) rows are still pruned: their
-  canonical store is `decisions/index.json` / `DM-*.md`, so the copy here is a
-  mirror (unchanged, tested behavior). Rows preserved verbatim in the quarantine
-  dir remain recoverable.
+  was emptied to 0 bytes. Repair now **preserves every reader-canonical non-lane
+  class** in place — canonical lifecycle events (those in
+  `LIFECYCLE_EVENT_TYPES`), retrospective lifecycle rows (the `type` envelope),
+  **and the `retrospective.*` (`event_name` envelope) stream written by
+  `emit_retrospective_event`** — so the repair predicate matches the durable
+  reader (`status/store.py::is_non_lane_event`) exactly. Before this, a mixed log
+  containing a `retrospective.completed` row still silently stripped it (the same
+  #2376 data-loss class in a different event format). A backstop also refuses to
+  write a 0-byte log when the source was non-empty. Decision-Moment
+  (`DecisionPoint*`) rows are still pruned: their canonical store is
+  `decisions/index.json` / `DM-*.md`, so the copy here is a mirror (unchanged,
+  tested behavior). Rows preserved verbatim in the quarantine dir remain
+  recoverable.
   - **Repair now anchors on the primary checkout so `SNAPSHOT_DRIFT` actually
     converges and stale coordination worktrees are left untouched (#2320).**
     `doctor mission-state --fix` already re-materializes `status.json` from

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -71,6 +71,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   canonical store is `decisions/index.json` / `DM-*.md`, so the copy here is a
   mirror (unchanged, tested behavior). Rows preserved verbatim in the quarantine
   dir remain recoverable.
+  - **Repair now anchors on the primary checkout so `SNAPSHOT_DRIFT` actually
+    converges and stale coordination worktrees are left untouched (#2320).**
+    `doctor mission-state --fix` already re-materializes `status.json` from
+    `status.events.jsonl`, but when invoked from inside a worktree the
+    invocation root pointed at that worktree, so the materialize landed there:
+    the **primary** `status.json` stayed frozen (a re-`--audit` reported the
+    same `SNAPSHOT_DRIFT` blocker) and uncommitted repairs were written into a
+    possibly-stale coordination worktree. Repair now re-anchors to the canonical
+    primary main-checkout via the single worktree-pointer parser
+    (`resolve_canonical_root`), so it always targets the primary
+    `kitty-specs/<slug>` (drift converges) and never dirties `.worktrees/`.
 - **The Op-index performance cache is now gitignored (#2341).**
   `kitty-ops/ops-index.jsonl` — the machine-local reverse-scan cache that powers
   `spec-kitty invocations list` — was never added to `.gitignore`, so a

--- a/src/specify_cli/cli/commands/_mission_state_doctor.py
+++ b/src/specify_cli/cli/commands/_mission_state_doctor.py
@@ -400,6 +400,19 @@ def run_mission_state(
         fixture_dir, include_fixtures, repo_root
     )
 
+    # Unify audit + fix on ONE canonical-root authority (#2320 follow-up). The
+    # ``--fix`` path already re-anchors to the primary main-checkout inside
+    # ``repair_repo`` (``_anchor_repair_root`` → ``resolve_canonical_root``), but
+    # ``--audit`` read the root as-resolved by ``locate_project_root`` (a
+    # *conditional* anchor that stops at the CWD's worktree). From a non-primary
+    # cwd the two modes therefore diverged: audit could read a stale worktree
+    # while fix wrote the primary. Re-anchor the shared root through the same
+    # helper so every mode resolves identically from any cwd. Fixture-dir
+    # (``scan_root``) and non-git shapes are honored verbatim by the helper.
+    from specify_cli.migration.mission_state import _anchor_repair_root
+
+    resolved_root = _anchor_repair_root(resolved_root, scan_root=resolved_fixture_dir)
+
     if mode == _MissionStateMode.FIX:
         _run_mission_repair(
             resolved_root, resolved_fixture_dir, mission, manifest_path, allow_dirty, json_output

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -477,6 +477,45 @@ def deterministic_ulid(seed: bytes | str) -> str:
     return "".join(reversed(chars))
 
 
+def _anchor_repair_root(repo_root: Path, *, scan_root: Path | None) -> Path:
+    """Re-anchor the invocation root to the canonical PRIMARY main-checkout.
+
+    ``doctor mission-state --fix`` is a repo-level canonicalization whose write
+    target is the *primary* checkout's ``kitty-specs/<slug>`` — the durable
+    per-mission status home for flattened / merged missions (those carrying no
+    live ``coordination_branch``). When the CLI is invoked from inside a
+    worktree (a coordination or lane worktree), the raw invocation root points
+    at that worktree, so the repair would land there instead: it (a) leaves the
+    primary ``status.json`` stale, so an ``--audit`` re-run still reports
+    ``SNAPSHOT_DRIFT`` (the materialize step ran against the wrong checkout),
+    and (b) writes uncommitted changes into a possibly-stale coordination
+    worktree — both symptoms of issue #2320.
+
+    Route through the single canonical worktree-pointer parser
+    (:func:`specify_cli.core.paths.resolve_canonical_root`) so repair always
+    operates on the primary checkout regardless of CWD.
+
+    ``scan_root`` (``--fixture-dir`` / packaged-fixtures mode) is a deliberate
+    override that points discovery at an arbitrary directory tree; re-anchoring
+    would drag the manifest/quarantine roots onto an enclosing real repo, so in
+    that mode the resolved input is honored verbatim. When no enclosing git repo
+    is found (ad-hoc test fixtures outside a git tree) the resolved input is also
+    returned unchanged, preserving the prior no-git behavior.
+    """
+    if scan_root is not None:
+        return repo_root.resolve()
+    from specify_cli.core.paths import (  # noqa: PLC0415
+        WorkspaceRootNotFound,
+        resolve_canonical_root,
+    )
+
+    try:
+        canonical: Path = resolve_canonical_root(repo_root)
+    except WorkspaceRootNotFound:
+        return repo_root.resolve()
+    return canonical
+
+
 def repair_repo(
     repo_root: Path,
     *,
@@ -486,7 +525,7 @@ def repair_repo(
     allow_dirty: bool = False,
 ) -> RepairReport:
     """Canonicalize historical mission state on disk and write a manifest."""
-    resolved_repo_root = repo_root.resolve()
+    resolved_repo_root = _anchor_repair_root(repo_root, scan_root=scan_root)
     mission_dirs = _select_mission_dirs(resolved_repo_root, scan_root=scan_root, mission=mission)
     if not mission_dirs:
         raise MissionStateRepairError("No mission directories found to repair.")

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -42,7 +42,7 @@ from specify_cli.migration.canonicalization import (
 )
 from specify_cli.status import ULID_PATTERN, Lane, StatusEvent
 from specify_cli.status import materialize_snapshot, materialize_to_json
-from specify_cli.status import is_retrospective_lifecycle_event
+from specify_cli.status import LIFECYCLE_EVENT_TYPES, is_retrospective_lifecycle_event
 
 MIGRATION_SCHEMA_VERSION = "1.0.0"
 CANONICAL_ENVELOPE_SCHEMA_VERSION = "3.0.0"
@@ -897,6 +897,13 @@ def _scan_raw_status_rows(repo_root: Path, mission_dir: Path) -> list[dict[str, 
     errors: list[dict[str, object]] = []
     rel = _repo_relpath(repo_root, status_path)
     for row in rows:
+        # Preserved-class non-lane rows (retrospective + canonical lifecycle
+        # events, issue #2376) legitimately live in status.events.jsonl and are
+        # left in place by the repair. They are not lane events, so the
+        # lane-event scans below (typed-row + forbidden-legacy-key, which recurse
+        # into another subsystem's payload) do not apply to them.
+        if _is_preserved_non_lane_row(row.data):
+            continue
         if "event_type" in row.data or "event_name" in row.data:
             errors.append(
                 {
@@ -1039,6 +1046,20 @@ def _repair_mission(
                 )
             before_events = _file_fingerprint(status_path)
             status_text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in canonical_rows)
+            # Backstop (#2376): never silently empty a previously-populated event
+            # log. Legitimate non-lane events are now preserved in
+            # ``canonical_rows``, so an empty result despite non-empty input means
+            # every row was dropped as genuinely foreign — an extraordinary
+            # outcome that fails loud (recorded as a mission error with a reason)
+            # rather than wiping the canonical log. Originals remain in the
+            # quarantine directory.
+            if raw_rows and not canonical_rows:
+                raise MissionStateRepairError(
+                    f"Refusing to empty {_repo_relpath(repo_root, status_path)}: "
+                    f"all {len(raw_rows)} row(s) were dropped by repair. This "
+                    "usually indicates a row-classification bug; the original "
+                    "rows are preserved verbatim in the quarantine directory."
+                )
             if status_path.read_text(encoding="utf-8") != status_text:
                 atomic_write(status_path, status_text)
             after_events = _file_fingerprint(status_path)
@@ -1235,30 +1256,49 @@ def _canonicalize_status_rows(
 _Row = dict[str, Any]
 
 
+def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
+    """Return True for non-lane rows the repair MUST keep in status.events.jsonl.
+
+    ``status.events.jsonl`` is a *shared* append log. Lane-transition rows are
+    flat (``wp_id`` / ``from_lane`` / ``to_lane``); other subsystems co-locate
+    ``event_type`` / ``type`` rows. Two of those classes have **no other
+    per-mission home**, so quarantining them is real data loss (issue #2376):
+
+    - **Retrospective lifecycle rows** (``type`` envelope) — contracted
+      provenance read back by retrospective consumers.
+    - **Canonical lifecycle events** whose ``event_type`` is in
+      ``LIFECYCLE_EVENT_TYPES`` (``MissionCreated``, ``SpecifyStarted``,
+      ``WPCreated``, …). :mod:`specify_cli.status.lifecycle_events` is their
+      sole durable per-mission writer and declares this stream "a safe target
+      for repair / replay tooling".
+
+    Other ``event_type`` rows (e.g. Decision-Moment ``DecisionPoint*``) are NOT
+    preserved here: their canonical store is elsewhere
+    (``decisions/index.json`` + ``DM-*.md``), so the copy in status.events.jsonl
+    is a prunable mirror — quarantining it (the shipped #980 behaviour) loses
+    nothing.
+    """
+    return (
+        is_retrospective_lifecycle_event(row)
+        or row.get("event_type") in LIFECYCLE_EVENT_TYPES
+    )
+
+
 def _rule_reject_non_status_event(
     row: _Row, _ctx: MigrationContext
 ) -> CanonicalStepResult[_Row]:
     """Rule 1: route non-lane rows that share status.events.jsonl.
 
-    Two dispositions, each mirroring how the other surfaces treat the row:
-
-    - Retrospective lifecycle rows (``type`` envelope, see
-      :func:`specify_cli.status.store.is_retrospective_lifecycle_event`)
-      are PRESERVED in place: the runtime reader skips them during
-      deserialization but retrospective consumers (``retrospect``,
-      ``retrospective.summary``, the runtime bridge) read them back from
-      status.events.jsonl, so quarantining them would destroy contracted
-      provenance. ``_scan_raw_status_rows`` tolerates them for the same
-      reason.
-    - Rows carrying ``event_type`` or ``event_name`` are QUARANTINED —
-      the same presence check ``_scan_raw_status_rows`` uses to flag
-      typed side-log rows, so repair removes exactly what the dry-run
-      scan reports. The ``event_name`` clause is deliberately broader
-      than the reader's skip set (which only skips ``event_name`` values
-      starting with ``retrospective.``): repair quarantines what the
-      reader would reject loudly.
+    - Rows whose only per-mission home is this file
+      (:func:`_is_preserved_non_lane_row`: retrospective + canonical lifecycle
+      events) are PRESERVED in place — the runtime reader skips them during lane
+      reduction but they are contracted data; quarantining them (issue #2376)
+      emptied healthy mission logs.
+    - Any other ``event_type`` / ``event_name`` row is QUARANTINED (its canonical
+      state, if any, lives elsewhere). ``_scan_raw_status_rows`` flags the same
+      class before a TeamSpace dry-run.
     """
-    if is_retrospective_lifecycle_event(row):
+    if _is_preserved_non_lane_row(row):
         return CanonicalStepResult(
             state=row,
             actions=(),

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -25,7 +25,11 @@ from urllib.parse import urlsplit
 from packaging.version import Version
 
 from specify_cli.core.atomic import atomic_write
-from specify_cli.core.paths import assert_safe_path_segment
+from specify_cli.core.paths import (
+    WorkspaceRootNotFound,
+    assert_safe_path_segment,
+    resolve_canonical_root,
+)
 from specify_cli.mission_metadata import (
     load_meta,
     load_meta_or_empty,
@@ -504,11 +508,6 @@ def _anchor_repair_root(repo_root: Path, *, scan_root: Path | None) -> Path:
     """
     if scan_root is not None:
         return repo_root.resolve()
-    from specify_cli.core.paths import (  # noqa: PLC0415
-        WorkspaceRootNotFound,
-        resolve_canonical_root,
-    )
-
     try:
         canonical: Path = resolve_canonical_root(repo_root)
     except WorkspaceRootNotFound:

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -1316,7 +1316,22 @@ def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
     (``decisions/index.json`` + ``DM-*.md``), so the copy in status.events.jsonl
     is a prunable mirror — quarantining it (the shipped #980 behaviour) loses
     nothing.
+
+    Kept in lock-step with the durable reader
+    :func:`specify_cli.status.store.is_non_lane_event`: a THIRD reader-preserved
+    class is the ``event_name``-envelope retrospective stream (rows whose
+    ``event_name`` starts with ``"retrospective."`` — written by
+    :func:`specify_cli.retrospective.events.emit_retrospective_event`, read back
+    as load-bearing state by the reducer / retrospective gate + summary, with no
+    other per-mission home). Omitting it re-opened the #2376 data-loss class in
+    a different event format (a mixed log with a ``retrospective.completed`` row
+    silently strips it). The reader's broader ``"event_type" in obj`` branch is
+    deliberately NOT mirrored here: the repair's ``LIFECYCLE_EVENT_TYPES``
+    narrowing is the intentional pruning divergence for Decision-Moment mirrors.
     """
+    event_name = row.get("event_name")
+    if isinstance(event_name, str) and event_name.startswith("retrospective."):
+        return True
     return (
         is_retrospective_lifecycle_event(row)
         or row.get("event_type") in LIFECYCLE_EVENT_TYPES

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -153,6 +153,7 @@ from .aggregate import (
     MissionStatus,
 )
 from .lifecycle_events import (
+    LIFECYCLE_EVENT_TYPES,
     PLAN_COMPLETED,
     PLAN_STARTED,
     REVIEWER_SELF_APPROVAL,
@@ -219,6 +220,7 @@ __all__ = [
     "IdentityState",
     "InvalidMissionSlug",
     "MissionMetadataUnavailable",
+    "LIFECYCLE_EVENT_TYPES",
     "MissionStatus",
     "PLAN_COMPLETED",
     "PLAN_STARTED",

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -31,7 +31,7 @@ test_no_dead_modules:
   # wp-lane-state-machine-fsm): upstream #1756 added m_3_3_0_session_presence_all_harnesses
   # and m_3_3_0_session_presence_claude_code; both auto-discovered via
   # pkgutil.iter_modules, never statically imported. Growth here is expected/routine.
-  category_1_auto_discovered_migrations: 87  # justification: +1 (86->87): m_3_2_0rc45_retire_standalone_skill_surface is an auto-discovered migration loaded via pkgutil.iter_modules, never statically imported.
+  category_1_auto_discovered_migrations: 88  # justification: +1 (87->88): m_3_2_4_derived_views_gitignore_backfill (#2370) is an auto-discovered migration loaded via pkgutil.iter_modules + @MigrationRegistry.register, never statically imported; it landed in #2370 without its allowlist entry.
   # justification: 3 schema generator modules consumed by
   # scripts/generate_schemas.py via importlib.import_module.
   # Shrunk from 4 → 3 when doctrine.missions.models gained a live

--- a/tests/architectural/test_no_dead_modules.py
+++ b/tests/architectural/test_no_dead_modules.py
@@ -237,6 +237,12 @@ _CATEGORY_1_AUTO_DISCOVERED_MIGRATIONS: frozenset[str] = frozenset(
         # m_3_2_0rc35_sync_state_gitignore, which is why that module is no longer
         # an orphan and was removed from this allowlist.)
         "specify_cli.upgrade.migrations.m_3_2_3_encoding_provenance_gitignore_backfill",
+        # 3.2.4 derived-mission-views gitignore backfill migration (#2370):
+        # auto-discovered via pkgutil.iter_modules + @MigrationRegistry.register;
+        # never statically imported by runtime code. Landed in #2370 without its
+        # allowlist entry (the core-misc path filter was not triggered there);
+        # the gap surfaced here. Same sibling shape as the m_3_2_3 backfill above.
+        "specify_cli.upgrade.migrations.m_3_2_4_derived_views_gitignore_backfill",
     }
 )
 

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -292,7 +292,6 @@ _CATEGORY_B_GRANDFATHERED_LEGACY: frozenset[str] = frozenset(
         "specify_cli.skills.manifest_store::SCHEMA_VERSION",
         "specify_cli.skills.manifest_store::load",
         "specify_cli.skills.manifest_store::save",
-        "specify_cli.status.lifecycle_events::LIFECYCLE_EVENT_TYPES",
         "specify_cli.status.lifecycle_events::MISSION_CREATED",
         "specify_cli.status.lifecycle_events::MISSION_EVENTS_FILENAME",
         "specify_cli.status.lifecycle_events::PROJECT_EVENTS_FILENAME",

--- a/tests/integration/migration/fixtures/01_non_status_event_type.json
+++ b/tests/integration/migration/fixtures/01_non_status_event_type.json
@@ -1,5 +1,5 @@
 {
-  "description": "Rule 1: non-status event rejected (event_type present) — early return quarantine",
+  "description": "Rule 1: non-status event rejected (generic event_type present) — early return quarantine",
   "input": {
     "data": {"event_type": "some_event", "wp_id": "WP01", "to_lane": "done"},
     "mission_slug": "test-mission",

--- a/tests/integration/migration/test_audit_primary_anchor.py
+++ b/tests/integration/migration/test_audit_primary_anchor.py
@@ -1,0 +1,129 @@
+"""Regression: ``doctor mission-state --audit`` anchors on the PRIMARY checkout.
+
+#2320 re-anchored the ``--fix`` path to the canonical primary main-checkout
+(inside ``repair_repo`` → ``_anchor_repair_root`` → ``resolve_canonical_root``),
+but the read-only ``--audit`` path resolved its root through
+``locate_project_root`` — a *conditional* anchor that stops at the CWD's
+worktree. From a non-primary cwd (a coordination / lane worktree) audit and fix
+therefore diverged: fix wrote the primary while audit could read a stale
+worktree, so a fixed mission still audited as broken (and vice-versa).
+
+The alphonso MINOR-a fold unifies both on the SAME authority at the
+``run_mission_state`` seam, so audit and fix resolve to the identical canonical
+root from any cwd. These tests exercise that seam through a real git worktree.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.core.paths import resolve_canonical_root
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+_MISSION_ID = "01KWNPA0Q8R9TVWXY2Z3A4B5C0"
+_SLUG = "audit-anchor-mission"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _seed_mission(root: Path) -> Path:
+    mission = root / "kitty-specs" / _SLUG
+    mission.mkdir(parents=True)
+    (mission / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": _SLUG,
+                "mission_id": _MISSION_ID,
+                "mission_type": "software-dev",
+                "target_branch": "main",
+                "created_at": "2026-07-04T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (mission / "status.events.jsonl").write_text(
+        json.dumps(
+            {
+                "actor": "claude-code",
+                "at": "2026-07-04T10:00:01+00:00",
+                "event_id": "01KWNPA0Q8R9TVWXY2Z3A4B5C6",
+                "execution_mode": "worktree",
+                "force": False,
+                "from_lane": "planned",
+                "to_lane": "claimed",
+                "mission_id": _MISSION_ID,
+                "mission_slug": _SLUG,
+                "wp_id": "WP01",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return mission
+
+
+def _make_primary_with_coord_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (primary_root, coord_worktree_root)."""
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-q", "-b", "main")
+    _git(primary, "config", "user.email", "audit-test@spec-kitty.test")
+    _git(primary, "config", "user.name", "audit test")
+    _seed_mission(primary)
+    _git(primary, "add", ".")
+    _git(primary, "commit", "-q", "-m", "baseline")
+
+    coord = tmp_path / f"{_SLUG}-coord"
+    _git(primary, "worktree", "add", "-q", "-b", f"kitty/mission-{_SLUG}-coord", str(coord))
+    return primary.resolve(), coord
+
+
+def test_audit_from_worktree_anchors_on_primary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invoked from a worktree, ``--audit`` must resolve the canonical PRIMARY
+    root — the same root ``--fix`` uses — not the worktree it was invoked from.
+
+    A spy on the audit engine captures the ``repo_root`` the audit actually runs
+    against. Before the fold that root was the worktree; after it is the primary
+    (== ``resolve_canonical_root(coord)``), so audit and fix agree.
+    """
+    from specify_cli.cli.commands import _mission_state_doctor as mod
+
+    primary_root, coord = _make_primary_with_coord_worktree(tmp_path)
+
+    captured: dict[str, Path] = {}
+    import specify_cli.audit as audit_mod
+
+    real_run_audit = audit_mod.run_audit
+
+    def _spy(options: object) -> object:
+        captured["root"] = options.repo_root  # type: ignore[attr-defined]
+        return real_run_audit(options)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(audit_mod, "run_audit", _spy)
+
+    mod.run_mission_state(
+        audit=True,
+        fix=False,
+        teamspace_dry_run=False,
+        json_output=True,
+        mission=None,
+        fail_on=None,
+        fixture_dir=None,
+        include_fixtures=False,
+        manifest_path=None,
+        allow_dirty=False,
+        repo_root=coord,
+    )
+
+    expected = resolve_canonical_root(coord)
+    assert captured["root"] == expected == primary_root, (
+        "audit must anchor on the canonical primary root (matching --fix), "
+        f"got {captured.get('root')!r}; expected {primary_root!r}"
+    )

--- a/tests/integration/migration/test_canonicalization_pipeline.py
+++ b/tests/integration/migration/test_canonicalization_pipeline.py
@@ -81,8 +81,13 @@ def _run_fixture(fixture: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def test_canonicalize_status_row_rejects_event_type_rows() -> None:
-    """A row with 'event_type' key is quarantined immediately; no further processing."""
+def test_canonicalize_status_row_rejects_generic_event_type_rows() -> None:
+    """A row with a generic 'event_type' (not a canonical lifecycle event) is
+    quarantined immediately; its canonical state, if any, lives elsewhere.
+
+    Canonical lifecycle events (whose only home is this file) are preserved
+    instead — see test_lifecycle_events_preserved.py (#2376).
+    """
     fixture = _load_fixture("01_non_status_event_type.json")
     actual = _run_fixture(fixture)
     expected = fixture["expected"]

--- a/tests/integration/migration/test_lifecycle_events_preserved.py
+++ b/tests/integration/migration/test_lifecycle_events_preserved.py
@@ -32,6 +32,8 @@ from spec_kitty_events.decisionpoint import DECISION_POINT_OPENED
 from specify_cli.decisions.emit import emit_decision_opened
 from specify_cli.decisions.models import DecisionStatus, IndexEntry, OriginFlow
 from specify_cli.migration.mission_state import _repair_mission
+from specify_cli.retrospective.events import CompletedPayload, emit_retrospective_event
+from specify_cli.retrospective.schema import ActorRef
 from specify_cli.status.lifecycle_events import (
     SPECIFY_STARTED,
     emit_artifact_phase,
@@ -182,6 +184,77 @@ def test_lifecycle_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
     # Only the DecisionPoint mirror is quarantined.
     assert result.quarantined_rows == 1
     surviving = _event_ids(log.read_text(encoding="utf-8"))
+    for event_id in lifecycle_ids:
+        assert event_id in surviving
+    assert decision_id not in surviving
+
+
+def _emit_retrospective_completed(mission_dir: Path) -> str:
+    """Emit a canonical ``retrospective.completed`` row; return its ``event_id``.
+
+    Retrospective rows use the ``event_name`` envelope (``retrospective.*``) —
+    a THIRD reader-preserved non-lane class (see
+    :func:`specify_cli.status.store.is_non_lane_event`). Their only per-mission
+    home is ``status.events.jsonl``; the reducer / retrospective gate + summary
+    read them back as load-bearing state.
+    """
+    event_id = emit_retrospective_event(
+        feature_dir=mission_dir,
+        mission_slug="m",
+        mission_id=_MISSION_ID,
+        mid8=_MISSION_ID[:8],
+        actor=ActorRef(kind="agent", id="claude", profile_id="reviewer-renata"),
+        event_name="retrospective.completed",
+        payload=CompletedPayload(
+            record_path="kitty-specs/m/retrospective/record.md",
+            record_hash="sha256:" + "0" * 64,
+            findings_summary={"helped": 3, "not_helpful": 0, "gaps": 1},
+            proposals_count=2,
+        ),
+    )
+    return event_id
+
+
+def test_retrospective_event_name_row_is_preserved(tmp_path: Path) -> None:
+    """#2376 residual: a ``retrospective.*`` (``event_name`` envelope) row shares
+    the log with lifecycle rows and MUST survive repair with zero quarantines.
+
+    This is the same #2376 data-loss class in a different event format: the
+    repair's ``_is_preserved_non_lane_row`` predicate must match the durable
+    reader ``is_non_lane_event``, which preserves rows whose ``event_name``
+    starts with ``"retrospective."``. Before the predicate was aligned the
+    retrospective row was silently stripped (``quarantined_rows == 1``).
+    """
+    mission_dir, log, lifecycle_ids, _ = _write_mission(tmp_path, with_decision=False)
+    retro_id = _emit_retrospective_completed(mission_dir)
+    before_ids = _event_ids(log.read_text(encoding="utf-8"))
+    assert retro_id in before_ids
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="retro")
+
+    assert result.status != "error", result.validation_errors
+    assert result.quarantined_rows == 0
+    surviving = _event_ids(log.read_text(encoding="utf-8"))
+    assert retro_id in surviving, "the retrospective.* row must survive repair"
+    for event_id in lifecycle_ids:
+        assert event_id in surviving
+
+
+def test_retrospective_row_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
+    """Mixed log with all three preserved classes + a prunable Decision mirror:
+    lifecycle + retrospective survive; only the DecisionPoint mirror is pruned."""
+    mission_dir, log, lifecycle_ids, decision_id = _write_mission(
+        tmp_path, with_decision=True
+    )
+    assert decision_id is not None
+    retro_id = _emit_retrospective_completed(mission_dir)
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="mixed-retro")
+
+    assert result.status != "error", result.validation_errors
+    assert result.quarantined_rows == 1
+    surviving = _event_ids(log.read_text(encoding="utf-8"))
+    assert retro_id in surviving
     for event_id in lifecycle_ids:
         assert event_id in surviving
     assert decision_id not in surviving

--- a/tests/integration/migration/test_lifecycle_events_preserved.py
+++ b/tests/integration/migration/test_lifecycle_events_preserved.py
@@ -11,65 +11,42 @@ emptied.
 Decision-Moment rows (``DecisionPoint*``) are intentionally NOT preserved here —
 their canonical store is ``decisions/index.json`` / ``DM-*.md``, so the copy in
 status.events.jsonl is a prunable mirror (the shipped #980 behaviour, retained).
+
+The fixtures are built through the canonical event producers (C-007 / #1248) —
+``emit_mission_created_local`` / ``emit_artifact_phase`` / ``emit_wp_created_local``
+for the lifecycle rows and ``emit_decision_opened`` for the Decision-Moment
+mirror — rather than hand-assembled ``{event_type, payload}`` dicts. The producers
+generate realistic Crockford ULID ``event_id`` values, which the assertions read
+back from the on-disk log.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from spec_kitty_events.decisionpoint import DECISION_POINT_OPENED
 
+from specify_cli.decisions.emit import emit_decision_opened
+from specify_cli.decisions.models import DecisionStatus, IndexEntry, OriginFlow
 from specify_cli.migration.mission_state import _repair_mission
+from specify_cli.status.lifecycle_events import (
+    SPECIFY_STARTED,
+    emit_artifact_phase,
+    emit_mission_created_local,
+    emit_wp_created_local,
+    mission_event_log_path,
+)
 
 pytestmark = pytest.mark.integration
 
 _MISSION_ID = "01KWN9D0MJ79NK1T90RWYY2Y7R"
-
-# Canonical lifecycle events (event_type in LIFECYCLE_EVENT_TYPES) — no other
-# per-mission home, so the repair MUST preserve them.
-_LIFECYCLE_ROWS: list[dict] = [
-    {
-        "event_id": "01KWN9D17PATBTWVQCEEYDE7PW",
-        "event_type": "MissionCreated",
-        "aggregate_id": _MISSION_ID,
-        "aggregate_type": "Mission",
-        "schema_version": "5.0.0",
-        "timestamp": "2026-07-04T00:45:35+00:00",
-        "payload": {"mission_slug": "m"},
-    },
-    {
-        "event_id": "01KWN9D2000000000000000001",
-        "event_type": "SpecifyStarted",
-        "aggregate_id": _MISSION_ID,
-        "aggregate_type": "Mission",
-        "schema_version": "5.0.0",
-        "timestamp": "2026-07-04T00:46:00+00:00",
-        "payload": {"mission_slug": "m"},
-    },
-    {
-        "event_id": "01KWN9D3000000000000000002",
-        "event_type": "WPCreated",
-        "aggregate_id": "WP01",
-        "aggregate_type": "WorkPackage",
-        "schema_version": "5.0.0",
-        "timestamp": "2026-07-04T00:47:00+00:00",
-        "payload": {"mission_slug": "m", "wp_id": "WP01"},
-    },
-]
-
-# Decision-Moment mirror row — canonical store is decisions/, so pruned.
-_DECISION_ROW = {
-    "event_id": "01KWN9YWCZBHNWQCKSY7EXMQDS",
-    "event_type": "DecisionPointOpened",
-    "at": "2026-07-04T00:55:20+00:00",
-    "payload": {"decision_point_id": "d1", "mission_slug": "m"},
-}
+_DECISION_ID = "01KWN9YWCZBHNWQCKSY7EXMQDS"
 
 
-def _write_mission(tmp_path: Path, rows: list[dict]) -> tuple[Path, Path]:
-    mission_dir = tmp_path / "kitty-specs" / "m"
-    mission_dir.mkdir(parents=True)
+def _seed_meta(mission_dir: Path) -> None:
     (mission_dir / "meta.json").write_text(
         json.dumps(
             {
@@ -82,11 +59,90 @@ def _write_mission(tmp_path: Path, rows: list[dict]) -> tuple[Path, Path]:
         ),
         encoding="utf-8",
     )
-    log = mission_dir / "status.events.jsonl"
-    log.write_text(
-        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+
+
+def _emit_lifecycle_events(mission_dir: Path) -> set[str]:
+    """Emit the three canonical lifecycle events; return their ``event_id`` set.
+
+    Uses the durable local-first producers (their *only* per-mission home is
+    ``status.events.jsonl``), so the repair MUST preserve every emitted row.
+    """
+    created = emit_mission_created_local(
+        mission_dir,
+        mission_slug="m",
+        mission_id=_MISSION_ID,
+        mission_number=None,
+        mission_type="software-dev",
+        target_branch="main",
+        created_at="2026-07-04T00:45:35+00:00",
     )
-    return mission_dir, log
+    specify = emit_artifact_phase(
+        mission_dir,
+        event_type=SPECIFY_STARTED,
+        mission_slug="m",
+        at="2026-07-04T00:46:00+00:00",
+    )
+    wp = emit_wp_created_local(
+        mission_dir,
+        mission_slug="m",
+        wp_id="WP01",
+        wp_title="Decompose the god-module",
+        created_at="2026-07-04T00:47:00+00:00",
+    )
+    assert created is not None
+    assert specify is not None
+    assert wp is not None
+    return {created["event_id"], specify["event_id"], wp["event_id"]}
+
+
+def _emit_decision_mirror(tmp_path: Path, mission_dir: Path) -> str:
+    """Emit a canonical ``DecisionPointOpened`` mirror; return its ``event_id``.
+
+    Its canonical store is ``decisions/``, so the copy in ``status.events.jsonl``
+    is a prunable mirror the repair quarantines.
+    """
+    entry = IndexEntry(
+        decision_id=_DECISION_ID,
+        origin_flow=OriginFlow.PLAN,
+        input_key="merge-strategy",
+        question="Which merge strategy for the god-module split?",
+        options=("consolidate", "defer"),
+        status=DecisionStatus.OPEN,
+        created_at=datetime(2026, 7, 4, 0, 55, 20, tzinfo=UTC),
+        mission_id=_MISSION_ID,
+        mission_slug="m",
+        step_id="plan.q1",
+    )
+    emit_decision_opened(
+        tmp_path, "m", decision_id=_DECISION_ID, entry=entry, actor="claude"
+    )
+    return _find_event_id(mission_event_log_path(mission_dir), DECISION_POINT_OPENED)
+
+
+def _write_mission(
+    tmp_path: Path, *, with_decision: bool
+) -> tuple[Path, Path, set[str], str | None]:
+    """Seed a mission whose event log is built via canonical producers.
+
+    Returns ``(mission_dir, log, lifecycle_event_ids, decision_event_id)``.
+    ``decision_event_id`` is ``None`` when ``with_decision`` is false.
+    """
+    mission_dir = tmp_path / "kitty-specs" / "m"
+    mission_dir.mkdir(parents=True)
+    _seed_meta(mission_dir)
+
+    lifecycle_ids = _emit_lifecycle_events(mission_dir)
+    decision_id = _emit_decision_mirror(tmp_path, mission_dir) if with_decision else None
+
+    return mission_dir, mission_event_log_path(mission_dir), lifecycle_ids, decision_id
+
+
+def _find_event_id(log: Path, event_type: str) -> str:
+    for line in log.read_text(encoding="utf-8").splitlines():
+        obj = json.loads(line)
+        if obj.get("event_type") == event_type:
+            return str(obj["event_id"])
+    raise AssertionError(f"no {event_type} row was written to {log}")
 
 
 def _event_ids(text: str) -> set[str]:
@@ -100,7 +156,7 @@ def _event_ids(text: str) -> set[str]:
 def test_lifecycle_only_log_is_fully_preserved(tmp_path: Path) -> None:
     """The moov-shaped failure: a log of only canonical lifecycle events must
     survive intact with zero quarantines (it was being emptied to 0 bytes)."""
-    mission_dir, log = _write_mission(tmp_path, list(_LIFECYCLE_ROWS))
+    mission_dir, log, _lifecycle_ids, _ = _write_mission(tmp_path, with_decision=False)
     before_ids = _event_ids(log.read_text(encoding="utf-8"))
 
     result = _repair_mission(tmp_path, mission_dir, run_id="lifecycle-only")
@@ -115,9 +171,10 @@ def test_lifecycle_only_log_is_fully_preserved(tmp_path: Path) -> None:
 def test_lifecycle_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
     """Mixed log: lifecycle events preserved; the DecisionPoint mirror is pruned
     (its canonical store is decisions/), and the log is not emptied."""
-    mission_dir, log = _write_mission(
-        tmp_path, [*_LIFECYCLE_ROWS, _DECISION_ROW]
+    mission_dir, log, lifecycle_ids, decision_id = _write_mission(
+        tmp_path, with_decision=True
     )
+    assert decision_id is not None
 
     result = _repair_mission(tmp_path, mission_dir, run_id="mixed")
 
@@ -125,15 +182,15 @@ def test_lifecycle_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
     # Only the DecisionPoint mirror is quarantined.
     assert result.quarantined_rows == 1
     surviving = _event_ids(log.read_text(encoding="utf-8"))
-    for row in _LIFECYCLE_ROWS:
-        assert row["event_id"] in surviving
-    assert _DECISION_ROW["event_id"] not in surviving
+    for event_id in lifecycle_ids:
+        assert event_id in surviving
+    assert decision_id not in surviving
 
 
 def test_backstop_never_empties_when_all_rows_preserved(tmp_path: Path) -> None:
     """Idempotence + backstop: re-running on a lifecycle-only log is a no-op and
     never empties it."""
-    mission_dir, log = _write_mission(tmp_path, list(_LIFECYCLE_ROWS))
+    mission_dir, log, lifecycle_ids, _ = _write_mission(tmp_path, with_decision=False)
 
     _repair_mission(tmp_path, mission_dir, run_id="first")
     first = log.read_text(encoding="utf-8")
@@ -142,4 +199,4 @@ def test_backstop_never_empties_when_all_rows_preserved(tmp_path: Path) -> None:
 
     assert first.strip()
     assert second.strip()
-    assert _event_ids(second) == {row["event_id"] for row in _LIFECYCLE_ROWS}
+    assert _event_ids(second) == lifecycle_ids

--- a/tests/integration/migration/test_lifecycle_events_preserved.py
+++ b/tests/integration/migration/test_lifecycle_events_preserved.py
@@ -1,0 +1,145 @@
+"""Regression: mission-state repair preserves canonical lifecycle events (#2376).
+
+A completed mission's ``status.events.jsonl`` legitimately holds canonical
+lifecycle events (``MissionCreated``, ``SpecifyStarted``, ``WPCreated``) whose
+*only* per-mission home is this file (see
+:mod:`specify_cli.status.lifecycle_events`). The repair previously quarantined
+all ``event_type`` rows and emptied such a log. This test pins the corrected
+contract: canonical lifecycle events are preserved in place; the log is never
+emptied.
+
+Decision-Moment rows (``DecisionPoint*``) are intentionally NOT preserved here —
+their canonical store is ``decisions/index.json`` / ``DM-*.md``, so the copy in
+status.events.jsonl is a prunable mirror (the shipped #980 behaviour, retained).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.migration.mission_state import _repair_mission
+
+pytestmark = pytest.mark.integration
+
+_MISSION_ID = "01KWN9D0MJ79NK1T90RWYY2Y7R"
+
+# Canonical lifecycle events (event_type in LIFECYCLE_EVENT_TYPES) — no other
+# per-mission home, so the repair MUST preserve them.
+_LIFECYCLE_ROWS: list[dict] = [
+    {
+        "event_id": "01KWN9D17PATBTWVQCEEYDE7PW",
+        "event_type": "MissionCreated",
+        "aggregate_id": _MISSION_ID,
+        "aggregate_type": "Mission",
+        "schema_version": "5.0.0",
+        "timestamp": "2026-07-04T00:45:35+00:00",
+        "payload": {"mission_slug": "m"},
+    },
+    {
+        "event_id": "01KWN9D2000000000000000001",
+        "event_type": "SpecifyStarted",
+        "aggregate_id": _MISSION_ID,
+        "aggregate_type": "Mission",
+        "schema_version": "5.0.0",
+        "timestamp": "2026-07-04T00:46:00+00:00",
+        "payload": {"mission_slug": "m"},
+    },
+    {
+        "event_id": "01KWN9D3000000000000000002",
+        "event_type": "WPCreated",
+        "aggregate_id": "WP01",
+        "aggregate_type": "WorkPackage",
+        "schema_version": "5.0.0",
+        "timestamp": "2026-07-04T00:47:00+00:00",
+        "payload": {"mission_slug": "m", "wp_id": "WP01"},
+    },
+]
+
+# Decision-Moment mirror row — canonical store is decisions/, so pruned.
+_DECISION_ROW = {
+    "event_id": "01KWN9YWCZBHNWQCKSY7EXMQDS",
+    "event_type": "DecisionPointOpened",
+    "at": "2026-07-04T00:55:20+00:00",
+    "payload": {"decision_point_id": "d1", "mission_slug": "m"},
+}
+
+
+def _write_mission(tmp_path: Path, rows: list[dict]) -> tuple[Path, Path]:
+    mission_dir = tmp_path / "kitty-specs" / "m"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": "m",
+                "mission_id": _MISSION_ID,
+                "mission_type": "software-dev",
+                "target_branch": "main",
+                "created_at": "2026-07-04T00:45:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    log = mission_dir / "status.events.jsonl"
+    log.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+    return mission_dir, log
+
+
+def _event_ids(text: str) -> set[str]:
+    return {
+        json.loads(line)["event_id"]
+        for line in text.splitlines()
+        if line.strip()
+    }
+
+
+def test_lifecycle_only_log_is_fully_preserved(tmp_path: Path) -> None:
+    """The moov-shaped failure: a log of only canonical lifecycle events must
+    survive intact with zero quarantines (it was being emptied to 0 bytes)."""
+    mission_dir, log = _write_mission(tmp_path, list(_LIFECYCLE_ROWS))
+    before_ids = _event_ids(log.read_text(encoding="utf-8"))
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="lifecycle-only")
+
+    assert result.status != "error", result.validation_errors
+    assert result.quarantined_rows == 0
+    after_text = log.read_text(encoding="utf-8")
+    assert after_text.strip(), "repair must not empty a lifecycle-only log"
+    assert _event_ids(after_text) == before_ids
+
+
+def test_lifecycle_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
+    """Mixed log: lifecycle events preserved; the DecisionPoint mirror is pruned
+    (its canonical store is decisions/), and the log is not emptied."""
+    mission_dir, log = _write_mission(
+        tmp_path, [*_LIFECYCLE_ROWS, _DECISION_ROW]
+    )
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="mixed")
+
+    assert result.status != "error", result.validation_errors
+    # Only the DecisionPoint mirror is quarantined.
+    assert result.quarantined_rows == 1
+    surviving = _event_ids(log.read_text(encoding="utf-8"))
+    for row in _LIFECYCLE_ROWS:
+        assert row["event_id"] in surviving
+    assert _DECISION_ROW["event_id"] not in surviving
+
+
+def test_backstop_never_empties_when_all_rows_preserved(tmp_path: Path) -> None:
+    """Idempotence + backstop: re-running on a lifecycle-only log is a no-op and
+    never empties it."""
+    mission_dir, log = _write_mission(tmp_path, list(_LIFECYCLE_ROWS))
+
+    _repair_mission(tmp_path, mission_dir, run_id="first")
+    first = log.read_text(encoding="utf-8")
+    _repair_mission(tmp_path, mission_dir, run_id="second")
+    second = log.read_text(encoding="utf-8")
+
+    assert first.strip()
+    assert second.strip()
+    assert _event_ids(second) == {row["event_id"] for row in _LIFECYCLE_ROWS}

--- a/tests/integration/migration/test_repair_primary_anchor.py
+++ b/tests/integration/migration/test_repair_primary_anchor.py
@@ -1,0 +1,171 @@
+"""Regression: mission-state repair anchors on the PRIMARY checkout (#2320).
+
+``doctor mission-state --fix`` is a repo-level canonicalization. When it is
+invoked from inside a worktree (a coordination or lane worktree), the raw
+invocation root points at that worktree. Before the #2320 fold, ``repair_repo``
+operated on whatever checkout it was handed, which produced the two symptoms the
+issue witnessed live:
+
+* **Mechanism 1 — drift never converges.** The materialize step re-wrote
+  ``status.json`` inside the *worktree*, leaving the PRIMARY checkout's
+  ``status.json`` frozen. A follow-up ``--audit`` (which reads the primary)
+  therefore still reported the same ``SNAPSHOT_DRIFT`` blocker.
+* **Mechanism 2 — writes into a stale coord worktree.** The repair left
+  uncommitted changes (``status.json`` / ``status.events.jsonl`` / ``.kittify/``)
+  inside a coordination worktree that should never have been mutated.
+
+The fix re-anchors ``repair_repo`` to the canonical primary main-checkout via
+the single worktree-pointer parser, so repair always targets the primary
+``kitty-specs/<slug>`` and never touches ``.worktrees/``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.audit.classifiers.status_json import classify_status_json
+from specify_cli.migration.mission_state import repair_repo
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+_MISSION_ID = "01KWNP7Q8R9TVWXY2Z3A4B5C00"
+_SLUG = "decompose-merge-god-module"
+
+# Canonical lifecycle: a WP walked all the way to ``done`` in the event log,
+# while the persisted status.json is frozen at ``planned`` (the live #2320
+# shape: "status.json frozen at event 11/88 — all WPs done in the log,
+# planned in the snapshot"). Realistic 26-char Crockford ULID event ids +
+# canonical 5.x lane vocabulary.
+_LANES = ["planned", "claimed", "in_progress", "for_review", "in_review", "approved", "done"]
+_EVENT_IDS = [
+    "01KWNP7Q8R9TVWXY2Z3A4B5C6D",
+    "01KWNP7Q8R9TVWXY2Z3A4B5C7E",
+    "01KWNP7Q8R9TVWXY2Z3A4B5C8F",
+    "01KWNP7Q8R9TVWXY2Z3A4B5C9G",
+    "01KWNP7Q8R9TVWXY2Z3A4B5CAH",
+    "01KWNP7Q8R9TVWXY2Z3A4B5CBJ",
+]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _lane_rows() -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for index, (from_lane, to_lane) in enumerate(zip(_LANES, _LANES[1:], strict=False)):
+        rows.append(
+            {
+                "actor": "claude-code",
+                "at": f"2026-07-03T10:00:{index + 1:02d}+00:00",
+                "event_id": _EVENT_IDS[index],
+                "execution_mode": "worktree",
+                "force": False,
+                "from_lane": from_lane,
+                "to_lane": to_lane,
+                "mission_id": _MISSION_ID,
+                "mission_slug": _SLUG,
+                "wp_id": "WP01",
+            }
+        )
+    return rows
+
+
+def _seed_mission(root: Path) -> Path:
+    """Seed a flattened mission with SNAPSHOT_DRIFT (log reaches done, snapshot planned)."""
+    mission = root / "kitty-specs" / _SLUG
+    mission.mkdir(parents=True)
+    (mission / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": _SLUG,
+                "mission_id": _MISSION_ID,
+                "mission_type": "software-dev",
+                "target_branch": "main",
+                "created_at": "2026-07-03T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (mission / "status.events.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in _lane_rows()), encoding="utf-8"
+    )
+    # Frozen / stale snapshot — the drift the audit flags.
+    (mission / "status.json").write_text(
+        json.dumps(
+            {"summary": {"planned": 1}, "work_packages": {"WP01": {"lane": "planned"}}},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return mission
+
+
+def _make_primary_with_coord_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (primary_mission_dir, coord_worktree_root) for a repo with drift."""
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-q", "-b", "main")
+    _git(primary, "config", "user.email", "repair-test@spec-kitty.test")
+    _git(primary, "config", "user.name", "repair test")
+    primary_mission = _seed_mission(primary)
+    _git(primary, "add", ".")
+    _git(primary, "commit", "-q", "-m", "baseline")
+
+    coord = tmp_path / f"{_SLUG}-coord"
+    _git(primary, "worktree", "add", "-q", "-b", f"kitty/mission-{_SLUG}-coord", str(coord))
+    return primary_mission, coord
+
+
+def test_repair_from_worktree_materializes_primary_status_json(tmp_path: Path) -> None:
+    """M1: invoked from a worktree, --fix must clear SNAPSHOT_DRIFT on the PRIMARY.
+
+    Before the fold the materialize step ran against the worktree, so the primary
+    stayed frozen and a re-audit still flagged the same blocker.
+    """
+    primary_mission, coord = _make_primary_with_coord_worktree(tmp_path)
+
+    before = classify_status_json(primary_mission)
+    assert any(f.code == "SNAPSHOT_DRIFT" for f in before), (
+        "fixture must start with the drift the issue describes"
+    )
+
+    # Invoke exactly as a CWD-inside-a-worktree run resolves the root.
+    repair_repo(coord, allow_dirty=True)
+
+    after = classify_status_json(primary_mission)
+    assert not any(f.code == "SNAPSHOT_DRIFT" for f in after), (
+        f"repair must re-materialize the PRIMARY status.json; residual findings: {after}"
+    )
+    summary = json.loads((primary_mission / "status.json").read_text(encoding="utf-8"))["summary"]
+    assert summary["done"] == 1
+    assert summary["planned"] == 0
+
+
+def test_repair_from_worktree_leaves_coord_worktree_clean(tmp_path: Path) -> None:
+    """M2: --fix must not write into the coordination worktree it was invoked from."""
+    _primary_mission, coord = _make_primary_with_coord_worktree(tmp_path)
+    coord_mission = coord / "kitty-specs" / _SLUG
+    coord_status_before = (coord_mission / "status.json").read_text(encoding="utf-8")
+
+    repair_repo(coord, allow_dirty=True)
+
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=coord,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert porcelain.strip() == "", (
+        f"repair must not dirty the coord worktree; porcelain: {porcelain!r}"
+    )
+    assert (coord_mission / "status.json").read_text(encoding="utf-8") == coord_status_before
+    # Belt-and-suspenders: no quarantine/manifest artifacts leaked into the worktree.
+    assert not (coord / ".kittify").exists()

--- a/tests/unit/migration/test_canonicalization_rules.py
+++ b/tests/unit/migration/test_canonicalization_rules.py
@@ -86,9 +86,13 @@ def _base_row(**overrides: Any) -> _Row:
 @pytest.mark.parametrize(
     "row, expect_error",
     [
-        # happy case — event_type present → quarantine error
+        # generic event_type (not a canonical lifecycle event) → quarantined;
+        # its canonical state, if any, lives in another store (#2376 / #980)
         ({"event_type": "some_event", "wp_id": "WP01"}, "quarantined_non_status_event"),
-        # happy case — event_name present → quarantine error
+        # canonical lifecycle event whose only per-mission home is this file →
+        # PRESERVED in place, never quarantined (#2376)
+        ({"event_type": "MissionCreated", "wp_id": "WP01"}, "preserved_non_lane_event"),
+        # bare event_name present → quarantine error
         ({"event_name": "custom_event"}, "quarantined_non_status_event"),
         # retrospective lifecycle type events → preserved in place, never quarantined
         ({"type": "RetrospectiveCaptured", "wp_id": "WP01"}, "preserved_non_lane_event"),


### PR DESCRIPTION
Fixes #2376.

## The bug

`spec-kitty upgrade` (via the TeamSpace mission-state gate) and `doctor mission-state --fix` run `repair_repo`, which **quarantined and deleted canonical lifecycle events** from `status.events.jsonl`. A completed mission whose log was all lifecycle events was emptied to **0 bytes** (`old_size 16052 → new_size 0`, 22/22 rows quarantined, `validation_errors: []`). Because the repair runs across *all* missions once any one trips the readiness gate, a single blocked mission mutilated the healthy ones.

## Root cause

`status/lifecycle_events.py` is the sole durable per-mission writer of canonical lifecycle events (`MissionCreated`, `SpecifyStarted`, `WPCreated`, …); it co-locates them in `status.events.jsonl` and its docstring declares the stream *"a safe target for repair / replay tooling."* The runtime reader (`status.store.is_non_lane_event`) preserves them in place. But the repair rule `_rule_reject_non_status_event` quarantined **every** `event_type` row except retrospective — destroying exactly those events. Their only per-mission home is this file, so quarantining is real data loss.

Timeline: the repair (#980, May 5) predates the lifecycle co-location (#1078, May 16) and was never reconciled with it.

## The fix (scoped deliberately)

Repair now **preserves in place** the rows whose only home is this file:
- retrospective rows (already preserved), and
- canonical lifecycle events whose `event_type` is in `LIFECYCLE_EVENT_TYPES`.

A shared `_is_preserved_non_lane_row` predicate is reused by both the repair rule and the dry-run scan (`_scan_raw_status_rows`) so they can't drift again. A **backstop** refuses to write a 0-byte log when the source was non-empty (records a mission error with a reason instead of silently emptying).

**Decision-Moment (`DecisionPoint*`) rows are intentionally left as-is (still pruned).** Their canonical store is `decisions/index.json` + `DM-*.md`, so the copy in `status.events.jsonl` is a prunable mirror — pruning it (the shipped #980 behavior) loses nothing. This keeps the repair's existing contract and its three tests (`test_mission_state_repair.py`, `test_teamspace_migration_rehearsal.py`) **passing unchanged**.

### Open question for maintainers (not addressed here)
The runtime reader *preserves* `DecisionPoint*` rows in place while the repair *prunes* them. Because the canonical decision store is separate, that's harmless today — but the reader/repair divergence is worth a ruling. Flagged on #2376 rather than changed here, since it would redefine the repair's output contract.

## Verification

- New regression coverage (`tests/integration/migration/test_lifecycle_events_preserved.py`): a lifecycle-only log survives with **0 quarantines** and is never emptied; a mixed log preserves lifecycle events while pruning the DecisionPoint mirror; re-running is idempotent.
- Existing maintainer tests unchanged and green: `tests/migration/test_mission_state_repair.py`, `tests/migration/test_teamspace_migration_rehearsal.py`, `tests/unit/migration/test_canonicalization_rules.py`, `tests/integration/migration/test_canonicalization_pipeline.py`, `tests/cli/commands/test_doctor_mission_state.py` — 116 passed.
- Replaying the fix against the real 22-row log that triggered #2376: **22 → 16 rows** (all 16 canonical lifecycle events preserved; 6 DecisionPoint mirrors pruned), log not emptied.
- `ruff` + `mypy` clean on changed sources.

## Recovery for repos already hit
Rows are preserved verbatim in `.kittify/migrations/mission-state/quarantine/…`. If the emptied log was not committed, `git checkout HEAD -- <mission>/status.events.jsonl` restores it.

---

**Also closes #2320** (folded in by maintainer): the same `repair_repo` pathway now anchors on the primary checkout via `resolve_canonical_root`, so `--fix` converges `SNAPSHOT_DRIFT` (re-materializes the primary `status.json`) and no longer writes into stale coordination worktrees. Audit unified on the same anchor.
