### PR TITLE
fix(#2409): surface repair drains retired skills manifest-driven (rebased+reviewed; supersedes #2428)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -65,6 +65,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `infer_authoritative_surface` produced an invalid `src/foo/*.py/` path. It now
   reduces a glob-bearing final path segment to its directory, so glob-only
   ownership infers a valid authoritative surface. (Fix landing via PR #2454.)
+- **A retired skill's projected files are now drained by surface repair instead
+  of orphaned forever (#2409).** When a skill was retired from the registry,
+  `spec-kitty upgrade --project` could not reconcile its leftover projections:
+  the repair path warned `Cannot repair … skill not found in registry` on every
+  subsequent upgrade and left the files in place (committed, where the repo
+  tracks skill surfaces; a dangling symlink, where the global root had dropped
+  the skill). Repair now reconciles retirements **manifest-driven**: entries in
+  `.kittify/skills-manifest.json` whose skill no longer exists in a *live*
+  registry have their projected files removed — symlinks unlinked, hash-clean
+  copies deleted, user-**modified** copies archived to
+  `.kittify/.migration-backup/agent-skills/` instead of deleted — emptied skill
+  dirs pruned, and the manifest entries dropped, silencing the repeat warning.
+  Only ledger-recorded paths are ever touched (a user-authored skill sharing
+  the projection root is never scanned), and an **empty** registry never
+  retires anything (a broken canonical source must not mass-drain the
+  manifest).
 - **Test-session state leaks closed: per-mission prompt-tmp namespace +
   workspace-context tombstone (#1842, #2032).** Runtime prompt files are now
   written under a per-repo/per-mission namespaced temp directory

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -82,6 +82,129 @@ def verify_installed_skills(project_path: Path) -> VerifyResult:
     return VerifyResult(ok=ok, missing=missing, drifted=drifted, errors=errors)
 
 
+def _retire_unregistered_skills(
+    project_path: Path,
+    manifest: ManagedSkillManifest,
+    registry: SkillRegistry,
+) -> tuple[int, set[str]]:
+    """Drain manifest entries whose skill no longer exists in the registry (#2409).
+
+    A skill retired from the registry/packs used to leave its projected files
+    orphaned forever: repair could not reconcile an entry with no canonical
+    source, warned ``skill not found in registry`` on every upgrade, and the
+    files stayed on disk (committed, where the repo tracks skill surfaces).
+
+    Manifest-driven by design: only paths the install ledger records as
+    projected by spec-kitty are touched — a user-authored skill sharing the
+    projection root is never scanned or removed. Per file:
+
+    * symlinks (delivery_mode ``symlink`` — broken or not, they point at the
+      machine-local global root) are unlinked;
+    * a regular file whose content still matches the recorded install hash is
+      removed;
+    * a user-MODIFIED file is archived to the installer's backup root
+      (``.kittify/.migration-backup/agent-skills/<ts>/``) instead of deleted.
+
+    Emptied skill directories are pruned. Returns
+    ``(retired_file_count, retired_skill_names)``.
+    """
+    # Safety valve: an EMPTY registry means the canonical source is missing or
+    # broken, not that every skill was retired — never mass-drain the manifest
+    # (and delete projected files) on that signal. Retirement requires a live
+    # registry that positively lacks the specific skill.
+    if not registry.discover_skills():
+        return 0, set()
+
+    retired_entries = [
+        entry
+        for entry in manifest.entries
+        if registry.get_skill(entry.skill_name) is None
+    ]
+    if not retired_entries:
+        return 0, set()
+
+    backup_root: Path | None = None
+    retired = 0
+    retired_names: set[str] = set()
+    kept: list[ManagedFileEntry] = []
+
+    for entry in manifest.entries:
+        if registry.get_skill(entry.skill_name) is not None:
+            kept.append(entry)
+            continue
+
+        dest = _project_managed_path(project_path, entry.installed_path)
+        if not dest.is_relative_to(project_path.resolve()):
+            logger.warning("Unsafe path %s: escapes project root", entry.installed_path)
+            kept.append(entry)
+            continue
+
+        try:
+            backup_root = _dispose_retired_file(
+                dest, entry, project_path, backup_root
+            )
+        except OSError as exc:
+            logger.warning(
+                "Could not remove retired skill file %s: %s", entry.installed_path, exc
+            )
+            kept.append(entry)
+            continue
+
+        _prune_empty_skill_dirs(dest, project_path)
+        retired += 1
+        retired_names.add(entry.skill_name)
+        logger.info(
+            "Retired skill %r: reconciled %s", entry.skill_name, entry.installed_path
+        )
+
+    manifest.entries = kept
+    return retired, retired_names
+
+
+def _dispose_retired_file(
+    dest: Path,
+    entry: ManagedFileEntry,
+    project_path: Path,
+    backup_root: Path | None,
+) -> Path | None:
+    """Remove one retired projected file, archiving user-modified content."""
+    from specify_cli.skills.installer import _archive_existing_path
+
+    if dest.is_symlink():
+        # Projection symlink into the (machine-local) global root — broken by
+        # the retirement or not, there is nothing user-authored to preserve.
+        dest.unlink(missing_ok=True)
+        return backup_root
+    if not dest.is_file():
+        return backup_root  # already gone (or a dir we do not own) — just drop the entry
+    if compute_content_hash(dest) == entry.content_hash:
+        dest.unlink()
+        return backup_root
+    # User-modified copy: archive instead of delete.
+    archived_root: Path = _archive_existing_path(dest, project_path, backup_root)
+    return archived_root
+
+
+def _prune_empty_skill_dirs(dest: Path, project_path: Path) -> None:
+    """Remove now-empty skill directories left by a retirement (max 2 levels)."""
+    current = dest.parent
+    for _ in range(2):
+        if current == project_path or not current.is_dir():
+            return
+        try:
+            next(current.iterdir())
+            return  # not empty
+        except StopIteration:
+            pass
+        except OSError:
+            return
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
 def repair_skills(
     project_path: Path,
     verify_result: VerifyResult,
@@ -89,19 +212,31 @@ def repair_skills(
 ) -> tuple[int, int]:
     """Repair missing and drifted skill files from the canonical registry.
 
-    Returns ``(repaired_count, failed_count)``.
+    Entries whose skill has been *retired* from the registry are reconciled by
+    removal (see ``_retire_unregistered_skills``) rather than warned about —
+    a retired skill is not repairable by construction (#2409).
+
+    Returns ``(repaired_count, failed_count)``; retirements count as repairs.
     """
     manifest = load_manifest(project_path)
     if manifest is None:
         manifest = ManagedSkillManifest()
 
-    repaired = 0
+    retired, retired_names = _retire_unregistered_skills(
+        project_path, manifest, registry
+    )
+    repaired = retired
     failed = 0
 
     entries_to_repair: list[ManagedFileEntry] = list(verify_result.missing)
     entries_to_repair.extend(entry for entry, _hash in verify_result.drifted)
 
     for entry in entries_to_repair:
+        if entry.skill_name in retired_names:
+            # Already reconciled as a retirement above — nothing to repair,
+            # and nothing to warn about (#2409).
+            continue
+
         # Guard against path traversal in installed_path
         dest = _project_managed_path(project_path, entry.installed_path)
         if not dest.is_relative_to(project_path.resolve()):

--- a/tests/specify_cli/skills/test_verifier.py
+++ b/tests/specify_cli/skills/test_verifier.py
@@ -390,3 +390,136 @@ def test_repair_rejects_unsafe_skill_name_for_global_sync(tmp_path: Path, monkey
 
     assert repaired == 0
     assert failed == 1
+
+
+# ── retired-skill reconciliation (#2409) ─────────────────────────────
+
+
+def _registry_with_kept_skill(tmp_path: Path) -> SkillRegistry:
+    """A live registry that positively lacks the retired skill."""
+    return _create_registry(
+        tmp_path, "kept-skill", {"SKILL.md": "---\nname: kept-skill\n---\n# Kept\n"}
+    )
+
+
+def test_retired_skill_broken_symlink_drained_without_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The #2409 loop: a retired skill's projection symlink breaks when the
+    global root drops the skill; repair used to warn 'not found in registry'
+    on every upgrade and leave the orphan. It must now drain it silently."""
+    registry = _registry_with_kept_skill(tmp_path)
+
+    installed_path = ".agents/skills/spk-team-upsun-cli-sync/SKILL.md"
+    dest = tmp_path / installed_path
+    dest.parent.mkdir(parents=True)
+    dest.symlink_to(tmp_path / "gone-global-root" / "SKILL.md")  # broken
+
+    entry = _make_entry(
+        skill_name="spk-team-upsun-cli-sync",
+        installed_path=installed_path,
+        delivery_mode="symlink",
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    verify_result = verify_installed_skills(tmp_path)
+    assert entry.installed_path in [e.installed_path for e in verify_result.missing]
+
+    with caplog.at_level("WARNING"):
+        repaired, failed = repair_skills(tmp_path, verify_result, registry)
+
+    assert failed == 0
+    assert repaired == 1
+    assert "not found in registry" not in caplog.text
+    assert not dest.is_symlink() and not dest.exists()
+    assert not dest.parent.exists(), "emptied skill dir must be pruned"
+    manifest = load_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.find_by_skill("spk-team-upsun-cli-sync") == []
+    # Re-running is a no-op: nothing left to reconcile, still no warning.
+    repaired2, failed2 = repair_skills(tmp_path, verify_installed_skills(tmp_path), registry)
+    assert (repaired2, failed2) == (0, 0)
+
+
+def test_retired_skill_clean_copy_removed(tmp_path: Path) -> None:
+    """A hash-clean copy-mode file of a retired skill is deleted outright."""
+    registry = _registry_with_kept_skill(tmp_path)
+    installed_path = ".claude/skills/retired-skill/SKILL.md"
+    entry = _setup_manifest_and_file(
+        tmp_path, installed_path, "# Retired\n", skill_name="retired-skill"
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    # Force the repair path with an unrelated missing entry so verify is not ok.
+    verify_result = VerifyResult(ok=False, missing=[])
+    repaired, failed = repair_skills(tmp_path, verify_result, registry)
+
+    assert (repaired, failed) == (1, 0)
+    assert not (tmp_path / installed_path).exists()
+    manifest = load_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.find_by_skill("retired-skill") == []
+
+
+def test_retired_skill_modified_copy_archived_not_deleted(tmp_path: Path) -> None:
+    """A user-MODIFIED copy of a retired skill is archived, never deleted."""
+    registry = _registry_with_kept_skill(tmp_path)
+    installed_path = ".claude/skills/retired-skill/SKILL.md"
+    entry = _setup_manifest_and_file(
+        tmp_path, installed_path, "# Retired\n", skill_name="retired-skill"
+    )
+    dest = tmp_path / installed_path
+    dest.write_text("# Retired — with my local edits\n", encoding="utf-8")
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    repaired, failed = repair_skills(tmp_path, VerifyResult(ok=False), registry)
+
+    assert (repaired, failed) == (1, 0)
+    assert not dest.exists()
+    backups = list(
+        (tmp_path / ".kittify" / ".migration-backup" / "agent-skills").rglob("SKILL.md")
+    )
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "# Retired — with my local edits\n"
+
+
+def test_empty_registry_never_retires(tmp_path: Path) -> None:
+    """An empty registry signals a broken canonical source, not mass
+    retirement — the manifest and files must be left untouched."""
+    registry = SkillRegistry(tmp_path / "_empty_registry")
+    installed_path = ".claude/skills/some-skill/SKILL.md"
+    entry = _setup_manifest_and_file(
+        tmp_path, installed_path, "# Skill\n", skill_name="some-skill"
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    repaired, failed = repair_skills(tmp_path, VerifyResult(ok=False), registry)
+
+    assert (repaired, failed) == (0, 0)
+    assert (tmp_path / installed_path).exists()
+    manifest = load_manifest(tmp_path)
+    assert manifest is not None
+    assert len(manifest.find_by_skill("some-skill")) == 1
+
+
+def test_user_authored_skill_in_projection_root_untouched(tmp_path: Path) -> None:
+    """Retirement is manifest-driven: a user-authored skill sharing the
+    projection root (absent from the manifest) is never scanned or removed."""
+    registry = _registry_with_kept_skill(tmp_path)
+
+    user_skill = tmp_path / ".claude" / "skills" / "my-own-skill" / "SKILL.md"
+    user_skill.parent.mkdir(parents=True)
+    user_skill.write_text("# Mine, not spec-kitty's\n", encoding="utf-8")
+
+    retired_path = ".claude/skills/retired-skill/SKILL.md"
+    entry = _setup_manifest_and_file(
+        tmp_path, retired_path, "# Retired\n", skill_name="retired-skill"
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    repaired, failed = repair_skills(tmp_path, VerifyResult(ok=False), registry)
+
+    assert (repaired, failed) == (1, 0)
+    assert not (tmp_path / retired_path).exists()
+    assert user_skill.exists()
+    assert user_skill.read_text(encoding="utf-8") == "# Mine, not spec-kitty's\n"


### PR DESCRIPTION
**Fixes #2409.** Supersedes #2428 by @rayjohnson — same fix, rebased onto current `main` (changelog conflict resolved) and landing-squad reviewed. Opened from a maintainer fork because a `workflow`-scope limitation on the maintainer token blocked force-pushing the rebase to the contributor fork branch; the commit retains @rayjohnson as author.

Original author's implementation, unchanged in substance: `repair_skills` now runs a manifest-driven retirement reconcile — for each `.kittify/skills-manifest.json` entry whose skill no longer exists in a *live* registry, projection symlinks are unlinked, hash-clean copies deleted, user-**modified** copies archived to the installer's backup root (never deleted), emptied dirs pruned, manifest entries dropped — silencing the repeat `skill not found in registry` warning.

### Landing squad (profile-loaded, model-disciplined) — LAND ×3
- **reviewer-renata (data-loss safety):** all 7 safety properties hold, each pinned by a non-vacuous test that would regress to data-loss if its guard were removed; adversarial probes of archive-vs-delete (unreadable hash / symlink-following / traversal / empty-registry mass-drain) all fail safe. 19 passed; full skills dir 284 passed; ruff clean; the one mypy finding (`_expected_content_hash`) is pre-existing on `main`.
- **architect-alphonso (charter/boundary):** User-Customization-Preservation compliance is exemplary — deletion is strictly manifest-ledger-gated (never a dir-walk), empty-registry is fail-closed, modified content archives through the installer's own backup seam. The copy-mode hash-clean orphan not reaching the drain via the `verify` gate is **non-regressive** and legitimately mission-scope.
- **paula-patterns (SSOT):** clean reuse of every canonical seam (archive, hashing, manifest load/save, registry, path derivation) — nothing re-implemented.

### Follow-ups (mission-scope, to be filed)
Verify-side retirement detection (widens the `VerifyResult`/`ok` contract); `discover_skills` memoization (perf).

Changelog updated. cc @rayjohnson @kentonium3

🤖 Generated with [Claude Code](https://claude.com/claude-code)