### PR TITLE
docs(changelog): record #2413/#2417 remediations landing via PR #2414

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: Changelog
 description: Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release.
 doc_status: active
-updated: '2026-07-05'
+updated: '2026-07-06'
 ---
 # Changelog
 
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3.2.4. Both health branches now use `packaging.Version` ordering
   (`avail > current`); unparseable versions are treated as no-upgrade so
   session start never breaks on a weird cache value.
+
+### ♻️ Changed
+
+- **Internal: version-comparison primitives consolidated into one canonical module (#2417, landing via PR #2414).**
+  Landing the #2413 fix surfaced three independent "is version A newer than
+  version B" implementations that had drifted apart in edge-case handling:
+  `cli/commands/upgrade.py::_version_is_newer` (caught the broad `Exception`
+  instead of the specific parse failure), `core/upgrade_probe.py::_classify`'s
+  inline comparison, and the `_upgrade_is_available` helper #2413 had just
+  added to `session_presence/manager.py`. All three now delegate to a new
+  pure module, `specify_cli.core.version_compare`
+  (`try_parse_version` / `is_version_newer`), with no CLI/click/typer
+  imports so it is safe to import from any layer; the two duplicate boolean
+  helpers are deleted outright, no aliases left behind. No user-facing
+  behavior change.
 
 ## [3.2.4] - 2026-07-05
 


### PR DESCRIPTION
## Summary

Fills in the previously-placeholder `[Unreleased] - 3.2.5` section of
`docs/changelog/CHANGELOG.md` with entries for the two changelog-worthy
commits currently on PR #2414 (open, being landed by a maintainer pass on
the `rayjohnson` fork — **not yet merged**):

- **🐛 Fixed — #2413.** The session-presence orientation banner recommended
  a downgrade on machines whose installed CLI was newer than the cached
  PyPI-latest (fresh release not yet cached, rc/dev installs), because the
  health check compared versions with a bare inequality instead of
  `packaging.Version` ordering.
- **♻️ Changed — #2417.** A maintainer-dispatched follow-up found during the
  #2413 landing pass: three independent "is version newer" implementations
  (`upgrade.py`, `upgrade_probe.py`, `session_presence/manager.py`) are
  consolidated into one canonical `specify_cli.core.version_compare` module.
  Internal/no user-facing behavior change.

A third candidate item (#2339 — `migration_id` dry-run contract pattern) is
**not** included: its commit was not present on PR #2414's commit list as of
this writing, so no entry was added for it (avoiding documenting work that
hasn't landed).

This PR is **docs-only** and safe to merge independently of #2414 — it just
narrates what #2414 is shipping. If #2414 lands with additional commits
before this merges, a follow-up changelog PR should cover the delta rather
than blocking this one.

## Test plan

- [x] `uv run python scripts/docs/sync_changelog.py --check` — passes
- [x] `uv run pytest tests/architectural/test_no_legacy_terminology.py -q` — 3 passed
- [x] Verified against PR #2414's actual commit diffs (`git show <sha>`) and
      issues #2413 / #2417, not just commit subject lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkEUzJqwXscGySRiaMGPtY