### PR TITLE
fix(#2430): dashboard reads planning artifacts primary-first, live status from coord

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Fixed
 
+- **Dashboard: PR-bound missions planned on a feature branch are visible again
+  (#2430).** The dashboard scanner resolved ONE directory per mission,
+  coord-worktree-first — but under coordination topology the two partitions
+  live on different surfaces: `spec-commit` lands planning artifacts
+  (`spec.md`/`plan.md`/`tasks.md`/`tasks/`/`meta.json`) on the **primary**
+  surface, while the live event log lives on the **coordination** branch. The
+  scanned `-coord` copy therefore held only status writes, so the legacy
+  existence filter (numeric prefix or `tasks/` present) silently dropped any
+  in-flight post-083 mission from `/api/features`, and artifact viewers/kanban
+  read the wrong surface. The scanner now splits the read per partition —
+  planning artifacts primary-first through the same kind-aware read seam the
+  #2331 identity fix uses (`resolve_planning_read_dir`), live lane state from
+  the gather-resolved coord surface — so an in-flight coordination mission
+  lists with its real spec/plan/tasks AND live kanban lanes. Same
+  coord-shadows-primary class as #2331; the accept-side sibling is #2404.
 - **Session banner no longer recommends a downgrade (#2413).** The
   session-presence health check decided "upgrade-available" with a bare
   inequality (`avail != current`), so any machine whose installed CLI was

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -778,13 +778,13 @@ def _build_event_log_kanban_stats(feature_dir: Path, tasks_dir: Path) -> dict[st
 
 
 def _build_kanban_stats(
-    feature_dir: Path,
+    planning_dir: Path,
     artifacts: dict[str, dict[str, Any]],
     status_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Build kanban lane counts.
 
-    ``feature_dir`` supplies the WP task files (planning surface);
+    ``planning_dir`` supplies the WP task files (planning surface);
     ``status_dir`` supplies the canonical event log — under coordination
     topology the two live on different surfaces (#2430). ``None`` keeps the
     single-surface behavior for legacy call sites.
@@ -793,10 +793,10 @@ def _build_kanban_stats(
     if not artifacts["kanban"]:
         return kanban_stats
 
-    tasks_dir = feature_dir / "tasks"
-    if is_legacy_format(feature_dir):
+    tasks_dir = planning_dir / "tasks"
+    if is_legacy_format(planning_dir):
         return _build_legacy_kanban_stats(tasks_dir)
-    return _build_event_log_kanban_stats(status_dir or feature_dir, tasks_dir)
+    return _build_event_log_kanban_stats(status_dir or planning_dir, tasks_dir)
 
 
 def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
@@ -972,6 +972,9 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> dict[str, list[di
     if not tasks_dir.exists():
         return lanes
 
+    # Legacy detection uses the planning surface by design: legacy lane
+    # directories are a planning artifact, and coord-topology missions are
+    # never legacy (they always carry an event log).
     if is_legacy_format(planning_dir):
         # Pre-3.0 layout: the boundary guard blocks mutation commands from
         # reaching this path; the dashboard read-only scan annotates the feature

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -433,6 +433,40 @@ def _resolve_identity_primary_first(
     return mission_id, mission_number
 
 
+def _resolve_planning_dir_primary_first(project_dir: Path, feature_dir: Path) -> Path:
+    """Resolve the *planning* surface for one scanned feature dir (#2430).
+
+    :func:`gather_feature_paths` returns ONE dir per feature, coord-first —
+    the right priority for live *status* (the append-only event log lives on
+    the coordination branch for coord-topology missions, C-001), but wrong for
+    *planning* artifacts: ``spec-commit`` lands ``spec.md`` / ``plan.md`` /
+    ``tasks.md`` / ``tasks/`` / ``meta.json`` on the PRIMARY surface for every
+    topology (write-surface-coherence). A scanned ``-coord`` dir therefore
+    holds only status writes mid-mission, and reading planning artifacts off
+    it made a PR-bound feature-branch mission invisible (#2430) — the same
+    coord-shadows-primary class as #2331.
+
+    Resolve the planning surface primary-first through the kind-aware read
+    seam (:func:`resolve_planning_read_dir` with ``TASKS_INDEX``, the same
+    seam #2331 uses for identity). Fall back to the scanned dir when the
+    resolver declines (unsafe segment, ambiguous handle) or the resolved dir
+    does not exist, so legacy / lane-only / test layouts keep their existing
+    behavior. The scanned ``feature_dir`` itself remains the status surface —
+    gather's registry-classified coord preference already encodes that.
+    """
+    from mission_runtime import MissionArtifactKind  # noqa: PLC0415 — late import, cold-start cost
+
+    try:
+        candidate = resolve_planning_read_dir(
+            project_dir, feature_dir.name, kind=MissionArtifactKind.TASKS_INDEX
+        )
+    except (ValueError, MissionSelectorAmbiguous):
+        return feature_dir
+    if candidate.exists():
+        return candidate
+    return feature_dir
+
+
 def _mission_record_key(feature_dir: Path, mission_id: str | None, mission_number: int | None) -> str:
     """Compute the canonical registry key for a mission.
 
@@ -544,12 +578,16 @@ def resolve_active_feature(
     return None
 
 
-def _count_wps_by_lane(tasks_dir: Path) -> dict[str, int]:
+def _count_wps_by_lane(tasks_dir: Path, status_dir: Path | None = None) -> dict[str, int]:
     """Count work packages by lane from the canonical event log.
 
     Raises ``CanonicalStatusNotFoundError`` when the event log is absent.
     WPs not present in the event log are treated as ``genesis`` and excluded
     from display counts until finalize-tasks seeds them.
+
+    ``status_dir`` names the surface holding the canonical event log; under
+    coordination topology it differs from the planning surface that holds
+    ``tasks/`` (#2430). ``None`` derives it from ``tasks_dir`` as before.
 
     Lane-to-column mapping is driven by :meth:`WPState.display_category`
     via :data:`_KANBAN_COLUMN_MAP`.
@@ -559,8 +597,8 @@ def _count_wps_by_lane(tasks_dir: Path) -> dict[str, int]:
     if not tasks_dir.exists():
         return counts
 
-    # feature_dir is the parent of tasks/
-    feature_dir = tasks_dir.parent
+    # Default: the event log lives beside tasks/ (single-surface layouts).
+    feature_dir = status_dir if status_dir is not None else tasks_dir.parent
 
     from specify_cli.status import get_all_wp_lanes
 
@@ -701,12 +739,14 @@ def _resolve_checkout_root(feature_dir: Path) -> Path | None:
 
 
 def _build_event_log_kanban_stats(feature_dir: Path, tasks_dir: Path) -> dict[str, Any]:
+    """Count WP lanes: ``tasks_dir`` lists the WPs (planning surface),
+    ``feature_dir`` holds the canonical event log (status surface, #2430)."""
     from specify_cli.status import CanonicalStatusNotFoundError
     from specify_cli.status import StoreError
 
     kanban_stats: dict[str, Any] = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
     try:
-        lane_counts = _count_wps_by_lane(tasks_dir)
+        lane_counts = _count_wps_by_lane(tasks_dir, status_dir=feature_dir)
         for lane, count in lane_counts.items():
             kanban_stats[lane] = count
             kanban_stats["total"] += count
@@ -737,7 +777,18 @@ def _build_event_log_kanban_stats(feature_dir: Path, tasks_dir: Path) -> dict[st
     return kanban_stats
 
 
-def _build_kanban_stats(feature_dir: Path, artifacts: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _build_kanban_stats(
+    feature_dir: Path,
+    artifacts: dict[str, dict[str, Any]],
+    status_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Build kanban lane counts.
+
+    ``feature_dir`` supplies the WP task files (planning surface);
+    ``status_dir`` supplies the canonical event log — under coordination
+    topology the two live on different surfaces (#2430). ``None`` keeps the
+    single-surface behavior for legacy call sites.
+    """
     kanban_stats: dict[str, Any] = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
     if not artifacts["kanban"]:
         return kanban_stats
@@ -745,7 +796,7 @@ def _build_kanban_stats(feature_dir: Path, artifacts: dict[str, dict[str, Any]])
     tasks_dir = feature_dir / "tasks"
     if is_legacy_format(feature_dir):
         return _build_legacy_kanban_stats(tasks_dir)
-    return _build_event_log_kanban_stats(feature_dir, tasks_dir)
+    return _build_event_log_kanban_stats(status_dir or feature_dir, tasks_dir)
 
 
 def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
@@ -754,13 +805,26 @@ def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
     feature_paths = gather_feature_paths(project_dir)
 
     for feature_id, feature_dir in feature_paths.items():
-        if not (re.match(r"^\d+", feature_dir.name) or (feature_dir / "tasks").exists()):
+        # Planning artifacts read primary-first (#2430); the scanned dir stays
+        # the live-status surface (gather is coord-first by construction).
+        planning_dir = _resolve_planning_dir_primary_first(project_dir, feature_dir)
+
+        # A coord-topology mission's scanned (coord) dir holds only status
+        # writes — its ``tasks/`` lives on the planning surface, so the
+        # existence filter must consult that surface too or a live in-flight
+        # mission with a post-083 (non-numeric) slug vanishes (#2430).
+        if not (
+            re.match(r"^\d+", feature_dir.name)
+            or (planning_dir / "tasks").exists()
+            or (feature_dir / "tasks").exists()
+        ):
             continue
 
-        friendly_name, meta_data = _read_dashboard_feature_meta(feature_dir)
-        artifacts = get_feature_artifacts(feature_dir, project_dir)
+        meta_dir = planning_dir if (planning_dir / "meta.json").exists() else feature_dir
+        friendly_name, meta_data = _read_dashboard_feature_meta(meta_dir)
+        artifacts = get_feature_artifacts(planning_dir, project_dir)
         workflow = get_workflow_status(artifacts)
-        kanban_stats = _build_kanban_stats(feature_dir, artifacts)
+        kanban_stats = _build_kanban_stats(planning_dir, artifacts, status_dir=feature_dir)
 
         worktree = _resolve_feature_worktree_info(project_dir, feature_dir)
         display_name = format_feature_display_name(feature_id, friendly_name)
@@ -770,7 +834,9 @@ def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
                 "id": feature_id,
                 "name": friendly_name,
                 "display_name": display_name,
-                "path": str(feature_dir.relative_to(project_dir)),
+                # Artifact viewers read planning content — point them at the
+                # planning surface, not a status-only coord husk (#2430).
+                "path": str(planning_dir.relative_to(project_dir)),
                 "artifacts": artifacts,
                 "workflow": workflow,
                 "kanban_stats": kanban_stats,
@@ -787,6 +853,7 @@ def _process_wp_file(
     prompt_file: Path,
     project_dir: Path,
     default_lane: str,
+    status_dir: Path | None = None,
 ) -> dict[str, Any] | None:
     """Process a single WP file and return task data or None on error."""
     content, error = read_file_resilient(prompt_file, auto_fix=True)
@@ -830,7 +897,11 @@ def _process_wp_file(
     canonical_wp_id = wp_id_match.group(1).upper() if wp_id_match else stem
 
     candidate = prompt_file.parent.parent
-    if has_event_log(candidate):
+    # The live event log may sit on the status surface (coord worktree) while
+    # the WP file being processed lives on the planning surface (#2430).
+    if status_dir is not None and has_event_log(status_dir):
+        lane = get_wp_lane(status_dir, canonical_wp_id)
+    elif has_event_log(candidate):
         lane = get_wp_lane(candidate, canonical_wp_id)
     elif has_event_log(candidate.parent):
         lane = get_wp_lane(candidate.parent, canonical_wp_id)
@@ -891,11 +962,17 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> dict[str, list[di
     if feature_dir is None or not feature_dir.exists():
         return lanes
 
-    tasks_dir = feature_dir / "tasks"
+    # WP task files live on the planning surface, the live event log on the
+    # status surface (the gather-resolved, coord-first ``feature_dir``) —
+    # split the read per partition (#2430).
+    planning_dir = _resolve_planning_dir_primary_first(project_dir, feature_dir)
+    status_dir = feature_dir
+
+    tasks_dir = planning_dir / "tasks"
     if not tasks_dir.exists():
         return lanes
 
-    if is_legacy_format(feature_dir):
+    if is_legacy_format(planning_dir):
         # Pre-3.0 layout: the boundary guard blocks mutation commands from
         # reaching this path; the dashboard read-only scan annotates the feature
         # as legacy without iterating lane subdirectories.
@@ -906,7 +983,7 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> dict[str, list[di
 
     for prompt_file in tasks_dir.glob("WP*.md"):
         try:
-            task_data = _process_wp_file(prompt_file, project_dir, "planned")
+            task_data = _process_wp_file(prompt_file, project_dir, "planned", status_dir=status_dir)
             if task_data is not None:
                 raw_lane = task_data.get("lane", "planned")
                 state = wp_state_for(raw_lane)

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -565,6 +565,7 @@ def test_status_only_coord_copy_does_not_hide_mission(tmp_path):
     # Planning artifacts render from the primary surface …
     assert feature["path"] == f"kitty-specs/{slug}"
     assert feature["artifacts"]["spec"]["exists"] is True
+    assert feature["artifacts"]["plan"]["exists"] is True
     assert feature["artifacts"]["tasks"]["exists"] is True
     # … and lane counts come from the coord worktree's LIVE event log, not the
     # primary's stale one.
@@ -574,6 +575,65 @@ def test_status_only_coord_copy_does_not_hide_mission(tmp_path):
     lanes = scanner.scan_feature_kanban(tmp_path, slug)
     assert [t["id"] for t in lanes["doing"]] == ["WP01"]
     assert lanes["planned"] == []
+
+
+def test_coord_event_log_wins_when_stale_behind_primary(tmp_path):
+    """#2430: coord event log is authoritative for status even when it lags behind primary.
+
+    Scenario: primary has WP01 in ``approved`` (ahead); coord has WP01 in
+    ``planned`` (stale/behind primary).  The dashboard must surface ``planned``
+    (coord wins), not ``approved`` (primary).
+
+    This is the inverse of ``test_dashboard_scans_prefer_coord_worktree_over_root_checkout``
+    which tests coord-ahead.  Together they prove coord preference is unconditional
+    — neither direction of lag overrides it.
+    """
+    slug = "coord-stale-primary-ahead-01KWST0A"
+
+    _git(["init", "--initial-branch=main"], tmp_path)
+    _git(["config", "user.email", "scanner@example.com"], tmp_path)
+    _git(["config", "user.name", "Scanner Test"], tmp_path)
+    _git(["config", "commit.gpgsign", "false"], tmp_path)
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(["add", "README.md"], tmp_path)
+    _git(["commit", "-q", "-m", "seed"], tmp_path)
+    coord_worktree = tmp_path / ".worktrees" / f"{slug}-coord"
+    _git(
+        ["worktree", "add", "-q", "-b", f"kitty/mission-{slug}", str(coord_worktree)],
+        tmp_path,
+    )
+
+    # PRIMARY: full planning artifacts + WP01 in ``approved`` (primary is ahead).
+    primary_dir = _create_feature(tmp_path, slug, lane="approved")
+    (primary_dir / "meta.json").write_text(
+        json.dumps({"mission_id": "01KWST0A0000000000000000ZZ", "mission_slug": slug}),
+        encoding="utf-8",
+    )
+
+    # COORD copy: status partition ONLY — WP01 stale at ``planned``.
+    coord_feature_dir = coord_worktree / "kitty-specs" / slug
+    coord_feature_dir.mkdir(parents=True)
+    _set_wp_lane(coord_feature_dir, "WP01", "planned")
+    assert not (coord_feature_dir / "tasks").exists()
+
+    features = scanner.scan_all_features(tmp_path)
+    ids = [f["id"] for f in features]
+    assert slug in ids, f"mission invisible on dashboard; got {ids}"
+    feature = next(f for f in features if f["id"] == slug)
+
+    # Planning artifacts anchor to the primary surface …
+    assert feature["path"] == f"kitty-specs/{slug}"
+    assert feature["artifacts"]["spec"]["exists"] is True
+    assert feature["artifacts"]["plan"]["exists"] is True
+    assert feature["artifacts"]["tasks"]["exists"] is True
+    # … and lane counts come unconditionally from the coord event log (planned),
+    # not the primary's ahead state (approved).
+    assert feature["kanban_stats"]["planned"] == 1
+    assert feature["kanban_stats"]["approved"] == 0
+
+    lanes = scanner.scan_feature_kanban(tmp_path, slug)
+    assert [t["id"] for t in lanes["planned"]] == ["WP01"]
+    assert lanes["approved"] == []
 
 
 def test_registry_resolves_canonical_id_for_inflight_coord_mission(tmp_path):

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -479,6 +479,13 @@ def test_dashboard_scans_prefer_coord_worktree_over_root_checkout(tmp_path):
     # disposes (C-SEAM-1). A bare ``-coord``-named directory is a husk and must
     # NOT shadow the primary surface. Register the worktree on a clean seed
     # commit so this exercises the real coord-preference path.
+    #
+    # #2430 refined WHAT the coord copy outranks for: the partitions split.
+    # Live *status* (the event log) reads coord-first — the coord "approved"
+    # lane must win over the primary's stale "planned". *Planning* artifacts
+    # (spec/plan/tasks — PRIMARY-partition for every topology per
+    # write-surface-coherence) read primary-first, so ``path`` anchors to the
+    # primary surface, never a coord copy.
     _git(["init", "--initial-branch=main"], tmp_path)
     _git(["config", "user.email", "scanner@example.com"], tmp_path)
     _git(["config", "user.name", "Scanner Test"], tmp_path)
@@ -501,11 +508,10 @@ def test_dashboard_scans_prefer_coord_worktree_over_root_checkout(tmp_path):
     assert len(features) == 1
     feature = features[0]
 
-    assert feature["path"] == f".worktrees/{slug}-coord/kitty-specs/{slug}"
+    # Planning surface anchors to primary (#2430) …
+    assert feature["path"] == f"kitty-specs/{slug}"
     assert feature["worktree"]["exists"] is True
-    assert feature["worktree"]["path"] == scanner.format_path_for_display(
-        str(coord_feature_dir.parents[1])
-    )
+    # … while live status still reads the coord worktree's event log.
     assert feature["kanban_stats"]["approved"] == 1
     assert feature["kanban_stats"]["planned"] == 0
 
@@ -513,6 +519,61 @@ def test_dashboard_scans_prefer_coord_worktree_over_root_checkout(tmp_path):
     assert len(lanes["approved"]) == 1
     assert len(lanes["planned"]) == 0
     assert lanes["approved"][0]["id"] == "WP01"
+
+
+def test_status_only_coord_copy_does_not_hide_mission(tmp_path):
+    """#2430: a PR-bound mission planned on a feature branch is scanned with a
+    coord worktree copy holding ONLY status writes (``status.events.jsonl`` /
+    ``status.json``) — no ``spec.md``, no ``tasks/``, no ``meta.json``, because
+    ``spec-commit`` lands planning artifacts on the primary surface. The
+    dashboard must still list the mission (planning from primary) with LIVE
+    lanes (status from coord)."""
+    slug = "cut-review-chunk-phase-01KWVYYG"  # post-083 slug: no numeric prefix
+
+    _git(["init", "--initial-branch=main"], tmp_path)
+    _git(["config", "user.email", "scanner@example.com"], tmp_path)
+    _git(["config", "user.name", "Scanner Test"], tmp_path)
+    _git(["config", "commit.gpgsign", "false"], tmp_path)
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(["add", "README.md"], tmp_path)
+    _git(["commit", "-q", "-m", "seed"], tmp_path)
+    coord_worktree = tmp_path / ".worktrees" / f"{slug}-coord"
+    _git(
+        ["worktree", "add", "-q", "-b", f"kitty/mission-{slug}", str(coord_worktree)],
+        tmp_path,
+    )
+
+    # PRIMARY: full planning artifacts + a STALE event log (lane: planned).
+    primary_dir = _create_feature(tmp_path, slug, lane="planned")
+    (primary_dir / "meta.json").write_text(
+        json.dumps({"mission_id": "01KWVYYG0000000000000000ZZ", "mission_slug": slug}),
+        encoding="utf-8",
+    )
+
+    # COORD copy: status partition ONLY — the live event log, nothing else.
+    coord_feature_dir = coord_worktree / "kitty-specs" / slug
+    coord_feature_dir.mkdir(parents=True)
+    _set_wp_lane(coord_feature_dir, "WP01", "in_progress")
+    assert not (coord_feature_dir / "tasks").exists()
+    assert not (coord_feature_dir / "spec.md").exists()
+
+    features = scanner.scan_all_features(tmp_path)
+    ids = [f["id"] for f in features]
+    assert slug in ids, f"mission invisible on dashboard (#2430); got {ids}"
+    feature = next(f for f in features if f["id"] == slug)
+
+    # Planning artifacts render from the primary surface …
+    assert feature["path"] == f"kitty-specs/{slug}"
+    assert feature["artifacts"]["spec"]["exists"] is True
+    assert feature["artifacts"]["tasks"]["exists"] is True
+    # … and lane counts come from the coord worktree's LIVE event log, not the
+    # primary's stale one.
+    assert feature["kanban_stats"]["doing"] == 1
+    assert feature["kanban_stats"]["planned"] == 0
+
+    lanes = scanner.scan_feature_kanban(tmp_path, slug)
+    assert [t["id"] for t in lanes["doing"]] == ["WP01"]
+    assert lanes["planned"] == []
 
 
 def test_registry_resolves_canonical_id_for_inflight_coord_mission(tmp_path):

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -841,6 +841,33 @@ def test_resolve_planning_dir_primary_first_falls_back_when_candidate_absent(
     assert not absent.exists()
 
 
+@pytest.mark.fast
+def test_resolve_planning_dir_primary_first_returns_candidate_when_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolver returns an existing primary dir → the candidate wins over feature_dir.
+
+    Covers scanner.py lines 465-466: the happy-path branch where the resolved
+    primary dir exists on disk and is returned in preference to the coord-resolved
+    scanned dir. Also kills the mutation-blind gap in the three fallback tests: a
+    stub that always returns ``feature_dir`` fails this test because
+    ``result != feature_dir`` is asserted.
+    """
+    feature_dir = tmp_path / "kitty-specs" / "001-has-primary"
+    feature_dir.mkdir(parents=True)
+    primary_dir = (
+        tmp_path / ".worktrees" / "001-has-primary-lane-1" / "kitty-specs" / "001-has-primary"
+    )
+    primary_dir.mkdir(parents=True)  # exists — resolver found a live primary checkout
+
+    monkeypatch.setattr(scanner, "resolve_planning_read_dir", lambda *_a, **_kw: primary_dir)
+
+    result = scanner._resolve_planning_dir_primary_first(tmp_path, feature_dir)
+
+    assert result == primary_dir
+    assert result != feature_dir
+
+
 # ── NFR-006: Dashboard kanban bucketing identity ───────────────────────────
 
 

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -769,6 +769,78 @@ def test_scan_feature_kanban_generic_exception_is_logged_and_skipped(
     )
 
 
+# ── _resolve_planning_dir_primary_first fallback paths (#2430) ─────────────
+
+
+@pytest.mark.fast
+def test_resolve_planning_dir_primary_first_falls_back_on_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ValueError from resolve_planning_read_dir returns the scanned dir (#2430).
+
+    Covers scanner.py lines 463-464: the except branch when the resolver
+    declines because the mission slug contains an unsafe segment.
+    """
+    feature_dir = tmp_path / "kitty-specs" / "001-bad-segment"
+    feature_dir.mkdir(parents=True)
+
+    def _raise_value_error(*_a: object, **_kw: object) -> Path:
+        raise ValueError("unsafe segment in mission slug")
+
+    monkeypatch.setattr(scanner, "resolve_planning_read_dir", _raise_value_error)
+
+    result = scanner._resolve_planning_dir_primary_first(tmp_path, feature_dir)
+
+    assert result == feature_dir
+
+
+@pytest.mark.fast
+def test_resolve_planning_dir_primary_first_falls_back_on_ambiguous_handle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MissionSelectorAmbiguous from the resolver returns the scanned dir (#2430).
+
+    Covers scanner.py lines 463-464: the except branch when multiple missions
+    share the same slug prefix and the resolver cannot disambiguate.
+    """
+    from specify_cli.missions._read_path_resolver import MissionSelectorAmbiguous
+
+    feature_dir = tmp_path / "kitty-specs" / "01KW-ambiguous"
+    feature_dir.mkdir(parents=True)
+
+    def _raise_ambiguous(*_a: object, **_kw: object) -> Path:
+        raise MissionSelectorAmbiguous(handle="01KW", candidates=["01KWN9D0", "01KWV531"])
+
+    monkeypatch.setattr(scanner, "resolve_planning_read_dir", _raise_ambiguous)
+
+    result = scanner._resolve_planning_dir_primary_first(tmp_path, feature_dir)
+
+    assert result == feature_dir
+
+
+@pytest.mark.fast
+def test_resolve_planning_dir_primary_first_falls_back_when_candidate_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resolved primary path that does not exist on disk returns the scanned dir.
+
+    Covers scanner.py line 467: the fallback when the resolver returns a
+    candidate path that has not been checked out locally (e.g. lane-only
+    worktree where the primary feature branch exists only in the registry).
+    """
+    feature_dir = tmp_path / "kitty-specs" / "001-remote-primary"
+    feature_dir.mkdir(parents=True)
+    absent = tmp_path / ".worktrees" / "001-remote-primary-lane-1" / "kitty-specs" / "001-remote-primary"
+    # absent is never created — must not exist
+
+    monkeypatch.setattr(scanner, "resolve_planning_read_dir", lambda *_a, **_kw: absent)
+
+    result = scanner._resolve_planning_dir_primary_first(tmp_path, feature_dir)
+
+    assert result == feature_dir
+    assert not absent.exists()
+
+
 # ── NFR-006: Dashboard kanban bucketing identity ───────────────────────────
 
 


### PR DESCRIPTION
Fixes #2430.

## The bug

The dashboard scanner resolves ONE directory per mission, coord-worktree-first (`gather_feature_paths`), and reads **everything** off it. Under coordination topology the two partitions live on different surfaces: `spec-commit` lands planning artifacts (`spec.md`/`plan.md`/`tasks.md`/`tasks/`/`meta.json`) on the **primary** surface for every topology (write-surface-coherence), while the append-only event log lives on the **coordination** branch (C-001). Mid-mission, the scanned `-coord` copy holds only `status.events.jsonl`/`status.json`/`analysis-report.md`, so:

- the legacy existence filter in `scan_all_features` (numeric prefix **or** `tasks/` present) silently dropped any in-flight post-083 mission (ULID slugs have no numeric prefix) from `/api/features` — **a running mission was invisible precisely because it was running**;
- had it passed the filter, artifact viewers and kanban would have rendered off a status-only husk.

Same coord-shadows-primary class as #2331 (fixed for *identity* by `_resolve_identity_primary_first`); the accept-side sibling is #2404.

## The fix — split the read per partition, through the existing seam

- **`_resolve_planning_dir_primary_first()`** — planning surface resolved through the kind-aware read seam (`resolve_planning_read_dir`, `TASKS_INDEX`), exactly the #2331 pattern. Falls back to the scanned dir when the resolver declines (unsafe segment, ambiguous handle) or the primary copy is absent, so legacy / lane-only / test layouts are unchanged.
- **`scan_all_features`** — existence filter, `meta.json`, artifacts, and the `path` the viewers use all anchor to the planning surface; kanban lane counts read the event log from the gather-resolved (coord-first) scanned dir via a `status_dir` parameter threaded through `_build_kanban_stats` → `_build_event_log_kanban_stats` → `_count_wps_by_lane` (weighted progress reads the status surface too).
- **`scan_feature_kanban` / `_process_wp_file`** — WP files enumerated from the planning surface, per-WP lanes from the status surface.
- **No new resolution authority**: gather's registry-classified coord preference (C-SEAM-1) *is* the status surface by construction — the fix deliberately does not add a second STATUS resolver, it only re-anchors the PRIMARY-partition reads.
- Non-coordination missions: both surfaces resolve identically — zero behavior change.

## Tests

- `test_dashboard_scans_prefer_coord_worktree_over_root_checkout` re-pinned to the per-partition contract: the coord event log **still wins for status** (the approved-lane assertions are unchanged); `path` now anchors primary, per write-surface-coherence.
- New `test_status_only_coord_copy_does_not_hide_mission`: reproduces the reported shape end-to-end — registered coord worktree whose mission copy holds ONLY the event log, full planning artifacts + stale event log on primary, non-numeric slug. Asserts the mission lists, artifacts come from primary, and lane counts + board come from the coord log (not the stale primary one).
- 241 dashboard tests green; terminology + census gates green; `ruff` + `mypy` clean.

## Verified against the live affected repo

On the reporting repo (agent-review-bot, the #2430 repro): before — 8 features, running mission absent; after — 10 features (**two** missions were being hidden by this), the in-flight mission listed with its real spec/plan/tasks from the feature branch checkout and live lanes from the coord event log, board rendering all 6 WPs mid-orchestration.

## Not in this PR

- `spec-commit` routing (whether planning artifacts *should* bypass the coordination branch on an unprotected primary) — the issue's deeper framing; the write-surface-coherence partition says the current routing is by design, so this PR fixes the read side to honor that partition. If the maintainers want to revisit the routing, that's a design conversation on #2430.
- #2404 (accept reads acceptance-matrix from stale coord) — same invariant, different seam; not touched here.