### PR TITLE
feat(#2504): dashboard WP cards show subtask progress (2/4, from checkbox rows)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -19,6 +19,17 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### ✨ Added
 
+- **Dashboard WP cards show subtask progress (#2504).** Cards (and the WP
+  detail view) previously showed a bare frontmatter count (`4 subtasks`);
+  they now show `2/4 subtasks` (with a ✓ at n/n), counted from the canonical
+  checkbox rows in the WP body — the same rows the lane-transition guard
+  blocks on, via a new shared single definition
+  (`core/subtask_rows.py`, now consumed by both the guard and the dashboard
+  so the two can't drift). WPs that don't track completion via checkboxes
+  keep the plain count badge (no false `0/N`). The kanban task payload gains
+  additive `subtasks_done`/`subtasks_total` fields; the typed-contract
+  baseline is regenerated accordingly.
+
 ### 🐛 Fixed
 
 ### ♻️ Changed

--- a/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
+++ b/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
@@ -153,6 +153,8 @@
         "subtasks": [
           "T1"
         ],
+        "subtasks_done": 0,
+        "subtasks_total": 0,
         "title": "WP02"
       }
     ],
@@ -172,6 +174,8 @@
         "subtasks": [
           "T1"
         ],
+        "subtasks_done": 0,
+        "subtasks_total": 0,
         "title": "WP03"
       }
     ],
@@ -190,6 +194,8 @@
         "subtasks": [
           "T1"
         ],
+        "subtasks_done": 0,
+        "subtasks_total": 0,
         "title": "WP01"
       }
     ]

--- a/src/specify_cli/cli/commands/agent/tasks_shared.py
+++ b/src/specify_cli/cli/commands/agent/tasks_shared.py
@@ -468,9 +468,11 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
     in_wp_section = False
     in_code_fence = False
 
-    # Canonical subtask row: ``- [ ] T001 ...``. A ``T`` id of at least three
-    # digits is mandatory (``\d{3,}`` so ids past T999 still block).
-    canonical_unchecked = re.compile(r"^-\s*\[\s*\]\s*(T\d{3,})\b")
+    # Canonical subtask row: ``- [ ] T001 ...`` — single shared definition
+    # (core.subtask_rows, also consumed by the dashboard's progress counts).
+    from specify_cli.core.subtask_rows import UNCHECKED_SUBTASK_ROW
+
+    canonical_unchecked = UNCHECKED_SUBTASK_ROW
 
     for line in lines:
         stripped = line.strip()

