### PR TITLE
fix(#2510): orchestrator-api transition derives subtasks_complete from the PRIMARY surface

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -21,6 +21,19 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **orchestrator-api `transition` no longer lets WPs into `for_review` with
+  unchecked subtasks (#2510).** The command trusted a caller-asserted
+  `--subtasks-complete`; left unset, emit-time inference read `tasks.md` off
+  the STATUS feature dir — the coordination worktree husk mid-mission, where
+  the PRIMARY-partition `tasks.md` never exists — and **failed open**,
+  silently bypassing the subtask guard native `move-task` enforces (field
+  evidence: four WPs reached `done` with 0/16 rows ticked, `force=false`).
+  Mirroring the command's own commit-gate precedent, the API now derives the
+  value server-side from the PRIMARY planning surface when the caller doesn't
+  assert it; explicit assertions keep working and `--force` keeps its bypass.
+  Fifth member of the coord-shadows-primary class
+  (#2331/#2430/#2502/#2508).
+
 ### ♻️ Changed
 
 ## [3.2.5] - 2026-07-08

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -1363,6 +1363,19 @@ def transition(
 
     if to_lane == Lane.FOR_REVIEW:
         _enforce_for_review_commit_gate(cmd, main_repo_root, mission, mission_dir, wp, force)
+        if subtasks_complete is None and not force:
+            # Subtask-gate parity with native move-task (#2510): left as None,
+            # the emit-time inference reads tasks.md off the STATUS feature
+            # dir — the coord worktree husk mid-mission, where tasks.md (a
+            # PRIMARY-partition artifact) never exists — and FAILS OPEN,
+            # letting WPs into for_review with every subtask unchecked.
+            # Derive server-side from the PRIMARY planning surface instead;
+            # an explicit caller assertion keeps working, --force bypasses.
+            from specify_cli.status.emit import _infer_subtasks_complete
+
+            subtasks_complete = _infer_subtasks_complete(
+                _planning_read_dir(main_repo_root, mission), wp
+            )
 
     from specify_cli.coordination.status_transition import emit_status_transition_transactional
     from specify_cli.status import TransitionError

--- a/tests/specify_cli/orchestrator_api/test_transition_subtask_gate.py
+++ b/tests/specify_cli/orchestrator_api/test_transition_subtask_gate.py
@@ -1,0 +1,159 @@
+"""#2510: the orchestrator-api transition derives subtasks_complete server-side.
+
+Field repro: an orchestrator-driven coordination mission moved four WPs
+``in_progress -> for_review`` with ``force=false`` while every ``- [ ] T###``
+row in ``tasks.md`` was unchecked. The orchestrator passes no
+``--subtasks-complete``; the API forwarded ``None``; emit-time inference read
+``tasks.md`` off the STATUS feature dir (the coord worktree husk — where the
+PRIMARY-partition ``tasks.md`` never exists) and FAILED OPEN.
+
+The API now mirrors the commit-gate precedent: when the caller does not
+assert the flag (and is not forcing), it derives the value from the PRIMARY
+planning surface before building the TransitionRequest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.orchestrator_api.commands import app
+
+pytestmark = [pytest.mark.fast]
+
+runner = CliRunner()
+
+_MISSION_ID = "01KV8NPCQ9ZX3R7W2M5T8H4FBD"
+_MID8 = _MISSION_ID[:8]
+_MISSION_SLUG = f"subtask-gate-repro-{_MID8}"
+
+_POLICY = json.dumps(
+    {
+        "orchestrator_id": "test-orch",
+        "orchestrator_version": "0.0.1",
+        "agent_family": "claude",
+        "approval_mode": "full_auto",
+        "sandbox_mode": "workspace_write",
+        "network_mode": "none",
+        "dangerous_flags": [],
+    }
+)
+
+
+def _seed_mission(tmp_path: Path, *, tasks_md: str) -> Path:
+    repo_root = tmp_path / "repo"
+    primary = repo_root / "kitty-specs" / _MISSION_SLUG
+    tasks_dir = primary / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (primary / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_id": _MISSION_ID,
+                "mission_slug": _MISSION_SLUG,
+                "slug": _MISSION_SLUG,
+                "mission_number": None,
+                "mission_type": "software-dev",
+                "status_phase": 2,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (primary / "tasks.md").write_text(tasks_md, encoding="utf-8")
+    (tasks_dir / "WP01.md").write_text(
+        "---\nwork_package_id: WP01\ntitle: Example\ndependencies: []\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    return repo_root
+
+
+def _run_transition(repo_root: Path, extra_args: list[str] | None = None) -> object | None:
+    """Invoke ``transition WP01 -> for_review`` capturing the TransitionRequest."""
+    captured: list[object] = []
+
+    def _capture(request, **_kwargs):  # noqa: ANN001 — mirrors the real signature
+        captured.append(request)
+
+        class _Event:
+            from_lane = "in_progress"
+            to_lane = "for_review"
+
+        return _Event()
+
+    with (
+        patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ),
+        patch(
+            "specify_cli.orchestrator_api.commands._enforce_for_review_commit_gate",
+            return_value=None,
+        ),
+        patch(
+            "specify_cli.coordination.status_transition.emit_status_transition_transactional",
+            side_effect=_capture,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "transition",
+                "--mission",
+                _MISSION_SLUG,
+                "--wp",
+                "WP01",
+                "--to",
+                "for_review",
+                "--actor",
+                "test-orch",
+                "--policy",
+                _POLICY,
+                *(extra_args or []),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    return captured[0] if captured else None
+
+
+_UNCHECKED_TASKS_MD = (
+    "# Tasks\n\n## WP01 — Repro\n- [ ] T001 First (WP01)\n- [ ] T002 Second (WP01)\n"
+)
+_CHECKED_TASKS_MD = (
+    "# Tasks\n\n## WP01 — Repro\n- [x] T001 First (WP01)\n- [x] T002 Second (WP01)\n"
+)
+
+
+def test_unasserted_flag_is_derived_false_from_primary_tasks_md(tmp_path: Path) -> None:
+    """The field repro: no --subtasks-complete + unchecked PRIMARY rows must
+    reach the guard as False — never None (which fails open off the husk)."""
+    repo_root = _seed_mission(tmp_path, tasks_md=_UNCHECKED_TASKS_MD)
+    request = _run_transition(repo_root)
+    assert request is not None
+    assert request.subtasks_complete is False
+
+
+def test_unasserted_flag_is_derived_true_when_all_checked(tmp_path: Path) -> None:
+    repo_root = _seed_mission(tmp_path, tasks_md=_CHECKED_TASKS_MD)
+    request = _run_transition(repo_root)
+    assert request is not None
+    assert request.subtasks_complete is True
+
+
+def test_explicit_caller_assertion_is_respected(tmp_path: Path) -> None:
+    """Contract compatibility: an explicit --subtasks-complete is not overridden."""
+    repo_root = _seed_mission(tmp_path, tasks_md=_UNCHECKED_TASKS_MD)
+    request = _run_transition(repo_root, ["--subtasks-complete"])
+    assert request is not None
+    assert request.subtasks_complete is True
+
+
+def test_force_skips_derivation(tmp_path: Path) -> None:
+    repo_root = _seed_mission(tmp_path, tasks_md=_UNCHECKED_TASKS_MD)
+    request = _run_transition(repo_root, ["--force"])
+    assert request is not None
+    assert request.subtasks_complete is None


### PR DESCRIPTION
Fixes #2510 — the subtask guard's silent bypass on every orchestrator-driven `for_review` transition.

## The chain (each link verified against a live repo)

1. The orchestrator never asserts `--subtasks-complete` → the API forwards `None`.
2. `None` reaches emit-time inference (`status/emit.py::_infer_subtasks_complete`), which reads `tasks.md` off the STATUS feature dir — the coordination worktree husk mid-mission, where the PRIMARY-partition `tasks.md` never exists — and **fails open** (`if not tasks_path.exists(): return True`).
3. The `wp_state` guard (`subtasks_complete is not True` blocks) therefore never fires.

Field evidence: four WPs reached `done` with **0/16** canonical rows ticked and `force=false` on every transition, while `_check_unchecked_subtasks` returns every unchecked id for the same WPs when consulted directly. **Fifth member of the coord-shadows-primary class** (#2331 / #2430 / #2502 / #2508) — this one with a fail-open default that converts the surface miss into a guard bypass.

## The fix

Mirrors the command's own commit-gate precedent (`_enforce_for_review_commit_gate`, ported explicitly so *"done without a commit is impossible through the orchestrator-api too"*): when `to_lane == for_review`, the caller did not assert the flag, and `--force` is absent, `transition` derives `subtasks_complete` **server-side from the PRIMARY planning surface** (`_planning_read_dir`, already computed two lines up) using the same inference emit would run — just pointed at the surface that actually holds `tasks.md`. Explicit caller assertions keep working (contract-compatible: no payload/flag changes); `--force` keeps its bypass.

## Tests

Four-case matrix on the captured `TransitionRequest`: unasserted + unchecked PRIMARY rows → `False` (guard blocks); all checked → `True`; explicit `--subtasks-complete` respected (not overridden); `--force` skips derivation. 10 api tests green, `ruff` clean.

## Deliberately not in this PR (noted on #2510)

- `_infer_subtasks_complete` itself is a third, drifted parallel of the subtask-row semantics (any-mention heading match = pre-#2346; counts any checkbox, not just `T###`). Once #2505's shared `core/subtask_rows.py` walker lands, consolidating the inference onto it retires the drift — better as a follow-up on top of #2505 than a cross-PR dependency here.
- Whether the inference's fail-open on missing `tasks.md` should survive at all — legacy-compat question for the maintainers.