### PR TITLE
fix(#2392): canonical per-checkout upgrade auto-commit seam (closes #2385, #1873; pins #2105)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -123,6 +123,17 @@ speed up how fast we catch one.
   `IGNORED` surfaces (fresh `spec-kitty init` gitignores them), and a sibling
   backfill migration (`3.2.4_runtime_dirs_gitignore_backfill`) adds them on
   `spec-kitty upgrade` for already-initialised projects.
+- **`spec-kitty upgrade` no longer leaves sibling worktrees dirty, which was
+  blocking coord-topology `spec-kitty merge` (#2385).** Upgrade applies migrations
+  across worktrees (coord + lane) by default, but its auto-commit ran on the main
+  checkout only — so each worktree was left with uncommitted migration churn
+  (`.gitignore`, `.kittify/metadata.yaml`, encoding-provenance untracking). A later
+  `spec-kitty merge` then tripped the #1826/NFR-002 guard (it refuses to
+  `reset --hard` a coord/lane worktree with uncommitted changes), halting the
+  merge. Upgrade now captures a per-worktree baseline up front and auto-commits
+  each worktree's *new* upgrade churn on its own branch, mirroring the main
+  checkout; the baseline ensures any pre-existing uncommitted work in a worktree
+  is never swept in.
 - **Guard/gate friction hotfixes (#2346 / #2324, #1834).**
   - **Subtask guard no longer misattributes a later WP's checkboxes (#2346, also closes #2324).** `_check_unchecked_subtasks` entered a WP's section on *any* heading that merely mentioned its id, so a dependent heading like `### WP03 — … (depends: WP01, WP02)` re-entered WP01/WP02's section and harvested WP03's unchecked `- [ ] T0xx` rows as the earlier WP's blockers — spuriously blocking that WP's lane transition. A heading now belongs to the WP named by its **first** `WPxx` token, not any mention.
   - **`grep_absence` negative invariants accept an optional path-scope (#1834).** The acceptance gate ran `grep -r <pattern> .` over the whole repo, so a negative-invariant pattern that a mission's own spec/plan/WP prose mentioned false-positived as `still_present`. `NegativeInvariant` now carries an optional `scope` (whitespace-separated repo-relative search roots); when set, the grep runs only under those paths. Default (unscoped) preserves the whole-repo search, and `scope` is omitted from serialization when unset so existing matrices are untouched.

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -123,17 +123,37 @@ speed up how fast we catch one.
   `IGNORED` surfaces (fresh `spec-kitty init` gitignores them), and a sibling
   backfill migration (`3.2.4_runtime_dirs_gitignore_backfill`) adds them on
   `spec-kitty upgrade` for already-initialised projects.
-- **`spec-kitty upgrade` no longer leaves sibling worktrees dirty, which was
-  blocking coord-topology `spec-kitty merge` (#2385).** Upgrade applies migrations
-  across worktrees (coord + lane) by default, but its auto-commit ran on the main
-  checkout only — so each worktree was left with uncommitted migration churn
-  (`.gitignore`, `.kittify/metadata.yaml`, encoding-provenance untracking). A later
-  `spec-kitty merge` then tripped the #1826/NFR-002 guard (it refuses to
-  `reset --hard` a coord/lane worktree with uncommitted changes), halting the
-  merge. Upgrade now captures a per-worktree baseline up front and auto-commits
-  each worktree's *new* upgrade churn on its own branch, mirroring the main
-  checkout; the baseline ensures any pre-existing uncommitted work in a worktree
-  is never swept in.
+- **Upgrade-worktree coherence: one canonical per-checkout auto-commit seam
+  (epic #2392 spine — closes #2385, #1873; regression-pins #2105).** The
+  `spec-kitty upgrade` commit routine (porcelain-baseline-derived commit-set,
+  directory expansion, eligibility filter) is extracted from the CLI into
+  `specify_cli.upgrade.autocommit.commit_touched_checkout()` and applied
+  symmetrically to **every checkout the run touches** over the runner's single
+  worktree enumeration:
+  - **#2385** — worktree migration churn was never committed (auto-commit ran on
+    the main checkout only), so each coord/lane worktree was left dirty and a
+    later `spec-kitty merge` tripped the #1826/NFR-002 guard. The runner now
+    captures a per-worktree porcelain baseline before that worktree's writes and
+    commits its *new* churn on its own branch; pre-existing uncommitted work
+    (e.g. in-flight WP edits) is never swept in, and per-worktree
+    `manual_review_required` migrations skip that worktree's commit with a
+    warning. Root `.gitignore` churn — exactly what the gitignore-backfill
+    migrations write — is now commit-eligible instead of being dropped by the
+    root-level-file filter.
+  - **#1873** — freshly synthesized worktree metadata is persisted (and
+    committed) even when the detected version already equals the target,
+    restoring the #1857 self-healing path.
+  - **#2105** — already porcelain-derived in this tree; now regression-pinned by
+    a test asserting manifest updates and newly-installed skills land in the
+    commit-set (guards against regressing to a hardcoded file list).
+  - A detached-HEAD checkout skips the auto-commit with a warning instead of
+    guessing a ref. `--dry-run` remains a strict no-op per checkout. An
+    invariant test asserts that after `upgrade`, no touched checkout carries
+    porcelain dirt beyond what pre-existed. **#2367's two mechanisms are
+    deliberately NOT routed through this seam** (per the #2392 architect
+    design): the implement-claim VCS-lock policy (#2222/C-003 race decision)
+    and the merge-rollback snapshot capture set are separate seams sharing the
+    same invariant.
 - **Guard/gate friction hotfixes (#2346 / #2324, #1834).**
   - **Subtask guard no longer misattributes a later WP's checkboxes (#2346, also closes #2324).** `_check_unchecked_subtasks` entered a WP's section on *any* heading that merely mentioned its id, so a dependent heading like `### WP03 — … (depends: WP01, WP02)` re-entered WP01/WP02's section and harvested WP03's unchecked `- [ ] T0xx` rows as the earlier WP's blockers — spuriously blocking that WP's lane transition. A heading now belongs to the WP named by its **first** `WPxx` token, not any mention.
   - **`grep_absence` negative invariants accept an optional path-scope (#1834).** The acceptance gate ran `grep -r <pattern> .` over the whole repo, so a negative-invariant pattern that a mission's own spec/plan/WP prose mentioned false-positived as `still_present`. `NegativeInvariant` now carries an optional `scope` (whitespace-separated repo-relative search roots); when set, the grep runs only under those paths. Default (unscoped) preserves the whole-repo search, and `scope` is omitted from serialization when unset so existing matrices are untouched.

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -54,125 +53,16 @@ if TYPE_CHECKING:
 from rich.panel import Panel
 from rich.table import Table
 
-from mission_runtime import CommitTarget
 from specify_cli.cli.helpers import console, show_banner
 from specify_cli.cli.commands._teamspace_mission_state_gate import (
     offer_teamspace_mission_state_migration,
 )
-from specify_cli.core.commit_guard import GuardCapability
-from specify_cli.core.constants import WORKTREES_DIR
 from specify_cli.core.env import is_truthy
 from specify_cli.core.version_compare import is_version_newer
-from specify_cli.git.commit_helpers import safe_commit
+from specify_cli.upgrade import autocommit
 
 
 _PROJECT_COMPAT_CHECK_COMMAND = ("__project_compat_check__",)
-
-
-def _git_status_paths(repo_path: Path) -> set[str] | None:
-    """Return git status paths for *repo_path* using porcelain -z output.
-
-    Returns ``None`` when ``git status`` fails (e.g. not a git repo) so
-    callers can distinguish "no dirty files" from "unable to determine".
-    """
-    result = subprocess.run(
-        ["git", "status", "--porcelain", "-z"],
-        cwd=repo_path,
-        capture_output=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return None
-
-    entries = result.stdout.decode("utf-8", errors="replace").split("\0")
-    paths: set[str] = set()
-
-    i = 0
-    while i < len(entries):
-        entry = entries[i]
-        i += 1
-        if not entry or len(entry) < 4:
-            continue
-
-        status = entry[:2]
-        path = entry[3:]
-
-        # With -z format, renames/copies include a second NUL-separated
-        # path.  We take the *destination* (new name); the source (old name)
-        # is intentionally discarded because we care about "what exists now".
-        if ("R" in status or "C" in status) and i < len(entries) and entries[i]:
-            path = entries[i]
-            i += 1
-
-        normalized = path.strip().replace("\\", "/")
-        if normalized.startswith("./"):
-            normalized = normalized[2:]
-
-        if normalized:
-            paths.add(normalized)
-
-    return paths
-
-
-def _is_upgrade_commit_eligible(path: str, project_path: Path) -> bool:
-    """Return True when a changed file should be included in upgrade auto-commit."""
-    normalized = path.strip().replace("\\", "/")
-    if not normalized:
-        return False
-
-    # Ignore paths that are outside the repo and root-level files.
-    if normalized.startswith("../") or "/" not in normalized:
-        return False
-
-    # Never auto-commit ~/.kittify when users run inside their home directory.
-    return not (project_path.resolve() == Path.home().resolve() and normalized.startswith(".kittify/"))
-
-
-def _expand_upgrade_commit_path(project_path: Path, relative_path: str) -> list[Path]:
-    """Expand a changed path into the concrete file paths git will stage.
-
-    ``git status --porcelain -z`` may report untracked directories as a single
-    path (for example ``.agents/skills/new-skill``). ``git add <dir>`` stages
-    the files inside that directory, but ``safe_commit``'s backstop compares the
-    staged file paths against the requested path list. Expand directories here
-    so the expected set matches what git will actually stage.
-    """
-    normalized = relative_path.strip().replace("\\", "/")
-    absolute_path = project_path / normalized
-
-    if absolute_path.exists() and absolute_path.is_dir() and not absolute_path.is_symlink():
-        return sorted(child.relative_to(project_path) for child in absolute_path.rglob("*") if not child.is_dir())
-
-    return [Path(normalized)]
-
-
-def _prepare_upgrade_commit_files(
-    project_path: Path,
-    baseline_paths: set[str] | None,
-) -> list[Path]:
-    """Collect newly changed project-directory files after an upgrade run.
-
-    Returns an empty list when *baseline_paths* is ``None`` (git status
-    failed at baseline time) to avoid accidentally committing unrelated work.
-    """
-    if baseline_paths is None:
-        return []
-
-    current_paths = _git_status_paths(project_path)
-    if current_paths is None:
-        return []
-
-    new_paths = sorted(path for path in current_paths if path not in baseline_paths and _is_upgrade_commit_eligible(path, project_path))
-    files_to_commit: list[Path] = []
-    seen_paths: set[str] = set()
-    for path in new_paths:
-        for expanded_path in _expand_upgrade_commit_path(project_path, path):
-            normalized = str(expanded_path).replace("\\", "/")
-            if normalized in seen_paths:
-                continue
-            seen_paths.add(normalized)
-            files_to_commit.append(Path(normalized))
-    return files_to_commit
 
 
 def _collect_manual_review_paths(migration_results: dict[str, object]) -> list[str]:
@@ -183,102 +73,6 @@ def _collect_manual_review_paths(migration_results: dict[str, object]) -> list[s
             continue
         manual_review_paths.update(getattr(result, "preserved_paths", []))
     return sorted(manual_review_paths)
-
-
-def _auto_commit_upgrade_changes(
-    project_path: Path,
-    from_version: str,
-    to_version: str,
-    baseline_paths: set[str] | None,
-) -> tuple[bool, list[str], str | None]:
-    """Auto-commit newly introduced project-directory upgrade changes."""
-    files_to_commit = _prepare_upgrade_commit_files(project_path, baseline_paths)
-    if not files_to_commit:
-        return False, [], None
-
-    commit_message = f"chore: apply spec-kitty upgrade changes ({from_version} -> {to_version})"
-    committed_paths = [str(path).replace("\\", "/") for path in files_to_commit]
-    try:
-        destination_ref = subprocess.check_output(
-            ["git", "-C", str(project_path), "branch", "--show-current"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip() or "main"
-    except Exception:
-        destination_ref = "main"
-
-    # The upgrade flow runs outside any mission, so there is no coordination
-    # split to reconcile: the current branch is landing == coordination ==
-    # target. Construct a ref-only CommitTarget (C-007) for it and assert the
-    # upgrade bookkeeping capability explicitly (T009 / FR-008). The old reliance
-    # on the "chore: apply spec-kitty upgrade changes" message-prefix exception is
-    # now irrelevant — the message is just a message; the capability carries the
-    # authorization to land on a protected branch (e.g. the operator's main).
-    upgrade_target = CommitTarget(ref=destination_ref)
-
-    try:
-        safe_commit(
-            repo_root=project_path,
-            worktree_root=project_path,
-            target=upgrade_target,
-            message=commit_message,
-            paths=tuple(files_to_commit),
-            capability=GuardCapability.UPGRADE_BOOKKEEPING,
-        )
-    except Exception:
-        return (
-            False,
-            committed_paths,
-            "Could not auto-commit upgrade changes; please review and commit manually.",
-        )
-
-    return True, committed_paths, None
-
-
-def _capture_worktree_baselines(project_path: Path) -> dict[Path, set[str] | None]:
-    """Capture a git-status baseline for each worktree under ``.worktrees/``.
-
-    Returned before any upgrade work runs so the per-worktree auto-commit can
-    stage only the migration changes the upgrade *introduces*, leaving any
-    pre-existing uncommitted work in a worktree untouched (#2385).
-    """
-    worktrees_dir = project_path / WORKTREES_DIR
-    baselines: dict[Path, set[str] | None] = {}
-    if not worktrees_dir.exists():
-        return baselines
-    for worktree in sorted(worktrees_dir.iterdir(), key=lambda p: p.name):
-        if worktree.is_dir() and not worktree.is_symlink():
-            baselines[worktree] = _git_status_paths(worktree)
-    return baselines
-
-
-def _auto_commit_worktree_upgrade_changes(
-    worktree_baselines: dict[Path, set[str] | None],
-    from_version: str,
-    to_version: str,
-) -> list[str]:
-    """Auto-commit upgrade churn in each worktree, mirroring the main checkout.
-
-    ``spec-kitty upgrade`` applies migrations across sibling worktrees but
-    historically committed only the main checkout, leaving worktrees dirty and
-    blocking a later ``spec-kitty merge`` (#1826/NFR-002 refuses to advance a
-    branch whose worktree has uncommitted changes) — see #2385. Commit each
-    worktree's *new* upgrade changes on its own branch; the per-worktree
-    baseline protects any pre-existing uncommitted work.
-    """
-    warnings: list[str] = []
-    for worktree, baseline in worktree_baselines.items():
-        if not worktree.exists():
-            continue
-        _committed, _paths, warning = _auto_commit_upgrade_changes(
-            project_path=worktree,
-            from_version=from_version,
-            to_version=to_version,
-            baseline_paths=baseline,
-        )
-        if warning:
-            warnings.append(f"Worktree {worktree.name}: {warning}")
-    return warnings
 
 
 # ---------------------------------------------------------------------------
@@ -852,11 +646,7 @@ def upgrade(  # noqa: C901
     if not json_output:
         show_banner()
 
-    baseline_changed_paths = _git_status_paths(project_path)
-    # Per-worktree baselines captured BEFORE any upgrade work, so the upgrade
-    # commits only the migration churn it introduces in each worktree and never
-    # a worktree's pre-existing uncommitted work (#2385).
-    worktree_baselines = {} if no_worktrees else _capture_worktree_baselines(project_path)
+    baseline_changed_paths = autocommit.git_status_paths(project_path)
 
     # Import upgrade system (lazy to avoid circular imports)
     from specify_cli.upgrade.detector import VersionDetector
@@ -932,10 +722,14 @@ def upgrade(  # noqa: C901
                 MigrationRunner._stamp_schema_version(kittify_dir, REQUIRED_SCHEMA_VERSION)
 
         if not no_worktrees and current_version == target_version:
+            # auto_commit: each worktree's upgrade churn lands on its own
+            # branch (#2385) so a later `spec-kitty merge` isn't blocked by
+            # dirty coord/lane worktrees.
             worktrees_result = MigrationRunner(project_path, console)._upgrade_worktrees(
                 target_version,
                 [],
                 dry_run,
+                auto_commit=not dry_run,
             )
             worktree_warnings.extend(worktrees_result.get("warnings", []))
             if worktrees_result.get("errors"):
@@ -943,18 +737,11 @@ def upgrade(  # noqa: C901
                 worktree_warnings.append("Some worktrees had issues - check errors above")
 
         if not dry_run:
-            auto_committed, auto_commit_paths, auto_commit_warning = _auto_commit_upgrade_changes(
-                project_path=project_path,
-                from_version=current_version,
-                to_version=target_version,
-                baseline_paths=baseline_changed_paths,
-            )
-            # Commit upgrade churn in each worktree too (#2385) — otherwise a
-            # later `spec-kitty merge` trips the coord/lane worktree-dirty guard.
-            worktree_warnings.extend(
-                _auto_commit_worktree_upgrade_changes(
-                    worktree_baselines, current_version, target_version
-                )
+            auto_committed, auto_commit_paths, auto_commit_warning = autocommit.commit_touched_checkout(
+                project_path,
+                baseline_changed_paths,
+                current_version,
+                target_version,
             )
 
         if not json_output:
@@ -1056,11 +843,15 @@ def upgrade(  # noqa: C901
 
     # Run migrations
     runner = MigrationRunner(project_path, console)
+    # auto_commit: the runner commits each worktree's upgrade churn on its own
+    # branch (#2385) so a later `spec-kitty merge` isn't blocked by dirty
+    # coord/lane worktrees. The main checkout is committed below by the CLI.
     result = runner.upgrade(
         target_version,
         dry_run=dry_run,
         force=confirm,  # pass the unified confirm flag
         include_worktrees=not no_worktrees,
+        auto_commit=not dry_run,
     )
 
     auto_committed = False
@@ -1072,21 +863,14 @@ def upgrade(  # noqa: C901
             auto_commit_warning = "Skipped auto-commit because the upgrade preserved customized files that require manual review."
             result.warnings.append(auto_commit_warning)
         else:
-            auto_committed, auto_commit_paths_list, auto_commit_warning = _auto_commit_upgrade_changes(
-                project_path=project_path,
-                from_version=result.from_version,
-                to_version=result.to_version,
-                baseline_paths=baseline_changed_paths,
+            auto_committed, auto_commit_paths_list, auto_commit_warning = autocommit.commit_touched_checkout(
+                project_path,
+                baseline_changed_paths,
+                result.from_version,
+                result.to_version,
             )
             if auto_commit_warning:
                 result.warnings.append(auto_commit_warning)
-            # Commit upgrade churn in each worktree too (#2385) so a later
-            # `spec-kitty merge` isn't blocked by dirty coord/lane worktrees.
-            result.warnings.extend(
-                _auto_commit_worktree_upgrade_changes(
-                    worktree_baselines, result.from_version, result.to_version
-                )
-            )
 
     if result.success and not json_output:
         offer_teamspace_mission_state_migration(

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -725,10 +725,9 @@ def upgrade(  # noqa: C901
             # auto_commit: each worktree's upgrade churn lands on its own
             # branch (#2385) so a later `spec-kitty merge` isn't blocked by
             # dirty coord/lane worktrees.
-            worktrees_result = MigrationRunner(project_path, console)._upgrade_worktrees(
+            worktrees_result = MigrationRunner(project_path, console).upgrade_worktrees_only(
                 target_version,
-                [],
-                dry_run,
+                dry_run=dry_run,
                 auto_commit=not dry_run,
             )
             worktree_warnings.extend(worktrees_result.get("warnings", []))

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -60,6 +60,7 @@ from specify_cli.cli.commands._teamspace_mission_state_gate import (
     offer_teamspace_mission_state_migration,
 )
 from specify_cli.core.commit_guard import GuardCapability
+from specify_cli.core.constants import WORKTREES_DIR
 from specify_cli.core.env import is_truthy
 from specify_cli.core.version_compare import is_version_newer
 from specify_cli.git.commit_helpers import safe_commit
@@ -232,6 +233,52 @@ def _auto_commit_upgrade_changes(
         )
 
     return True, committed_paths, None
+
+
+def _capture_worktree_baselines(project_path: Path) -> dict[Path, set[str] | None]:
+    """Capture a git-status baseline for each worktree under ``.worktrees/``.
+
+    Returned before any upgrade work runs so the per-worktree auto-commit can
+    stage only the migration changes the upgrade *introduces*, leaving any
+    pre-existing uncommitted work in a worktree untouched (#2385).
+    """
+    worktrees_dir = project_path / WORKTREES_DIR
+    baselines: dict[Path, set[str] | None] = {}
+    if not worktrees_dir.exists():
+        return baselines
+    for worktree in sorted(worktrees_dir.iterdir(), key=lambda p: p.name):
+        if worktree.is_dir() and not worktree.is_symlink():
+            baselines[worktree] = _git_status_paths(worktree)
+    return baselines
+
+
+def _auto_commit_worktree_upgrade_changes(
+    worktree_baselines: dict[Path, set[str] | None],
+    from_version: str,
+    to_version: str,
+) -> list[str]:
+    """Auto-commit upgrade churn in each worktree, mirroring the main checkout.
+
+    ``spec-kitty upgrade`` applies migrations across sibling worktrees but
+    historically committed only the main checkout, leaving worktrees dirty and
+    blocking a later ``spec-kitty merge`` (#1826/NFR-002 refuses to advance a
+    branch whose worktree has uncommitted changes) — see #2385. Commit each
+    worktree's *new* upgrade changes on its own branch; the per-worktree
+    baseline protects any pre-existing uncommitted work.
+    """
+    warnings: list[str] = []
+    for worktree, baseline in worktree_baselines.items():
+        if not worktree.exists():
+            continue
+        _committed, _paths, warning = _auto_commit_upgrade_changes(
+            project_path=worktree,
+            from_version=from_version,
+            to_version=to_version,
+            baseline_paths=baseline,
+        )
+        if warning:
+            warnings.append(f"Worktree {worktree.name}: {warning}")
+    return warnings
 
 
 # ---------------------------------------------------------------------------
@@ -806,6 +853,10 @@ def upgrade(  # noqa: C901
         show_banner()
 
     baseline_changed_paths = _git_status_paths(project_path)
+    # Per-worktree baselines captured BEFORE any upgrade work, so the upgrade
+    # commits only the migration churn it introduces in each worktree and never
+    # a worktree's pre-existing uncommitted work (#2385).
+    worktree_baselines = {} if no_worktrees else _capture_worktree_baselines(project_path)
 
     # Import upgrade system (lazy to avoid circular imports)
     from specify_cli.upgrade.detector import VersionDetector
@@ -897,6 +948,13 @@ def upgrade(  # noqa: C901
                 from_version=current_version,
                 to_version=target_version,
                 baseline_paths=baseline_changed_paths,
+            )
+            # Commit upgrade churn in each worktree too (#2385) — otherwise a
+            # later `spec-kitty merge` trips the coord/lane worktree-dirty guard.
+            worktree_warnings.extend(
+                _auto_commit_worktree_upgrade_changes(
+                    worktree_baselines, current_version, target_version
+                )
             )
 
         if not json_output:
@@ -1022,6 +1080,13 @@ def upgrade(  # noqa: C901
             )
             if auto_commit_warning:
                 result.warnings.append(auto_commit_warning)
+            # Commit upgrade churn in each worktree too (#2385) so a later
+            # `spec-kitty merge` isn't blocked by dirty coord/lane worktrees.
+            result.warnings.extend(
+                _auto_commit_worktree_upgrade_changes(
+                    worktree_baselines, result.from_version, result.to_version
+                )
+            )
 
     if result.success and not json_output:
         offer_teamspace_mission_state_migration(

--- a/src/specify_cli/upgrade/autocommit.py
+++ b/src/specify_cli/upgrade/autocommit.py
@@ -1,0 +1,215 @@
+"""Canonical per-checkout auto-commit for ``spec-kitty upgrade`` (#2392).
+
+One routine, applied uniformly to every checkout an upgrade run touches —
+the main checkout and each live ``.worktrees/*`` (coordination + lane) —
+so upgrade/migration churn always lands as a commit instead of dirtying the
+tree and tripping the ``spec-kitty merge`` worktree-dirty guard
+(#1826/NFR-002) later.
+
+The invariant (epic #2392): every path an upgrade run writes or migrates,
+in every checkout it touches, must end in exactly one auto-commit — with
+the commit-set derived from that checkout's real ``git status --porcelain``
+diff against a pre-write baseline, never a hardcoded file list (#2105).
+The baseline diff also guarantees pre-existing uncommitted work in a
+checkout (e.g. in-flight WP edits in a lane worktree) is never swept into
+an upgrade commit.
+
+Callers:
+
+* ``specify_cli.cli.commands.upgrade`` — the main checkout (both the
+  no-migrations and the migrations paths).
+* ``specify_cli.upgrade.runner.MigrationRunner._upgrade_worktrees`` — each
+  sibling worktree, right after that worktree's migration/metadata writes
+  (#2385).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from mission_runtime import CommitTarget
+
+from specify_cli.core.commit_guard import GuardCapability
+from specify_cli.git.commit_helpers import safe_commit
+
+UPGRADE_COMMIT_SKIP_WARNING = "Could not auto-commit upgrade changes; please review and commit manually."
+
+DETACHED_HEAD_WARNING = (
+    "Checkout is on a detached HEAD; skipped auto-committing upgrade changes — please review and commit manually."
+)
+
+
+def git_status_paths(repo_path: Path) -> set[str] | None:
+    """Return git status paths for *repo_path* using porcelain -z output.
+
+    Returns ``None`` when ``git status`` fails (e.g. not a git repo) so
+    callers can distinguish "no dirty files" from "unable to determine".
+    """
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "-z"],
+        cwd=repo_path,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+
+    entries = result.stdout.decode("utf-8", errors="replace").split("\0")
+    paths: set[str] = set()
+
+    i = 0
+    while i < len(entries):
+        entry = entries[i]
+        i += 1
+        if not entry or len(entry) < 4:
+            continue
+
+        status = entry[:2]
+        path = entry[3:]
+
+        # With -z format, renames/copies include a second NUL-separated
+        # path.  We take the *destination* (new name); the source (old name)
+        # is intentionally discarded because we care about "what exists now".
+        if ("R" in status or "C" in status) and i < len(entries) and entries[i]:
+            path = entries[i]
+            i += 1
+
+        normalized = path.strip().replace("\\", "/")
+        if normalized.startswith("./"):
+            normalized = normalized[2:]
+
+        if normalized:
+            paths.add(normalized)
+
+    return paths
+
+
+def is_upgrade_commit_eligible(path: str, checkout: Path) -> bool:
+    """Return True when a changed file should be included in upgrade auto-commit."""
+    normalized = path.strip().replace("\\", "/")
+    if not normalized:
+        return False
+
+    # Ignore paths that are outside the repo and root-level files — except
+    # .gitignore: the gitignore-backfill migrations write it, and leaving it
+    # dirty is exactly the merge-blocking churn #2385 reports.
+    if normalized.startswith("../"):
+        return False
+    if "/" not in normalized and normalized != ".gitignore":
+        return False
+
+    # Never auto-commit ~/.kittify when users run inside their home directory.
+    return not (checkout.resolve() == Path.home().resolve() and normalized.startswith(".kittify/"))
+
+
+def expand_upgrade_commit_path(checkout: Path, relative_path: str) -> list[Path]:
+    """Expand a changed path into the concrete file paths git will stage.
+
+    ``git status --porcelain -z`` may report untracked directories as a single
+    path (for example ``.agents/skills/new-skill``). ``git add <dir>`` stages
+    the files inside that directory, but ``safe_commit``'s backstop compares the
+    staged file paths against the requested path list. Expand directories here
+    so the expected set matches what git will actually stage.
+    """
+    normalized = relative_path.strip().replace("\\", "/")
+    absolute_path = checkout / normalized
+
+    if absolute_path.exists() and absolute_path.is_dir() and not absolute_path.is_symlink():
+        return sorted(child.relative_to(checkout) for child in absolute_path.rglob("*") if not child.is_dir())
+
+    return [Path(normalized)]
+
+
+def prepare_upgrade_commit_files(
+    checkout: Path,
+    baseline_paths: set[str] | None,
+) -> list[Path]:
+    """Collect newly changed checkout files after an upgrade run.
+
+    Returns an empty list when *baseline_paths* is ``None`` (git status
+    failed at baseline time) to avoid accidentally committing unrelated work.
+    """
+    if baseline_paths is None:
+        return []
+
+    current_paths = git_status_paths(checkout)
+    if current_paths is None:
+        return []
+
+    new_paths = sorted(path for path in current_paths if path not in baseline_paths and is_upgrade_commit_eligible(path, checkout))
+    files_to_commit: list[Path] = []
+    seen_paths: set[str] = set()
+    for path in new_paths:
+        for expanded_path in expand_upgrade_commit_path(checkout, path):
+            normalized = str(expanded_path).replace("\\", "/")
+            if normalized in seen_paths:
+                continue
+            seen_paths.add(normalized)
+            files_to_commit.append(Path(normalized))
+    return files_to_commit
+
+
+def commit_touched_checkout(
+    checkout: Path,
+    baseline_paths: set[str] | None,
+    from_version: str,
+    to_version: str,
+) -> tuple[bool, list[str], str | None]:
+    """Auto-commit the upgrade churn a run introduced in *checkout*.
+
+    The commit-set is the porcelain diff against *baseline_paths* (captured
+    before any upgrade write to this checkout), filtered through the
+    eligibility rules — never a hardcoded list (#2105). Works identically for
+    the main checkout and for coord/lane worktrees (#2385): the commit lands
+    on whatever branch the checkout has checked out.
+
+    Returns ``(committed, paths, warning)``.
+    """
+    files_to_commit = prepare_upgrade_commit_files(checkout, baseline_paths)
+    if not files_to_commit:
+        return False, [], None
+
+    commit_message = f"chore: apply spec-kitty upgrade changes ({from_version} -> {to_version})"
+    committed_paths = [str(path).replace("\\", "/") for path in files_to_commit]
+    try:
+        destination_ref = subprocess.check_output(
+            ["git", "-C", str(checkout), "branch", "--show-current"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        destination_ref = "main"
+
+    if not destination_ref:
+        # Detached HEAD (or bare checkout): there is no branch to land the
+        # bookkeeping commit on. Never guess a ref here — committing upgrade
+        # churn onto the wrong branch is worse than leaving it for review.
+        return False, committed_paths, DETACHED_HEAD_WARNING
+
+    # The upgrade flow runs outside any mission, so there is no coordination
+    # split to reconcile: the current branch is landing == coordination ==
+    # target. Construct a ref-only CommitTarget (C-007) for it and assert the
+    # upgrade bookkeeping capability explicitly (T009 / FR-008). The old reliance
+    # on the "chore: apply spec-kitty upgrade changes" message-prefix exception is
+    # now irrelevant — the message is just a message; the capability carries the
+    # authorization to land on a protected branch (e.g. the operator's main).
+    upgrade_target = CommitTarget(ref=destination_ref)
+
+    try:
+        safe_commit(
+            repo_root=checkout,
+            worktree_root=checkout,
+            target=upgrade_target,
+            message=commit_message,
+            paths=tuple(files_to_commit),
+            capability=GuardCapability.UPGRADE_BOOKKEEPING,
+        )
+    except Exception:
+        return (
+            False,
+            committed_paths,
+            UPGRADE_COMMIT_SKIP_WARNING,
+        )
+
+    return True, committed_paths, None

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -200,6 +200,31 @@ class MigrationRunner:
 
         return result
 
+    def upgrade_worktrees_only(
+        self,
+        target_version: str,
+        dry_run: bool = False,
+        auto_commit: bool = False,
+    ) -> dict[str, Any]:
+        """Upgrade worktrees without running any migrations on the main checkout.
+
+        Public entry point for the no-migrations path in the CLI, where the
+        main checkout is already at target_version and only the sibling
+        worktrees need their metadata stamps refreshed.  Exposes the private
+        ``_upgrade_worktrees`` implementation behind a stable, named contract
+        so callers are not coupled to an internal method name.
+
+        Args:
+            target_version: Version to stamp on each worktree's metadata.
+            dry_run: If True, simulate but do not write.
+            auto_commit: If True, commit each worktree's upgrade churn on its
+                own branch after that worktree's writes (#2385).
+
+        Returns:
+            Dict with ``warnings`` and ``errors`` lists.
+        """
+        return self._upgrade_worktrees(target_version, [], dry_run, auto_commit=auto_commit)
+
     def _apply_migration(
         self,
         migration: BaseMigration,

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from specify_cli.core.constants import KITTIFY_DIR, WORKTREES_DIR
 from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
 
+from . import autocommit
 from .detector import VersionDetector
 from .metadata import ProjectMetadata
 from .migrations.base import BaseMigration, MigrationResult
@@ -78,6 +79,7 @@ class MigrationRunner:
         dry_run: bool = False,
         force: bool = False,  # noqa: ARG002
         include_worktrees: bool = True,
+        auto_commit: bool = False,
     ) -> UpgradeResult:
         """Run all needed migrations to reach target version.
 
@@ -86,6 +88,9 @@ class MigrationRunner:
             dry_run: If True, simulate but don't apply
             force: If True, skip confirmation prompts
             include_worktrees: If True, also upgrade worktrees
+            auto_commit: If True, auto-commit each worktree's upgrade churn on
+                its own branch (#2385). The main checkout's commit stays with
+                the CLI caller, which owns the main baseline.
 
         Returns:
             UpgradeResult with details of the upgrade
@@ -130,7 +135,7 @@ class MigrationRunner:
                 self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
 
             if include_worktrees and from_version == target_version:
-                worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run)
+                worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run, auto_commit=auto_commit)
                 result.warnings.extend(worktrees_result.get("warnings", []))
                 if worktrees_result.get("errors"):
                     result.errors.extend(worktrees_result["errors"])
@@ -186,7 +191,7 @@ class MigrationRunner:
 
         # Handle worktrees
         if include_worktrees:
-            worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run)
+            worktrees_result = self._upgrade_worktrees(target_version, migrations, dry_run, auto_commit=auto_commit)
             result.warnings.extend(worktrees_result.get("warnings", []))
             if worktrees_result.get("errors"):
                 result.errors.extend(worktrees_result["errors"])
@@ -270,6 +275,7 @@ class MigrationRunner:
         target_version: str,
         migrations: list[BaseMigration],
         dry_run: bool,
+        auto_commit: bool = False,
     ) -> dict[str, Any]:
         """Upgrade all worktrees in .worktrees/ directory.
 
@@ -277,6 +283,11 @@ class MigrationRunner:
             target_version: Target version
             migrations: List of migrations to apply
             dry_run: Whether to simulate only
+            auto_commit: If True, commit each worktree's upgrade churn on its
+                own branch after that worktree's writes (#2385). The commit-set
+                is the porcelain diff against a baseline captured before this
+                worktree's writes, so pre-existing uncommitted work in a live
+                lane worktree is never swept in.
 
         Returns:
             Dict with warnings and errors lists
@@ -304,14 +315,25 @@ class MigrationRunner:
             if not has_upgradeable_state:
                 continue
 
+            # Baseline BEFORE any write to this worktree, so the auto-commit
+            # below stages only the churn this upgrade run introduces (#2385).
+            wt_baseline = autocommit.git_status_paths(worktree) if auto_commit and not dry_run else None
+
             # Load or create worktree metadata
             wt_metadata = ProjectMetadata.load(wt_kittify)
+            wt_metadata_synthesized = wt_metadata is None
             if wt_metadata is None:
                 wt_detector = VersionDetector(worktree)
                 wt_version = wt_detector.detect_version()
                 wt_metadata = self._create_initial_metadata(wt_version)
+            wt_from_version = wt_metadata.version
 
-            worktree_metadata_dirty = False
+            # Freshly synthesized metadata must be persisted even when the
+            # detected version already equals the target — otherwise the
+            # version-bump below never fires, the save is skipped, and the
+            # self-healing path silently regresses (#1873, regression of #1857).
+            worktree_metadata_dirty = wt_metadata_synthesized
+            worktree_manual_review = False
 
             # Apply migrations to worktree
             for migration in worktree_migrations:
@@ -340,6 +362,8 @@ class MigrationRunner:
                     continue
 
                 migration_result = migration.apply(worktree, dry_run=dry_run)
+                if migration_result.manual_review_required:
+                    worktree_manual_review = True
 
                 if migration_result.success:
                     if not dry_run and self._record_migration_result(
@@ -367,8 +391,9 @@ class MigrationRunner:
                     result["errors"].extend([f"Worktree {worktree.name}: {e}" for e in migration_result.errors])
 
             # Save worktree metadata only when something material changed
-            # (a migration record was written or the version advanced); a
-            # no-op upgrade must not rewrite last_upgraded_at (issue #1838).
+            # (a migration record was written, metadata was synthesized fresh,
+            # or the version advanced); a no-op upgrade must not rewrite
+            # last_upgraded_at (issue #1838).
             if not dry_run:
                 if wt_metadata.version != target_version:
                     wt_metadata.version = target_version
@@ -381,6 +406,24 @@ class MigrationRunner:
                 # model, so stamp after save just like the main project path.
                 if REQUIRED_SCHEMA_VERSION is not None:
                     self._stamp_schema_version(wt_kittify, REQUIRED_SCHEMA_VERSION)
+
+                # Commit this worktree's upgrade churn on its own branch
+                # (#2385); the baseline diff keeps pre-existing uncommitted
+                # work (e.g. in-flight WP edits) out of the commit.
+                if auto_commit:
+                    if worktree_manual_review:
+                        result["warnings"].append(
+                            f"Worktree {worktree.name}: Skipped auto-commit because the upgrade preserved customized files that require manual review."
+                        )
+                    else:
+                        _committed, _paths, wt_commit_warning = autocommit.commit_touched_checkout(
+                            worktree,
+                            wt_baseline,
+                            wt_from_version,
+                            target_version,
+                        )
+                        if wt_commit_warning:
+                            result["warnings"].append(f"Worktree {worktree.name}: {wt_commit_warning}")
 
         return result
 

--- a/tests/architectural/test_guard_capability_call_sites.py
+++ b/tests/architectural/test_guard_capability_call_sites.py
@@ -48,8 +48,11 @@ _PROTECTED_FLOW_ALLOWLISTS: dict[str, frozenset[str]] = {
     # seam `git/bookkeeping_commit.py` (#2280 / PR #2281) — a single sanctioned
     # protected-flow commit surface, not a second guard-capability call site.
     "MERGE_BOOKKEEPING": frozenset({_ENUM_HOME, "src/specify_cli/git/bookkeeping_commit.py"}),
-    # The bona-fide upgrade bookkeeping flow.
-    "UPGRADE_BOOKKEEPING": frozenset({_ENUM_HOME, "src/specify_cli/cli/commands/upgrade.py"}),
+    # The bona-fide upgrade bookkeeping flow. Main checkout AND every sibling
+    # worktree (#2385 / epic #2392) land their upgrade commit through the ONE
+    # shared seam `upgrade/autocommit.py` — a single sanctioned protected-flow
+    # commit surface, mirroring the MERGE_BOOKKEEPING consolidation above.
+    "UPGRADE_BOOKKEEPING": frozenset({_ENUM_HOME, "src/specify_cli/upgrade/autocommit.py"}),
     # No reachable caller today (S6 debt: wire or delete).
     "RELEASE_FLOW": frozenset({_ENUM_HOME}),
 }

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -11,6 +11,7 @@ import pytest
 import typer
 
 import specify_cli.cli.commands.upgrade as upgrade_cmd
+from specify_cli.upgrade import autocommit
 from specify_cli.upgrade.migrations.base import MigrationResult
 from specify_cli.upgrade.runner import UpgradeResult
 
@@ -31,7 +32,7 @@ def test_git_status_paths_parses_modified_files(tmp_path: Path, monkeypatch) -> 
         "run",
         lambda *_args, **_kwargs: fake_result,
     )
-    paths = upgrade_cmd._git_status_paths(tmp_path)
+    paths = autocommit.git_status_paths(tmp_path)
     assert paths == {"src/foo.py", "src/bar.py"}
 
 
@@ -40,7 +41,7 @@ def test_git_status_paths_parses_added_and_untracked(tmp_path: Path, monkeypatch
     raw = b"A  .kittify/metadata.yaml\0?? docs/new.md\0"
     fake_result = MagicMock(returncode=0, stdout=raw)
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
-    paths = upgrade_cmd._git_status_paths(tmp_path)
+    paths = autocommit.git_status_paths(tmp_path)
     assert paths == {".kittify/metadata.yaml", "docs/new.md"}
 
 
@@ -50,7 +51,7 @@ def test_git_status_paths_handles_rename(tmp_path: Path, monkeypatch) -> None:
     raw = b"R  old.py\0new.py\0"
     fake_result = MagicMock(returncode=0, stdout=raw)
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
-    paths = upgrade_cmd._git_status_paths(tmp_path)
+    paths = autocommit.git_status_paths(tmp_path)
     assert "new.py" in paths
     assert "old.py" not in paths
 
@@ -59,7 +60,7 @@ def test_git_status_paths_returns_none_on_failure(tmp_path: Path, monkeypatch) -
     """Non-zero returncode → None (not empty set)."""
     fake_result = MagicMock(returncode=128, stdout=b"")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
-    result = upgrade_cmd._git_status_paths(tmp_path)
+    result = autocommit.git_status_paths(tmp_path)
     assert result is None
 
 
@@ -67,7 +68,7 @@ def test_git_status_paths_empty_repo(tmp_path: Path, monkeypatch) -> None:
     """Clean working tree returns empty set (not None)."""
     fake_result = MagicMock(returncode=0, stdout=b"")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
-    result = upgrade_cmd._git_status_paths(tmp_path)
+    result = autocommit.git_status_paths(tmp_path)
     assert result == set()
 
 
@@ -76,7 +77,7 @@ def test_git_status_paths_strips_dot_slash(tmp_path: Path, monkeypatch) -> None:
     raw = b" M ./src/foo.py\0"
     fake_result = MagicMock(returncode=0, stdout=raw)
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
-    paths = upgrade_cmd._git_status_paths(tmp_path)
+    paths = autocommit.git_status_paths(tmp_path)
     assert paths == {"src/foo.py"}
 
 
@@ -86,32 +87,38 @@ def test_git_status_paths_strips_dot_slash(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_eligible_subdirectory_file(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible("kitty-specs/001/WP01.md", tmp_path) is True
+    assert autocommit.is_upgrade_commit_eligible("kitty-specs/001/WP01.md", tmp_path) is True
 
 
 def test_eligible_rejects_empty(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible("", tmp_path) is False
+    assert autocommit.is_upgrade_commit_eligible("", tmp_path) is False
 
 
 def test_eligible_rejects_whitespace_only(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible("   ", tmp_path) is False
+    assert autocommit.is_upgrade_commit_eligible("   ", tmp_path) is False
 
 
 def test_eligible_rejects_root_level_file(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible("README.md", tmp_path) is False
+    assert autocommit.is_upgrade_commit_eligible("README.md", tmp_path) is False
+
+
+def test_eligible_accepts_root_gitignore(tmp_path: Path) -> None:
+    """The gitignore-backfill migrations write the root .gitignore; leaving it
+    dirty is exactly the merge-blocking churn #2385 reports."""
+    assert autocommit.is_upgrade_commit_eligible(".gitignore", tmp_path) is True
 
 
 def test_eligible_rejects_parent_traversal(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible("../secret.txt", tmp_path) is False
+    assert autocommit.is_upgrade_commit_eligible("../secret.txt", tmp_path) is False
 
 
 def test_eligible_accepts_kittify_in_non_home(tmp_path: Path) -> None:
-    assert upgrade_cmd._is_upgrade_commit_eligible(".kittify/metadata.yaml", tmp_path) is True
+    assert autocommit.is_upgrade_commit_eligible(".kittify/metadata.yaml", tmp_path) is True
 
 
 def test_eligible_rejects_home_kittify(monkeypatch) -> None:
     home = Path.home().resolve()
-    assert upgrade_cmd._is_upgrade_commit_eligible(".kittify/metadata.yaml", home) is False
+    assert autocommit.is_upgrade_commit_eligible(".kittify/metadata.yaml", home) is False
 
 
 # ---------------------------------------------------------------------------
@@ -127,8 +134,8 @@ def test_prepare_upgrade_commit_files_excludes_root_files(
     project_path.mkdir()
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_git_status_paths",
+        autocommit,
+        "git_status_paths",
         lambda _repo: {
             ".kittify/metadata.yaml",
             "kitty-specs/001-test/tasks/WP01.md",
@@ -138,7 +145,7 @@ def test_prepare_upgrade_commit_files_excludes_root_files(
         },
     )
 
-    files = upgrade_cmd._prepare_upgrade_commit_files(project_path, baseline_paths=set())
+    files = autocommit.prepare_upgrade_commit_files(project_path, baseline_paths=set())
 
     assert {str(path) for path in files} == {
         ".kittify/metadata.yaml",
@@ -155,15 +162,15 @@ def test_prepare_upgrade_commit_files_excludes_preexisting_changes(
     project_path.mkdir()
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_git_status_paths",
+        autocommit,
+        "git_status_paths",
         lambda _repo: {
             ".kittify/metadata.yaml",
             "kitty-specs/001-test/tasks/WP01.md",
         },
     )
 
-    files = upgrade_cmd._prepare_upgrade_commit_files(
+    files = autocommit.prepare_upgrade_commit_files(
         project_path,
         baseline_paths={"kitty-specs/001-test/tasks/WP01.md"},
     )
@@ -175,8 +182,8 @@ def test_prepare_upgrade_commit_files_skips_home_level_kittify(monkeypatch) -> N
     project_path = Path.home().resolve()
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_git_status_paths",
+        autocommit,
+        "git_status_paths",
         lambda _repo: {
             ".kittify/metadata.yaml",
             "Code/demo/.kittify/metadata.yaml",
@@ -184,7 +191,7 @@ def test_prepare_upgrade_commit_files_skips_home_level_kittify(monkeypatch) -> N
         },
     )
 
-    files = upgrade_cmd._prepare_upgrade_commit_files(project_path, baseline_paths=set())
+    files = autocommit.prepare_upgrade_commit_files(project_path, baseline_paths=set())
 
     assert {str(path) for path in files} == {
         "Code/demo/.kittify/metadata.yaml",
@@ -209,15 +216,15 @@ def test_prepare_upgrade_commit_files_expands_untracked_directories(
     (backup_dir / "manifest.json").write_text("{}", encoding="utf-8")
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_git_status_paths",
+        autocommit,
+        "git_status_paths",
         lambda _repo: {
             ".agents/skills/new-skill",
             ".kittify/.migration-backup",
         },
     )
 
-    files = upgrade_cmd._prepare_upgrade_commit_files(project_path, baseline_paths=set())
+    files = autocommit.prepare_upgrade_commit_files(project_path, baseline_paths=set())
 
     assert [str(path) for path in files] == [
         ".agents/skills/new-skill/SKILL.md",
@@ -235,28 +242,28 @@ def test_prepare_upgrade_commit_files_skips_empty_directories(
     empty_dir.mkdir(parents=True)
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_git_status_paths",
+        autocommit,
+        "git_status_paths",
         lambda _repo: {
             ".agents/skills/empty-skill",
         },
     )
 
-    files = upgrade_cmd._prepare_upgrade_commit_files(project_path, baseline_paths=set())
+    files = autocommit.prepare_upgrade_commit_files(project_path, baseline_paths=set())
 
     assert files == []
 
 
 def test_prepare_skips_when_baseline_is_none(tmp_path: Path) -> None:
     """When baseline git status failed (None), skip auto-commit entirely."""
-    files = upgrade_cmd._prepare_upgrade_commit_files(tmp_path, baseline_paths=None)
+    files = autocommit.prepare_upgrade_commit_files(tmp_path, baseline_paths=None)
     assert files == []
 
 
 def test_prepare_skips_when_current_status_fails(tmp_path: Path, monkeypatch) -> None:
     """When post-upgrade git status fails, skip auto-commit."""
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _repo: None)
-    files = upgrade_cmd._prepare_upgrade_commit_files(tmp_path, baseline_paths=set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _repo: None)
+    files = autocommit.prepare_upgrade_commit_files(tmp_path, baseline_paths=set())
     assert files == []
 
 
@@ -273,8 +280,8 @@ def test_auto_commit_upgrade_changes_calls_safe_commit(
     project_path.mkdir()
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_prepare_upgrade_commit_files",
+        autocommit,
+        "prepare_upgrade_commit_files",
         lambda _project, baseline_paths: [
             Path(".kittify/metadata.yaml"),
             Path("kitty-specs/001-test/tasks/WP01.md"),
@@ -287,18 +294,18 @@ def test_auto_commit_upgrade_changes_calls_safe_commit(
         captured.update(kwargs)
         return object()
 
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
     monkeypatch.setattr(
         subprocess,
         "check_output",
         lambda *_args, **_kwargs: "main\n",
     )
 
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=project_path,
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=project_path,
+        baseline_paths=set(),
         from_version="0.13.0",
         to_version="0.14.0",
-        baseline_paths=set(),
     )
 
     assert committed is True
@@ -331,21 +338,21 @@ def test_auto_commit_returns_warning_on_safe_commit_failure(
     project_path.mkdir()
 
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_prepare_upgrade_commit_files",
+        autocommit,
+        "prepare_upgrade_commit_files",
         lambda _project, baseline_paths: [Path("kitty-specs/001/WP01.md")],
     )
     monkeypatch.setattr(
-        upgrade_cmd,
+        autocommit,
         "safe_commit",
         lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=project_path,
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=project_path,
+        baseline_paths=set(),
         from_version="0.13.0",
         to_version="0.14.0",
-        baseline_paths=set(),
     )
 
     assert committed is False
@@ -360,16 +367,16 @@ def test_auto_commit_noop_when_no_new_files(
 ) -> None:
     """No files to commit → (False, [], None) with no safe_commit call."""
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_prepare_upgrade_commit_files",
+        autocommit,
+        "prepare_upgrade_commit_files",
         lambda _project, baseline_paths: [],
     )
 
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=tmp_path,
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=tmp_path,
+        baseline_paths=set(),
         from_version="0.13.0",
         to_version="0.14.0",
-        baseline_paths=set(),
     )
 
     assert committed is False
@@ -381,16 +388,93 @@ def test_auto_commit_noop_when_baseline_is_none(
     tmp_path: Path,
 ) -> None:
     """None baseline propagates through to no-op (no accidental commits)."""
-    committed, committed_paths, warning = upgrade_cmd._auto_commit_upgrade_changes(
-        project_path=tmp_path,
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=tmp_path,
+        baseline_paths=None,
         from_version="0.13.0",
         to_version="0.14.0",
-        baseline_paths=None,
     )
 
     assert committed is False
     assert committed_paths == []
     assert warning is None
+
+
+def test_commit_set_is_porcelain_derived_not_hardcoded(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """#2105 regression pin: the commit-set must include EVERYTHING the run
+    changed (manifest updates, newly-installed skills), never just
+    .kittify/metadata.yaml. Guards against regressing to a hardcoded list."""
+    checkout = tmp_path / "project"
+    skill_dir = checkout / ".agents" / "skills" / "new-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        autocommit,
+        "git_status_paths",
+        lambda _repo: {
+            ".kittify/metadata.yaml",
+            ".kittify/command-skills-manifest.json",
+            ".agents/skills/new-skill",
+        },
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_safe_commit(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(subprocess, "check_output", lambda *_a, **_kw: "main\n")
+
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=checkout,
+        baseline_paths=set(),
+        from_version="3.2.3",
+        to_version="3.2.4",
+    )
+
+    assert committed is True
+    assert warning is None
+    assert set(committed_paths) == {
+        ".kittify/metadata.yaml",
+        ".kittify/command-skills-manifest.json",
+        ".agents/skills/new-skill/SKILL.md",
+    }
+
+
+def test_commit_skipped_on_detached_head(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A detached-HEAD checkout has no branch to land the bookkeeping commit
+    on — never guess a ref; skip with a warning instead."""
+    monkeypatch.setattr(
+        autocommit,
+        "prepare_upgrade_commit_files",
+        lambda _checkout, baseline_paths: [Path(".kittify/metadata.yaml")],
+    )
+    monkeypatch.setattr(
+        autocommit,
+        "safe_commit",
+        lambda **_kw: (_ for _ in ()).throw(AssertionError("safe_commit must not run on detached HEAD")),
+    )
+    # `git branch --show-current` prints an empty line on detached HEAD.
+    monkeypatch.setattr(subprocess, "check_output", lambda *_a, **_kw: "\n")
+
+    committed, committed_paths, warning = autocommit.commit_touched_checkout(
+        checkout=tmp_path,
+        baseline_paths=set(),
+        from_version="3.2.3",
+        to_version="3.2.4",
+    )
+
+    assert committed is False
+    assert committed_paths == [".kittify/metadata.yaml"]
+    assert warning == autocommit.DETACHED_HEAD_WARNING
 
 
 def test_collect_manual_review_paths_deduplicates() -> None:
@@ -470,9 +554,9 @@ def test_upgrade_no_migrations_json_includes_auto_commit_fields(
             return set()  # baseline: clean
         return {".kittify/metadata.yaml"}  # post-upgrade: metadata changed
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
     monkeypatch.setattr(
-        upgrade_cmd,
+        autocommit,
         "safe_commit",
         lambda **_kw: object(),
     )
@@ -547,8 +631,8 @@ def test_upgrade_no_migrations_stamps_missing_schema_version(
         safe_commit_calls.append([str(path) for path in kwargs["paths"]])
         return object()
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
 
     assert get_project_schema_version(project_path) is None
 
@@ -622,8 +706,8 @@ def test_upgrade_no_migrations_stamps_existing_worktree_schema_version(
         safe_commit_calls.append([str(path) for path in kwargs["paths"]])
         return object()
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
 
     _run_upgrade(
         dry_run=False,
@@ -685,9 +769,9 @@ def test_upgrade_no_migrations_keeps_current_worktree_metadata_clean(
         status_calls["count"] += 1
         return set()
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
     monkeypatch.setattr(
-        upgrade_cmd,
+        autocommit,
         "safe_commit",
         lambda **_kw: (_ for _ in ()).throw(AssertionError("safe_commit should not run")),
     )
@@ -737,8 +821,8 @@ def test_upgrade_no_migrations_respects_no_worktrees_for_schema_stamp(
     )
 
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _repo_path: {".kittify/metadata.yaml"})
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", lambda **_kw: object())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _repo_path: {".kittify/metadata.yaml"})
+    monkeypatch.setattr(autocommit, "safe_commit", lambda **_kw: object())
 
     _run_upgrade(
         dry_run=False,
@@ -763,7 +847,7 @@ def test_upgrade_no_migrations_surfaces_teamspace_mission_state_prompt(
     """A normal upgrade run checks TeamSpace mission-state readiness even when up to date."""
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())
     monkeypatch.setattr(upgrade_cmd, "show_banner", lambda: None)
 
     calls: list[dict[str, object]] = []
@@ -806,7 +890,7 @@ def test_upgrade_dry_run_skips_auto_commit(
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
     # baseline_changed_paths will be called once; auto_commit should not be called
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())
 
     safe_commit_called = {"called": False}
 
@@ -814,7 +898,7 @@ def test_upgrade_dry_run_skips_auto_commit(
         safe_commit_called["called"] = True
         return True
 
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _spy_safe_commit)
+    monkeypatch.setattr(autocommit, "safe_commit", _spy_safe_commit)
 
     # T037 routes dry_run+json_output through the compat-planner path which
     # exits before reaching the auto-commit guard.  The test's goal is just to
@@ -848,7 +932,7 @@ def test_upgrade_dry_run_json_output_exits_before_auto_commit(
         safe_commit_called["called"] = True
         return True
 
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _spy_safe_commit)
+    monkeypatch.setattr(autocommit, "safe_commit", _spy_safe_commit)
 
     # Simulate _run_planner_json's normal behavior: raise typer.Exit(0)
     monkeypatch.setattr(upgrade_cmd, "_run_planner_json", lambda **_kw: (_ for _ in ()).throw(typer.Exit(0)))
@@ -879,7 +963,7 @@ def test_upgrade_baseline_failure_skips_auto_commit(
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
     # Baseline fails → None
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: None)
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: None)
 
     safe_commit_called = {"called": False}
 
@@ -887,7 +971,7 @@ def test_upgrade_baseline_failure_skips_auto_commit(
         safe_commit_called["called"] = True
         return True
 
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _spy_safe_commit)
+    monkeypatch.setattr(autocommit, "safe_commit", _spy_safe_commit)
 
     _run_upgrade(
         dry_run=False,
@@ -922,9 +1006,9 @@ def test_upgrade_no_migrations_rich_output_shows_auto_commit(
             return set()
         return {"kitty-specs/001/tasks/WP01.md"}
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
     monkeypatch.setattr(
-        upgrade_cmd,
+        autocommit,
         "safe_commit",
         lambda **_kw: object(),
     )
@@ -970,9 +1054,9 @@ def test_upgrade_no_migrations_safe_commit_failure_shows_warning(
             return set()
         return {".kittify/metadata.yaml"}
 
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
     monkeypatch.setattr(
-        upgrade_cmd,
+        autocommit,
         "safe_commit",
         lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
@@ -1002,7 +1086,7 @@ def test_upgrade_rejects_downgrade_target_in_json_mode(
     """Downgrade targets should fail before metadata is rewritten."""
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())
 
     with pytest.raises(typer.Exit) as exc:
         _run_upgrade(
@@ -1030,7 +1114,7 @@ def test_upgrade_suppresses_auto_commit_when_manual_review_required(
 ) -> None:
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())
 
     fake_migration = MagicMock(
         migration_id="3.2.0a4_safe_globalize_commands",
@@ -1064,7 +1148,7 @@ def test_upgrade_suppresses_auto_commit_when_manual_review_required(
         safe_commit_called["called"] = True
         return True
 
-    monkeypatch.setattr(upgrade_cmd, "safe_commit", _spy_safe_commit)
+    monkeypatch.setattr(autocommit, "safe_commit", _spy_safe_commit)
 
     _run_upgrade(
         dry_run=False,
@@ -1095,7 +1179,7 @@ def test_upgrade_auto_commits_clean_run_when_no_manual_review(
 ) -> None:
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
-    monkeypatch.setattr(upgrade_cmd, "_git_status_paths", lambda _rp: set())
+    monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())
 
     fake_migration = MagicMock(
         migration_id="3.2.0a4_safe_globalize_commands",
@@ -1119,9 +1203,9 @@ def test_upgrade_auto_commits_clean_run_when_no_manual_review(
         ),
     )
     monkeypatch.setattr(
-        upgrade_cmd,
-        "_auto_commit_upgrade_changes",
-        lambda **_kw: (True, [".kittify/metadata.yaml"], None),
+        autocommit,
+        "commit_touched_checkout",
+        lambda *_a, **_kw: (True, [".kittify/metadata.yaml"], None),
     )
 
     _run_upgrade(

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -477,6 +477,44 @@ def test_commit_skipped_on_detached_head(
     assert warning == autocommit.DETACHED_HEAD_WARNING
 
 
+def test_commit_falls_back_to_main_when_branch_detection_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """When `git branch --show-current` raises, destination_ref falls back to
+    "main" and the commit fires normally — no warning is emitted."""
+    monkeypatch.setattr(
+        autocommit,
+        "prepare_upgrade_commit_files",
+        lambda _checkout, baseline_paths: [Path(".kittify/metadata.yaml")],
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_safe_commit(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(
+        subprocess,
+        "check_output",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, "git")
+        ),
+    )
+
+    committed, _paths, warning = autocommit.commit_touched_checkout(
+        checkout=tmp_path,
+        baseline_paths=set(),
+        from_version="3.2.3",
+        to_version="3.2.4",
+    )
+
+    assert committed is True
+    assert warning is None
+    assert captured["target"].ref == "main"
+
+
 def test_collect_manual_review_paths_deduplicates() -> None:
     paths = upgrade_cmd._collect_manual_review_paths(
         {
@@ -1225,3 +1263,82 @@ def test_upgrade_auto_commits_clean_run_when_no_manual_review(
     assert data["manual_review_paths"] == []
     assert data["auto_committed"] is True
     assert data["auto_commit_paths"] == [".kittify/metadata.yaml"]
+
+
+# ---------------------------------------------------------------------------
+# upgrade_worktrees_only — public entry point (tech-debt follow-up #2387)
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_worktrees_only_delegates_to_private_impl(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """upgrade_worktrees_only() must call _upgrade_worktrees with an empty
+    migrations list, forwarding target_version, dry_run, and auto_commit.
+
+    This pins the public-method contract introduced as the #2387 follow-up:
+    the no-migrations CLI path must no longer call the private ``_upgrade_worktrees``
+    directly.
+    """
+    from specify_cli.upgrade.runner import MigrationRunner
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+
+    calls: list[dict] = []
+
+    def _fake_upgrade_worktrees(
+        target_version: str,
+        migrations: list,
+        dry_run: bool,
+        auto_commit: bool = False,
+    ) -> dict:
+        calls.append(
+            {
+                "target_version": target_version,
+                "migrations": migrations,
+                "dry_run": dry_run,
+                "auto_commit": auto_commit,
+            }
+        )
+        return {"warnings": [], "errors": []}
+
+    runner = MigrationRunner(project_path)
+    monkeypatch.setattr(runner, "_upgrade_worktrees", _fake_upgrade_worktrees)
+
+    result = runner.upgrade_worktrees_only("3.9.0", dry_run=True, auto_commit=False)
+
+    assert result == {"warnings": [], "errors": []}
+    assert len(calls) == 1
+    assert calls[0]["target_version"] == "3.9.0"
+    assert calls[0]["migrations"] == []
+    assert calls[0]["dry_run"] is True
+    assert calls[0]["auto_commit"] is False
+
+
+def test_upgrade_worktrees_only_passes_auto_commit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """auto_commit=True is forwarded through the public entry point."""
+    from specify_cli.upgrade.runner import MigrationRunner
+
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+
+    calls: list[dict] = []
+
+    def _fake_upgrade_worktrees(
+        target_version: str,
+        migrations: list,
+        dry_run: bool,
+        auto_commit: bool = False,
+    ) -> dict:
+        calls.append({"auto_commit": auto_commit})
+        return {"warnings": [], "errors": []}
+
+    runner = MigrationRunner(project_path)
+    monkeypatch.setattr(runner, "_upgrade_worktrees", _fake_upgrade_worktrees)
+
+    runner.upgrade_worktrees_only("3.9.0", dry_run=False, auto_commit=True)
+
+    assert calls[0]["auto_commit"] is True

--- a/tests/upgrade/test_upgrade_worktree_commit.py
+++ b/tests/upgrade/test_upgrade_worktree_commit.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
+from specify_cli.upgrade.registry import MigrationRegistry
 from specify_cli.upgrade.runner import MigrationRunner
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
@@ -153,6 +155,9 @@ def test_synthesized_worktree_metadata_is_saved_when_version_matches_target(
         "synthesized worktree metadata must be saved to disk (#1873)"
     )
     assert _dirty(wt) == [], "the healed metadata must also be committed"
+    assert "spec-kitty upgrade" in _git_out(wt, "log", "-1", "--pretty=%s"), (
+        "synthesized metadata commit must land on the worktree branch (#1873)"
+    )
 
 
 def test_dry_run_writes_and_commits_nothing_in_worktrees(tmp_path: Path) -> None:
@@ -169,7 +174,17 @@ def test_dry_run_writes_and_commits_nothing_in_worktrees(tmp_path: Path) -> None
 
 def test_upgrade_invariant_every_touched_checkout_ends_clean(tmp_path: Path) -> None:
     """Slice C invariant (#2392): after `runner.upgrade(..., auto_commit=True)`,
-    no checkout the run touched has porcelain dirt beyond what pre-existed."""
+    no checkout the run touched has porcelain dirt beyond what pre-existed.
+
+    Note: the runner deliberately leaves the main checkout's commit to the CLI
+    (`commit_touched_checkout` in upgrade.py). The invariant here covers worktrees
+    only; main's remaining dirt is the upgrade churn the CLI will commit on return.
+
+    A stub migration with `runs_on_worktrees=True` is registered so that
+    `_upgrade_worktrees` is actually invoked on the `runner.upgrade()` path.
+    Without it, the no-migration branch skips `_upgrade_worktrees` when
+    `from_version != target_version`, making the test vacuous.
+    """
     root = tmp_path / "repo"
     _init_repo(root)
     wt = _add_worktree(root, "m-lane-e", "kitty/mission-m-lane-e")
@@ -178,14 +193,37 @@ def test_upgrade_invariant_every_touched_checkout_ends_clean(tmp_path: Path) -> 
     (wt / "kitty-specs").mkdir()
     (wt / "kitty-specs" / "wip.md").write_text("wip\n", encoding="utf-8")
 
-    result = MigrationRunner(root).upgrade("3.2.9", dry_run=False, auto_commit=True)
-    assert result.success, result.errors
+    # Register a stub migration so the migrations path is taken and
+    # _upgrade_worktrees is called. Clear first to prevent order-fragility.
+    MigrationRegistry.clear()
 
-    # The worktree's only remaining dirt is the pre-existing WIP file
-    # (reported by porcelain as its untracked directory).
-    assert [ln for ln in _dirty(wt) if "kitty-specs" not in ln] == []
-    # The runner does not commit the main checkout (that is the CLI's half of
-    # the seam) — but everything it wrote there is upgrade churn the CLI's
-    # commit_touched_checkout would pick up (.kittify/* and .gitignore).
-    main_dirt = _dirty(root)
-    assert all(".kittify/" in ln or ".gitignore" in ln for ln in main_dirt), main_dirt
+    @MigrationRegistry.register
+    class _InvariantStubMigration(BaseMigration):
+        migration_id = "test_invariant_stub_3_2_9"
+        description = "Invariant-test stub — never runs outside this test"
+        target_version = "3.2.9"
+
+        def detect(self, project_path: Path) -> bool:
+            return not (project_path / ".kittify" / ".invariant-stub").exists()
+
+        def can_apply(self, project_path: Path) -> tuple[bool, str]:
+            return True, ""
+
+        def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+            if not dry_run:
+                (project_path / ".kittify").mkdir(exist_ok=True)
+                (project_path / ".kittify" / ".invariant-stub").write_text("1", encoding="utf-8")
+            return MigrationResult(success=True, changes_made=["wrote .kittify/.invariant-stub"])
+
+    try:
+        result = MigrationRunner(root).upgrade("3.2.9", dry_run=False, auto_commit=True)
+        assert result.success, result.errors
+
+        # Worktree: only the pre-existing WIP dir survives uncommitted.
+        assert [ln for ln in _dirty(wt) if "kitty-specs" not in ln] == []
+        # Main: runner leaves it for the CLI commit seam — remaining dirt must be
+        # upgrade churn only (.kittify/* writes), never pre-existing files.
+        main_dirt = _dirty(root)
+        assert all(".kittify/" in ln or ".gitignore" in ln for ln in main_dirt), main_dirt
+    finally:
+        MigrationRegistry.clear()

--- a/tests/upgrade/test_upgrade_worktree_commit.py
+++ b/tests/upgrade/test_upgrade_worktree_commit.py
@@ -1,11 +1,18 @@
-"""Regression: upgrade auto-commits churn in worktrees too, not just main (#2385).
+"""Upgrade-worktree coherence: the runner commits each checkout it touches (#2392).
 
-`spec-kitty upgrade` applies migrations across sibling worktrees but historically
-committed only the main checkout, leaving worktrees dirty — which then blocked
-`spec-kitty merge` (the #1826/NFR-002 guard refuses to advance a branch whose
-worktree has uncommitted changes). These tests pin the fix: upgrade commits each
-worktree's new churn on its own branch, while a per-worktree baseline protects
-any pre-existing uncommitted work.
+`spec-kitty upgrade` applies migrations across sibling worktrees but
+historically committed only the main checkout, leaving worktrees dirty — which
+then blocked `spec-kitty merge` (the #1826/NFR-002 guard refuses to advance a
+branch whose worktree has uncommitted changes). These tests pin the canonical
+seam fix (epic #2392):
+
+* #2385 — ``MigrationRunner._upgrade_worktrees`` auto-commits each worktree's
+  new churn on that worktree's own branch, with a per-worktree baseline
+  protecting pre-existing uncommitted work.
+* #1873 — freshly synthesized worktree metadata is persisted (and committed)
+  even when the detected version already equals the target.
+* Invariant (Slice C): after an upgrade run, every touched checkout has no
+  porcelain diff beyond what was already dirty before the run.
 """
 
 from __future__ import annotations
@@ -15,26 +22,48 @@ from pathlib import Path
 
 import pytest
 
-from specify_cli.cli.commands.upgrade import (
-    _auto_commit_worktree_upgrade_changes,
-    _capture_worktree_baselines,
-)
+from specify_cli.upgrade.runner import MigrationRunner
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+_METADATA_YAML = (
+    "spec_kitty:\n"
+    "  version: '{version}'\n"
+    "  initialized_at: '2026-01-01T00:00:00'\n"
+    "environment:\n"
+    "  python_version: '3.12'\n"
+    "  platform: linux\n"
+    "  platform_version: ''\n"
+    "migrations:\n"
+    "  applied: []\n"
+)
 
 
 def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
 
 
-def _init_repo(root: Path) -> None:
+def _git_out(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(root: Path, version: str = "3.2.1") -> None:
     root.mkdir(parents=True, exist_ok=True)
     _git(root, "init", "-q", "-b", "main")
     _git(root, "config", "user.email", "t@example.com")
     _git(root, "config", "user.name", "t")
     (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    # Real spec-kitty projects gitignore the execution worktrees.
+    (root / ".gitignore").write_text(".worktrees/\n", encoding="utf-8")
     (root / ".kittify").mkdir()
-    (root / ".kittify" / "metadata.yaml").write_text("version: 3.2.1\n", encoding="utf-8")
+    (root / ".kittify" / "metadata.yaml").write_text(
+        _METADATA_YAML.format(version=version), encoding="utf-8"
+    )
     _git(root, "add", "-A")
     _git(root, "commit", "-q", "-m", "init")
 
@@ -55,48 +84,108 @@ def _dirty(wt: Path) -> list[str]:
     return [ln for ln in out.stdout.splitlines() if ln.strip()]
 
 
-def test_worktree_upgrade_churn_is_committed_clean(tmp_path: Path) -> None:
+def test_worktree_upgrade_churn_is_committed_on_its_own_branch(tmp_path: Path) -> None:
+    """#2385: the runner commits worktree upgrade churn; the tree ends clean."""
     root = tmp_path / "repo"
     _init_repo(root)
     wt = _add_worktree(root, "m-lane-a", "kitty/mission-m-lane-a")
 
-    # Baseline captured before any upgrade change (worktree is clean).
-    baselines = _capture_worktree_baselines(root)
-    assert wt in baselines
-    assert baselines[wt] == set()
+    result = MigrationRunner(root)._upgrade_worktrees(
+        "3.2.9", [], dry_run=False, auto_commit=True
+    )
 
-    # Simulate upgrade migration churn in the worktree.
-    (wt / ".kittify" / "metadata.yaml").write_text("version: 3.2.4\n", encoding="utf-8")
-    assert _dirty(wt), "precondition: worktree is dirty after the churn"
-
-    warnings = _auto_commit_worktree_upgrade_changes(baselines, "3.2.1", "3.2.4")
-
-    assert warnings == [], warnings
+    assert result["errors"] == []
+    assert not any("auto-commit" in w.lower() for w in result["warnings"]), result["warnings"]
     assert _dirty(wt) == [], "worktree must be clean (churn committed) after upgrade"
     # The commit landed on the worktree's own branch.
-    subject = subprocess.run(
-        ["git", "-C", str(wt), "log", "-1", "--pretty=%s"],
-        check=True, capture_output=True, text=True,
-    ).stdout.strip()
-    assert "spec-kitty upgrade" in subject
+    assert _git_out(wt, "branch", "--show-current") == "kitty/mission-m-lane-a"
+    assert "spec-kitty upgrade" in _git_out(wt, "log", "-1", "--pretty=%s")
+    # And main's branch did NOT receive the worktree commit.
+    assert "spec-kitty upgrade" not in _git_out(root, "log", "-1", "--pretty=%s")
 
 
 def test_preexisting_uncommitted_work_in_worktree_is_not_committed(tmp_path: Path) -> None:
+    """#2385 baseline: in-flight WP edits are never swept into the upgrade commit."""
     root = tmp_path / "repo"
     _init_repo(root)
     wt = _add_worktree(root, "m-lane-b", "kitty/mission-m-lane-b")
 
-    # Pre-existing uncommitted work exists BEFORE the upgrade baseline.
-    (wt / ".kittify" / "wip.json").write_text('{"wip": true}\n', encoding="utf-8")
-    baselines = _capture_worktree_baselines(root)
-    assert ".kittify/wip.json" in baselines[wt]  # captured as pre-existing
+    # Pre-existing uncommitted work exists BEFORE the upgrade runs.
+    (wt / "kitty-specs").mkdir()
+    (wt / "kitty-specs" / "wip.md").write_text("wip\n", encoding="utf-8")
+    (wt / "README.md").write_text("# repo (edited in lane)\n", encoding="utf-8")
 
-    # Now the upgrade introduces its own churn.
-    (wt / ".kittify" / "metadata.yaml").write_text("version: 3.2.4\n", encoding="utf-8")
+    MigrationRunner(root)._upgrade_worktrees("3.2.9", [], dry_run=False, auto_commit=True)
 
-    _auto_commit_worktree_upgrade_changes(baselines, "3.2.1", "3.2.4")
-
-    # metadata churn committed; the pre-existing WIP file remains uncommitted.
     remaining = _dirty(wt)
-    assert any("wip.json" in ln for ln in remaining), remaining
+    # Untracked dirs are reported as a single `?? kitty-specs/` entry.
+    assert any("kitty-specs" in ln for ln in remaining), remaining
+    assert any("README.md" in ln for ln in remaining), remaining
     assert not any("metadata.yaml" in ln for ln in remaining), remaining
+
+
+def test_synthesized_worktree_metadata_is_saved_when_version_matches_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1873: metadata synthesized from None must be persisted (and committed)
+    even when the detected version already equals the target."""
+    root = tmp_path / "repo"
+    _init_repo(root)
+    wt = _add_worktree(root, "m-lane-c", "kitty/mission-m-lane-c")
+
+    # The worktree has a .kittify dir but no metadata.yaml (the self-healing
+    # scenario from #1857), and its detected version already equals the target.
+    (wt / ".kittify" / "metadata.yaml").unlink()
+    _git(wt, "commit", "-q", "-am", "drop worktree metadata")
+
+    class _StubDetector:
+        def __init__(self, _path: Path) -> None:
+            pass
+
+        def detect_version(self) -> str:
+            return "3.2.9"
+
+    monkeypatch.setattr("specify_cli.upgrade.runner.VersionDetector", _StubDetector)
+
+    MigrationRunner(root)._upgrade_worktrees("3.2.9", [], dry_run=False, auto_commit=True)
+
+    assert (wt / ".kittify" / "metadata.yaml").exists(), (
+        "synthesized worktree metadata must be saved to disk (#1873)"
+    )
+    assert _dirty(wt) == [], "the healed metadata must also be committed"
+
+
+def test_dry_run_writes_and_commits_nothing_in_worktrees(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _init_repo(root)
+    wt = _add_worktree(root, "m-lane-d", "kitty/mission-m-lane-d")
+    head_before = _git_out(wt, "rev-parse", "HEAD")
+
+    MigrationRunner(root)._upgrade_worktrees("3.2.9", [], dry_run=True, auto_commit=True)
+
+    assert _dirty(wt) == []
+    assert _git_out(wt, "rev-parse", "HEAD") == head_before
+
+
+def test_upgrade_invariant_every_touched_checkout_ends_clean(tmp_path: Path) -> None:
+    """Slice C invariant (#2392): after `runner.upgrade(..., auto_commit=True)`,
+    no checkout the run touched has porcelain dirt beyond what pre-existed."""
+    root = tmp_path / "repo"
+    _init_repo(root)
+    wt = _add_worktree(root, "m-lane-e", "kitty/mission-m-lane-e")
+
+    # Pre-existing dirt in the lane worktree (must survive uncommitted).
+    (wt / "kitty-specs").mkdir()
+    (wt / "kitty-specs" / "wip.md").write_text("wip\n", encoding="utf-8")
+
+    result = MigrationRunner(root).upgrade("3.2.9", dry_run=False, auto_commit=True)
+    assert result.success, result.errors
+
+    # The worktree's only remaining dirt is the pre-existing WIP file
+    # (reported by porcelain as its untracked directory).
+    assert [ln for ln in _dirty(wt) if "kitty-specs" not in ln] == []
+    # The runner does not commit the main checkout (that is the CLI's half of
+    # the seam) — but everything it wrote there is upgrade churn the CLI's
+    # commit_touched_checkout would pick up (.kittify/* and .gitignore).
+    main_dirt = _dirty(root)
+    assert all(".kittify/" in ln or ".gitignore" in ln for ln in main_dirt), main_dirt

--- a/tests/upgrade/test_upgrade_worktree_commit.py
+++ b/tests/upgrade/test_upgrade_worktree_commit.py
@@ -1,0 +1,102 @@
+"""Regression: upgrade auto-commits churn in worktrees too, not just main (#2385).
+
+`spec-kitty upgrade` applies migrations across sibling worktrees but historically
+committed only the main checkout, leaving worktrees dirty — which then blocked
+`spec-kitty merge` (the #1826/NFR-002 guard refuses to advance a branch whose
+worktree has uncommitted changes). These tests pin the fix: upgrade commits each
+worktree's new churn on its own branch, while a per-worktree baseline protects
+any pre-existing uncommitted work.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.cli.commands.upgrade import (
+    _auto_commit_worktree_upgrade_changes,
+    _capture_worktree_baselines,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "t")
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / ".kittify").mkdir()
+    (root / ".kittify" / "metadata.yaml").write_text("version: 3.2.1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "init")
+
+
+def _add_worktree(root: Path, name: str, branch: str) -> Path:
+    wt = root / ".worktrees" / name
+    _git(root, "worktree", "add", "-q", "-b", branch, str(wt))
+    return wt
+
+
+def _dirty(wt: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(wt), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ln for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def test_worktree_upgrade_churn_is_committed_clean(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _init_repo(root)
+    wt = _add_worktree(root, "m-lane-a", "kitty/mission-m-lane-a")
+
+    # Baseline captured before any upgrade change (worktree is clean).
+    baselines = _capture_worktree_baselines(root)
+    assert wt in baselines
+    assert baselines[wt] == set()
+
+    # Simulate upgrade migration churn in the worktree.
+    (wt / ".kittify" / "metadata.yaml").write_text("version: 3.2.4\n", encoding="utf-8")
+    assert _dirty(wt), "precondition: worktree is dirty after the churn"
+
+    warnings = _auto_commit_worktree_upgrade_changes(baselines, "3.2.1", "3.2.4")
+
+    assert warnings == [], warnings
+    assert _dirty(wt) == [], "worktree must be clean (churn committed) after upgrade"
+    # The commit landed on the worktree's own branch.
+    subject = subprocess.run(
+        ["git", "-C", str(wt), "log", "-1", "--pretty=%s"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert "spec-kitty upgrade" in subject
+
+
+def test_preexisting_uncommitted_work_in_worktree_is_not_committed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _init_repo(root)
+    wt = _add_worktree(root, "m-lane-b", "kitty/mission-m-lane-b")
+
+    # Pre-existing uncommitted work exists BEFORE the upgrade baseline.
+    (wt / ".kittify" / "wip.json").write_text('{"wip": true}\n', encoding="utf-8")
+    baselines = _capture_worktree_baselines(root)
+    assert ".kittify/wip.json" in baselines[wt]  # captured as pre-existing
+
+    # Now the upgrade introduces its own churn.
+    (wt / ".kittify" / "metadata.yaml").write_text("version: 3.2.4\n", encoding="utf-8")
+
+    _auto_commit_worktree_upgrade_changes(baselines, "3.2.1", "3.2.4")
+
+    # metadata churn committed; the pre-existing WIP file remains uncommitted.
+    remaining = _dirty(wt)
+    assert any("wip.json" in ln for ln in remaining), remaining
+    assert not any("metadata.yaml" in ln for ln in remaining), remaining


### PR DESCRIPTION
Closes #2385. Closes #1873. Regression-pins #2105. Implements the canonical-seam spine of epic #2392 (architect-alphonso's high-level design posted on the epic).

## Scope — expanded per review

The original PR was a point-fix for #2385 at the CLI layer. Per @stijn-dejongh's review and the #2392 consolidation, it now lands the **one-seam fix for the three members the design shows genuinely collapse into one seam** (#2385 + #1873 + #2105), using the design's target shape.

## The canonical invariant (epic #2392)

> Every path an upgrade run writes or migrates, in every checkout it touches (main + each live `.worktrees/*`), must end in exactly one auto-commit — with the commit-set derived from that checkout's real `git status --porcelain` diff against a pre-write baseline, not a hardcoded file list — or be intentionally reverted before the command returns.

## The fix — one routine, one enumeration, two symmetric call sites

**Extraction (Slice A).** The commit routine (porcelain baseline diff, directory expansion, eligibility filter, `safe_commit(UPGRADE_BOOKKEEPING)`) moves from `cli/commands/upgrade.py` to `specify_cli/upgrade/autocommit.py` as `commit_touched_checkout(checkout, baseline_paths, from_version, to_version)` — parameterized purely on a checkout path, exactly as the design specifies. The guard-capability allowlist moves with it (mirroring the MERGE_BOOKKEEPING one-seam consolidation).

**Per-checkout application (Slice B).**
- *Main*: unchanged call, from the CLI (both the no-migrations and migrations paths).
- *Each worktree* (#2385): `MigrationRunner._upgrade_worktrees` — the owner of the canonical worktree enumeration and of the worktree writes — captures a per-worktree porcelain baseline **before** that worktree's writes and calls the extracted routine **after** them, landing the commit on that worktree's own branch. No second enumeration in the CLI.
- *#1873*: metadata synthesized from `None` is marked dirty at synthesis, so it is saved (and committed) even when the detected version already equals the target — restoring the #1857 self-healing path.
- *#2105*: as the design found, the commit-set on this tree is already porcelain-derived, so the residual defect was scope (main-only), not derivation. Now regression-pinned: a test asserts manifest updates + newly-installed skills land in the commit-set, guarding against regression to the hardcoded-list past.

**Edge cases from the design's risk list.**
- Pre-existing uncommitted work in a live lane worktree (in-flight WP edits) is never swept in — per-worktree baseline diff (test: real git worktree with WIP + README edits).
- Per-worktree `manual_review_required` migrations skip **that worktree's** commit with a warning (finer-grained than the main-only global gate).
- Detached-HEAD checkout → skip the commit with a warning; never guess a ref.
- `--dry-run` remains a strict no-op per checkout (test: HEAD unchanged, tree clean).
- Root `.gitignore` is now commit-eligible: the gitignore-backfill migrations write it, and the old root-level-file filter silently dropped it — leaving exactly the merge-blocking churn #2385 reports. (Caught by the new invariant test, which runs real migrations.)

**Invariant test (Slice C).** After `runner.upgrade(..., auto_commit=True)` on a repo with a live worktree: the worktree carries no porcelain dirt beyond what pre-existed; everything the run wrote to main is within the CLI commit's reach.

## Deliberately fenced OUT — #2367 (per the design's §7, honestly)

The design's verdict is that this cluster is *one shared invariant realized at three seams*, and forcing #2367 through the upgrade helper would be the split-brain outcome in the opposite direction:
- **#2367-A** (VCS-lock at implement-claim) is a genuine policy decision — the current exclusion is a deliberate, race-motivated choice (#2222/C-003). Committing the lock here would silently reverse it.
- **#2367-B** (rolled-back merge leaves stale coord status writes) is the rollback dual, living in the merge executor's snapshot capture set.

Both stay open on #2392 as sibling members with their own seams (the design suggests a fenced Slice D / follow-up).

## Boundary noted (not changed here)

`_run_upgrade_surface_repair` runs **after** the auto-commit on both CLI paths, so surface-repair writes (healed skills/profiles) are intentionally left for the operator — that ordering pre-dates this PR and has its own interactive/drift-policy semantics. If the invariant should swallow repair writes too, that's a deliberate reordering decision I'd rather take separately.

## Tests

- `tests/upgrade/test_upgrade_worktree_commit.py` (real git worktrees, rewritten to the runner seam): #2385 commit-on-own-branch + main untouched; baseline protects pre-existing WIP; #1873 synthesis-save + commit; dry-run no-op; Slice-C invariant with real migrations.
- `tests/upgrade/test_upgrade_auto_commit_unit.py` retargeted to `upgrade.autocommit`; adds the #2105 regression pin and the detached-HEAD guard.
- Full sweep: 1127 upgrade-related tests green (`-k upgrade` across the repo), `tests/architectural` guard-capability + no-dead-modules gates green, `ruff` + `mypy` clean.