### PR TITLE
fix(sync): route runtime callers through canonical target authority (#2146)

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -2536,7 +2536,9 @@ def status(  # noqa: C901
 
     # Load configuration
     config = SyncConfig()
-    server_url = config.get_server_url()
+    # Show the resolved runtime target (SPEC_KITTY_SAAS_URL precedence folded
+    # in) — the URL sync actually hits — not the raw config.toml value (#2146).
+    server_url = config.resolve_runtime_target().resolved_server_url
     saas_enabled = is_saas_sync_enabled()
     queue = OfflineQueue()
     tm = get_token_manager()
@@ -3160,7 +3162,9 @@ def doctor() -> None:  # noqa: C901
 
     # --- 2. Auth status ---
     config = SyncConfig()
-    server_url = config.get_server_url()
+    # Resolved runtime target (env precedence folded in), not the raw
+    # config.toml value, so the diagnostics row matches what sync hits (#2146).
+    server_url = config.resolve_runtime_target().resolved_server_url
     table.add_row("Server URL", server_url)
 
     tm = get_token_manager()

--- a/src/specify_cli/sync/background.py
+++ b/src/specify_cli/sync/background.py
@@ -395,7 +395,7 @@ class BackgroundSyncService:
                 result = sync_all_queued_events(
                     queue=self.queue,
                     auth_token=access_token,
-                    server_url=self.config.get_server_url(),
+                    server_url=self.config.resolve_runtime_target().resolved_server_url,
                     batch_size=1000,
                     show_progress=show_progress,
                 )
@@ -455,7 +455,7 @@ class BackgroundSyncService:
             result = batch_sync(
                 queue=self.queue,
                 auth_token=access_token,
-                server_url=self.config.get_server_url(),
+                server_url=self.config.resolve_runtime_target().resolved_server_url,
                 limit=1000,
                 show_progress=False,
             )
@@ -541,7 +541,7 @@ class BackgroundSyncService:
         if not tasks:
             return
 
-        server_url = self.config.get_server_url()
+        server_url = self.config.resolve_runtime_target().resolved_server_url
         for task in tasks:
             outcome = push_content(task, access_token, server_url)
             self._handle_body_outcome(task, outcome)

--- a/src/specify_cli/sync/sharing_client.py
+++ b/src/specify_cli/sync/sharing_client.py
@@ -33,7 +33,10 @@ class RepositorySharingClientError(RuntimeError):
 
 
 def _base_url() -> str:
-    return SyncConfig().get_server_url().rstrip("/")
+    # Canonical runtime target authority (#2146): resolve the target we will
+    # actually hit (SPEC_KITTY_SAAS_URL precedence folded in), not the raw
+    # config.toml accessor. resolved_server_url is already normalized.
+    return SyncConfig().resolve_runtime_target().resolved_server_url
 
 
 def _error_from_response(response: httpx.Response) -> RepositorySharingClientError:

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -179,8 +179,10 @@ class SaaSTrackerClient:
     Parameters
     ----------
     sync_config:
-        Provides the server base URL.  Falls back to a default
-        ``SyncConfig()`` when *None*.
+        Provides the resolved runtime target URL (``SPEC_KITTY_SAAS_URL``
+        precedence folded in via ``resolve_runtime_target()``).  Falls back
+        to a default ``SyncConfig()`` when *None*.  The URL is resolved at
+        construction time and cached for the object lifetime.
     timeout:
         Per-request HTTP timeout in seconds (default 30).
 

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -197,7 +197,11 @@ class SaaSTrackerClient:
         timeout: float = 30.0,
     ) -> None:
         self._sync_config = sync_config or SyncConfig()
-        self._base_url: str = self._sync_config.get_server_url()
+        # Canonical runtime target authority (#2146): resolve the URL we will
+        # actually hit — folding in SPEC_KITTY_SAAS_URL precedence — instead of
+        # the raw config.toml accessor, which returns the hardcoded default and
+        # would silently ignore an env override.
+        self._base_url: str = self._sync_config.resolve_runtime_target().resolved_server_url
         self._timeout = timeout
 
     _STATUS_PATH = "/api/v1/tracker/status/"

--- a/tests/auth/integration/test_refresh_through_transport.py
+++ b/tests/auth/integration/test_refresh_through_transport.py
@@ -189,6 +189,8 @@ def _stub_sync_deps():
     # SyncConfig stub
     mock_config = MagicMock()
     mock_config.get_server_url.return_value = "https://saas.test"
+    # status/doctor now read the resolved runtime target (#2146).
+    mock_config.resolve_runtime_target.return_value.resolved_server_url = "https://saas.test"
     mock_config.config_file = "/tmp/test-sync-config.toml"
 
     # OfflineQueue stub

--- a/tests/sync/test_sync_doctor.py
+++ b/tests/sync/test_sync_doctor.py
@@ -120,6 +120,10 @@ class TestDoctorCommand:
 
         mock_config = MagicMock()
         mock_config.get_server_url.return_value = "https://test.example.com"
+        # Doctor now reads the resolved runtime target for the Server URL row (#2146).
+        mock_config.resolve_runtime_target.return_value.resolved_server_url = (
+            "https://test.example.com"
+        )
         mock_config_cls.return_value = mock_config
 
         now = datetime.now(UTC)
@@ -197,6 +201,10 @@ class TestDoctorCommand:
 
         mock_config = MagicMock()
         mock_config.get_server_url.return_value = "https://test.example.com"
+        # Doctor now reads the resolved runtime target for the Server URL row (#2146).
+        mock_config.resolve_runtime_target.return_value.resolved_server_url = (
+            "https://test.example.com"
+        )
         mock_config_cls.return_value = mock_config
 
         past = datetime(2020, 1, 1, tzinfo=UTC)

--- a/tests/sync/test_sync_status_command.py
+++ b/tests/sync/test_sync_status_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from rich.console import Console
@@ -34,6 +35,10 @@ def test_status_reads_dashboard_daemon_state_without_booting_local_runtime(monke
 
         def get_server_url(self) -> str:
             return "https://spec-kitty-dev.fly.dev"
+
+        def resolve_runtime_target(self, **_kwargs: object) -> SimpleNamespace:
+            # The status command now reads the resolved runtime target (#2146).
+            return SimpleNamespace(resolved_server_url="https://spec-kitty-dev.fly.dev")
 
     def fail_if_called(*_args, **_kwargs):
         raise AssertionError("status() should not start local background sync services")

--- a/tests/sync/test_target_authority_wiring.py
+++ b/tests/sync/test_target_authority_wiring.py
@@ -274,12 +274,12 @@ def test_single_resolved_url_across_surfaces(wiring_root: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_tracker_client_base_url_follows_resolved_target(wiring_root: Path) -> None:
+def test_tracker_client_base_url_follows_resolved_target(
+    wiring_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The tracker SaaS client hits the resolved (env-override) target, not config."""
     _write_config(wiring_root, CONFIG_URL)
-    import os
-
-    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+    monkeypatch.setenv("SPEC_KITTY_SAAS_URL", ENV_URL)
 
     client = SaaSTrackerClient()
     resolved = resolve_sync_target().resolved_server_url
@@ -288,12 +288,12 @@ def test_tracker_client_base_url_follows_resolved_target(wiring_root: Path) -> N
     assert client._base_url == resolved  # same single target as auth/readiness
 
 
-def test_sharing_client_base_url_follows_resolved_target(wiring_root: Path) -> None:
+def test_sharing_client_base_url_follows_resolved_target(
+    wiring_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The repository-sharing client resolves the env-override target, not config."""
     _write_config(wiring_root, CONFIG_URL)
-    import os
-
-    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+    monkeypatch.setenv("SPEC_KITTY_SAAS_URL", ENV_URL)
 
     assert sharing_client._base_url() == ENV_URL
     assert sharing_client._base_url() == resolve_sync_target().resolved_server_url
@@ -308,9 +308,7 @@ def test_background_full_sync_posts_to_resolved_target(
     observable state, not call order (NFR-001) — under a whole-process override.
     """
     _write_config(wiring_root, CONFIG_URL)
-    import os
-
-    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+    monkeypatch.setenv("SPEC_KITTY_SAAS_URL", ENV_URL)
 
     captured: dict[str, str] = {}
 
@@ -338,5 +336,6 @@ def test_background_full_sync_posts_to_resolved_target(
     service = BackgroundSyncService(queue=MagicMock(), config=SyncConfig())
     service._perform_full_sync()
 
+    assert "server_url" in captured, "_fake_sync_all was not called — _perform_full_sync did not reach the batch poster"
     assert captured["server_url"] == ENV_URL
     assert captured["server_url"] == resolve_sync_target().resolved_server_url

--- a/tests/sync/test_target_authority_wiring.py
+++ b/tests/sync/test_target_authority_wiring.py
@@ -15,10 +15,15 @@ no real port: the resolver and every probe here are pure/in-process.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 from specify_cli.saas import readiness
+from specify_cli.sync import sharing_client
+from specify_cli.sync.background import BackgroundSyncService
+from specify_cli.sync.batch import BatchSyncResult
+from specify_cli.sync.config import SyncConfig
 from specify_cli.sync.owner import compute_foreground_identity
 from specify_cli.sync.preflight import collect_foreground_identity
 from specify_cli.sync.queue import write_active_scope
@@ -26,6 +31,7 @@ from specify_cli.sync.target_authority import (
     QueueScopeStatus,
     resolve_sync_target,
 )
+from specify_cli.tracker.saas_client import SaaSTrackerClient
 
 pytestmark = [pytest.mark.fast]
 
@@ -257,3 +263,80 @@ def test_single_resolved_url_across_surfaces(wiring_root: Path) -> None:
     assert readiness_url == CONFIG_URL
     assert owner_url == CONFIG_URL
     assert preflight_url == CONFIG_URL
+
+
+# ---------------------------------------------------------------------------
+# #2146 — remaining runtime clients (tracker, sharing, background sync) key off
+# the one resolved target, not the raw config.toml accessor. Robert's #2246
+# review named these three as still reading ``get_server_url()`` (hardcoded
+# default), so they could post to the config target while auth/readiness point
+# at the env override. These prove they now resolve the same URL (SC-008).
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_client_base_url_follows_resolved_target(wiring_root: Path) -> None:
+    """The tracker SaaS client hits the resolved (env-override) target, not config."""
+    _write_config(wiring_root, CONFIG_URL)
+    import os
+
+    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+
+    client = SaaSTrackerClient()
+    resolved = resolve_sync_target().resolved_server_url
+
+    assert client._base_url == ENV_URL
+    assert client._base_url == resolved  # same single target as auth/readiness
+
+
+def test_sharing_client_base_url_follows_resolved_target(wiring_root: Path) -> None:
+    """The repository-sharing client resolves the env-override target, not config."""
+    _write_config(wiring_root, CONFIG_URL)
+    import os
+
+    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+
+    assert sharing_client._base_url() == ENV_URL
+    assert sharing_client._base_url() == resolve_sync_target().resolved_server_url
+
+
+def test_background_full_sync_posts_to_resolved_target(
+    wiring_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The background daemon posts queued events to the resolved (env) target.
+
+    Captures the ``server_url`` the daemon actually hands to the batch poster —
+    observable state, not call order (NFR-001) — under a whole-process override.
+    """
+    _write_config(wiring_root, CONFIG_URL)
+    import os
+
+    os.environ["SPEC_KITTY_SAAS_URL"] = ENV_URL
+
+    captured: dict[str, str] = {}
+
+    def _fake_sync_all(
+        *,
+        queue: object,
+        auth_token: str,
+        server_url: str,
+        batch_size: int,
+        show_progress: bool,
+    ) -> BatchSyncResult:
+        captured["server_url"] = server_url
+        return BatchSyncResult()
+
+    monkeypatch.setattr(
+        "specify_cli.sync.background.is_saas_sync_enabled", lambda: True
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.background._fetch_access_token_sync", lambda: "tok"
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.background.sync_all_queued_events", _fake_sync_all
+    )
+
+    service = BackgroundSyncService(queue=MagicMock(), config=SyncConfig())
+    service._perform_full_sync()
+
+    assert captured["server_url"] == ENV_URL
+    assert captured["server_url"] == resolve_sync_target().resolved_server_url

--- a/tests/sync/tracker/test_saas_client.py
+++ b/tests/sync/tracker/test_saas_client.py
@@ -64,6 +64,11 @@ def mock_credential_store() -> MagicMock:
 def mock_sync_config() -> MagicMock:
     config = MagicMock()
     config.get_server_url.return_value = "https://saas.example.com"
+    # The client now resolves its base URL via the canonical target authority
+    # (#2146), not the raw get_server_url accessor.
+    config.resolve_runtime_target.return_value.resolved_server_url = (
+        "https://saas.example.com"
+    )
     return config
 
 


### PR DESCRIPTION
**Draft for @stijn-priivacy** (core is your lane — handing off for your merge call).

Implements the concrete fix Robert endorsed in his #2246 review, which he explicitly recommended over that PR's approach.

## The bug (real on `origin/main`)

Several **runtime** surfaces still read the raw `SyncConfig.get_server_url()` accessor — a `config.toml`-only reader with a hardcoded `spec-kitty-dev.fly.dev` default — instead of the canonical `resolve_runtime_target().resolved_server_url`, which folds in `SPEC_KITTY_SAAS_URL` precedence. With an env override set, `auth`/`readiness` resolve to the env target while these surfaces silently post to the config target: the SC-008 split-brain the target-authority work (#2146) exists to prevent.

## Change

Move the runtime callers onto the resolved target:
- `tracker/saas_client.py:200` — `SaaSTrackerClient` base URL
- `sync/sharing_client.py:36` — `_base_url()`
- `sync/background.py:398 / :458 / :544` — full sync, batch sync, body drain

And make the two diagnostics rows honest so they show what sync actually hits, not the raw config value:
- `sync status` "Server URL"
- `sync doctor` "Server URL"

**No new crash surface.** `resolve_runtime_target()` calls `resolve_sync_target(process_wide_override=True)`, so an env/config disagreement classifies as a clean whole-process override (env wins) and never raises `SyncTargetSplitBrainError` into these paths. The fail-closed guard stays reserved for the `process_wide_override=False` setup/diagnostic paths.

**Deliberately left alone:**
- `get_server_url()` / `set_server_url()` — still the `config.toml` accessors the resolver itself consumes.
- `sync server` (the show/set command, `sync.py:1815`) — it manages the config value by design, so it correctly reads the raw accessor.

## Tests (Robert's stated done-when)

Extended `tests/sync/test_target_authority_wiring.py` with proofs that tracker, sharing, and background sync all resolve the **same** URL as auth/readiness under a whole-process override — including capturing the `server_url` the daemon actually hands to the batch poster (observable state, not call order, per NFR-001). Updated the tracker/status/doctor config mocks to the resolver contract.

- `tests/sync/test_target_authority_wiring.py` — 11 passed (8 existing + 3 new)
- `tests/sync/tracker/` — 445 passed
- `tests/sync/` sharing+background — 82 passed
- status + doctor — 5 passed
- `tests/architectural/` boundary + terminology — 7 passed
- `ruff check` clean; `mypy --strict src/specify_cli` introduces no new findings on the changed lines (the 12 pre-existing advisory findings are all in charter/dashboard/runtime).

Claim + rationale on the issue: #2146.