### PR TITLE
ci(docs-pages): don't cancel in-progress Pages deploys (fix intermittent 'try again later')

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -23,7 +23,13 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  # Allow only one concurrent Pages deployment, but do NOT cancel an in-progress
+  # one — cancelling a run mid-deploy leaves the Pages backend with a half-synced
+  # deployment, and the next push then collides with "Deployment failed, try again
+  # later". This matches GitHub's recommended Pages pattern (let production
+  # deployments complete). Queued runs between the in-progress and latest are
+  # still skipped by the group, so only the newest waiting deploy runs.
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
## Problem

The **Deploy Docs to GitHub Pages** workflow intermittently fails with `Deployment failed, try again later.` during `syncing_files` — **3 of the last 8** `main` deploys (e.g. runs on `7d3bbd5c3`, `b79ef419f`, `3e99fda80`). The `build` job always succeeds; only the Pages `deploy` step fails, so it's not a content/config problem.

## Root cause

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: true   # ← the problem
```

With rapid-fire merges to `main`, a new push **cancels** an in-progress Pages deploy that has already created a deployment mid-sync on GitHub's side; the next run then collides with that half-finished deployment → `try again later`.

## Fix

Set `cancel-in-progress: false`, matching **GitHub's recommended Pages pattern** (*"do NOT cancel in-progress runs — allow production deployments to complete"*). The `group: "pages"` still serializes to one deployment at a time; queued runs between the in-progress and latest are skipped, so only the newest waiting deploy runs. No content or build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)