### PR TITLE
fix(#2413): session banner compares versions by ordering, not inequality

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -15,7 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 3.2.5
 
-_No changes yet — entries land here as missions merge._
+### 🐛 Fixed
+
+- **Session banner no longer recommends a downgrade (#2413).** The
+  session-presence health check decided "upgrade-available" with a bare
+  inequality (`avail != current`), so any machine whose installed CLI was
+  *newer* than the cached PyPI latest — a fresh release not yet in the 1-hour
+  cache, or an rc/dev install — got "⚠ Upgrade available: 3.2.2" while running
+  3.2.4. Both health branches now use `packaging.Version` ordering
+  (`avail > current`); unparseable versions are treated as no-upgrade so
+  session start never breaks on a weird cache value.
 
 ## [3.2.4] - 2026-07-05
 

--- a/kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json
+++ b/kitty-specs/cli-upgrade-nag-lazy-project-migrations-01KQ6YDN/contracts/compat-planner.json
@@ -193,7 +193,7 @@
         "required": ["migration_id", "target_schema_version", "description"],
         "additionalProperties": false,
         "properties": {
-          "migration_id": { "type": "string", "pattern": "^[a-z0-9_]{1,128}$" },
+          "migration_id": { "type": "string", "pattern": "^[a-z0-9_.]{1,128}$" },
           "target_schema_version": { "type": "integer", "minimum": 0, "maximum": 1000 },
           "description": { "type": "string", "maxLength": 256 },
           "files_modified": {

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -61,6 +61,7 @@ from specify_cli.cli.commands._teamspace_mission_state_gate import (
 )
 from specify_cli.core.commit_guard import GuardCapability
 from specify_cli.core.env import is_truthy
+from specify_cli.core.version_compare import is_version_newer
 from specify_cli.git.commit_helpers import safe_commit
 
 
@@ -300,17 +301,6 @@ def _run_cli_mode(
 # ---------------------------------------------------------------------------
 
 
-def _version_is_newer(latest: str | None, installed: str) -> bool:
-    if latest is None:
-        return False
-    try:
-        from packaging.version import Version
-
-        return Version(latest) > Version(installed)
-    except Exception:  # noqa: BLE001
-        return False
-
-
 def _agent_check_payload() -> dict[str, object]:
     """Return machine-readable upgrade readiness for agent prompt preambles."""
     from specify_cli.compat import (
@@ -363,7 +353,7 @@ def _agent_check_payload() -> dict[str, object]:
         payload["reason"] = "nag_disabled"
         return payload
 
-    if not _version_is_newer(latest_version, cli_status.installed_version):
+    if not is_version_newer(latest_version, cli_status.installed_version):
         return payload
 
     if is_truthy(os.environ.get(ENV_UPGRADE_DISABLED)):

--- a/src/specify_cli/core/upgrade_probe.py
+++ b/src/specify_cli/core/upgrade_probe.py
@@ -29,7 +29,8 @@ from enum import StrEnum
 from typing import Any
 
 import httpx
-from packaging.version import InvalidVersion, Version
+
+from specify_cli.core.version_compare import is_version_newer, try_parse_version
 
 PYPI_JSON_URL = "https://pypi.org/pypi/spec-kitty-cli/json"
 """PyPI's standard JSON metadata endpoint for the ``spec-kitty-cli`` package."""
@@ -190,21 +191,18 @@ def _classify(
     PEP 440 version. Network/parse failures are handled upstream in
     :func:`probe_pypi`.
     """
-    try:
-        installed_ver = Version(installed)
-    except InvalidVersion:
+    installed_ver = try_parse_version(installed)
+    if installed_ver is None:
         return UpgradeChannel.UNKNOWN
 
-    latest_ver: Version | None
-    try:
-        latest_ver = Version(latest)
-    except InvalidVersion:
-        # Latest is malformed — fall through to releases-membership check.
-        latest_ver = None
+    # ``latest`` may be malformed — try_parse_version falls through to the
+    # releases-membership check below (via is_version_newer returning False)
+    # rather than raising.
+    latest_ver = try_parse_version(latest)
 
     if latest_ver is not None and installed_ver == latest_ver:
         return UpgradeChannel.ALREADY_CURRENT
-    if latest_ver is not None and installed_ver > latest_ver:
+    if is_version_newer(installed, latest):
         return UpgradeChannel.AHEAD_OF_PYPI
 
     # installed != latest (or latest unparseable). Check releases membership.

--- a/src/specify_cli/core/version_compare.py
+++ b/src/specify_cli/core/version_compare.py
@@ -1,0 +1,58 @@
+"""Canonical version-comparison primitives shared across upgrade surfaces (#2417).
+
+Before this module existed, "is candidate version newer than current version"
+was implemented independently in three places:
+
+- ``cli/commands/upgrade.py::_version_is_newer`` — caught the broad
+  ``Exception`` (``# noqa: BLE001``) rather than the specific parse failure.
+- ``core/upgrade_probe.py::_classify`` — a richer PyPI-channel classifier
+  that needs version *parsing* and *ordering* as building blocks alongside
+  releases-membership checks; only its comparison sub-logic is unified here.
+- ``session_presence/manager.py::_upgrade_is_available`` — added to fix #2413,
+  where a bare inequality (``avail != current``) reported "upgrade available"
+  whenever the cached PyPI latest lagged the installed version (fresh release
+  not yet cached, rc/dev installs), instead of comparing ordering.
+
+This module is the single source of truth for both operations. It is pure
+(no CLI/click/typer imports) so it is safe to import from any layer — CLI
+commands, core probes, session-presence writers, or future callers.
+"""
+
+from __future__ import annotations
+
+from packaging.version import InvalidVersion, Version
+
+
+def try_parse_version(value: str | None) -> Version | None:
+    """Parse *value* as a PEP 440 version, or return ``None`` if it cannot be.
+
+    ``None``, the empty string, and any string ``packaging.version`` rejects
+    all resolve to ``None``. Callers that need a well-formed comparison
+    target should treat ``None`` as "unknown — do not compare".
+    """
+    if not value:
+        return None
+    try:
+        return Version(value)
+    except InvalidVersion:
+        return None
+
+
+def is_version_newer(candidate: str | None, current: str) -> bool:
+    """Return True iff *candidate* is a parseable version strictly newer than *current*.
+
+    - ``None``, empty, or unparseable *candidate* -> ``False`` (never blocks
+      on bad input).
+    - Unparseable *current* -> ``False`` (conservative: can't prove an
+      upgrade exists if we can't parse the baseline).
+    """
+    candidate_ver = try_parse_version(candidate)
+    if candidate_ver is None:
+        return False
+    current_ver = try_parse_version(current)
+    if current_ver is None:
+        return False
+    return candidate_ver > current_ver
+
+
+__all__ = ["is_version_newer", "try_parse_version"]

--- a/src/specify_cli/session_presence/manager.py
+++ b/src/specify_cli/session_presence/manager.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
+from packaging.version import InvalidVersion, Version
+
 from .content import SessionPresenceContent
 from .upgrade_check import UpgradeChecker
 from .writers.registry import get_writer
@@ -24,6 +26,23 @@ if TYPE_CHECKING:
     from specify_cli.core.agent_config import AgentConfig
 
 _logger = logging.getLogger(__name__)
+
+
+def _upgrade_is_available(avail: str | None, current: str) -> bool:
+    """Return True only when *avail* is strictly newer than *current* (#2413).
+
+    A bare inequality reported "Upgrade available: 3.2.2" to a machine running
+    3.2.4 whenever the cached PyPI latest lagged the installed version (fresh
+    release not yet in the cache, rc/dev installs). Unparseable versions are
+    treated as no-upgrade so the banner never recommends a downgrade or blows
+    up session start.
+    """
+    if not avail:
+        return False
+    try:
+        return Version(avail) > Version(current)
+    except InvalidVersion:
+        return False
 
 
 class InstallResult(NamedTuple):
@@ -82,13 +101,13 @@ class SessionPresenceManager:
             result = compat_plan(inv, project_root_resolver=_resolver)
             if result.decision == Decision.BLOCK_PROJECT_MIGRATION:
                 health = "migration-required"
-            elif avail and avail != current:
+            elif _upgrade_is_available(avail, current):
                 health = "upgrade-available"
             else:
                 health = "healthy"
         except Exception:
             # Best-effort health check — never block session start
-            health = "upgrade-available" if avail and avail != current else "healthy"
+            health = "upgrade-available" if _upgrade_is_available(avail, current) else "healthy"
 
         return SessionPresenceContent(current, slug, health, avail)
 

--- a/src/specify_cli/session_presence/manager.py
+++ b/src/specify_cli/session_presence/manager.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
-from packaging.version import InvalidVersion, Version
+from specify_cli.core.version_compare import is_version_newer
 
 from .content import SessionPresenceContent
 from .upgrade_check import UpgradeChecker
@@ -26,23 +26,6 @@ if TYPE_CHECKING:
     from specify_cli.core.agent_config import AgentConfig
 
 _logger = logging.getLogger(__name__)
-
-
-def _upgrade_is_available(avail: str | None, current: str) -> bool:
-    """Return True only when *avail* is strictly newer than *current* (#2413).
-
-    A bare inequality reported "Upgrade available: 3.2.2" to a machine running
-    3.2.4 whenever the cached PyPI latest lagged the installed version (fresh
-    release not yet in the cache, rc/dev installs). Unparseable versions are
-    treated as no-upgrade so the banner never recommends a downgrade or blows
-    up session start.
-    """
-    if not avail:
-        return False
-    try:
-        return Version(avail) > Version(current)
-    except InvalidVersion:
-        return False
 
 
 class InstallResult(NamedTuple):
@@ -101,13 +84,13 @@ class SessionPresenceManager:
             result = compat_plan(inv, project_root_resolver=_resolver)
             if result.decision == Decision.BLOCK_PROJECT_MIGRATION:
                 health = "migration-required"
-            elif _upgrade_is_available(avail, current):
+            elif is_version_newer(avail, current):
                 health = "upgrade-available"
             else:
                 health = "healthy"
         except Exception:
             # Best-effort health check — never block session start
-            health = "upgrade-available" if _upgrade_is_available(avail, current) else "healthy"
+            health = "upgrade-available" if is_version_newer(avail, current) else "healthy"
 
         return SessionPresenceContent(current, slug, health, avail)
 

--- a/tests/architectural/ci_topology_census.json
+++ b/tests/architectural/ci_topology_census.json
@@ -192,7 +192,7 @@
     },
     {
       "dir": "session_presence",
-      "loc": 1246,
+      "loc": 1229,
       "cone_roots": [
         "tests/specify_cli/session_presence"
       ],

--- a/tests/architectural/ci_topology_census.json
+++ b/tests/architectural/ci_topology_census.json
@@ -192,7 +192,7 @@
     },
     {
       "dir": "session_presence",
-      "loc": 1227,
+      "loc": 1246,
       "cone_roots": [
         "tests/specify_cli/session_presence"
       ],

--- a/tests/specify_cli/core/test_version_compare.py
+++ b/tests/specify_cli/core/test_version_compare.py
@@ -1,0 +1,97 @@
+"""Contract tests for the canonical version-comparison primitive (#2417).
+
+Consolidates three independent "is this version newer" implementations that
+previously lived in ``cli/commands/upgrade.py``, ``core/upgrade_probe.py``,
+and ``session_presence/manager.py`` (the last one added by #2413's fix for
+the bare-inequality bug: comparing ``avail != current`` instead of ordering
+``avail > current``). This matrix mirrors
+``tests/specify_cli/session_presence/test_manager.py::TestUpgradeIsAvailable``
+plus the epoch/local-version-identifier cases flagged as an untested gap
+during PR review.
+"""
+
+from __future__ import annotations
+
+from specify_cli.core.version_compare import is_version_newer, try_parse_version
+
+
+class TestIsVersionNewer:
+    """Matrix for ``is_version_newer(candidate, current) -> bool``."""
+
+    def test_newer_available(self) -> None:
+        assert is_version_newer("3.3.0", "3.2.4") is True
+
+    def test_equal_versions(self) -> None:
+        assert is_version_newer("3.2.4", "3.2.4") is False
+
+    def test_older_available_the_2413_bug(self) -> None:
+        # A bare inequality would report this as "available"; ordering must not.
+        assert is_version_newer("3.2.2", "3.2.4") is False
+
+    def test_prerelease_ordering_rc_behind_release(self) -> None:
+        # An installed rc ahead of the published release is NOT an upgrade to it.
+        assert is_version_newer("3.2.5rc1", "3.2.5") is False
+
+    def test_prerelease_ordering_release_ahead_of_its_own_rc(self) -> None:
+        # A published release IS an upgrade over its own rc.
+        assert is_version_newer("3.2.5", "3.2.4rc39") is True
+
+    def test_none_candidate(self) -> None:
+        assert is_version_newer(None, "3.2.4") is False
+
+    def test_empty_candidate(self) -> None:
+        assert is_version_newer("", "3.2.4") is False
+
+    def test_unparseable_candidate(self) -> None:
+        assert is_version_newer("not-a-version", "3.2.4") is False
+
+    def test_unparseable_current(self) -> None:
+        assert is_version_newer("3.3.0", "not-a-version") is False
+
+    def test_both_unparseable(self) -> None:
+        assert is_version_newer("also-not-a-version", "not-a-version") is False
+
+    def test_epoch_version_newer(self) -> None:
+        # PEP 440 epoch segment dominates the rest of the version.
+        assert is_version_newer("1!1.0.0", "2024.1.1") is True
+
+    def test_epoch_version_not_newer(self) -> None:
+        assert is_version_newer("2024.1.1", "1!1.0.0") is False
+
+    def test_epoch_versions_equal(self) -> None:
+        assert is_version_newer("1!3.2.4", "1!3.2.4") is False
+
+    def test_local_version_identifier_newer(self) -> None:
+        # Local version identifiers (+local) sort after their base release.
+        assert is_version_newer("3.2.4+local.1", "3.2.4") is True
+
+    def test_local_version_identifier_not_newer_than_itself(self) -> None:
+        assert is_version_newer("3.2.4+local.1", "3.2.4+local.1") is False
+
+    def test_local_version_identifier_current_side(self) -> None:
+        # A plain release is not newer than a local build of that same release.
+        assert is_version_newer("3.2.4", "3.2.4+local.1") is False
+
+
+class TestTryParseVersion:
+    """Matrix for the shared parsing primitive used by ``is_version_newer``
+    and by ``core.upgrade_probe._classify``'s richer state machine."""
+
+    def test_parses_valid_version(self) -> None:
+        from packaging.version import Version
+
+        assert try_parse_version("3.2.4") == Version("3.2.4")
+
+    def test_none_returns_none(self) -> None:
+        assert try_parse_version(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert try_parse_version("") is None
+
+    def test_unparseable_returns_none(self) -> None:
+        assert try_parse_version("not-a-version") is None
+
+    def test_epoch_and_local_parse(self) -> None:
+        from packaging.version import Version
+
+        assert try_parse_version("1!2.0.0+local") == Version("1!2.0.0+local")

--- a/tests/specify_cli/core/test_version_compare.py
+++ b/tests/specify_cli/core/test_version_compare.py
@@ -12,7 +12,11 @@ during PR review.
 
 from __future__ import annotations
 
+import pytest
+
 from specify_cli.core.version_compare import is_version_newer, try_parse_version
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 class TestIsVersionNewer:

--- a/tests/specify_cli/session_presence/test_manager.py
+++ b/tests/specify_cli/session_presence/test_manager.py
@@ -315,3 +315,95 @@ class TestBuildContent:
             content = manager._build_content()
 
         assert content.health == "healthy"
+
+    def test_health_healthy_when_cached_latest_is_older_than_installed(
+        self, tmp_path: Path
+    ) -> None:
+        """#2413 regression: a stale PyPI cache (or an rc/dev install newer than
+        the published latest) must not report an 'upgrade' to an older version."""
+        from specify_cli.compat import Decision
+
+        manager = _make_manager(tmp_path)
+        mock_plan_result = MagicMock()
+        mock_plan_result.decision = Decision.ALLOW
+
+        with (
+            patch(
+                "specify_cli.session_presence.manager.UpgradeChecker"
+            ) as mock_checker_cls,
+            patch(
+                "importlib.metadata.version",
+                return_value="3.2.4",
+            ),
+            patch(
+                "specify_cli.compat.plan",
+                return_value=mock_plan_result,
+            ),
+        ):
+            mock_checker_cls.return_value.get_available_version.return_value = "3.2.2"
+            content = manager._build_content()
+
+        assert content.health == "healthy"
+
+    def test_health_healthy_when_older_latest_and_compat_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """#2413: the exception-fallback branch must use the same ordering."""
+        manager = _make_manager(tmp_path)
+
+        with (
+            patch(
+                "specify_cli.session_presence.manager.UpgradeChecker"
+            ) as mock_checker_cls,
+            patch(
+                "importlib.metadata.version",
+                return_value="3.2.4",
+            ),
+            patch(
+                "specify_cli.compat.plan",
+                side_effect=Exception("no compat"),
+            ),
+        ):
+            mock_checker_cls.return_value.get_available_version.return_value = "3.2.2"
+            content = manager._build_content()
+
+        assert content.health == "healthy"
+
+
+class TestUpgradeIsAvailable:
+    """Matrix for the #2413 ordering helper."""
+
+    def test_newer_available(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        assert _upgrade_is_available("3.3.0", "3.2.4") is True
+
+    def test_equal_versions(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        assert _upgrade_is_available("3.2.4", "3.2.4") is False
+
+    def test_older_available_the_2413_bug(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        assert _upgrade_is_available("3.2.2", "3.2.4") is False
+
+    def test_prerelease_ordering(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        # An installed rc ahead of the published release is NOT upgradable to it.
+        assert _upgrade_is_available("3.2.4", "3.2.5rc1") is False
+        # A published release IS an upgrade over its own rc.
+        assert _upgrade_is_available("3.2.4", "3.2.4rc39") is True
+
+    def test_none_and_empty(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        assert _upgrade_is_available(None, "3.2.4") is False
+        assert _upgrade_is_available("", "3.2.4") is False
+
+    def test_unparseable_versions(self) -> None:
+        from specify_cli.session_presence.manager import _upgrade_is_available
+
+        assert _upgrade_is_available("not-a-version", "3.2.4") is False
+        assert _upgrade_is_available("3.3.0", "not-a-version") is False

--- a/tests/specify_cli/session_presence/test_manager.py
+++ b/tests/specify_cli/session_presence/test_manager.py
@@ -370,40 +370,9 @@ class TestBuildContent:
         assert content.health == "healthy"
 
 
-class TestUpgradeIsAvailable:
-    """Matrix for the #2413 ordering helper."""
-
-    def test_newer_available(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        assert _upgrade_is_available("3.3.0", "3.2.4") is True
-
-    def test_equal_versions(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        assert _upgrade_is_available("3.2.4", "3.2.4") is False
-
-    def test_older_available_the_2413_bug(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        assert _upgrade_is_available("3.2.2", "3.2.4") is False
-
-    def test_prerelease_ordering(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        # An installed rc ahead of the published release is NOT upgradable to it.
-        assert _upgrade_is_available("3.2.4", "3.2.5rc1") is False
-        # A published release IS an upgrade over its own rc.
-        assert _upgrade_is_available("3.2.4", "3.2.4rc39") is True
-
-    def test_none_and_empty(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        assert _upgrade_is_available(None, "3.2.4") is False
-        assert _upgrade_is_available("", "3.2.4") is False
-
-    def test_unparseable_versions(self) -> None:
-        from specify_cli.session_presence.manager import _upgrade_is_available
-
-        assert _upgrade_is_available("not-a-version", "3.2.4") is False
-        assert _upgrade_is_available("3.3.0", "not-a-version") is False
+# NOTE: the #2413 ordering-helper matrix (TestUpgradeIsAvailable) moved to
+# tests/specify_cli/core/test_version_compare.py::TestIsVersionNewer as part
+# of #2417's consolidation of the three independent "is version newer"
+# implementations into specify_cli.core.version_compare.is_version_newer.
+# manager.py now imports that canonical helper directly (see _build_content
+# above) rather than defining its own private comparison function.


### PR DESCRIPTION
Fixes #2413.

## The bug

The session-presence orientation banner decided `upgrade-available` with a **bare inequality** in both health branches of `SessionPresenceManager._build_content` (`src/specify_cli/session_presence/manager.py`):

```python
elif avail and avail != current:          # compat-plan branch
...
health = "upgrade-available" if avail and avail != current else "healthy"   # exception fallback
```

`avail` is the cached PyPI `latest_version` (`~/.kittify/last-cli-check.json`, 1-hour TTL, stale values served by design). Whenever the installed CLI is **newer** than that cache — a fresh release not yet fetched, an rc/dev install — the banner says `⚠ Upgrade available: 3.2.2` while 3.2.4 is running, recommending a downgrade. With 3.2.4 released today, every machine with a stale cache shows this.

## The fix

One helper, used by both branches:

```python
def _upgrade_is_available(avail: str | None, current: str) -> bool:
    if not avail:
        return False
    try:
        return Version(avail) > Version(current)
    except InvalidVersion:
        return False
```

`packaging` is already a dependency (`upgrade/runner.py` uses it for downgrade refusal). Unparseable/None/empty versions are treated as no-upgrade, preserving the module's never-block-session-start contract.

## Tests

- Behavioral regressions in `TestBuildContent`: cached latest **older** than installed → `healthy`, in both the compat-plan branch and the exception-fallback branch (the #2413 report).
- `TestUpgradeIsAvailable` matrix: newer → True; equal → False; older (the bug) → False; rc ordering both directions (`3.2.4` vs `3.2.5rc1` → False, `3.2.4` vs `3.2.4rc39` → True); None/empty/unparseable → False.
- Full `tests/specify_cli/session_presence/` + `test_session_start.py`: 170 passed. `ruff` + `mypy` clean.


---

Closes #2417 (folded into this PR by a maintainer landing-pass op — see comments below).
