### PR TITLE
fix(#2446): infer_authoritative_surface handles filename-glob owned_files

### DIFF
--- a/src/specify_cli/ownership/inference.py
+++ b/src/specify_cli/ownership/inference.py
@@ -155,7 +155,9 @@ def infer_authoritative_surface(owned_files: list[str]) -> str:
     """Derive the authoritative_surface from a list of owned_files patterns.
 
     Returns the longest common path prefix shared by all owned_files entries.
-    Trailing ``/**`` and ``/*`` wildcards are stripped before comparison.
+    A glob-bearing final path segment (whole-wildcard tokens like ``/**``/``/*``
+    *and* filename globs like ``*.py``, ``data_?.json`` or ``[abc].py``) is
+    reduced to its containing directory before comparison.
 
     Args:
         owned_files: List of glob patterns.
@@ -167,10 +169,20 @@ def infer_authoritative_surface(owned_files: list[str]) -> str:
         return ""
 
     def _strip_glob(pattern: str) -> str:
-        for suffix in ("/**", "/*", "**", "*"):
-            if pattern.endswith(suffix):
-                return pattern[: -len(suffix)]
-        return pattern
+        """Reduce a glob pattern to its containing directory prefix.
+
+        When the *last* path segment carries a glob metacharacter (``*``,
+        ``?`` or ``[``) — covering both whole-wildcard tokens (``**``, ``*``)
+        and filename globs (``*.py``, ``data_?.json``, ``[abc].py``) — drop
+        that segment and keep its directory. A plain literal path is returned
+        unchanged. In every case the result carries no trailing ``/``: the
+        single-entry branch re-appends one and the multi-entry branch splits
+        on ``/``, so a trailing slash would create a spurious empty segment.
+        """
+        head, _, tail = pattern.rpartition("/")
+        if any(ch in tail for ch in "*?["):
+            return head
+        return pattern.rstrip("/")
 
     stripped = [_strip_glob(p) for p in owned_files]
 

--- a/tests/specify_cli/ownership/test_inference.py
+++ b/tests/specify_cli/ownership/test_inference.py
@@ -13,6 +13,7 @@ from specify_cli.ownership.inference import (
     infer_ownership,
 )
 from specify_cli.ownership.models import ExecutionMode, OwnershipManifest
+from specify_cli.ownership.validation import validate_authoritative_surface
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +150,80 @@ class TestInferAuthoritativeSurface:
     def test_planning_artifact_path(self) -> None:
         surface = infer_authoritative_surface(["kitty-specs/057-feature/**"])
         assert surface == "kitty-specs/057-feature/"
+
+    # --- #2446: single-entry filename globs must resolve to their directory ---
+
+    def test_single_entry_filename_glob_py(self) -> None:
+        """`src/foo/*.py` (trailing filename glob) → its directory `src/foo/`."""
+        assert infer_authoritative_surface(["src/foo/*.py"]) == "src/foo/"
+
+    def test_single_entry_filename_glob_ts(self) -> None:
+        assert infer_authoritative_surface(["src/foo/*.ts"]) == "src/foo/"
+
+    def test_single_entry_question_glob(self) -> None:
+        assert infer_authoritative_surface(["src/foo/data_?.json"]) == "src/foo/"
+
+    def test_single_entry_charclass_glob(self) -> None:
+        assert infer_authoritative_surface(["src/foo/[abc].py"]) == "src/foo/"
+
+    # --- #2446 regression guards: existing wildcard shapes unchanged ---
+
+    def test_double_star_still_strips_to_dir(self) -> None:
+        assert infer_authoritative_surface(["src/foo/**"]) == "src/foo/"
+
+    def test_single_star_still_strips_to_dir(self) -> None:
+        assert infer_authoritative_surface(["src/foo/*"]) == "src/foo/"
+
+    def test_plain_trailing_slash_dir_unchanged(self) -> None:
+        assert infer_authoritative_surface(["src/foo/"]) == "src/foo/"
+
+    # --- #2446: multi-entry filename globs sharing a dir collapse to that dir ---
+
+    def test_two_entry_same_dir_filename_globs(self) -> None:
+        surface = infer_authoritative_surface(["src/api/*.py", "src/api/*.ts"])
+        assert surface == "src/api/"
+
+    def test_two_entry_disjoint_top_level_returns_empty(self) -> None:
+        """Two entries with no shared top-level segment have no common prefix.
+
+        Empty is correct-by-design: collapsing two disjoint top-level trees
+        (e.g. ``src/`` and ``docs/``) into one authoritative surface would
+        over-broaden the WP's blast radius. Such WPs must declare an explicit
+        ``authoritative_surface`` or ``scope``. The #2446 filename-glob fix
+        neither does nor should change this.
+        """
+        assert infer_authoritative_surface(["src/foo/*.py", "docs/bar.md"]) == ""
+
+
+# ---------------------------------------------------------------------------
+# #2446: inferred surface must satisfy authoritative-surface validation
+# (finalize-tasks calls infer_authoritative_surface then
+#  validate_authoritative_surface — the inferred value must pass the gate.)
+# ---------------------------------------------------------------------------
+
+
+class TestInferredSurfacePassesValidation:
+    @pytest.mark.parametrize(
+        "owned",
+        [
+            ["src/foo/*.py"],
+            ["src/foo/*.ts"],
+            ["src/foo/data_?.json"],
+            ["src/foo/[abc].py"],
+            ["src/foo/**"],
+            ["src/foo/*"],
+            ["src/foo/"],
+            ["src/api/*.py", "src/api/*.ts"],
+        ],
+    )
+    def test_inferred_surface_validates(self, owned: list[str]) -> None:
+        surface = infer_authoritative_surface(owned)
+        manifest = OwnershipManifest(
+            execution_mode=ExecutionMode.CODE_CHANGE,
+            owned_files=tuple(owned),
+            authoritative_surface=surface,
+        )
+        assert validate_authoritative_surface(manifest) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2446.

## Problem
`finalize-tasks` failed ownership validation for a WP whose `owned_files` used a **filename glob** (e.g. `src/foo/*.py`) with no explicit `authoritative_surface`. `_strip_glob` (`src/specify_cli/ownership/inference.py`) only stripped a *whole trailing wildcard token* (`/**`, `/*`, `*`), so `src/foo/*.py` (ending in `.py`) was left intact and the single-entry branch appended `/` → `src/foo/*.py/`, which `validate_authoritative_surface` rejects (not a prefix of `src/foo/*.py`). A WP the tool auto-populated failed the tool's own validation.

## Fix
Reduce a **glob-bearing final path segment** (containing `*`, `?`, or `[`) to its containing directory via `rpartition('/')`. `src/foo/*.py` → `src/foo`; existing `/**`, `/*`, plain-dir behavior preserved.

**Correction to the reporter's suggested shape:** returning `head + '/'` breaks the multi-entry common-prefix path (`['src/api/*.py','src/api/*.ts']` → `src/api//`, double slash → invalid). The fix returns a **bare** `head`; the single-entry branch re-appends the one `/`, and the multi-entry branch splits on `/`, so no spurious empty segment. Proven by a dedicated multi-entry test.

## RED-first evidence
Tests committed **before** the fix. Pre-fix: **8 failed** (the 4 single-entry glob cases + the 4 glob params of `test_inferred_surface_validates`, which ties `infer`→ the real `validate` gate) with the exact bug signature. Post-fix: ownership dir **148 passed**, finalize-tasks ownership suite **63 passed**. `ruff`/`mypy` clean.

Tests cover `*.py`/`*.ts`/`?`/`[abc]` globs, `/**` & `/*` regression guards, plain-dir unchanged, multi-entry same-dir globs, and the two-entry disjoint-top-level case (empty surface is **by-design** — collapsing disjoint trees would over-broaden the WP blast radius; such WPs need an explicit `authoritative_surface`).

## Out of scope (pre-existing, not introduced)
A lone literal file entry (`['src/foo/bar.py']`) still yields `src/foo/bar.py/` under both old and new code — a separate pre-existing quirk of the single-entry trailing-slash append, unchanged by this glob fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)