--- a/src/specify_cli/cli/commands/agent/tasks_shared.py
+++ b/src/specify_cli/cli/commands/agent/tasks_shared.py
@@ -463,50 +463,17 @@ def _check_unchecked_subtasks(repo_root: Path, mission_slug: str, wp_id: str, _f
     # command rows (e.g. ``- [ ] swift test``, ``- [ ] git status --short``),
     # prose, and anything inside fenced code blocks are intentionally ignored —
     # they are not work-package subtasks and must not block a lane transition.
-    lines = content.split("\n")
-    unchecked: list[str] = []
-    in_wp_section = False
-    in_code_fence = False
+    #
+    # Section walking + row patterns are the single shared definition in
+    # ``core.subtask_rows`` (also consumed by the dashboard's progress counts,
+    # #2504) — including the #2346/#2324 first-WPxx-token heading rule.
+    from specify_cli.core.subtask_rows import iter_wp_section_subtask_rows
 
-    # Canonical subtask row: ``- [ ] T001 ...`` — single shared definition
-    # (core.subtask_rows, also consumed by the dashboard's progress counts).
-    from specify_cli.core.subtask_rows import UNCHECKED_SUBTASK_ROW
-
-    canonical_unchecked = UNCHECKED_SUBTASK_ROW
-
-    for line in lines:
-        stripped = line.strip()
-
-        # Toggle fenced-code-block state on ``` or ~~~ markers. Task-like lines
-        # inside fenced code blocks (examples in implementation notes) must not
-        # be treated as real subtasks.
-        if stripped.startswith(("```", "~~~")):
-            in_code_fence = not in_code_fence
-            continue
-
-        if in_code_fence:
-            continue
-
-        # A heading belongs to the WP named by its FIRST ``WPxx`` token (the
-        # section's own id), NOT any mention — so ``### WP03 ... (depends: WP01,
-        # WP02)`` does not re-enter WP01/WP02's section (#2346 / #2324).
-        heading_wp: str | None = None
-        if re.match(r"^#{2,4}[^#]", line):
-            wp_tokens = re.findall(r"\bWP\d{2,}\b", line)
-            heading_wp = wp_tokens[0] if wp_tokens else None
-        if heading_wp == wp_id:
-            in_wp_section = True
-            continue
-        if in_wp_section and heading_wp is not None and heading_wp != wp_id:
-            break  # entered a different WP's section
-
-        # Look for unchecked canonical task rows in this WP's section
-        if in_wp_section:
-            unchecked_match = canonical_unchecked.match(stripped)
-            if unchecked_match:
-                unchecked.append(unchecked_match.group(1))
-
-    return unchecked
+    return [
+        task_id
+        for task_id, checked in iter_wp_section_subtask_rows(content, wp_id)
+        if not checked
+    ]
 
 
 def _validate_ready_for_review(

--- a/src/specify_cli/core/subtask_rows.py
+++ b/src/specify_cli/core/subtask_rows.py
@@ -1,0 +1,51 @@
+"""Canonical work-package subtask row patterns — single definition (#2504).
+
+A WP's subtasks are the checkbox rows of the form ``- [ ] T001 <desc>`` /
+``- [x] T001 <desc>`` in ``tasks.md`` and the WP prompt body. The
+lane-transition guard blocks on unchecked rows; the dashboard reports
+done/total progress. Both consume THESE patterns — do not re-derive them
+locally (canonical-sources rule).
+
+Semantics (mirrors the guard, ``_check_unchecked_subtasks``):
+
+* A ``T`` id of at least three digits is mandatory (``\\d{3,}`` so ids past
+  T999 still match).
+* Only implementation rows count: validation/procedure command rows
+  (``- [ ] swift test``), prose checkboxes, and anything inside fenced code
+  blocks are not work-package subtasks.
+"""
+
+from __future__ import annotations
+
+from kernel._safe_re import re
+
+#: Unchecked canonical subtask row: ``- [ ] T001 ...`` (blocks lane transitions).
+UNCHECKED_SUBTASK_ROW = re.compile(r"^-\s*\[\s*\]\s*(T\d{3,})\b")
+
+#: Checked canonical subtask row: ``- [x] T001 ...``.
+CHECKED_SUBTASK_ROW = re.compile(r"^-\s*\[[xX]\]\s*(T\d{3,})\b")
+
+
+def count_subtask_rows(text: str) -> tuple[int, int]:
+    """Return ``(done, total)`` canonical subtask rows in *text*.
+
+    Rows inside fenced code blocks (``` or ~~~) are ignored — task-like
+    example lines in implementation notes are not real subtasks, matching the
+    guard's fence handling.
+    """
+    done = 0
+    total = 0
+    in_code_fence = False
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_code_fence = not in_code_fence
+            continue
+        if in_code_fence:
+            continue
+        if CHECKED_SUBTASK_ROW.match(stripped):
+            done += 1
+            total += 1
+        elif UNCHECKED_SUBTASK_ROW.match(stripped):
+            total += 1
+    return done, total

--- a/src/specify_cli/core/subtask_rows.py
+++ b/src/specify_cli/core/subtask_rows.py
@@ -17,6 +17,8 @@ Semantics (mirrors the guard, ``_check_unchecked_subtasks``):
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from kernel._safe_re import re
 
 #: Unchecked canonical subtask row: ``- [ ] T001 ...`` (blocks lane transitions).
@@ -48,4 +50,62 @@ def count_subtask_rows(text: str) -> tuple[int, int]:
             total += 1
         elif UNCHECKED_SUBTASK_ROW.match(stripped):
             total += 1
+    return done, total
+
+
+def iter_wp_section_subtask_rows(tasks_md_text: str, wp_id: str) -> Iterator[tuple[str, bool]]:
+    """Yield ``(task_id, checked)`` for canonical rows in *wp_id*'s tasks.md section.
+
+    The standard convention keeps the checkable ``- [ ] T### …`` rows in
+    ``tasks.md``, grouped under per-WP headings — the source the
+    lane-transition guard blocks on. Section semantics mirror the guard
+    exactly:
+
+    * a heading (``##``–``####``) belongs to the WP named by its FIRST
+      ``WPxx`` token, NOT any mention — so ``### WP03 … (depends: WP01)``
+      does not re-enter WP01's section (#2346 / #2324);
+    * entering a different WP's heading ends the section;
+    * fenced code blocks are ignored.
+    """
+    in_wp_section = False
+    in_code_fence = False
+    for line in tasks_md_text.split("\n"):
+        stripped = line.strip()
+
+        if stripped.startswith(("```", "~~~")):
+            in_code_fence = not in_code_fence
+            continue
+        if in_code_fence:
+            continue
+
+        heading_wp: str | None = None
+        if re.match(r"^#{2,4}[^#]", line):
+            wp_tokens = re.findall(r"\bWP\d{2,}\b", line)
+            heading_wp = wp_tokens[0] if wp_tokens else None
+        if heading_wp == wp_id:
+            in_wp_section = True
+            continue
+        if in_wp_section and heading_wp is not None and heading_wp != wp_id:
+            break  # entered a different WP's section
+
+        if not in_wp_section:
+            continue
+
+        checked_match = CHECKED_SUBTASK_ROW.match(stripped)
+        if checked_match:
+            yield checked_match.group(1), True
+            continue
+        unchecked_match = UNCHECKED_SUBTASK_ROW.match(stripped)
+        if unchecked_match:
+            yield unchecked_match.group(1), False
+
+
+def count_wp_section_subtask_rows(tasks_md_text: str, wp_id: str) -> tuple[int, int]:
+    """Return ``(done, total)`` canonical rows in *wp_id*'s tasks.md section."""
+    done = 0
+    total = 0
+    for _task_id, checked in iter_wp_section_subtask_rows(tasks_md_text, wp_id):
+        total += 1
+        if checked:
+            done += 1
     return done, total

--- a/src/specify_cli/dashboard/api_types.py
+++ b/src/specify_cli/dashboard/api_types.py
@@ -92,6 +92,10 @@ class KanbanTaskData(TypedDict, total=False):
     title: str
     lane: str
     subtasks: list[Any]
+    # Progress from the canonical checkbox rows in the WP body (#2504);
+    # (0, 0) when the WP doesn't track completion via checkboxes.
+    subtasks_done: int
+    subtasks_total: int
     agent: str
     model: str
     agent_profile: str

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -851,6 +851,8 @@ def _process_wp_file(
             "title": f"⚠️ Encoding Error: {prompt_file.name}",
             "lane": default_lane,
             "subtasks": [],
+            "subtasks_done": 0,
+            "subtasks_total": 0,
             "agent": "",
             "model": "",
             "assignee": "",
@@ -915,11 +917,22 @@ def _process_wp_file(
 
     if not model_str:
         model_str = str(wp_meta_dict.model or "") if wp_meta_dict.model else ""
+
+    # Progress from the canonical checkbox rows in the WP body (#2504) —
+    # the same rows the lane-transition guard counts, via the shared
+    # definition. (0, 0) when the WP doesn't track completion via checkboxes;
+    # the frontend then falls back to the plain frontmatter count badge.
+    from specify_cli.core.subtask_rows import count_subtask_rows
+
+    subtasks_done, subtasks_total = count_subtask_rows(prompt_body)
+
     return {
         "id": wp_id,
         "title": title,
         "lane": lane,
         "subtasks": wp_meta_dict.subtasks or [],
+        "subtasks_done": subtasks_done,
+        "subtasks_total": subtasks_total,
         "agent": agent_str,
         "model": model_str,
         "agent_profile": wp_meta_dict.agent_profile or "",

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -840,6 +840,7 @@ def _process_wp_file(
     project_dir: Path,
     default_lane: str,
     status_dir: Path | None = None,
+    tasks_md_text: str | None = None,
 ) -> dict[str, Any] | None:
     """Process a single WP file and return task data or None on error."""
     content, error = read_file_resilient(prompt_file, auto_fix=True)
@@ -918,13 +919,24 @@ def _process_wp_file(
     if not model_str:
         model_str = str(wp_meta_dict.model or "") if wp_meta_dict.model else ""
 
-    # Progress from the canonical checkbox rows in the WP body (#2504) —
-    # the same rows the lane-transition guard counts, via the shared
-    # definition. (0, 0) when the WP doesn't track completion via checkboxes;
-    # the frontend then falls back to the plain frontmatter count badge.
-    from specify_cli.core.subtask_rows import count_subtask_rows
+    # Progress from the canonical ``- [ ] T###`` checkbox rows (#2504), via the
+    # shared definitions the lane-transition guard consumes. Standard layout
+    # keeps them in tasks.md's per-WP section (the guard's blocking source) —
+    # prefer that; fall back to rows in the WP body for repos that keep the
+    # checklist in the prompt file. (0, 0) when neither tracks completion via
+    # checkboxes; the frontend then shows the plain frontmatter count badge.
+    from specify_cli.core.subtask_rows import (
+        count_subtask_rows,
+        count_wp_section_subtask_rows,
+    )
 
-    subtasks_done, subtasks_total = count_subtask_rows(prompt_body)
+    subtasks_done, subtasks_total = 0, 0
+    if tasks_md_text is not None:
+        subtasks_done, subtasks_total = count_wp_section_subtask_rows(
+            tasks_md_text, canonical_wp_id
+        )
+    if subtasks_total == 0:
+        subtasks_done, subtasks_total = count_subtask_rows(prompt_body)
 
     return {
         "id": wp_id,
@@ -980,12 +992,26 @@ def scan_feature_kanban(project_dir: Path, feature_id: str) -> dict[str, list[di
         # as legacy without iterating lane subdirectories.
         return lanes
 
+    # Read tasks.md once for the whole board: its per-WP sections carry the
+    # canonical subtask checkbox rows used for card progress (#2504).
+    tasks_md_text: str | None = None
+    tasks_md = planning_dir / "tasks.md"
+    if tasks_md.exists():
+        with contextlib.suppress(OSError, UnicodeDecodeError):
+            tasks_md_text = tasks_md.read_text(encoding="utf-8-sig")
+
     # New format: scan flat tasks/ directory, lane from event log
     from specify_cli.status import CanonicalStatusNotFoundError
 
     for prompt_file in tasks_dir.glob("WP*.md"):
         try:
-            task_data = _process_wp_file(prompt_file, project_dir, "planned", status_dir=status_dir)
+            task_data = _process_wp_file(
+                prompt_file,
+                project_dir,
+                "planned",
+                status_dir=status_dir,
+                tasks_md_text=tasks_md_text,
+            )
             if task_data is not None:
                 raw_lane = task_data.get("lane", "planned")
                 state = wp_state_for(raw_lane)

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -514,7 +514,9 @@ function renderKanban(lanes, weightedPercentage) {
                 ${task.agent ? `<span class="badge agent">${escapeHtml(task.agent)}</span>` : ''}
                 ${task.agent_profile ? `<span class="badge profile">${escapeHtml(task.agent_profile)}</span>` : ''}
                 ${task.role ? `<span class="badge role">${escapeHtml(task.role)}</span>` : ''}
-                ${task.subtasks?.length > 0 ?
+                ${task.subtasks_total > 0 ?
+                  `<span class="badge subtasks">${task.subtasks_done}/${task.subtasks_total} subtasks${task.subtasks_done === task.subtasks_total ? ' ✓' : ''}</span>` :
+                  task.subtasks?.length > 0 ?
                   `<span class="badge subtasks">${task.subtasks.length} subtask${task.subtasks.length !== 1 ? 's' : ''}</span>` : ''}
             </div>
         </div>
@@ -617,7 +619,9 @@ function showPromptModal(task) {
     if (metaEl) {
         const metaItems = [];
         if (task.lane) metaItems.push(`<span>Lane: ${escapeHtml(formatLaneName(task.lane))}</span>`);
-        if (task.subtasks?.length) {
+        if (task.subtasks_total > 0) {
+            metaItems.push(`<span>${task.subtasks_done}/${task.subtasks_total} subtasks complete</span>`);
+        } else if (task.subtasks?.length) {
             metaItems.push(`<span>${task.subtasks.length} subtask${task.subtasks.length !== 1 ? 's' : ''}</span>`);
         }
         if (task.phase) metaItems.push(`<span>Phase: ${escapeHtml(task.phase)}</span>`);

--- a/tests/specify_cli/core/test_subtask_rows.py
+++ b/tests/specify_cli/core/test_subtask_rows.py
@@ -1,0 +1,70 @@
+"""Tests for the canonical subtask-row patterns and progress counter (#2504)."""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.core.subtask_rows import (
+    CHECKED_SUBTASK_ROW,
+    UNCHECKED_SUBTASK_ROW,
+    count_subtask_rows,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_counts_checked_and_unchecked_rows() -> None:
+    body = (
+        "# Work Package Prompt: Demo\n"
+        "- [x] T001 Build the thing\n"
+        "- [X] T002 Build the other thing\n"
+        "- [ ] T003 Verify the thing\n"
+    )
+    assert count_subtask_rows(body) == (2, 3)
+
+
+def test_non_implementation_checkboxes_are_not_subtasks() -> None:
+    """Command/validation rows and prose checkboxes don't count — mirrors the
+    lane-transition guard's semantics."""
+    body = (
+        "- [ ] T004 Real subtask\n"
+        "- [ ] swift test\n"
+        "- [x] git status --short\n"
+        "- [ ] remember to hydrate\n"
+        "- [ ] T99 too-short id does not count\n"
+    )
+    assert count_subtask_rows(body) == (0, 1)
+
+
+def test_fenced_code_blocks_are_ignored() -> None:
+    body = (
+        "- [x] T001 Done\n"
+        "```\n"
+        "- [ ] T002 example row inside a fence\n"
+        "```\n"
+        "~~~\n"
+        "- [x] T003 another fenced example\n"
+        "~~~\n"
+        "- [ ] T004 Real remaining work\n"
+    )
+    assert count_subtask_rows(body) == (1, 2)
+
+
+def test_no_checkbox_rows_is_zero_zero() -> None:
+    assert count_subtask_rows("# Just prose\n\nNo checklists here.\n") == (0, 0)
+
+
+def test_ids_past_t999_still_match() -> None:
+    assert UNCHECKED_SUBTASK_ROW.match("- [ ] T1000 big mission")
+    assert CHECKED_SUBTASK_ROW.match("- [x] T1000 big mission")
+
+
+def test_guard_consumes_the_shared_unchecked_pattern() -> None:
+    """The lane-transition guard and the dashboard must share ONE definition."""
+    import inspect
+
+    from specify_cli.cli.commands.agent import tasks_shared
+
+    source = inspect.getsource(tasks_shared._check_unchecked_subtasks)
+    assert "UNCHECKED_SUBTASK_ROW" in source
+    assert 're.compile(r"^-' not in source

--- a/tests/specify_cli/core/test_subtask_rows.py
+++ b/tests/specify_cli/core/test_subtask_rows.py
@@ -59,12 +59,55 @@ def test_ids_past_t999_still_match() -> None:
     assert CHECKED_SUBTASK_ROW.match("- [x] T1000 big mission")
 
 
-def test_guard_consumes_the_shared_unchecked_pattern() -> None:
-    """The lane-transition guard and the dashboard must share ONE definition."""
+def test_wp_section_counts_only_that_wps_rows() -> None:
+    tasks_md = (
+        "# Tasks\n"
+        "## WP01 — Acquisition (depends: none)\n"
+        "- [x] T001 fetchChangedFileContents (WP01)\n"
+        "- [ ] T002 Windowing + caps (WP01)\n"
+        "## WP02 — Rendering (depends: WP01)\n"
+        "- [ ] T006 ReviewRequest fields (WP02)\n"
+        "- [x] T007 Block-B rendering (WP02)\n"
+    )
+    from specify_cli.core.subtask_rows import count_wp_section_subtask_rows
+
+    assert count_wp_section_subtask_rows(tasks_md, "WP01") == (1, 2)
+    assert count_wp_section_subtask_rows(tasks_md, "WP02") == (1, 2)
+    assert count_wp_section_subtask_rows(tasks_md, "WP03") == (0, 0)
+
+
+def test_wp_section_depends_heading_does_not_reenter() -> None:
+    """#2346/#2324: a heading mentioning WP01 in its depends list belongs to
+    the WP named by its FIRST WPxx token and must not re-enter WP01's section."""
+    tasks_md = (
+        "## WP01 — First\n"
+        "- [ ] T001 real WP01 work\n"
+        "## WP03 — Third (depends: WP01, WP02)\n"
+        "- [ ] T009 WP03 work that must not count for WP01\n"
+    )
+    from specify_cli.core.subtask_rows import count_wp_section_subtask_rows
+
+    assert count_wp_section_subtask_rows(tasks_md, "WP01") == (0, 1)
+    assert count_wp_section_subtask_rows(tasks_md, "WP03") == (0, 1)
+
+
+def test_wp_section_walker_yields_ids_and_checked_state() -> None:
+    from specify_cli.core.subtask_rows import iter_wp_section_subtask_rows
+
+    tasks_md = "## WP01\n- [x] T001 done\n- [ ] T002 pending\n"
+    assert list(iter_wp_section_subtask_rows(tasks_md, "WP01")) == [
+        ("T001", True),
+        ("T002", False),
+    ]
+
+
+def test_guard_consumes_the_shared_section_walker() -> None:
+    """The lane-transition guard and the dashboard must share ONE definition
+    of both the row patterns and the WP-section walk."""
     import inspect
 
     from specify_cli.cli.commands.agent import tasks_shared
 
     source = inspect.getsource(tasks_shared._check_unchecked_subtasks)
-    assert "UNCHECKED_SUBTASK_ROW" in source
+    assert "iter_wp_section_subtask_rows" in source
     assert 're.compile(r"^-' not in source

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -82,6 +82,46 @@ agent: codex
     assert task["subtasks"] == ["T001", "T002", "T003"]  # frontmatter untouched
 
 
+def test_wp_progress_prefers_tasks_md_sections(tmp_path):
+    """Standard layout (#2504): the canonical ``- [ ] T###`` rows live in
+    tasks.md's per-WP sections (the guard's blocking source); the WP body
+    carries unnumbered acceptance checkboxes that must NOT count."""
+    feature_dir = _create_feature(tmp_path)
+    (feature_dir / "tasks.md").write_text(
+        """# Tasks
+
+## WP01 — Demo (depends: none)
+- [x] T001 Build the thing (WP01)
+- [x] T002 Wire the thing (WP01)
+- [ ] T003 Verify the thing (WP01)
+
+## WP02 — Other
+- [ ] T006 Unrelated row that must not count for WP01
+""",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks" / "WP01-demo.md").write_text(
+        """---
+work_package_id: WP01
+subtasks: ["T001", "T002", "T003"]
+agent: codex
+---
+# Work Package Prompt: Demo
+
+Acceptance criteria (unnumbered — not canonical subtask rows):
+- [ ] bounded concurrency; per-file fail-open
+- [ ] deterministic output
+""",
+        encoding="utf-8",
+    )
+
+    lanes = scanner.scan_feature_kanban(tmp_path, feature_dir.name)
+    task = next(t for lane in lanes.values() for t in lane)
+
+    assert task["subtasks_done"] == 2
+    assert task["subtasks_total"] == 3
+
+
 def test_wp_without_checkbox_rows_reports_zero_totals(tmp_path):
     """No checkbox rows → (0, 0); the frontend falls back to the plain
     frontmatter count badge rather than showing a false 0/N."""

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -54,6 +54,47 @@ def _create_feature(tmp_path: Path, slug: str = "001-demo-feature", *, lane: str
     return _create_feature_at(tmp_path / "kitty-specs" / slug, lane=lane)
 
 
+def test_wp_cards_report_subtask_progress(tmp_path):
+    """#2504: WP cards carry done/total counted from the body's canonical
+    checkbox rows — the same rows the lane-transition guard blocks on."""
+    feature_dir = _create_feature(tmp_path)
+    (feature_dir / "tasks" / "WP01-demo.md").write_text(
+        """---
+work_package_id: WP01
+subtasks: ["T001", "T002", "T003"]
+agent: codex
+---
+# Work Package Prompt: Demo
+
+- [x] T001 Build the thing
+- [ ] T002 Verify the thing
+- [x] T003 Document the thing
+- [ ] swift test
+""",
+        encoding="utf-8",
+    )
+
+    lanes = scanner.scan_feature_kanban(tmp_path, feature_dir.name)
+    task = next(t for lane in lanes.values() for t in lane)
+
+    assert task["subtasks_done"] == 2
+    assert task["subtasks_total"] == 3  # the command row is not a subtask
+    assert task["subtasks"] == ["T001", "T002", "T003"]  # frontmatter untouched
+
+
+def test_wp_without_checkbox_rows_reports_zero_totals(tmp_path):
+    """No checkbox rows → (0, 0); the frontend falls back to the plain
+    frontmatter count badge rather than showing a false 0/N."""
+    feature_dir = _create_feature(tmp_path)  # fixture body has no checkboxes
+
+    lanes = scanner.scan_feature_kanban(tmp_path, feature_dir.name)
+    task = next(t for lane in lanes.values() for t in lane)
+
+    assert task["subtasks_total"] == 0
+    assert task["subtasks_done"] == 0
+    assert task["subtasks"] == ["T1"]
+
+
 def test_scan_all_features_detects_feature(tmp_path):
     feature_dir = _create_feature(tmp_path)
     features = scanner.scan_all_features(tmp_path)


### PR DESCRIPTION
Fixes #2504.

## What

Kanban WP cards and the WP detail view showed a bare frontmatter count (`4 subtasks`) with no completion signal — even though completion state already exists as the canonical checkbox rows in the WP body (the rows the lane-transition guard blocks on), and `_process_wp_file` already ships the full body to the frontend. Cards now show **`2/4 subtasks`** (✓ at n/n); the detail view shows `2/4 subtasks complete`.

## How — one shared definition, no parallel regex

- **`core/subtask_rows.py`**: the canonical subtask-row patterns (unchecked **and** the new checked variant) plus `count_subtask_rows(text) → (done, total)`, with exactly the guard's semantics: `T\d{3,}` implementation rows only (command/validation rows like `- [ ] swift test` and prose checkboxes excluded), fenced code blocks ignored.
- **`_check_unchecked_subtasks`** now consumes the shared unchecked pattern (behavior identical) — and a test pins that it does, so the guard and the dashboard can never drift apart on what counts as a subtask.
- **Scanner** emits additive `subtasks_done`/`subtasks_total` on each kanban task (encoding-error variant reports (0, 0)); `KanbanTaskData` declares both; the FR-014 typed-contract baseline is **deliberately regenerated** (6 additive lines — the byte-identical gate caught the payload change exactly as designed, and this is a conscious contract addition, not drift).
- **Frontend**: badge + detail meta use done/total when the body has checkbox rows, and **fall back to the existing count badge when it doesn't** — a WP that doesn't track completion via checkboxes never shows a false `0/N`.

## Tests

Pattern/counter matrix (checked+unchecked mix, non-implementation rows excluded, fence handling, `T1000+` ids, zero case), the guard-shares-definition pin, and scanner integration (progress counted from the body, frontmatter `subtasks` list untouched, no-checkbox fallback). 254 dashboard tests + dead-modules/terminology gates green; `ruff` + `mypy` clean.

## Related

Sibling PR #2503 (in review) fixes the artifact viewers for in-flight coordination missions; both branch from current main and don't overlap.