### PR TITLE
fix(sync): honest SaaS opt-in message + typed remote_sync fields (#2264 slice)

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -50,6 +50,7 @@ from specify_cli.core.vcs import (
 )
 
 from specify_cli.sync.queue import QueueStats
+from specify_cli.core.saas_sync_config import saas_sync_opt_in_recorded_message
 from specify_cli.sync.feature_flags import (
     SAAS_SYNC_ENV_VAR,
     is_saas_sync_enabled,
@@ -1374,12 +1375,16 @@ def opt_in(
         remember_repo_default=not checkout_only,
     )
 
-    console.print(
-        f"[green]✓[/green] Enabled SaaS sync for this checkout "
-        f"([cyan]{refreshed.repo_slug or refreshed.project_slug or refreshed.project_uuid}[/cyan])."
-    )
+    # Honest confirmation (#2264): opt-in writes LOCAL routing flags only — no
+    # auth, no remote round-trip, no history import. The message must not imply
+    # remote materialization (the prior "Enabled SaaS sync" wording was the
+    # false-green that escalated #2264 to P1).
+    scope_label = refreshed.repo_slug or refreshed.project_slug or refreshed.project_uuid
+    console.print(f"[green]✓[/green] {saas_sync_opt_in_recorded_message(scope_label)}")
     if not checkout_only and refreshed.repo_slug:
-        console.print("[dim]Future checkouts of this repository will also default to sync enabled.[/dim]")
+        console.print(
+            "[dim]Future checkouts of this repository will also default to this local preference.[/dim]"
+        )
 
 
 def _detect_workspace_context() -> tuple[Path, str | None]:
@@ -2358,6 +2363,17 @@ def _emit_status_check_json() -> None:
         "exit_code": 0 if ok else 2,
         "auth_required": auth_required,
         "auth_present": auth_present,
+        # Remote/import honesty (#2264). ``ok`` stays boundary/transport
+        # coherence ONLY — it never reflects remote materialization. These typed
+        # fields carry remote-project + historical-import state so a consumer
+        # asserting SaaS population reads THESE, not ``ok``. Honest ``unknown``
+        # until the import engine (#2262) populates them.
+        "remote_sync": {
+            "remote_project_state": "unknown",
+            "materialized_at": None,
+            "historical_import_state": "unknown",
+            "last_blocker_sample": None,
+        },
         "live_orphan_daemon_count": live_orphan_count,
         "foreground": {
             "package_version": fg.package_version,

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1361,8 +1361,11 @@ def opt_in(
     _require_daemon_owner_coherence("spec-kitty sync opt-in")
 
     if not is_saas_sync_enabled():
-        console.print(f"[dim]{saas_sync_disabled_message()}[/dim]")
-        return
+        # Non-green + non-zero (#2264 item 3): opt-in cannot take effect while
+        # the rollout flag is off, so a dim exit-0 "success" is misleading.
+        # Surface the disabled state clearly and exit non-zero.
+        console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
+        raise typer.Exit(1)
 
     enforce_teamspace_mission_state_ready(
         console=console,

--- a/src/specify_cli/core/saas_sync_config.py
+++ b/src/specify_cli/core/saas_sync_config.py
@@ -24,7 +24,14 @@ _DISABLED_MESSAGE = (
     "Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` to opt in."
 )
 
-__all__ = ["SAAS_SYNC_ENV_VAR", "is_saas_sync_enabled", "saas_sync_disabled_message"]
+_OPT_IN_RECORDED_BASE = "Local sync preference recorded for this checkout"
+
+__all__ = [
+    "SAAS_SYNC_ENV_VAR",
+    "is_saas_sync_enabled",
+    "saas_sync_disabled_message",
+    "saas_sync_opt_in_recorded_message",
+]
 
 
 def is_saas_sync_enabled() -> bool:
@@ -44,3 +51,17 @@ def saas_sync_disabled_message() -> str:
     ``contracts/saas_rollout.md`` and bumping the contract version.
     """
     return _DISABLED_MESSAGE
+
+
+def saas_sync_opt_in_recorded_message(scope_label: str | None = None) -> str:
+    """Return the honest confirmation for ``spec-kitty sync opt-in`` (#2264).
+
+    ``opt-in`` writes LOCAL routing flags only — no auth, no remote round-trip,
+    no history import. This message must therefore NOT imply remote
+    materialization or history: it states only that a local preference was
+    recorded. The prior wording ("Enabled SaaS sync for this checkout") was the
+    false-green that escalated #2264 to P1. Wording is asserted by tests.
+    """
+    if scope_label:
+        return f"{_OPT_IN_RECORDED_BASE} ({scope_label})."
+    return f"{_OPT_IN_RECORDED_BASE}."

--- a/tests/cli/commands/test_sync_saas_honesty.py
+++ b/tests/cli/commands/test_sync_saas_honesty.py
@@ -1,0 +1,110 @@
+"""SaaS-sync success-reporting honesty (#2264).
+
+First-time SaaS sync could report success at every local touchpoint while the
+remote project was an empty shell. Two honest-reporting fixes are covered here:
+
+* ``sync opt-in`` states only that a LOCAL preference was recorded — it must not
+  imply remote materialization or history import (the "Enabled SaaS sync"
+  false-green that escalated #2264 to P1).
+* ``sync status --check --json`` carries typed ``remote_sync`` fields for
+  remote-project + historical-import state, so consumers read those rather than
+  inferring remote population from ``ok`` (which stays boundary-coherence only).
+  The honest-``unknown`` slice ships now; populated values follow #2262.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import sync as sync_command
+from specify_cli.cli.commands.sync import app
+from specify_cli.core.saas_sync_config import saas_sync_opt_in_recorded_message
+from specify_cli.sync.daemon import DaemonSingletonReport, SyncDaemonStatus
+from unittest.mock import patch
+
+pytestmark = pytest.mark.fast
+
+runner = CliRunner()
+
+_REMOTE_IMPLYING = ("enabled saas sync", "materialized", "history", "imported", "remote")
+
+
+def test_opt_in_message_states_only_a_local_preference() -> None:
+    msg = saas_sync_opt_in_recorded_message()
+    lowered = msg.lower()
+    assert "recorded" in lowered, msg
+    for banned in _REMOTE_IMPLYING:
+        assert banned not in lowered, f"opt-in message implies remote work: {banned!r} in {msg!r}"
+
+
+def test_opt_in_message_includes_scope_without_overclaiming() -> None:
+    msg = saas_sync_opt_in_recorded_message("acme/widgets")
+    assert "acme/widgets" in msg
+    assert "enabled saas sync" not in msg.lower()
+
+
+def _healthy_status() -> SyncDaemonStatus:
+    return SyncDaemonStatus(
+        healthy=True,
+        url="http://127.0.0.1:9400",
+        port=9400,
+        token="t",
+        pid=4242,
+        sync_running=True,
+        last_sync=None,
+        consecutive_failures=0,
+        websocket_status="Connected",
+        protocol_version=1,
+        package_version="3.2.0",
+    )
+
+
+def _extract_json(output: str) -> dict[str, Any]:
+    """Parse the JSON object from mixed CLI output (rich may prepend lines)."""
+    start = output.index("{")
+    payload: dict[str, Any] = json.loads(output[start:])
+    return payload
+
+
+def test_status_check_json_carries_honest_unknown_remote_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--check --json exposes typed remote/import fields, honest-``unknown`` for now."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setattr(sync_command, "is_saas_sync_enabled", lambda: True)
+
+    cred_dir = tmp_path / ".spec-kitty"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    (cred_dir / "credentials").write_text(
+        "[user]\n"
+        'username = "tester@example.com"\n'
+        'team_slug = "t-private"\n'
+        "[server]\n"
+        'url = "https://spec-kitty-dev.fly.dev"\n',
+        encoding="utf-8",
+    )
+
+    with (
+        patch("specify_cli.sync.daemon.get_sync_daemon_status", return_value=_healthy_status()),
+        patch(
+            "specify_cli.sync.daemon.scan_sync_daemons",
+            return_value=DaemonSingletonReport(state_pid=4242, state_file_present=True, orphan_processes=()),
+        ),
+        patch.object(sync_command, "_check_server_connection", return_value=("Reachable", None)),
+    ):
+        result = runner.invoke(app, ["status", "--check", "--json"])
+
+    payload = _extract_json(result.output)
+    remote_sync = payload["remote_sync"]
+    assert remote_sync["remote_project_state"] == "unknown"
+    assert remote_sync["historical_import_state"] == "unknown"
+    assert remote_sync["materialized_at"] is None
+    assert remote_sync["last_blocker_sample"] is None
+    # Regression guard: ``ok`` remains boundary-coherence, independent of remote_sync.
+    assert "ok" in payload

--- a/tests/cli/commands/test_sync_saas_honesty.py
+++ b/tests/cli/commands/test_sync_saas_honesty.py
@@ -48,6 +48,24 @@ def test_opt_in_message_includes_scope_without_overclaiming() -> None:
     assert "enabled saas sync" not in msg.lower()
 
 
+def test_opt_in_exits_non_zero_when_sync_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """opt-in with the rollout flag off must be non-green + non-zero (#2264 item 3).
+
+    A dim exit-0 message read as success even though nothing was enabled.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setattr(sync_command, "is_saas_sync_enabled", lambda: False)
+
+    with patch.object(sync_command, "_require_daemon_owner_coherence", return_value=None):
+        result = runner.invoke(app, ["opt-in"])
+
+    assert result.exit_code != 0, f"opt-in must exit non-zero when disabled (output={result.output!r})"
+    assert "SPEC_KITTY_ENABLE_SAAS_SYNC" in result.output
+
+
 def _healthy_status() -> SyncDaemonStatus:
     return SyncDaemonStatus(
         healthy=True,


### PR DESCRIPTION
Refs #2264 (does not close it — this is the Phase-1 honest-reporting slice; see remaining below). Part of unblocking the #2262 import-history epic (its other blocker, #2263, is already closed).

## Problem (P1 false-green)
- `sync opt-in` writes **local routing flags only** but printed `✓ Enabled SaaS sync for this checkout` — implying remote enablement that never happened. This false-green is what escalated #2264 to P1.
- `sync status --check --json`'s `ok` is **boundary/transport coherence only**, yet nothing carried remote/import state — so a consumer could read "success" off `ok` against a registered-but-empty remote project.

## Fix (additive, honest-`unknown` slice)
- New CORE helper `saas_sync_opt_in_recorded_message()`; opt-in now states only that a **local preference was recorded** (asserted against the constant — no wording implying remote materialization/history).
- New typed `remote_sync` block on `sync status --check --json`: `remote_project_state` / `materialized_at` / `historical_import_state` / `last_blocker_sample`, honest `unknown`/null now. **`ok` semantics unchanged** (regression-guarded) — consumers assert remote population against these fields, not `ok`. Populated values arrive with #2262's import engine.

## Tests
`tests/cli/commands/test_sync_saas_honesty.py` — 3 passed: opt-in message honesty, `--check --json` field presence, `ok`-independence guard. Existing `--check` diagnostics test still green (payload change is additive). ruff + mypy clean. No `__init__.py` change → no version bump.

## Remaining for #2264 (separate slices, not in this PR)
- **Item 3:** strict sync path returns non-zero / non-green when `is_saas_sync_enabled()` is False.
- **Item 4:** SaaS dashboard renders the five remote/import state cells (`spec-kitty-saas` repo) — consumes these fields.

Draft per the charter's draft-PR-first / operator-merges norm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)