### PR TITLE
docs+test follow-up to #2449: finish the mission_detection.py allowlist cleanup

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2771,9 +2771,9 @@ jobs:
             'src/doctrine/*'
             'src/charter/*'
             'src/specify_cli/status/*'
-            # branch-based mission-slug detection #2443: the phantom entry
-            # src/specify_cli/core/mission_detection.py never existed anywhere in
-            # git history. That logic is DEFINED at
+            # branch-based mission-slug detection #2443: the stale entry
+            # src/specify_cli/core/mission_detection.py rotted when that module
+            # was removed/superseded. Its branch-slug logic now lives at
             # src/specify_cli/lanes/branch_naming.py::parse_mission_slug_from_branch
             # -- core/vcs/detection.py only imports/consumes it. No already-listed
             # critical path above or below is an ancestor of it, so the entry is

--- a/docs/guides/coverage-signals.md
+++ b/docs/guides/coverage-signals.md
@@ -2,7 +2,7 @@
 title: Coverage signals — reconciling the three "coverage" numbers
 description: 'Why SonarCloud coverage, new_coverage, and the internal diff-coverage CI gate disagree — and how to tell an expected scope difference from a real coverage regression.'
 doc_status: active
-updated: '2026-07-07'
+updated: '2026-07-08'
 related:
 - docs/guides/testing-flakiness.md
 - docs/guides/testing-parallel.md
