### PR TITLE
fix(#2508): anchor status-commit mechanism selection on PRIMARY identity meta

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -21,6 +21,21 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **`agent action implement`/`review` status commits engage the coordination
+  transaction again mid-mission (#2508).** `_commit_workflow_change` selected
+  its commit mechanism by reading `meta.json` off the passed `feature_dir` —
+  which, for an in-flight coordination mission, is the topology-aware STATUS
+  dir (the coord worktree copy) where `meta.json` never exists (identity is a
+  PRIMARY-partition artifact). The `(None, None, None)` husk read silently
+  dropped every WP status commit into the legacy `safe_commit` fallback, which
+  targets the seam-resolved coordination branch from the PRIMARY checkout and
+  refuses when the primary has the mission's feature branch checked out —
+  hard-blocking `agent action implement` on PR-bound coordination missions.
+  Mechanism selection now anchors identity on the `PRIMARY_METADATA` read
+  surface (the file's existing choke point); `feature_dir` remains
+  authoritative for status file paths and rollback truncation. Same
+  coord-shadows-primary class as #2331/#2430/#2502, on the write-mechanism
+  side.
 ### ♻️ Changed
 
 ## [3.2.5] - 2026-07-08

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -600,7 +600,22 @@ def _commit_workflow_change(
     Raises:
         typer.Exit(1): On commit failure (after rollback).
     """
-    coord_branch, mission_id, mid8 = _load_coord_branch_meta(feature_dir)
+    # Mission identity (coordination_branch / mission_id / mid8) is a
+    # PRIMARY-partition artifact — meta.json never transits the coordination
+    # branch — while ``feature_dir`` is the topology-aware STATUS dir (the
+    # coord worktree copy for an in-flight coordination mission, which holds
+    # no meta.json). Reading identity off that husk returned (None, None,
+    # None) mid-mission and silently dropped every status commit into the
+    # legacy safe_commit path, which then demanded the coordination branch be
+    # checked out on the PRIMARY checkout (#2508). Anchor identity on the
+    # PRIMARY_METADATA read surface; ``feature_dir`` stays authoritative for
+    # the status file paths / rollback truncation below.
+    _identity_dir = _resolve_workflow_read_dir(
+        repo_root=repo_root,
+        mission_slug=mission_slug,
+        kind=MissionArtifactKind.PRIMARY_METADATA,
+    )
+    coord_branch, mission_id, mid8 = _load_coord_branch_meta(_identity_dir)
     events_path = feature_dir / _STATUS_EVENTS_FILENAME
     status_path = feature_dir / _STATUS_FILENAME
     # T017: the seam-resolved STATUS_STATE placement. The MECHANISM choice

--- a/tests/agent/test_workflow_review_lane_gate.py
+++ b/tests/agent/test_workflow_review_lane_gate.py
@@ -438,6 +438,86 @@ def test_commit_workflow_change_syncs_lane_after_coord_commit(
     assert calls == ["commit", "sync"]
 
 
+def test_commit_workflow_change_reads_identity_from_primary_not_status_husk(
+    workflow_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2508: mid-mission, the action-implement path threads the topology-aware
+    STATUS dir (the coord worktree copy — which holds NO meta.json) as
+    ``feature_dir``. Mechanism selection must anchor identity on the PRIMARY
+    surface and still engage the coordination transaction — never fall into
+    the legacy safe_commit path that demands the coord branch on primary."""
+    workflow._reset_workflow_receipts()
+    mission_slug = "demo-feature-01J6XW9K"
+    mid8 = "01J6XW9K"
+    mission_id = "01J6XW9KABCDEFGHJKMNPQRSTV"
+    coord_branch = f"kitty/mission-{mission_slug}"
+
+    # PRIMARY: identity meta lives here (PRIMARY-partition artifact).
+    primary_dir = workflow_repo / "kitty-specs" / mission_slug
+    primary_dir.mkdir(parents=True)
+    (primary_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": mission_slug,
+                "mission_id": mission_id,
+                "mid8": mid8,
+                "coordination_branch": coord_branch,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # STATUS husk: the coord worktree copy — status files only, NO meta.json.
+    husk_dir = (
+        workflow_repo
+        / ".worktrees"
+        / f"{mission_slug}-coord"
+        / "kitty-specs"
+        / mission_slug
+    )
+    husk_dir.mkdir(parents=True)
+    event_path = husk_dir / "status.events.jsonl"
+    event_path.write_text("", encoding="utf-8")
+    assert not (husk_dir / "meta.json").exists()
+
+    transaction_calls: list[dict[str, object]] = []
+    legacy_calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        workflow,
+        "_commit_via_coordination_transaction",
+        lambda **kwargs: transaction_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "_commit_via_legacy_safe_commit",
+        lambda **kwargs: legacy_calls.append(kwargs),
+    )
+
+    workflow._commit_workflow_change(
+        repo_root=workflow_repo,
+        feature_dir=husk_dir,
+        mission_slug=mission_slug,
+        target_branch="feat/some-feature-branch",
+        paths=[event_path],
+        message="chore: Start WP03 implementation [claude-code]",
+        operation="planned -> claimed for WP03",
+        wp_id="WP03",
+        pre_emit_event_size=0,
+        pre_emit_status_bytes=None,
+    )
+
+    assert legacy_calls == [], (
+        "identity must come from the PRIMARY meta.json — the legacy "
+        "safe_commit fallback means the husk read lost it (#2508)"
+    )
+    assert len(transaction_calls) == 1
+    assert transaction_calls[0]["coord_branch"] == coord_branch
+    assert transaction_calls[0]["mission_id"] == mission_id
+    assert transaction_calls[0]["mid8"] == mid8
+
+
 def test_commit_workflow_change_reverts_coord_commit_on_lane_sync_refusal(
     workflow_repo: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Fixes #2508 — a live hard-blocker on PR-bound coordination missions, hit today driving `agent action implement` against an in-flight mission.

## The bug

`_commit_workflow_change` selects BookkeepingTransaction vs the legacy `safe_commit` fallback via `_load_coord_branch_meta(feature_dir)`. The action-implement/review paths thread the **topology-aware STATUS dir** as `feature_dir` (`_canonical_status_feature_dir` → `resolve_handle_to_read_path`) — which for an in-flight coordination mission is the coord worktree copy, where `meta.json` **never exists** (identity is PRIMARY-partition and never transits the coordination branch). The husk read returns `(None, None, None)`, so:

- the modern transaction path (which correctly lands the commit on the coordination branch via the coord worktree) never engages;
- the legacy fallback runs `safe_commit(repo_root=primary, worktree_root=primary, target=CommitTarget(ref=<seam-resolved coord branch>))` — and refuses when the primary checkout has the mission's **feature branch** checked out: *"chore: Start WP03 implementation" demands the coordination branch on the primary checkout.*

`move-task`'s status write routed correctly minutes earlier under the same build, which localizes the defect to this mechanism selector. Notably, `_canonical_status_feature_dir`'s own docstring describes the read seam anchoring identity on PRIMARY meta — the commit site just didn't use that anchor. Same coord-shadows-primary class as #2331 / #2430 / #2502, on the **write-mechanism-selection** side.

## The fix

One resolution added at the single `_load_coord_branch_meta` call site: anchor identity on the module's existing choke point — `_resolve_workflow_read_dir(kind=MissionArtifactKind.PRIMARY_METADATA)` — and load the `coordination_branch`/`mission_id`/`mid8` triple from that. `feature_dir` stays authoritative for what it's correct for: the status file paths and the rollback truncation. Non-coordination missions resolve both to the same dir — no behavior change.

## Verification

- Regression test: primary `meta.json` + status-only coord husk passed as `feature_dir` → the coordination transaction engages with the primary-read triple; the legacy fallback is never touched.
- Verified against the live blocked repo: the identity dir resolves to the primary surface and the full triple loads.
- `tests/agent/`: 1450 passed; `ruff` clean.

## Related

The diagnostic log just above the selector (seam-vs-caller `target_branch` divergence) fired in the field exactly as designed — it just wasn't wired into the decision. This PR keeps it as-is.