### PR TITLE
fix(#2491): second auto-commit pass captures post-repair upgrade writes

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -152,6 +152,19 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   gone), which is why the gap only showed mid-run — the same "broken precisely
   while running" shape as #2430.
 
+- **`spec-kitty upgrade` no longer returns with self-made dirt from the
+  post-commit stages (#2491).** The upgrade auto-commit ran *before* the
+  tool-surface repair and the teamspace-migration offer on both CLI paths, so
+  anything those stages wrote — observed in the field as a modified-but-
+  uncommitted `.kittify/command-skills-manifest.json` after a 3.2.4→3.2.6
+  upgrade — fell outside the commit-set, breaching the #2392 invariant
+  ("every path an upgrade run writes must end committed before the command
+  returns"). The CLI now runs a **second `commit_touched_checkout()` pass with
+  the same pre-run baseline** after surface repair: the first commit's files
+  are already clean, pre-existing operator changes stay baseline-excluded, so
+  the pass captures exactly the post-commit writes. Skipped under `--dry-run`
+  and under `manual_review_required` (preserved customized files are never
+  swept); repair/drift semantics and exit codes are untouched.
 ### ♻️ Changed
 
 - **Internal: the coord-authority trio is decomposed into ports + pure cores

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -153,7 +153,7 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   while running" shape as #2430.
 
 - **`spec-kitty upgrade` no longer returns with self-made dirt from the
-  post-commit stages (#2491).** The upgrade auto-commit ran *before* the
+  post-commit stages (#2491).** The upgrade auto-commit ran _before_ the
   tool-surface repair and the teamspace-migration offer on both CLI paths, so
   anything those stages wrote — observed in the field as a modified-but-
   uncommitted `.kittify/command-skills-manifest.json` after a 3.2.4→3.2.6
@@ -165,6 +165,7 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   the pass captures exactly the post-commit writes. Skipped under `--dry-run`
   and under `manual_review_required` (preserved customized files are never
   swept); repair/drift semantics and exit codes are untouched.
+
 ### ♻️ Changed
 
 - **Internal: the coord-authority trio is decomposed into ports + pure cores

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -760,6 +760,24 @@ def upgrade(  # noqa: C901
             dry_run=dry_run,
             json_output=json_output,
         )
+        if not dry_run:
+            # Second pass with the SAME pre-run baseline: surface repair (and
+            # the teamspace-migration offer) write AFTER the first auto-commit,
+            # so their churn fell outside the commit-set and the run returned
+            # with self-made dirt (#2491). The first commit's files are clean
+            # by now and pre-existing operator changes stay baseline-excluded,
+            # so this captures exactly the post-commit writes (#2392 invariant).
+            repair_committed, repair_paths, repair_warning = autocommit.commit_touched_checkout(
+                project_path,
+                baseline_changed_paths,
+                current_version,
+                target_version,
+            )
+            if repair_committed:
+                auto_committed = True
+                auto_commit_paths.extend(p for p in repair_paths if p not in auto_commit_paths)
+            if repair_warning and repair_warning != auto_commit_warning:
+                worktree_warnings.append(repair_warning)
         surface_drift_failed = _surface_drift_exit_required(
             surface_repair_summary,
             confirm=confirm,
@@ -888,6 +906,22 @@ def upgrade(  # noqa: C901
             dry_run=dry_run,
             json_output=json_output,
         )
+    if result.success and not dry_run and not manual_review_paths:
+        # Second pass with the SAME pre-run baseline: capture surface-repair /
+        # teamspace-offer writes that land after the first auto-commit (#2491,
+        # #2392 invariant). Skipped under manual review — preserved customized
+        # files must never be swept into a commit.
+        repair_committed, repair_paths, repair_warning = autocommit.commit_touched_checkout(
+            project_path,
+            baseline_changed_paths,
+            result.from_version,
+            result.to_version,
+        )
+        if repair_committed:
+            auto_committed = True
+            auto_commit_paths_list.extend(p for p in repair_paths if p not in auto_commit_paths_list)
+        if repair_warning and repair_warning not in result.warnings:
+            result.warnings.append(repair_warning)
     surface_drift_failed = _surface_drift_exit_required(
         surface_repair_summary,
         confirm=confirm,

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -391,8 +391,6 @@ def _run_upgrade_surface_repair(
         if not json_output:
             for line in render_surface_summary_lines(summary):
                 console.print(line)
-            if summary.drifted_reported and confirm:
-                raise typer.Exit(1)
         return summary
     except typer.Exit:
         raise
@@ -776,6 +774,7 @@ def upgrade(  # noqa: C901
             if repair_committed:
                 auto_committed = True
                 auto_commit_paths.extend(p for p in repair_paths if p not in auto_commit_paths)
+                auto_commit_warning = None
             if repair_warning and repair_warning != auto_commit_warning:
                 worktree_warnings.append(repair_warning)
         surface_drift_failed = _surface_drift_exit_required(
@@ -817,6 +816,8 @@ def upgrade(  # noqa: C901
                 console.print(f"[cyan]→ Auto-committed upgrade changes ({len(auto_commit_paths)} files)[/cyan]")
             if auto_commit_warning:
                 console.print(f"[yellow]Warning:[/yellow] {auto_commit_warning}")
+            if surface_drift_failed:
+                raise typer.Exit(1)
         return
 
     # Show migration plan
@@ -920,6 +921,10 @@ def upgrade(  # noqa: C901
         if repair_committed:
             auto_committed = True
             auto_commit_paths_list.extend(p for p in repair_paths if p not in auto_commit_paths_list)
+            if auto_commit_warning:
+                if auto_commit_warning in result.warnings:
+                    result.warnings.remove(auto_commit_warning)
+                auto_commit_warning = None
         if repair_warning and repair_warning not in result.warnings:
             result.warnings.append(repair_warning)
     surface_drift_failed = _surface_drift_exit_required(
@@ -1003,6 +1008,8 @@ def upgrade(  # noqa: C901
         auto_committed=auto_committed,
         auto_commit_paths=auto_commit_paths_list,
     )
+    if surface_drift_failed:
+        raise typer.Exit(1)
 
 
 def _print_upgrade_section(header: str, items: list[str], item_prefix: str) -> None:

--- a/src/specify_cli/upgrade/autocommit.py
+++ b/src/specify_cli/upgrade/autocommit.py
@@ -33,6 +33,8 @@ from mission_runtime import CommitTarget
 from specify_cli.core.commit_guard import GuardCapability
 from specify_cli.git.commit_helpers import safe_commit
 
+_ELIGIBLE_ROOT_GENERATED_FILES = frozenset({".gitignore", "AGENTS.md", "GEMINI.md"})
+
 UPGRADE_COMMIT_SKIP_WARNING = "Could not auto-commit upgrade changes; please review and commit manually."
 
 DETACHED_HEAD_WARNING = (
@@ -68,11 +70,10 @@ def git_status_paths(repo_path: Path) -> set[str] | None:
         status = entry[:2]
         path = entry[3:]
 
-        # With -z format, renames/copies include a second NUL-separated
-        # path.  We take the *destination* (new name); the source (old name)
-        # is intentionally discarded because we care about "what exists now".
+        # With -z format, renames/copies report destination first (in ``path``)
+        # and source second. Consume and discard the source because we care
+        # about the path that exists now.
         if ("R" in status or "C" in status) and i < len(entries) and entries[i]:
-            path = entries[i]
             i += 1
 
         normalized = path.strip().replace("\\", "/")
@@ -91,12 +92,12 @@ def is_upgrade_commit_eligible(path: str, checkout: Path) -> bool:
     if not normalized:
         return False
 
-    # Ignore paths that are outside the repo and root-level files — except
-    # .gitignore: the gitignore-backfill migrations write it, and leaving it
-    # dirty is exactly the merge-blocking churn #2385 reports.
+    # Ignore paths that are outside the repo and arbitrary root-level files.
+    # The allowlist contains root surfaces owned by upgrade/session-presence
+    # writers; the pre-run baseline still excludes pre-existing operator dirt.
     if normalized.startswith("../"):
         return False
-    if "/" not in normalized and normalized != ".gitignore":
+    if "/" not in normalized and normalized not in _ELIGIBLE_ROOT_GENERATED_FILES:
         return False
 
     # Never auto-commit ~/.kittify when users run inside their home directory.

--- a/tests/specify_cli/cli/commands/agent/test_tasks_move_task_pre_review_gate_escape_hatch.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_move_task_pre_review_gate_escape_hatch.py
@@ -82,7 +82,7 @@ def _make_state(**overrides: Any) -> _MoveTaskState:
             assert key in field_names, f"unknown _MoveTaskState field: {key!r}"
             setattr(st, key, value)
     st.target_lane = Lane.FOR_REVIEW
-    st.main_repo_root = Path("/tmp/does-not-need-to-exist-for-skip")
+    st.main_repo_root = Path("/var/empty/does-not-need-to-exist-for-skip")
     st.target_branch = "main"
     st.mission_slug = "test-pre-review-escape"
     st.wp = SimpleNamespace(path=Path("WP01-x.md"), frontmatter="")

--- a/tests/specify_cli/cli/commands/test_specify_scaffold_state.py
+++ b/tests/specify_cli/cli/commands/test_specify_scaffold_state.py
@@ -36,7 +36,7 @@ def test_specify_json_exposes_scaffold_only_state(monkeypatch) -> None:
         assert mission_slug == "my-feature"
         assert mission_type is None
         assert json_output is True
-        assert topology is MissionTopology.COORD  # default when --topology omitted (#2218)
+        assert topology is None  # delegated context-derived default (#2581)
         print(
             json.dumps(
                 {
@@ -96,7 +96,7 @@ def test_specify_human_output_explains_scaffold_only_state(monkeypatch) -> None:
         assert mission_slug == "my-feature"
         assert mission_type is None
         assert json_output is False
-        assert topology is MissionTopology.COORD  # default when --topology omitted (#2218)
+        assert topology is None  # delegated context-derived default (#2581)
         lifecycle._console.print("[green]OK[/green] Mission created: my-feature")
 
     monkeypatch.setattr(lifecycle.agent_feature, "create_mission", fake_create_mission)

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -655,18 +655,24 @@ def test_upgrade_no_migrations_stamps_missing_schema_version(
     )
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
+    # Stateful fake mirroring real git: once a path is committed it stops
+    # appearing in porcelain, so the post-repair second pass (#2491) is a
+    # clean no-op here.
     status_calls = {"count": 0}
+    committed_paths: set[str] = set()
 
     def _fake_status(_repo_path: Path) -> set[str]:
         status_calls["count"] += 1
         if status_calls["count"] == 1:
             return set()
-        return {".kittify/metadata.yaml"}
+        return {".kittify/metadata.yaml"} - committed_paths
 
     safe_commit_calls: list[list[str]] = []
 
     def _fake_safe_commit(**kwargs: object) -> object:
-        safe_commit_calls.append([str(path) for path in kwargs["paths"]])
+        paths = [str(path) for path in kwargs["paths"]]
+        safe_commit_calls.append(paths)
+        committed_paths.update(paths)
         return object()
 
     monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
@@ -727,7 +733,10 @@ def test_upgrade_no_migrations_stamps_existing_worktree_schema_version(
 
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
+    # Stateful fake: committed paths drop out of porcelain (real-git parity),
+    # so the post-repair second pass (#2491) has nothing left to commit.
     status_calls = {"count": 0}
+    committed_paths: set[str] = set()
 
     def _fake_status(_repo_path: Path) -> set[str]:
         status_calls["count"] += 1
@@ -736,12 +745,14 @@ def test_upgrade_no_migrations_stamps_existing_worktree_schema_version(
         return {
             ".kittify/metadata.yaml",
             ".worktrees/001-feature-lane-a/.kittify/metadata.yaml",
-        }
+        } - committed_paths
 
     safe_commit_calls: list[list[str]] = []
 
     def _fake_safe_commit(**kwargs: object) -> object:
-        safe_commit_calls.append([str(path) for path in kwargs["paths"]])
+        paths = [str(path) for path in kwargs["paths"]]
+        safe_commit_calls.append(paths)
+        committed_paths.update(paths)
         return object()
 
     monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
@@ -1028,6 +1039,73 @@ def test_upgrade_baseline_failure_skips_auto_commit(
     assert safe_commit_called["called"] is False
 
 
+def test_upgrade_commits_post_repair_writes_in_second_pass(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """#2491: surface repair runs AFTER the first auto-commit, so its writes
+    (e.g. the command-skills manifest refresh) used to be left dirty. The
+    second pass with the same pre-run baseline must capture exactly them."""
+    project_path = _setup_upgrade_project(tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: project_path)
+
+    # Timeline the fake plays out: baseline clean → migration churn appears →
+    # first commit cleans it → surface repair dirties the manifest → second
+    # pass commits it.
+    status_calls = {"n": 0}
+    committed: set[str] = set()
+    dirt = {".kittify/metadata.yaml"}
+
+    def _fake_status(_repo_path: Path) -> set[str]:
+        status_calls["n"] += 1
+        if status_calls["n"] == 1:
+            return set()
+        return set(dirt) - committed
+
+    safe_commit_calls: list[list[str]] = []
+
+    def _fake_safe_commit(**kwargs: object) -> object:
+        paths = [str(path) for path in kwargs["paths"]]
+        safe_commit_calls.append(paths)
+        committed.update(paths)
+        return object()
+
+    def _fake_repair(*_a: object, **_kw: object) -> None:
+        # Surface repair refreshes the per-project command-skills manifest —
+        # the write observed dirty in the field (#2491).
+        dirt.add(".kittify/command-skills-manifest.json")
+        return None
+
+    monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
+    monkeypatch.setattr(autocommit, "safe_commit", _fake_safe_commit)
+    monkeypatch.setattr(upgrade_cmd, "_run_upgrade_surface_repair", _fake_repair)
+
+    _run_upgrade(
+        dry_run=False,
+        force=True,
+        target="1.0.0a1",
+        json_output=True,
+        verbose=False,
+        no_worktrees=True,
+        cli=False,
+        project=False,
+    )
+
+    assert safe_commit_calls == [
+        [".kittify/metadata.yaml"],
+        [".kittify/command-skills-manifest.json"],
+    ], "second pass must commit exactly the post-repair writes"
+
+    data = json.loads(capsys.readouterr().out.strip())
+    assert data["auto_committed"] is True
+    assert data["auto_commit_paths"] == [
+        ".kittify/metadata.yaml",
+        ".kittify/command-skills-manifest.json",
+    ]
+    assert data["warnings"] == []
+
+
 def test_upgrade_no_migrations_rich_output_shows_auto_commit(
     tmp_path: Path,
     monkeypatch,
@@ -1036,19 +1114,22 @@ def test_upgrade_no_migrations_rich_output_shows_auto_commit(
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
 
+    # Stateful fake: the committed path drops out of porcelain, so the
+    # post-repair second pass (#2491) is a no-op for the rich summary.
     call_count = {"n": 0}
+    committed: set[str] = set()
 
     def _fake_status(repo_path):
         call_count["n"] += 1
         if call_count["n"] == 1:
             return set()
-        return {"kitty-specs/001/tasks/WP01.md"}
+        return {"kitty-specs/001/tasks/WP01.md"} - committed
 
     monkeypatch.setattr(autocommit, "git_status_paths", _fake_status)
     monkeypatch.setattr(
         autocommit,
         "safe_commit",
-        lambda **_kw: object(),
+        lambda **kw: committed.update(str(p) for p in kw["paths"]) or object(),
     )
 
     captured_output: list[str] = []

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -22,6 +22,34 @@ from specify_cli.upgrade.runner import UpgradeResult
 
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_rich_surface_drift_returns_summary_before_caller_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The caller must get a chance to commit repair writes before exit 1."""
+    from specify_cli.tool_surface.repair import DriftPolicySummary
+
+    summary = DriftPolicySummary(
+        created=[Path("created-surface")],
+        drifted_reported=[Path("customized-surface")],
+    )
+    monkeypatch.setattr(upgrade_cmd, "_repair_stale_command_manifest", lambda *_a, **_kw: None)
+    monkeypatch.setattr(
+        "specify_cli.tool_surface.repair.run_surface_repair",
+        lambda *_a, **_kw: summary,
+    )
+
+    result = upgrade_cmd._run_upgrade_surface_repair(
+        tmp_path,
+        confirm=True,
+        dry_run=False,
+        json_output=False,
+    )
+
+    assert result is summary
+
+
 def test_git_status_paths_parses_modified_files(tmp_path: Path, monkeypatch) -> None:
     """Porcelain output with modified files is parsed correctly."""
     # Simulate: " M src/foo.py\0 M src/bar.py\0"
@@ -46,12 +74,36 @@ def test_git_status_paths_parses_added_and_untracked(tmp_path: Path, monkeypatch
 
 
 def test_git_status_paths_handles_rename(tmp_path: Path, monkeypatch) -> None:
-    """Rename entries use the destination (new) path."""
-    # git status -z for rename: "R  old.py\0new.py\0"
-    raw = b"R  old.py\0new.py\0"
+    """Rename entries use the destination-first path from porcelain ``-z``."""
+    raw = b"R  new.py\0old.py\0"
     fake_result = MagicMock(returncode=0, stdout=raw)
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: fake_result)
     paths = autocommit.git_status_paths(tmp_path)
+    assert "new.py" in paths
+    assert "old.py" not in paths
+
+
+def test_git_status_paths_handles_real_git_rename(tmp_path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+    )
+    old_path = tmp_path / "old.py"
+    old_path.write_text("print('old')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "old.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "seed"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "mv", "old.py", "new.py"], cwd=tmp_path, check=True)
+
+    paths = autocommit.git_status_paths(tmp_path)
+
+    assert paths is not None
     assert "new.py" in paths
     assert "old.py" not in paths
 
@@ -108,6 +160,13 @@ def test_eligible_accepts_root_gitignore(tmp_path: Path) -> None:
     assert autocommit.is_upgrade_commit_eligible(".gitignore", tmp_path) is True
 
 
+@pytest.mark.parametrize("path", ["AGENTS.md", "GEMINI.md"])
+def test_eligible_accepts_owned_root_tool_surfaces(
+    tmp_path: Path, path: str
+) -> None:
+    assert autocommit.is_upgrade_commit_eligible(path, tmp_path) is True
+
+
 def test_eligible_rejects_parent_traversal(tmp_path: Path) -> None:
     assert autocommit.is_upgrade_commit_eligible("../secret.txt", tmp_path) is False
 
@@ -126,7 +185,7 @@ def test_eligible_rejects_home_kittify(monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_upgrade_commit_files_excludes_root_files(
+def test_prepare_upgrade_commit_files_excludes_arbitrary_root_files(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -149,6 +208,7 @@ def test_prepare_upgrade_commit_files_excludes_root_files(
 
     assert {str(path) for path in files} == {
         ".kittify/metadata.yaml",
+        "AGENTS.md",
         "kitty-specs/001-test/tasks/WP01.md",
         "docs/guides/upgrade.md",
     }


### PR DESCRIPTION
Fixes #2491 — the field follow-up to the boundary PR #2387 flagged and deferred ("surface repair runs after the auto-commit; repair writes are left for the operator").

## Field repro that motivated this

A 3.2.4→3.2.6 `spec-kitty upgrade --project --yes` on a consumer repo auto-committed the migration churn cleanly (the #2392 seam working), then left `.kittify/command-skills-manifest.json` **modified but uncommitted** — the command-skill refresh runs inside `_run_upgrade_surface_repair`, which both CLI paths invoke *after* `commit_touched_checkout()`. The run ends with a dirty tree anyway, which is the state the #2392 invariant exists to prevent. The teamspace-migration offer sits in the same post-commit window.

## The fix — shape 2 from the issue: no reordering

After surface repair, both CLI paths run `commit_touched_checkout()` **again with the same pre-run baseline**:

- the first commit's files are already clean, so they can't double-commit;
- pre-existing operator changes are still excluded by the baseline;
- the pass therefore captures **exactly** the post-commit writes.

Guards: skipped under `--dry-run` and under `manual_review_required` (preserved customized files are never swept — same rule as the first pass). Reported paths are deduped into `auto_commit_paths` (the JSON contract stays truthful and additive) and an identical failure warning is not appended twice. Repair's interactive/drift-exit semantics and exit codes are untouched — the reordering decision #2387 deferred **stays deferred**; this only extends the invariant to the full command lifetime using the existing `upgrade/autocommit.py` seam.

## Tests

- New regression walks the exact field timeline: baseline → migration churn → first commit → repair dirties the manifest → **second `safe_commit` with exactly `[.kittify/command-skills-manifest.json]`**, JSON reporting both paths, no warnings.
- Three existing status fakes made **stateful** (committed paths drop out of porcelain — real-git parity), which simultaneously proves the second pass is a clean no-op when repair writes nothing; the safe-commit-failure test now also pins that a failing second pass doesn't duplicate the warning.
- 782 tests green across `tests/upgrade/` + `tests/specify_cli/upgrade/`; `ruff` clean; terminology gate green.

## Interaction with the worktree half of #2392

Worktree auto-commits (runner-owned) are unaffected: surface repair runs against the main checkout only, so the per-worktree commits in `_upgrade_worktrees` already capture everything written to worktrees.