### PR TITLE
docs(tasks): document create_intent ownership metadata

### DIFF
--- a/.kittify/overrides/missions/software-dev/command-templates/tasks.md
+++ b/.kittify/overrides/missions/software-dev/command-templates/tasks.md
@@ -196,6 +196,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
@@ -211,6 +211,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/prompts/test_tasks_prompt_ownership_metadata.py
+++ b/tests/prompts/test_tasks_prompt_ownership_metadata.py
@@ -1,0 +1,61 @@
+"""Regression tests for /spec-kitty.tasks ownership metadata guidance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TASKS_PROMPT_SURFACES = (
+    _REPO_ROOT
+    / "src"
+    / "doctrine"
+    / "missions"
+    / "mission-steps"
+    / "software-dev"
+    / "tasks"
+    / "prompt.md",
+    _REPO_ROOT
+    / ".kittify"
+    / "overrides"
+    / "missions"
+    / "software-dev"
+    / "command-templates"
+    / "tasks.md",
+)
+
+
+def _ownership_metadata_section(prompt_path: Path) -> str:
+    text = prompt_path.read_text(encoding="utf-8")
+    marker = "**OWNERSHIP METADATA (required by finalize-tasks)**"
+    start = text.index(marker)
+    next_heading = text.index("**Ownership rules**", start)
+    return text[start:next_heading]
+
+
+@pytest.mark.parametrize("prompt_path", _TASKS_PROMPT_SURFACES, ids=lambda path: path.as_posix())
+def test_tasks_prompt_documents_create_intent_with_required_ownership_fields(prompt_path: Path) -> None:
+    section = _ownership_metadata_section(prompt_path)
+
+    for field in ("`execution_mode`", "`owned_files`", "`authoritative_surface`", "`create_intent`"):
+        assert field in section
+
+
+@pytest.mark.parametrize("prompt_path", _TASKS_PROMPT_SURFACES, ids=lambda path: path.as_posix())
+def test_tasks_prompt_explains_create_intent_for_planned_new_owned_files(prompt_path: Path) -> None:
+    section = _ownership_metadata_section(prompt_path)
+
+    assert "planned-new" in section or "planned new" in section
+    assert "zero-match" in section or "zero match" in section
+
+
+@pytest.mark.parametrize("prompt_path", _TASKS_PROMPT_SURFACES, ids=lambda path: path.as_posix())
+def test_tasks_prompt_prevents_duplicate_create_intent_stubs(prompt_path: Path) -> None:
+    section = _ownership_metadata_section(prompt_path)
+
+    assert "single `create_intent` key" in section
+    assert "stub `create_intent: []`" in section
+    assert "replace it instead of adding a duplicate block" in section

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/tasks.prompt.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/tasks.toml
@@ -233,6 +233,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/tasks.toml
@@ -233,6 +233,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/tasks.md
@@ -234,6 +234,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/tasks.SKILL.md
@@ -232,6 +232,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.

--- a/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/tasks.SKILL.md
@@ -232,6 +232,7 @@ Prompts do not rediscover feature context. Commands do.
    - `execution_mode`: Either `"code_change"` (source code) or `"planning_artifact"` (kitty-specs docs)
    - `owned_files`: List of glob patterns for files this WP touches. Example: `["src/myapp/auth/**", "tests/myapp/test_auth.py"]`
    - `authoritative_surface`: Path prefix that must be a prefix of at least one owned_files entry. Example: `"src/myapp/auth/"`
+   - `create_intent`: List of repo-root-relative literal paths this WP will create. Use this when an `owned_files` entry names a planned-new file that does not exist yet, so finalize-tasks treats the zero-match as an intentional planned-new-file instead of a validation failure. Example: `["tests/myapp/test_new_auth.py"]`. Keep a single `create_intent` key; if a stub `create_intent: []` already exists, replace it instead of adding a duplicate block.
 
    **Ownership rules**:
    - No two WPs may have overlapping `owned_files`.


### PR DESCRIPTION
## Summary

- Document `create_intent` in the `/spec-kitty.tasks` ownership metadata guidance for the canonical tasks prompt and the tracked project mission override.
- Explain that `create_intent` is for planned-new repo-root-relative literal paths whose `owned_files` entry may otherwise zero-match during finalize-tasks validation.
- Explicitly tell agents to keep a single `create_intent` key and replace an existing `create_intent: []` stub instead of adding a duplicate block.
- Add regression coverage for the ownership metadata contract and update the rendered slash-command / command-skill snapshots.

## Validation

- `uv run --extra test pytest tests/prompts/test_tasks_prompt_ownership_metadata.py tests/prompts/test_prompt_fragment_rendering.py tests/specify_cli/regression/test_twelve_agent_parity.py::test_command_output_unchanged tests/specify_cli/regression/test_twelve_agent_parity.py::test_toml_command_output_is_parseable tests/specify_cli/skills/test_command_renderer.py::test_snapshot -q -k 'tasks or prompt_fragment or ownership_metadata'`
  - `85 passed, 128 deselected`
- `git diff --check` — PASS
- Added-line secret heuristic — no hits
- Foreground independent review via `codex exec` — PASS; no security or logic blockers
- Pre-PR live duplicate check — issue still open/unassigned, no claim comments, no timeline PR refs, no semantic open-PR hits, and no exact open-PR file collisions

## Notes

Refs #2249.

This PR updates prompt/generated-command guidance only; it does not change parser behavior.

---
Closes #2249 — documents the previously-undocumented `create_intent` key and the empty-stub duplicate-key foot-gun this PR resolves.
