### PR TITLE
fix(saas_client): remove hardcoded api.spec-kitty.io default, fail closed (#2248)

### DIFF
--- a/src/specify_cli/cli/commands/decision.py
+++ b/src/specify_cli/cli/commands/decision.py
@@ -539,7 +539,7 @@ def cmd_widen(
         raise typer.Exit(0)
 
     try:
-        client = SaasClient.from_env()
+        client = SaasClient.from_env(repo_root=locate_project_root() or Path.cwd())
         response = client.post_widen(decision_id=decision_id, invited=invited_list)
         typer.echo(json.dumps(
             {

--- a/src/specify_cli/saas_client/auth.py
+++ b/src/specify_cli/saas_client/auth.py
@@ -3,7 +3,8 @@
 Reads ``SPEC_KITTY_SAAS_URL``, ``SPEC_KITTY_SAAS_TOKEN``, and optional
 ``SPEC_KITTY_TEAM_SLUG`` from the
 environment, falling back to ``.kittify/saas-auth.json`` when env vars are
-absent.  Raises ``SaasAuthError`` if no token can be resolved.
+absent.  Raises ``SaasAuthError`` if no token — or no SaaS URL — can be
+resolved. Per decision D-5 there is no hardcoded SaaS domain fallback.
 """
 
 from __future__ import annotations
@@ -14,8 +15,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from specify_cli.saas_client.errors import SaasAuthError
-
-_DEFAULT_SAAS_URL = "https://api.spec-kitty.io"
 
 
 @dataclass(frozen=True)
@@ -33,7 +32,8 @@ def load_auth_context(repo_root: Path | None = None) -> AuthContext:
     Resolution order:
     1. ``SPEC_KITTY_SAAS_TOKEN`` / ``SPEC_KITTY_SAAS_URL`` env vars.
     2. ``.kittify/saas-auth.json`` relative to *repo_root* (if provided).
-    3. Raises ``SaasAuthError`` if no token is found.
+    3. Raises ``SaasAuthError`` if no token is found, or if no SaaS URL is
+       supplied by either source (D-5: no hardcoded domain fallback).
 
     Args:
         repo_root: Optional path to the repository root.  Used to locate
@@ -67,7 +67,15 @@ def load_auth_context(repo_root: Path | None = None) -> AuthContext:
             "SPEC_KITTY_SAAS_TOKEN not set and .kittify/saas-auth.json not found"
         )
 
+    # D-5: there is NO hardcoded SaaS domain (see auth/config.get_saas_base_url,
+    # which raises when SPEC_KITTY_SAAS_URL is unset). The URL must come from the
+    # environment or the auth file; falling back to a baked-in domain silently
+    # points the client at the wrong server (#2248 / #2146 canonical target
+    # authority). Fail closed instead.
     if not url:
-        url = _DEFAULT_SAAS_URL
+        raise SaasAuthError(
+            "SaaS URL not configured: set SPEC_KITTY_SAAS_URL or provide "
+            '"saas_url" in .kittify/saas-auth.json (D-5: no hardcoded SaaS domain).'
+        )
 
     return AuthContext(saas_url=url, token=token, team_slug=team_slug)

--- a/src/specify_cli/saas_client/auth.py
+++ b/src/specify_cli/saas_client/auth.py
@@ -43,13 +43,14 @@ def load_auth_context(repo_root: Path | None = None) -> AuthContext:
         Resolved :class:`AuthContext`.
 
     Raises:
-        SaasAuthError: If no token can be resolved.
+        SaasAuthError: If no token can be resolved, or if no SaaS URL is
+            supplied by env var or auth file (D-5: no hardcoded domain fallback).
     """
     url = os.environ.get("SPEC_KITTY_SAAS_URL", "").strip()
     token = os.environ.get("SPEC_KITTY_SAAS_TOKEN", "").strip()
     team_slug = os.environ.get("SPEC_KITTY_TEAM_SLUG", "").strip() or None
 
-    if not token and repo_root is not None:
+    if (not token or not url) and repo_root is not None:
         auth_file = repo_root / ".kittify" / "saas-auth.json"
         if auth_file.exists():
             try:
@@ -58,7 +59,7 @@ def load_auth_context(repo_root: Path | None = None) -> AuthContext:
                 raise SaasAuthError(
                     f"Failed to read .kittify/saas-auth.json: {exc}"
                 ) from exc
-            token = data.get("token", "").strip()
+            token = token or data.get("token", "").strip()
             url = url or data.get("saas_url", "").strip()
             team_slug = team_slug or data.get("team_slug") or None
 

--- a/src/specify_cli/saas_client/client.py
+++ b/src/specify_cli/saas_client/client.py
@@ -57,7 +57,8 @@ class SaasClient:
     """Thin HTTP client for spec-kitty SaaS endpoints.
 
     Args:
-        base_url: Root URL of the SaaS API, e.g. ``https://api.spec-kitty.io``.
+        base_url: Root URL of the SaaS API (from ``SPEC_KITTY_SAAS_URL`` /
+            auth context; D-5 — no hardcoded domain).
         token: Bearer token for authentication.
         timeout: Default request timeout in seconds.  Individual methods may
             override this for their specific use-case.

--- a/tests/architectural/ci_topology_census.json
+++ b/tests/architectural/ci_topology_census.json
@@ -4,187 +4,8 @@
   "rule": "D in worklist iff D is a direct child directory of src/specify_cli/ AND sum(LOC of *.py under D) >= t_loc AND no src-backed dorny filter group (excluding any_src) globs src/specify_cli/<D>/.",
   "worklist": [
     {
-      "dir": "audit",
-      "cone_roots": [
-        "tests/audit",
-        "tests/specify_cli/audit"
-      ],
-      "target_group": "auth_audit_git",
-      "target_shard": "auth-audit-git"
-    },
-    {
-      "dir": "auth",
-      "cone_roots": [
-        "tests/auth"
-      ],
-      "target_group": "auth_audit_git",
-      "target_shard": "auth-audit-git"
-    },
-    {
-      "dir": "bulk_edit",
-      "cone_roots": [
-        "tests/specify_cli/bulk_edit"
-      ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "calibration",
-      "cone_roots": [
-        "tests/calibration"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "compat",
-      "cone_roots": [
-        "tests/specify_cli/compat"
-      ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
-    },
-    {
-      "dir": "context",
-      "cone_roots": [
-        "tests/context",
-        "tests/specify_cli/context"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "decisions",
-      "cone_roots": [
-        "tests/specify_cli/decisions"
-      ],
-      "target_group": "closeout",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "doc_analysis",
-      "cone_roots": [],
-      "target_group": "closeout",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "doctrine",
-      "cone_roots": [
-        "tests/specify_cli/doctrine"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "dossier",
-      "cone_roots": [
-        "tests/dossier",
-        "tests/specify_cli/dossier"
-      ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "events",
-      "cone_roots": [
-        "tests/specify_cli/events"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "git",
-      "cone_roots": [
-        "tests/git",
-        "tests/git_ops",
-        "tests/specify_cli/git"
-      ],
-      "target_group": "auth_audit_git",
-      "target_shard": "auth-audit-git"
-    },
-    {
-      "dir": "intake",
-      "cone_roots": [],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "invocation",
-      "cone_roots": [
-        "tests/invocation",
-        "tests/specify_cli/invocation"
-      ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
-    },
-    {
-      "dir": "migration",
-      "cone_roots": [
-        "tests/migration",
-        "tests/specify_cli/migration"
-      ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
-    },
-    {
-      "dir": "mission_loader",
-      "cone_roots": [
-        "tests/unit/mission_loader"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "mission_v1",
-      "cone_roots": [
-        "tests/specify_cli/mission_v1"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "orchestrator_api",
-      "cone_roots": [
-        "tests/specify_cli/orchestrator_api"
-      ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "ownership",
-      "cone_roots": [
-        "tests/specify_cli/ownership"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "paths",
-      "cone_roots": [
-        "tests/paths"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "policy",
-      "cone_roots": [
-        "tests/policy"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "readiness",
-      "cone_roots": [
-        "tests/readiness",
-        "tests/specify_cli/readiness"
-      ],
-      "target_group": "closeout",
-      "target_shard": "misc"
-    },
-    {
       "dir": "retrospective",
+      "loc": 6805,
       "cone_roots": [
         "tests/retrospective",
         "tests/specify_cli/retrospect",
@@ -194,45 +15,36 @@
       "target_shard": "misc"
     },
     {
-      "dir": "saas_client",
+      "dir": "migration",
+      "loc": 5607,
       "cone_roots": [
-        "tests/specify_cli/saas_client"
+        "tests/migration",
+        "tests/specify_cli/migration"
       ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
     },
     {
-      "dir": "session_presence",
+      "dir": "auth",
+      "loc": 5140,
       "cone_roots": [
-        "tests/specify_cli/session_presence"
+        "tests/auth"
       ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
+      "target_group": "auth_audit_git",
+      "target_shard": "auth-audit-git"
     },
     {
-      "dir": "skills",
+      "dir": "compat",
+      "loc": 5072,
       "cone_roots": [
-        "tests/specify_cli/skills"
-      ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "task_utils",
-      "cone_roots": [],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "template",
-      "cone_roots": [
-        "tests/test_template"
+        "tests/specify_cli/compat"
       ],
       "target_group": "lifecycle",
       "target_shard": "specify-cli-heavy"
     },
     {
       "dir": "tracker",
+      "loc": 3966,
       "cone_roots": [
         "tests/tracker"
       ],
@@ -240,13 +52,83 @@
       "target_shard": "specify-cli-rest"
     },
     {
-      "dir": "validators",
-      "cone_roots": [],
+      "dir": "doctrine",
+      "loc": 3918,
+      "cone_roots": [
+        "tests/specify_cli/doctrine"
+      ],
       "target_group": "governance",
       "target_shard": "misc"
     },
     {
+      "dir": "dossier",
+      "loc": 3246,
+      "cone_roots": [
+        "tests/dossier",
+        "tests/specify_cli/dossier"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "invocation",
+      "loc": 2916,
+      "cone_roots": [
+        "tests/invocation",
+        "tests/specify_cli/invocation"
+      ],
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
+    },
+    {
+      "dir": "skills",
+      "loc": 2865,
+      "cone_roots": [
+        "tests/specify_cli/skills"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "git",
+      "loc": 2770,
+      "cone_roots": [
+        "tests/git",
+        "tests/git_ops",
+        "tests/specify_cli/git"
+      ],
+      "target_group": "auth_audit_git",
+      "target_shard": "auth-audit-git"
+    },
+    {
+      "dir": "audit",
+      "loc": 2104,
+      "cone_roots": [
+        "tests/audit",
+        "tests/specify_cli/audit"
+      ],
+      "target_group": "auth_audit_git",
+      "target_shard": "auth-audit-git"
+    },
+    {
+      "dir": "orchestrator_api",
+      "loc": 1956,
+      "cone_roots": [
+        "tests/specify_cli/orchestrator_api"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "doc_analysis",
+      "loc": 1864,
+      "cone_roots": [],
+      "target_group": "closeout",
+      "target_shard": "misc"
+    },
+    {
       "dir": "widen",
+      "loc": 1785,
       "cone_roots": [
         "tests/specify_cli/widen"
       ],
@@ -254,10 +136,160 @@
       "target_shard": "misc"
     },
     {
+      "dir": "decisions",
+      "loc": 1539,
+      "cone_roots": [
+        "tests/specify_cli/decisions"
+      ],
+      "target_group": "closeout",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "readiness",
+      "loc": 1447,
+      "cone_roots": [
+        "tests/readiness",
+        "tests/specify_cli/readiness"
+      ],
+      "target_group": "closeout",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "mission_v1",
+      "loc": 1337,
+      "cone_roots": [
+        "tests/specify_cli/mission_v1"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "mission_loader",
+      "loc": 1297,
+      "cone_roots": [
+        "tests/unit/mission_loader"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
       "dir": "workspace",
+      "loc": 1283,
       "cone_roots": [
         "tests/specify_cli/workspace"
       ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "bulk_edit",
+      "loc": 1276,
+      "cone_roots": [
+        "tests/specify_cli/bulk_edit"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "session_presence",
+      "loc": 1227,
+      "cone_roots": [
+        "tests/specify_cli/session_presence"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "policy",
+      "loc": 1193,
+      "cone_roots": [
+        "tests/policy"
+      ],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "ownership",
+      "loc": 1114,
+      "cone_roots": [
+        "tests/specify_cli/ownership"
+      ],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "context",
+      "loc": 1056,
+      "cone_roots": [
+        "tests/context",
+        "tests/specify_cli/context"
+      ],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "validators",
+      "loc": 770,
+      "cone_roots": [],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "template",
+      "loc": 748,
+      "cone_roots": [
+        "tests/test_template"
+      ],
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
+    },
+    {
+      "dir": "intake",
+      "loc": 728,
+      "cone_roots": [],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "calibration",
+      "loc": 634,
+      "cone_roots": [
+        "tests/calibration"
+      ],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "paths",
+      "loc": 577,
+      "cone_roots": [
+        "tests/paths"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "events",
+      "loc": 574,
+      "cone_roots": [
+        "tests/specify_cli/events"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "saas_client",
+      "loc": 561,
+      "cone_roots": [
+        "tests/specify_cli/saas_client"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "task_utils",
+      "loc": 505,
+      "cone_roots": [],
       "target_group": "platform",
       "target_shard": "specify-cli-rest"
     }

--- a/tests/architectural/ci_topology_census.json
+++ b/tests/architectural/ci_topology_census.json
@@ -4,29 +4,16 @@
   "rule": "D in worklist iff D is a direct child directory of src/specify_cli/ AND sum(LOC of *.py under D) >= t_loc AND no src-backed dorny filter group (excluding any_src) globs src/specify_cli/<D>/.",
   "worklist": [
     {
-      "dir": "retrospective",
-      "loc": 6805,
+      "dir": "audit",
       "cone_roots": [
-        "tests/retrospective",
-        "tests/specify_cli/retrospect",
-        "tests/specify_cli/retrospective"
+        "tests/audit",
+        "tests/specify_cli/audit"
       ],
-      "target_group": "closeout",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "migration",
-      "loc": 5607,
-      "cone_roots": [
-        "tests/migration",
-        "tests/specify_cli/migration"
-      ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
+      "target_group": "auth_audit_git",
+      "target_shard": "auth-audit-git"
     },
     {
       "dir": "auth",
-      "loc": 5140,
       "cone_roots": [
         "tests/auth"
       ],
@@ -34,8 +21,23 @@
       "target_shard": "auth-audit-git"
     },
     {
+      "dir": "bulk_edit",
+      "cone_roots": [
+        "tests/specify_cli/bulk_edit"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "calibration",
+      "cone_roots": [
+        "tests/calibration"
+      ],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
       "dir": "compat",
-      "loc": 5072,
       "cone_roots": [
         "tests/specify_cli/compat"
       ],
@@ -43,17 +45,30 @@
       "target_shard": "specify-cli-heavy"
     },
     {
-      "dir": "tracker",
-      "loc": 3966,
+      "dir": "context",
       "cone_roots": [
-        "tests/tracker"
+        "tests/context",
+        "tests/specify_cli/context"
       ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "decisions",
+      "cone_roots": [
+        "tests/specify_cli/decisions"
+      ],
+      "target_group": "closeout",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "doc_analysis",
+      "cone_roots": [],
+      "target_group": "closeout",
+      "target_shard": "misc"
     },
     {
       "dir": "doctrine",
-      "loc": 3918,
       "cone_roots": [
         "tests/specify_cli/doctrine"
       ],
@@ -62,7 +77,6 @@
     },
     {
       "dir": "dossier",
-      "loc": 3246,
       "cone_roots": [
         "tests/dossier",
         "tests/specify_cli/dossier"
@@ -71,27 +85,15 @@
       "target_shard": "specify-cli-rest"
     },
     {
-      "dir": "invocation",
-      "loc": 2916,
+      "dir": "events",
       "cone_roots": [
-        "tests/invocation",
-        "tests/specify_cli/invocation"
+        "tests/specify_cli/events"
       ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
-    },
-    {
-      "dir": "skills",
-      "loc": 2865,
-      "cone_roots": [
-        "tests/specify_cli/skills"
-      ],
-      "target_group": "agent_surface",
+      "target_group": "platform",
       "target_shard": "specify-cli-rest"
     },
     {
       "dir": "git",
-      "loc": 2770,
       "cone_roots": [
         "tests/git",
         "tests/git_ops",
@@ -101,18 +103,47 @@
       "target_shard": "auth-audit-git"
     },
     {
-      "dir": "audit",
-      "loc": 2104,
+      "dir": "intake",
+      "cone_roots": [],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "invocation",
       "cone_roots": [
-        "tests/audit",
-        "tests/specify_cli/audit"
+        "tests/invocation",
+        "tests/specify_cli/invocation"
       ],
-      "target_group": "auth_audit_git",
-      "target_shard": "auth-audit-git"
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
+    },
+    {
+      "dir": "migration",
+      "cone_roots": [
+        "tests/migration",
+        "tests/specify_cli/migration"
+      ],
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
+    },
+    {
+      "dir": "mission_loader",
+      "cone_roots": [
+        "tests/unit/mission_loader"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "mission_v1",
+      "cone_roots": [
+        "tests/specify_cli/mission_v1"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
     },
     {
       "dir": "orchestrator_api",
-      "loc": 1956,
       "cone_roots": [
         "tests/specify_cli/orchestrator_api"
       ],
@@ -120,33 +151,31 @@
       "target_shard": "specify-cli-rest"
     },
     {
-      "dir": "doc_analysis",
-      "loc": 1864,
-      "cone_roots": [],
-      "target_group": "closeout",
+      "dir": "ownership",
+      "cone_roots": [
+        "tests/specify_cli/ownership"
+      ],
+      "target_group": "governance",
       "target_shard": "misc"
     },
     {
-      "dir": "widen",
-      "loc": 1785,
+      "dir": "paths",
       "cone_roots": [
-        "tests/specify_cli/widen"
+        "tests/paths"
       ],
-      "target_group": "closeout",
-      "target_shard": "misc"
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
     },
     {
-      "dir": "decisions",
-      "loc": 1539,
+      "dir": "policy",
       "cone_roots": [
-        "tests/specify_cli/decisions"
+        "tests/policy"
       ],
-      "target_group": "closeout",
+      "target_group": "governance",
       "target_shard": "misc"
     },
     {
       "dir": "readiness",
-      "loc": 1447,
       "cone_roots": [
         "tests/readiness",
         "tests/specify_cli/readiness"
@@ -155,131 +184,17 @@
       "target_shard": "misc"
     },
     {
-      "dir": "mission_v1",
-      "loc": 1337,
+      "dir": "retrospective",
       "cone_roots": [
-        "tests/specify_cli/mission_v1"
+        "tests/retrospective",
+        "tests/specify_cli/retrospect",
+        "tests/specify_cli/retrospective"
       ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "mission_loader",
-      "loc": 1297,
-      "cone_roots": [
-        "tests/unit/mission_loader"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "workspace",
-      "loc": 1283,
-      "cone_roots": [
-        "tests/specify_cli/workspace"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "bulk_edit",
-      "loc": 1276,
-      "cone_roots": [
-        "tests/specify_cli/bulk_edit"
-      ],
-      "target_group": "agent_surface",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "session_presence",
-      "loc": 1227,
-      "cone_roots": [
-        "tests/specify_cli/session_presence"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "policy",
-      "loc": 1193,
-      "cone_roots": [
-        "tests/policy"
-      ],
-      "target_group": "governance",
+      "target_group": "closeout",
       "target_shard": "misc"
-    },
-    {
-      "dir": "ownership",
-      "loc": 1114,
-      "cone_roots": [
-        "tests/specify_cli/ownership"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "context",
-      "loc": 1056,
-      "cone_roots": [
-        "tests/context",
-        "tests/specify_cli/context"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "validators",
-      "loc": 770,
-      "cone_roots": [],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "template",
-      "loc": 748,
-      "cone_roots": [
-        "tests/test_template"
-      ],
-      "target_group": "lifecycle",
-      "target_shard": "specify-cli-heavy"
-    },
-    {
-      "dir": "intake",
-      "loc": 728,
-      "cone_roots": [],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "calibration",
-      "loc": 634,
-      "cone_roots": [
-        "tests/calibration"
-      ],
-      "target_group": "governance",
-      "target_shard": "misc"
-    },
-    {
-      "dir": "paths",
-      "loc": 577,
-      "cone_roots": [
-        "tests/paths"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
-    },
-    {
-      "dir": "events",
-      "loc": 574,
-      "cone_roots": [
-        "tests/specify_cli/events"
-      ],
-      "target_group": "platform",
-      "target_shard": "specify-cli-rest"
     },
     {
       "dir": "saas_client",
-      "loc": 561,
       "cone_roots": [
         "tests/specify_cli/saas_client"
       ],
@@ -287,9 +202,62 @@
       "target_shard": "specify-cli-rest"
     },
     {
+      "dir": "session_presence",
+      "cone_roots": [
+        "tests/specify_cli/session_presence"
+      ],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "skills",
+      "cone_roots": [
+        "tests/specify_cli/skills"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
       "dir": "task_utils",
-      "loc": 505,
       "cone_roots": [],
+      "target_group": "platform",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "template",
+      "cone_roots": [
+        "tests/test_template"
+      ],
+      "target_group": "lifecycle",
+      "target_shard": "specify-cli-heavy"
+    },
+    {
+      "dir": "tracker",
+      "cone_roots": [
+        "tests/tracker"
+      ],
+      "target_group": "agent_surface",
+      "target_shard": "specify-cli-rest"
+    },
+    {
+      "dir": "validators",
+      "cone_roots": [],
+      "target_group": "governance",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "widen",
+      "cone_roots": [
+        "tests/specify_cli/widen"
+      ],
+      "target_group": "closeout",
+      "target_shard": "misc"
+    },
+    {
+      "dir": "workspace",
+      "cone_roots": [
+        "tests/specify_cli/workspace"
+      ],
       "target_group": "platform",
       "target_shard": "specify-cli-rest"
     }

--- a/tests/specify_cli/cli/commands/test_decision_widen_subcommand.py
+++ b/tests/specify_cli/cli/commands/test_decision_widen_subcommand.py
@@ -250,6 +250,32 @@ class TestLivePath:
         assert result.exit_code == 1
         assert "server error" in result.output
 
+    def test_live_path_passes_repo_root_to_from_env(self, tmp_path: Path) -> None:
+        """cmd_widen passes repo_root to SaasClient.from_env.
+
+        D-5: file-auth path (.kittify/saas-auth.json) must be reachable from the
+        widen command — requires from_env(repo_root=<path>), not from_env() (#2248).
+        """
+        mock_client = MagicMock()
+        mock_client.post_widen.return_value = _make_widen_response()
+        captured: list[object] = []
+
+        def _capture_from_env(repo_root: object = None) -> object:
+            captured.append(repo_root)
+            return mock_client
+
+        with patch("specify_cli.saas_client.client.SaasClient.from_env", side_effect=_capture_from_env):
+            result = _invoke(
+                ["decision", "widen", DECISION_ID, "--invited", "101"],
+                cwd=tmp_path,
+            )
+        assert result.exit_code == 0, f"exit {result.exit_code}\n{result.output}"
+        assert len(captured) == 1
+        assert captured[0] is not None, (
+            "from_env must receive a repo_root so .kittify/saas-auth.json is reachable (D-5 / #2248)"
+        )
+        assert isinstance(captured[0], Path)
+
 
 # ---------------------------------------------------------------------------
 # Error paths

--- a/tests/specify_cli/saas_client/test_client.py
+++ b/tests/specify_cli/saas_client/test_client.py
@@ -114,11 +114,13 @@ def test_load_auth_context_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ctx.team_slug == "my-team"
 
 
-def test_load_auth_context_default_url(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_auth_context_raises_when_no_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """D-5: with a token but no SaaS URL from env or file, fail closed — no
+    hardcoded ``api.spec-kitty.io`` fallback (#2248 / #2146)."""
     monkeypatch.setenv("SPEC_KITTY_SAAS_TOKEN", "test-token")
     monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
-    ctx = load_auth_context()
-    assert ctx.saas_url == "https://api.spec-kitty.io"
+    with pytest.raises(SaasAuthError, match="SaaS URL not configured"):
+        load_auth_context()
 
 
 def test_load_auth_context_from_file(

--- a/tests/specify_cli/saas_client/test_client.py
+++ b/tests/specify_cli/saas_client/test_client.py
@@ -123,6 +123,55 @@ def test_load_auth_context_raises_when_no_url(monkeypatch: pytest.MonkeyPatch) -
         load_auth_context()
 
 
+def test_load_auth_context_env_token_file_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D-5: token from env + URL from file is a valid mixed-source resolution.
+
+    The file-read block runs whenever either the token or the URL is still
+    missing after the env pass (#2248 logic fix).  Env token + file saas_url
+    must resolve successfully without requiring SPEC_KITTY_SAAS_URL to be set.
+    """
+    monkeypatch.setenv("SPEC_KITTY_SAAS_TOKEN", "env-token")
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    auth_dir = tmp_path / ".kittify"
+    auth_dir.mkdir()
+    (auth_dir / "saas-auth.json").write_text(
+        json.dumps({"saas_url": "https://file-url.example"})
+    )
+    ctx = load_auth_context(repo_root=tmp_path)
+    assert ctx.token == "env-token"
+    assert ctx.saas_url == "https://file-url.example"
+
+
+def test_load_auth_context_raises_when_file_has_no_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D-5 file branch: file token present but no saas_url key → fail closed."""
+    monkeypatch.delenv("SPEC_KITTY_SAAS_TOKEN", raising=False)
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    auth_dir = tmp_path / ".kittify"
+    auth_dir.mkdir()
+    (auth_dir / "saas-auth.json").write_text(json.dumps({"token": "file-token"}))
+    with pytest.raises(SaasAuthError, match="SaaS URL not configured"):
+        load_auth_context(repo_root=tmp_path)
+
+
+def test_load_auth_context_raises_when_file_has_empty_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D-5 file branch: empty-string saas_url in file → fail closed (strip normalises it)."""
+    monkeypatch.delenv("SPEC_KITTY_SAAS_TOKEN", raising=False)
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    auth_dir = tmp_path / ".kittify"
+    auth_dir.mkdir()
+    (auth_dir / "saas-auth.json").write_text(
+        json.dumps({"token": "file-token", "saas_url": ""})
+    )
+    with pytest.raises(SaasAuthError, match="SaaS URL not configured"):
+        load_auth_context(repo_root=tmp_path)
+
+
 def test_load_auth_context_from_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #2248. Unblocked by the #2146 canonical-target-authority decision.

## Problem
`saas_client/auth.py:18` hardcoded `_DEFAULT_SAAS_URL = "https://api.spec-kitty.io"` and `load_auth_context` fell back to it when neither `SPEC_KITTY_SAAS_URL` nor `.kittify/saas-auth.json` supplied a URL — contradicting **D-5** ("no hardcoded SaaS domain anywhere; callers must set `SPEC_KITTY_SAAS_URL`"), and risking silently pointing the client at the wrong server.

## Fix
- Remove `_DEFAULT_SAAS_URL`; when no URL resolves from env or the auth file, **raise `SaasAuthError` (fail closed)** — mirrors `auth/config.get_saas_base_url`'s D-5 contract. The `.kittify/saas-auth.json` `saas_url` remains a valid source.
- Reconcile the enshrining test: `test_load_auth_context_default_url` (asserted the hardcoded literal) → `test_load_auth_context_raises_when_no_url` (asserts the D-5 raise). Env-URL and file-URL positive paths already covered by neighboring tests.
- Genericize the `client.py` docstring example that named the domain.

## Safety
All `load_auth_context` callers already handle `SaasAuthError`: the plan/specify/charter interviews wrap it best-effort (`except Exception`), and `client.py` documents it as raised. So the new no-URL raise is caught exactly where the pre-existing no-token raise already was — no caller breaks.

## Verification
`tests/specify_cli/saas_client/test_client.py` — 31 passed. ruff + mypy clean. No `__init__.py` change → no version bump.

Draft per the landing doctrine; ready for your review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)