### PR TITLE
chore: open 3.2.6 development cycle

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.5
+  version: 3.2.6
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,6 +13,16 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 3.2.6
+
+_The 3.2.6 development cycle is open. Entries land here as missions merge._
+
+### ✨ Added
+
+### 🐛 Fixed
+
+### ♻️ Changed
+
 ## [3.2.5] - 2026-07-08
 
 ### ✨ Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.5"
+version = "3.2.6"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2098,7 +2098,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.5"
+version = "3.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Open the 3.2.6 development cycle

Post-release housekeeping after **v3.2.5** shipped. Bumps the version across all four version-carrying surfaces and opens a fresh changelog section:

- `pyproject.toml`: `3.2.5` → `3.2.6`
- `.kittify/metadata.yaml`: `version: 3.2.5` → `3.2.6` (kept in sync — FR-601)
- `uv.lock`: `spec-kitty-cli` pin refreshed `3.2.5` → `3.2.6` (**version-pin only — no dependency upgrades**)
- `docs/changelog/CHANGELOG.md`: new empty `## [Unreleased] - 3.2.6`

`validate_release --mode branch` ✅, metadata-sync + versioning + terminology gates ✅ (56 passed). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