@@ -48,7 +48,7 @@ src/kernel/*
 src/doctrine/*
 src/charter/*
 src/specify_cli/status/*
-src/specify_cli/core/mission_detection.py
+src/specify_cli/lanes/branch_naming.py
 src/specify_cli/dashboard/handlers/*
 src/specify_cli/dashboard/scanner.py
 src/specify_cli/merge/*
@@ -191,9 +191,12 @@ the PR so the next reader does not re-litigate it.
   change in this same mission wires `sonar.projectVersion` from `pyproject.toml`
   so the baseline resets per release cycle; the effect lands on the **next
   nightly run after that change merges**, not on merge itself.
-- **One stale entry in the internal allowlist.** The critical-path `--include`
-  list references `src/specify_cli/core/mission_detection.py`, which no longer
-  exists at that path (the module moved). This is an incidental staleness nit in
-  the internal gate's config, **not** a SonarCloud misconfiguration, and it is
-  out of scope for this document; a small follow-up to refresh the allowlist is
-  recommended rather than fixed here.
+- **Internal allowlist entry repointed.** The critical-path `--include` list
+  references `src/specify_cli/lanes/branch_naming.py`
+  (`parse_mission_slug_from_branch`) — the real defining home of the
+  branch-based mission-slug detection. An earlier draft pointed this entry at a
+  path that had since been removed/superseded; #2443 repointed it to this
+  defining home in **both** authorities (the workflow `--include` array and
+  `tests/release/test_diff_coverage_policy.py`). This was always an incidental
+  staleness nit in the internal gate's config, **not** a SonarCloud
+  misconfiguration.

--- a/docs/plans/testing/ci-coverage-gate-tuning.md
+++ b/docs/plans/testing/ci-coverage-gate-tuning.md
@@ -43,7 +43,7 @@ See the `diff-cover` step in `.github/workflows/ci-quality.yml` for the
 authoritative list. At time of writing it covers:
 
 - `src/specify_cli/status/` — status model
-- `src/specify_cli/core/mission_detection.py` — mission detection
+- `src/specify_cli/lanes/branch_naming.py` — branch-based mission-slug detection
 - `src/specify_cli/dashboard/handlers/` — dashboard API handlers
 
 ### Related

--- a/tests/release/test_diff_coverage_policy.py
+++ b/tests/release/test_diff_coverage_policy.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.architectural._gate_coverage import load_workflow_model
+
 # ---------------------------------------------------------------------------
 # Locate project root and report path
 # ---------------------------------------------------------------------------
@@ -49,6 +51,31 @@ REQUIRED_SECTIONS = [
 # The two mutually-exclusive decision markers (the checked-box variants)
 DECISION_CLOSE = "[x] close_with_evidence"
 DECISION_TIGHTEN = "[x] tighten_workflow"
+
+# The enforced critical-path allowlist, mirrored from the ci-quality.yml
+# ``critical_paths=( ... )`` shell array. This module and the workflow are the
+# two authorities for the allowlist; ``test_critical_path_include_set_matches_workflow``
+# asserts set-equality between them, so drift in EITHER authority fails.
+#
+# '#2443': the 'src/specify_cli/core/mission_detection.py' entry rotted when
+# that module was removed/superseded — its branch-slug logic now lives at
+# lanes/branch_naming.py::parse_mission_slug_from_branch (core/vcs/detection.py
+# only imports/consumes it). It was repointed to its real defining home, not
+# dropped, in both authorities. 'src/specify_cli/next/*' was likewise removed by
+# unshim wave 2 (mission ci-suite-map-bind FR-004e), leaving the live successors
+# below pinned.
+CRITICAL_PATH_MODULES = [
+    "src/kernel/*",
+    "src/doctrine/*",
+    "src/charter/*",
+    "src/specify_cli/status/*",
+    "src/specify_cli/lanes/branch_naming.py",
+    "src/specify_cli/dashboard/handlers/*",
+    "src/specify_cli/dashboard/scanner.py",
+    "src/specify_cli/merge/*",
+    "src/runtime/next/*",
+    "src/mission_runtime/*",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -267,31 +294,7 @@ def test_tighten_workflow_passes_large_pr_sample() -> None:
     #    and NOT contain generic non-critical paths (proving large PRs that
     #    only touch non-critical files are exempt from the hard gate)
     # ------------------------------------------------------------------
-    critical_path_modules = [
-        "src/kernel/*",
-        "src/doctrine/*",
-        "src/charter/*",
-        "src/specify_cli/status/*",
-        # 'src/specify_cli/core/mission_detection.py' repointed (#2443): the
-        # phantom never existed in git history. Branch-based mission-slug
-        # detection is DEFINED at
-        # lanes/branch_naming.py::parse_mission_slug_from_branch
-        # (core/vcs/detection.py only imports/consumes it); no already-listed
-        # critical path is an ancestor of it, so the entry is repointed to its
-        # real defining home, not dropped. Lockstep with the ci-quality.yml
-        # --include array (both authorities change in the same commit).
-        "src/specify_cli/lanes/branch_naming.py",
-        "src/specify_cli/dashboard/handlers/*",
-        "src/specify_cli/dashboard/scanner.py",
-        "src/specify_cli/merge/*",
-        # 'src/specify_cli/next/*' removed (mission ci-suite-map-bind
-        # FR-004e): the package was deleted by unshim wave 2, leaving a
-        # vacuous critical-path entry with zero --cov emitters; the live
-        # successors below stay pinned.
-        "src/runtime/next/*",
-        "src/mission_runtime/*",
-    ]
-    for module in critical_path_modules:
+    for module in CRITICAL_PATH_MODULES:
         assert module in enforced_run, f"Critical-path module '{module}' is missing from the --include list in the enforced diff-coverage step."
 
     # Non-critical-path glob must NOT appear in the enforced --include list.
@@ -347,4 +350,34 @@ def test_tighten_workflow_passes_large_pr_sample() -> None:
     assert re.search(r"quality-gate:\s*\n(?:.*\n)*?\s+needs:\s*\n(?:.*\n)*?\s+- diff-coverage", workflow_text), (
         "quality-gate must depend on diff-coverage so a red coverage gate "
         "cannot be masked by a green aggregate check."
+    )
+
+
+@pytest.mark.fast
+def test_critical_path_include_set_matches_workflow() -> None:
+    """Set-equality guard (#2449 fold): the workflow's critical-path ``--include``
+    array and this module's ``CRITICAL_PATH_MODULES`` list must be the SAME set.
+
+    ``test_tighten_workflow_passes_large_pr_sample`` only checks that every
+    hardcoded module appears in the workflow (a one-directional *subset* check),
+    so a module added to the ci-quality.yml ``critical_paths=( ... )`` array but
+    never mirrored here would pass silently. Parsing the real workflow via the
+    canonical ``tests.architectural._gate_coverage`` parser and asserting
+    set-equality makes drift in EITHER authority fail.
+
+    Both authorities use identical raw glob forms (e.g. ``src/kernel/*``), so no
+    per-side glob stripping is needed — the comparison is raw-to-raw, which is
+    strictly stronger (it also catches a glob-shape divergence).
+    """
+    model = load_workflow_model(_WORKFLOW_PATH)
+    workflow_paths = frozenset(model.diff_cover_critical_paths)
+    hardcoded = frozenset(CRITICAL_PATH_MODULES)
+
+    assert workflow_paths == hardcoded, (
+        "Critical-path allowlist drift between the two authorities.\n"
+        f"  only in ci-quality.yml : {sorted(workflow_paths - hardcoded)}\n"
+        f"  only in test list      : {sorted(hardcoded - workflow_paths)}\n"
+        "Update BOTH .github/workflows/ci-quality.yml (the critical_paths array) "
+        "and this module's CRITICAL_PATH_MODULES together — they are lockstep "
+        "authorities."
     )


### PR DESCRIPTION
Follow-up to the merged #2449 (Refs #2443). #2449's landing squad flagged three items that its preemptive merge landed without; this completes them.

## What
1. **Live-doc phantom refresh (the MAJOR gap).** #2449 repointed the `diff-coverage` allowlist off the stale `src/specify_cli/core/mission_detection.py` in the CI + test authorities, but two **live** docs still named it — `docs/guides/coverage-signals.md` (which literally said the allowlist refresh "is recommended rather than fixed here") and `docs/plans/testing/ci-coverage-gate-tuning.md`. Both now point at `src/specify_cli/lanes/branch_naming.py`; the resolved caveat is removed. `rg mission_detection docs/` is now clean (shipped-doctrine `git-operations-matrix.md` stays tracked in #2447).
2. **Corrected rationale comment.** The allowlist comment in `ci-quality.yml` + `test_diff_coverage_policy.py` claimed the entry "never existed in git history" — it did (a removed rename of `feature_detection.py`). Reworded to the accurate stale/superseded framing. The `ci-quality.yml` comment is kept **paren/quote-free** so the canonical `_diff_cover_critical_paths` parser still extracts all entries.
3. **Set-equality drift guard.** `test_critical_path_include_set_matches_workflow` parses the real workflow via the canonical parser and asserts set-equality with the test's `CRITICAL_PATH_MODULES` — closing the prior subset-only check so drift in *either* allowlist authority now fails.

## Verification
- `test_diff_coverage_policy.py` + `test_ci_quality_path_filters.py` + terminology guard: **22 passed, 2 skipped**.
- `check_docs_freshness --ci`: **exit=0, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)