### PR TITLE
fix(#2502): dashboard artifact viewers read the planning surface, not the coord husk

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -21,6 +21,20 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **Dashboard artifact viewers no longer render empty for in-flight
+  coordination missions (#2502).** #2431 re-anchored the mission *list* and
+  *kanban* to read planning artifacts primary-first, but the viewer endpoint
+  family (`/api/research`, contracts/checklists listings, the spec/plan file
+  server) still resolved the feature dir through the coord-first resolver —
+  landing on the status-only coord husk, so clicking spec/plan/research on a
+  running mission showed nothing while the board showed the work. A new
+  `resolve_feature_planning_dir()` composes the coord-first resolver with the
+  primary-first planning re-anchor; all viewer endpoints use it, and
+  `handle_kanban`'s split reads are made explicit (legacy-format check =
+  planning surface; weighted-progress read stays on the coord-first status
+  surface). Finished missions were unaffected (their coord worktrees are
+  gone), which is why the gap only showed mid-run — the same "broken precisely
+  while running" shape as #2430.
 ### ♻️ Changed
 
 ## [3.2.5] - 2026-07-08

--- a/src/specify_cli/dashboard/handlers/features.py
+++ b/src/specify_cli/dashboard/handlers/features.py
@@ -23,6 +23,7 @@ from ..scanner import (
     read_only_weighted_percentage,
     resolve_active_feature,
     resolve_feature_dir,
+    resolve_feature_planning_dir,
     scan_all_features,
     scan_feature_kanban,
 )
@@ -157,9 +158,13 @@ class FeatureHandler(DashboardHandler):
             project_path = _require_project_path(self.project_dir)
             kanban_data = cast(dict[str, list[KanbanTaskData]], scan_feature_kanban(project_path, feature_id))
 
-            # Check if feature uses legacy format
+            # Legacy-format is a PLANNING-surface question — a coord husk has
+            # no tasks/ tree and would wrongly read as non-legacy (#2502). The
+            # weighted-percentage read below stays on the coord-first dir:
+            # the live event log is a STATUS-surface artifact.
+            planning_dir = resolve_feature_planning_dir(project_path, feature_id)
+            is_legacy = is_legacy_format(planning_dir) if planning_dir else False
             feature_dir = resolve_feature_dir(project_path, feature_id)
-            is_legacy = is_legacy_format(feature_dir) if feature_dir else False
 
             # Pre-compute weighted progress for the kanban panel.
             # WP11/FR-014(a): the dashboard is a read-only viewer. It MUST NOT
@@ -199,7 +204,10 @@ class FeatureHandler(DashboardHandler):
 
         feature_id = parts[3]
         project_path = _require_project_path(self.project_dir)
-        feature_dir = resolve_feature_dir(project_path, feature_id)
+        # Planning-surface read: an in-flight coordination mission's coord
+        # copy holds only status writes, so viewers must re-anchor to the
+        # primary planning surface (#2502).
+        feature_dir = resolve_feature_planning_dir(project_path, feature_id)
 
         if len(parts) == 4:
             response: ResearchResponse = {"main_file": None, "artifacts": []}
@@ -301,7 +309,10 @@ class FeatureHandler(DashboardHandler):
         if self.project_dir is None:
             raise RuntimeError("dashboard project_dir is not configured")
         project_path = Path(self.project_dir)
-        feature_dir = resolve_feature_dir(project_path, feature_id)
+        # Planning-surface read: an in-flight coordination mission's coord
+        # copy holds only status writes, so viewers must re-anchor to the
+        # primary planning surface (#2502).
+        feature_dir = resolve_feature_planning_dir(project_path, feature_id)
 
         if len(parts) == 4:
             # Return directory listing
@@ -392,7 +403,10 @@ class FeatureHandler(DashboardHandler):
         if self.project_dir is None:
             raise RuntimeError("dashboard project_dir is not configured")
         project_path = Path(self.project_dir)
-        feature_dir = resolve_feature_dir(project_path, feature_id)
+        # Planning-surface read: an in-flight coordination mission's coord
+        # copy holds only status writes, so viewers must re-anchor to the
+        # primary planning surface (#2502).
+        feature_dir = resolve_feature_planning_dir(project_path, feature_id)
 
         artifact_map = {
             "spec": "spec.md",

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -53,6 +53,7 @@ __all__ = [
     # (WP01 harden-dead-symbol-gate-01KW0RJR).
     "read_only_weighted_percentage",
     "resolve_feature_dir",
+    "resolve_feature_planning_dir",
     "resolve_active_feature",
     "scan_all_features",
     "scan_feature_kanban",
@@ -560,6 +561,27 @@ def resolve_feature_dir(project_dir: Path, feature_id: str) -> Path | None:
     """Resolve the on-disk directory for the requested feature."""
     feature_paths = gather_feature_paths(project_dir)
     return feature_paths.get(feature_id)
+
+
+def resolve_feature_planning_dir(project_dir: Path, feature_id: str) -> Path | None:
+    """Resolve the PLANNING surface for the requested feature (#2502).
+
+    :func:`resolve_feature_dir` is coord-first — correct for live *status*
+    (the event log lives on the coordination branch), wrong for *planning*
+    artifacts (``spec.md`` / ``plan.md`` / ``research*`` / ``contracts/`` /
+    ``checklists/`` live on the primary surface for every topology). An
+    in-flight coordination mission's coord copy is a status-only husk, so an
+    artifact viewer reading it renders empty (#2502) — the same
+    coord-shadows-primary class as #2331/#2430.
+
+    Compose the coord-first resolver with the primary-first planning
+    re-anchor so viewer endpoints read the surface that actually holds the
+    content. For non-coordination missions both resolve to the same dir.
+    """
+    feature_dir = resolve_feature_dir(project_dir, feature_id)
+    if feature_dir is None:
+        return None
+    return _resolve_planning_dir_primary_first(project_dir, feature_dir)
 
 
 def resolve_active_feature(

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -636,6 +636,51 @@ def test_coord_event_log_wins_when_stale_behind_primary(tmp_path):
     assert lanes["approved"] == []
 
 
+def test_resolve_feature_planning_dir_reanchors_viewer_reads(tmp_path):
+    """#2502: the artifact-viewer endpoints (spec/plan/research/contracts/
+    checklists) resolve their feature dir coord-first, so an in-flight
+    coordination mission's viewers rendered empty off the status-only husk.
+    ``resolve_feature_planning_dir`` must re-anchor to the primary surface,
+    while the plain resolver keeps returning the coord dir (status authority
+    for the kanban's weighted-progress read)."""
+    slug = "review-context-depth-01KX2EQ9"  # post-083 slug, live coord worktree
+
+    _git(["init", "--initial-branch=main"], tmp_path)
+    _git(["config", "user.email", "scanner@example.com"], tmp_path)
+    _git(["config", "user.name", "Scanner Test"], tmp_path)
+    _git(["config", "commit.gpgsign", "false"], tmp_path)
+    (tmp_path / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(["add", "README.md"], tmp_path)
+    _git(["commit", "-q", "-m", "seed"], tmp_path)
+    coord_worktree = tmp_path / ".worktrees" / f"{slug}-coord"
+    _git(
+        ["worktree", "add", "-q", "-b", f"kitty/mission-{slug}", str(coord_worktree)],
+        tmp_path,
+    )
+
+    # PRIMARY: full planning artifacts, including the viewer content.
+    primary_dir = _create_feature(tmp_path, slug, lane="in_progress")
+    (primary_dir / "research.md").write_text("# Research\n", encoding="utf-8")
+
+    # COORD copy: status partition only (the in-flight husk).
+    coord_feature_dir = coord_worktree / "kitty-specs" / slug
+    coord_feature_dir.mkdir(parents=True)
+    _set_wp_lane(coord_feature_dir, "WP01", "in_progress")
+    assert not (coord_feature_dir / "research.md").exists()
+
+    coord_dir = scanner.resolve_feature_dir(tmp_path, slug)
+    planning_dir = scanner.resolve_feature_planning_dir(tmp_path, slug)
+
+    assert coord_dir == coord_feature_dir  # status authority unchanged
+    assert planning_dir == primary_dir  # viewers re-anchored (#2502)
+    assert (planning_dir / "research.md").exists()
+    assert (planning_dir / "spec.md").exists()
+
+
+def test_resolve_feature_planning_dir_unknown_feature_is_none(tmp_path):
+    assert scanner.resolve_feature_planning_dir(tmp_path, "no-such-mission") is None
+
+
 def test_registry_resolves_canonical_id_for_inflight_coord_mission(tmp_path):
     """#2331: a mid-orchestration mission (registered coord worktree, meta.json
     absent from the coord tree) must resolve to its canonical ULID in the


### PR DESCRIPTION
Fixes #2502 — the third and (per an exhaustive grep of `resolve_feature_dir` call sites) final coord-shadows-primary endpoint family in the dashboard, missed by #2431.

## The gap

#2431 re-anchored the mission **list** and **kanban** to read planning artifacts primary-first. But the artifact **viewer** endpoints — `handle_research`, `_handle_artifact_directory` (contracts/checklists), `handle_artifact` (the spec/plan file server) — still resolved their feature dir through the coord-first `resolve_feature_dir()` and read planning content off it. For an **in-flight** coordination mission that's the status-only coord husk:

- `GET /api/features` → `spec=true plan=true research=true` ✅
- `GET /api/research/<slug>` → `{"main_file": null, "artifacts": []}` ❌ — the UI shows the board working and every artifact tab empty.

Finished missions were unaffected (coord worktree removed → gather falls through to primary), so the gap only shows **mid-run** — the same "broken precisely while running" shape as #2430.

## The fix — one public composition, four sites

- `scanner.resolve_feature_planning_dir(project_dir, feature_id)`: `resolve_feature_dir` (coord-first — still the status authority) composed with the existing `_resolve_planning_dir_primary_first` re-anchor from #2431. No new resolution logic.
- The three viewer sites use it.
- `handle_kanban`'s split reads made explicit: `is_legacy_format` is a planning-surface question (a husk has no `tasks/` tree and would wrongly read as non-legacy), while `read_only_weighted_percentage` **stays coord-first** — the live event log is STATUS-partition.

## Verified against the live affected repo

For the reporting repo's in-flight mission: plain resolver → coord husk (`research.md` absent); planning resolver → primary dir (`research.md` + `spec.md` present). The regression test reproduces the exact shape (registered coord worktree, status-only mission copy, full planning on primary, post-083 slug) and pins both halves: viewers re-anchored, status authority unchanged.

248 dashboard tests green; `ruff` clean; terminology gate green; `mypy` shows only the pre-existing `DashboardHandler`-subclass finding.

## Class status

With this, every dashboard read of a PRIMARY-partition artifact routes through the #2431 seam. The remaining known member of the class outside the dashboard is #2404 (accept reads `acceptance-matrix.json` from a stale coord worktree) — different command, not touched here.