### PR TITLE
docs: doctrine-extensibility epic (#2466) → 3.2.x roadmap + community feedback templates & label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: "🐛 Bug report"
+about: "Something isn't working as documented"
+title: "[bug] "
+labels: ["bug"]
+---
+
+## What happened
+<!-- The actual behavior. -->
+
+## What you expected
+<!-- The behavior you expected instead. -->
+
+## Steps to reproduce
+1.
+2.
+
+## Environment
+- spec-kitty version (`spec-kitty --version`):
+- OS:
+- AI agent (if relevant):
+
+## Logs / output
+<!-- Paste any error output or a relevant log excerpt. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📖 Contributing guide & how to give feedback
+    url: https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/guides/contributing.md
+    about: How to contribute — including issues tagged "feedback-welcome" that want your input (no code required).

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,18 @@
+---
+name: "✨ Enhancement / new capability"
+about: "Propose a concrete new capability or an improvement to an existing one"
+title: "[enhancement] "
+labels: ["enhancement"]
+---
+
+## Problem or motivation
+<!-- What need does this address, and for whom? -->
+
+## Proposed solution
+<!-- What would you like to see happen? -->
+
+## Alternatives considered
+<!-- Other approaches you weighed, if any. -->
+
+## Additional context
+<!-- Links, examples, or prior discussion. -->

--- a/.github/ISSUE_TEMPLATE/idea_brainstorm.md
+++ b/.github/ISSUE_TEMPLATE/idea_brainstorm.md
@@ -1,0 +1,18 @@
+---
+name: "💡 Idea / brainstorm / feedback"
+about: "Share an idea, use-case, or feedback — no code or full proposal required. Great for shaping open decisions."
+title: "[idea] "
+labels: ["feedback-welcome"]
+---
+
+## The idea or feedback
+<!-- What are you thinking? A rough sketch is completely fine. -->
+
+## Problem or use-case it addresses
+<!-- What would this make easier, and for whom? -->
+
+## Where you'd like input
+<!-- Anything you're unsure about, or want maintainers / the community to weigh in on. -->
+
+---
+> Issues with the **`feedback-welcome`** label are open for community input — comment freely; you don't need to submit code. Well-scoped ideas often become the seed of a tracked mission.

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,8 @@ sdd-*/
 !.github/workflows/
 !.github/workflows/*.yml
 !.github/PULL_REQUEST_TEMPLATE.md
+!.github/ISSUE_TEMPLATE/
+!.github/ISSUE_TEMPLATE/*
 .roo/
 .amazonq/
 .pytest_cache/

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -19,6 +19,16 @@ Spec Kitty is inspired by GitHub's [Spec Kit](https://github.com/github/spec-kit
 
 Please note that this project is released with a [Contributor Code of Conduct](../../CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
+## Ways to contribute (no code required)
+
+You don't need to write code to help shape Spec Kitty. **Ideas, use-cases, and objections are genuinely wanted** — especially on design decisions still in flight.
+
+- **Look for the [`feedback-welcome`](https://github.com/Priivacy-ai/spec-kitty/labels/feedback-welcome) label.** Issues carrying it are open for community input; many contain an **Open decision** block calling out exactly where we'd like your perspective. Comment freely — a rough thought is more useful than silence.
+- **Filing something new?** Use the **💡 Idea / brainstorm / feedback** issue template (it auto-applies `feedback-welcome`), or the bug / enhancement templates for concrete reports. A partial sketch is fine — a maintainer will triage it and, if it's actionable, turn it into a tracked mission.
+- **No pressure to formalize.** You don't have to write a full proposal; tell us the problem you hit or the outcome you want, and we'll take it from there.
+
+Well-scoped feedback often becomes the seed of a mission, so this is one of the highest-leverage ways to contribute.
+
 ## Developer Setup
 
 After cloning, bootstrap your environment:

--- a/docs/release-goals/3.2.x.md
+++ b/docs/release-goals/3.2.x.md
@@ -29,6 +29,27 @@ execution loop, so directives, tactics, agent profiles, and mission-step contrac
 what `next`/the commands do — not just sit as resolvable config. Close the gap between "doctrine
 exists" and "doctrine governs execution."
 
+**Epic [#2466](https://github.com/Priivacy-ai/spec-kitty/issues/2466) — Doctrine/Charter extensibility &
+the pack ecosystem.** Turn the doctrine substrate from *built-in behaviour* into an *author-able pack
+ecosystem*, so customers define/refine their own doctrine (mission types, assets, shortcodes) against
+the same activation/cascade/DRG machinery. Much of the core/workflow/topology/status work was the
+enabler. **The whole epic is in 3.2.x — the dependency order is sequencing, not phasing** (if items
+slip to 3.3.x later, that's a future call):
+
+- **#2467 (keystone · L)** — split the monolithic `built-in` doctrine into packs + **compound packs**
+  (pack manifest `depends_on`, DAG resolution + cycle-detection in the activation engine). Land as a
+  pure refactor + compat shim first; everything below builds on it.
+- **#2468 (L)** — promote `mission-type` to a first-class doctrine artifact kind (behaviour-as-config;
+  retires the deliberate `MissionTypeNotAnArtifactKind` side-channel — needs a decision record).
+- **#2471 (M)** — extract the pack validator (`validate_pack` + `DoctrineHealthReport`) as a
+  dependency-light CI tester with no full-CLI import (mirrors the shared-package-boundary layering).
+- **#2469 (S)** — loose-contract `assets` kind · **#2470 (M)** — shortcodes / harness-command aliases
+  as doctrine (extends the `command_renderer`/manifest pipeline, not a fork).
+- **#2472 (S)** — decide the `procedure` kind's fate after #2468 · **#2473 (M · orthogonal)** —
+  scheduled model-discipline currency pipeline (human-in-loop PR, never auto-merge).
+
+Open decisions ride on the issues (#2469 kind-vs-`template` · #2472 procedure fate · #2473 fold-vs-track).
+
 ### G2 — Strangle out our core domains
 Continue the #1619 runtime/state decomposition: take each **core domain** (identity/naming,
 path/read-path, coordination/topology, status, lanes, ownership) onto its **canonical SSOT**, route


### PR DESCRIPTION
Two related docs/community changes.

### 1. Roadmap — doctrine-extensibility epic
Adds **Epic #2466 ("Doctrine/Charter extensibility & the pack ecosystem", children #2467–#2473)** to the 3.2.x roadmap under **G1** (deepen doctrine/charter/DRG impact). Per operator decision the **whole epic is in 3.2.x** — the dependency order (keystone #2467 → the rest) is *sequencing*, not phasing.

### 2. Community feedback funnel
- New **`feedback-welcome`** label (applied to the open-decision issues #2469/#2472/#2473) signalling *community feedback & brainstorming welcome — no code required*.
- **`.github/ISSUE_TEMPLATE/`**: `idea_brainstorm` (auto-applies `feedback-welcome`), `bug_report`, `enhancement_request`, + `config.yml` chooser linking the contributing guide. Templates funnel structured, pre-labeled community input (orthogonal to programmatic filing) and often seed a tracked mission.
- **`.gitignore`**: negation for `.github/ISSUE_TEMPLATE/` (the broad `.github/*` ignore was hiding them), matching the existing `!.github/workflows/` style.
- **`docs/guides/contributing.md`**: a *"Ways to contribute (no code required)"* section.

Docs/community only — no runtime code. Terminology guard green. Follow-up (needs admin, not in this PR): enabling GitHub **Discussions** as the home for open-ended brainstorming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)