### PR TITLE
chore(release): open 3.2.5 development cycle

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.4
+  version: 3.2.5
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 3.2.5
+
+_No changes yet — entries land here as missions merge._
+
 ## [3.2.4] - 2026-07-05
 
 Spec Kitty 3.2.4 is a reliability-and-trust release. It fixes a batch of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.4"
+version = "3.2.5"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2098,7 +2098,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.4"
+version = "3.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

3.2.4 is [tagged and published to PyPI](https://github.com/Priivacy-ai/spec-kitty/releases/tag/v3.2.4). This opens the 3.2.5 development cycle by bumping all four version sources together (mirrors the 3.2.3→3.2.4 cycle-open, commits `55e4657f7` + `7f9b662af`):

- `pyproject.toml`: 3.2.4 → 3.2.5
- `.kittify/metadata.yaml` `spec_kitty.version`: 3.2.4 → 3.2.5
- `uv.lock` `spec-kitty-cli`: 3.2.4 → 3.2.5 (via `uv lock`)
- `docs/changelog/CHANGELOG.md`: new `[Unreleased] - 3.2.5` placeholder section above `[3.2.4]`

## Test plan
- [x] `python3 scripts/release/validate_release.py --mode branch --consistency-only` — passes
- [x] `uv run python scripts/docs/sync_changelog.py --check` — clean
- [x] `uv lock --check` — clean
- [x] `pytest tests/architectural/test_no_legacy_terminology.py` — 3 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)