### PR TITLE
fix(#2513): uncheck tasks.md subtask rows on WP rollback to planned

### DIFF
--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -440,6 +440,7 @@ from specify_cli.cli.commands.agent.tasks_move_task import (
     _mt_resolve_feedback as _mt_resolve_feedback,
     _mt_resolve_pre_review_workspace as _mt_resolve_pre_review_workspace,
     _mt_resolve_targets as _mt_resolve_targets,
+    _mt_uncheck_rollback_subtasks as _mt_uncheck_rollback_subtasks,
     _mt_review_config_section as _mt_review_config_section,
     _mt_run_decision as _mt_run_decision,
     _mt_run_pre_review_gate as _mt_run_pre_review_gate,

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -62,6 +62,7 @@ from specify_cli.agent_tasks_ports import (
 from specify_cli.cli.commands.agent.tasks_finalize_validation import (
     _read_transactional_wp_lane,
 )
+from specify_cli.cli.commands.agent.tasks_outline import TASKS_MD_FILENAME
 from specify_cli.cli.commands.agent.tasks_materialization import (
     _collect_status_artifacts,
     _persist_review_artifact_override,
@@ -86,6 +87,7 @@ from specify_cli.cli.commands.agent.tasks_transition_core import (
 from specify_cli.core.commit_guard import GuardCapability
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.paths import is_worktree_context
+from specify_cli.core.subtask_rows import uncheck_wp_section_subtask_rows
 from specify_cli.core.utils import write_text_within_directory
 from specify_cli.git import SafeCommitPathPolicyError
 from specify_cli.missions._read_path_resolver import (
@@ -1471,7 +1473,58 @@ def _mt_persist_wp_file(st: _MoveTaskState, ports: TasksPorts) -> None:
     _mt_persist_tracker_refs(st, skip_target_commit)
 
 
-# --- phase G/H: review-lock release + result output --------------------------
+# --- phase G: subtask uncheck on planned rollback (#2513) --------------------
+
+
+def _mt_uncheck_rollback_subtasks(st: _MoveTaskState, ports: TasksPorts) -> None:
+    """Uncheck ``- [x] T### …`` rows for *st.task_id*'s section on rollback to planned.
+
+    A WP rolled back to ``planned`` must be fully re-implemented.  Leaving its
+    subtask rows checked is a lie — the gate would pass immediately on the next
+    ``for_review`` transition without any work being re-done (#2513).
+
+    Read/write path: ``tasks.md`` is a TASKS_INDEX (primary-partition) artifact
+    — resolve through ``ports.fs.planning_read_dir(kind=TASKS_INDEX)`` so a
+    coord-topology mission's ``-coord`` husk cannot shadow the real primary
+    (same anchor as the subtask gate and ``mark-status``).  Auto-commit
+    follows the same ``commit_artifact`` route used by ``mark-status``.
+
+    Failures are non-fatal (logged, never ``typer.Exit``): a missing
+    ``tasks.md`` is silently skipped; commit failures are warnings.
+    """
+    from specify_cli.cli.commands.agent import tasks as _tasks
+    handle = MissionHandle(repo_root=st.main_repo_root, mission_slug=st.mission_slug)
+    feature_dir = ports.fs.planning_read_dir(handle, kind=MissionArtifactKind.TASKS_INDEX)
+    tasks_md = feature_dir / TASKS_MD_FILENAME
+    if not tasks_md.exists():
+        return
+    original = tasks_md.read_text(encoding="utf-8")
+    updated = uncheck_wp_section_subtask_rows(original, st.task_id)
+    if updated == original:
+        return  # nothing to uncheck — no write, no commit
+    tasks_md.write_text(updated, encoding="utf-8")
+    if not st.resolved_auto_commit:
+        return
+    spec_number = st.mission_slug.split("-")[0] if "-" in st.mission_slug else st.mission_slug
+    commit_msg = f"chore: Uncheck {st.task_id} subtasks on rollback to planned (spec {spec_number})"
+    try:
+        ports.coord.commit_artifact(
+            handle,
+            (tasks_md.resolve(),),
+            commit_msg,
+            kind=MissionArtifactKind.TASKS_INDEX,
+            policy=_tasks.ProtectionPolicy.resolve(st.main_repo_root),
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.getLogger(__name__).warning(
+            "Failed to auto-commit subtask uncheck for %s in %s: %s",
+            st.task_id,
+            st.mission_slug,
+            exc,
+        )
+
+
+# --- phase H: review-lock release + result output ----------------------------
 
 
 def _mt_release_review_lock(st: _MoveTaskState) -> None:
@@ -1519,6 +1572,8 @@ def _mt_execute(st: _MoveTaskState, ports: TasksPorts) -> None:
                 fallback_approved=True,
             )
         _mt_persist_wp_file(st, ports)
+    if st.target_lane == Lane.PLANNED:
+        _mt_uncheck_rollback_subtasks(st, ports)
     _mt_release_review_lock(st)
 
 

--- a/src/specify_cli/core/subtask_rows.py
+++ b/src/specify_cli/core/subtask_rows.py
@@ -1,0 +1,72 @@
+"""Work-package subtask row utilities for tasks.md manipulation (#2513).
+
+Provides text-level transformations on the canonical ``- [ ] T### …`` /
+``- [x] T### …`` rows that live in ``tasks.md`` WP sections. Section and
+fence semantics mirror those in ``_check_unchecked_subtasks`` (#2346 /
+#2324 heading rule) — a WP section is bounded by the heading whose FIRST
+``WPxx`` token matches the target WP id.
+
+Note: PR #2505 introduces additional read-only utilities to this module
+(``iter_wp_section_subtask_rows``, ``count_wp_section_subtask_rows``).
+When both PRs land, the section-traversal logic here and in #2505 should
+be unified — one canonical walk shared by all callers.
+"""
+
+from __future__ import annotations
+
+from kernel._safe_re import re
+
+#: Checked canonical subtask row: ``- [x] T001 ...``.
+_CHECKED_SUBTASK_ROW = re.compile(r"^-\s*\[[xX]\]\s*(T\d{3,})\b")
+
+
+def uncheck_wp_section_subtask_rows(tasks_md_text: str, wp_id: str) -> str:
+    """Return *tasks_md_text* with all checked T### rows in *wp_id*'s section unchecked.
+
+    Applies the same section and fence semantics as the lane-transition guard:
+
+    * a heading (``##``–``####``) belongs to the WP named by its FIRST
+      ``WPxx`` token — ``### WP03 … (depends: WP01)`` does not re-enter
+      WP01's section (#2346 / #2324);
+    * entering a different WP's heading ends the section;
+    * rows inside fenced code blocks are ignored.
+
+    Returns the original text unchanged when the section has no checked rows
+    (no allocation, no write).  Used by ``move-task --to planned`` to reset
+    subtask state on WP rollback (#2513): a rolled-back WP must be
+    re-implemented, so leaving its subtasks checked would be a lie.
+    """
+    lines = tasks_md_text.split("\n")
+    in_wp_section = False
+    in_code_fence = False
+    changed = False
+    result: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(("```", "~~~")):
+            in_code_fence = not in_code_fence
+            result.append(line)
+            continue
+        if in_code_fence:
+            result.append(line)
+            continue
+        heading_wp: str | None = None
+        if re.match(r"^#{2,4}[^#]", line):
+            wp_tokens = re.findall(r"\bWP\d{2,}\b", line)
+            heading_wp = wp_tokens[0] if wp_tokens else None
+        if heading_wp == wp_id:
+            in_wp_section = True
+            result.append(line)
+            continue
+        if in_wp_section and heading_wp is not None and heading_wp != wp_id:
+            in_wp_section = False
+            result.append(line)
+            continue
+        if in_wp_section and _CHECKED_SUBTASK_ROW.match(stripped):
+            new_line = re.sub(r"\[[xX]\]", "[ ]", line, count=1)
+            if new_line != line:
+                changed = True
+            result.append(new_line)
+        else:
+            result.append(line)
+    return "\n".join(result) if changed else tasks_md_text

--- a/tests/specify_cli/cli/commands/agent/test_move_task_uncheck_rollback.py
+++ b/tests/specify_cli/cli/commands/agent/test_move_task_uncheck_rollback.py
@@ -1,0 +1,185 @@
+"""Unit tests for _mt_uncheck_rollback_subtasks (#2513).
+
+When ``move-task --to planned`` rolls a WP back, the WP's checked subtask
+rows in tasks.md must be unchecked — otherwise the lane-transition gate
+passes immediately on the next ``for_review`` without the work being re-done.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _make_state(
+    tmp_path: Path,
+    *,
+    task_id: str = "WP01",
+    mission_slug: str = "001-test-mission",
+    resolved_auto_commit: bool = True,
+) -> object:
+    """Build a minimal _MoveTaskState for rollback-uncheck tests."""
+    from specify_cli.cli.commands.agent.tasks_move_task import _MoveTaskState
+    from specify_cli.status import Lane
+
+    return _MoveTaskState(
+        task_id=task_id,
+        to="planned",
+        mission=None,
+        agent=None,
+        assignee=None,
+        shell_pid=None,
+        note=None,
+        review_feedback_file=None,
+        approval_ref=None,
+        reviewer=None,
+        self_review_fallback=False,
+        intended_reviewer=None,
+        reviewer_failure_reason=None,
+        done_override_reason=None,
+        force=False,
+        tracker_ref=None,
+        skip_review_artifact_check=False,
+        auto_commit=None,
+        json_output=False,
+        target_lane=Lane.PLANNED,
+        main_repo_root=tmp_path,
+        mission_slug=mission_slug,
+        resolved_auto_commit=resolved_auto_commit,
+    )
+
+
+def _make_ports(feature_dir: Path) -> MagicMock:
+    """Build a TasksPorts mock whose fs.planning_read_dir returns *feature_dir*."""
+    ports = MagicMock()
+    ports.fs.planning_read_dir.return_value = feature_dir
+    ports.coord.commit_artifact.return_value = MagicMock(status="committed")
+    return ports
+
+
+TASKS_WITH_CHECKED = """\
+## WP01 — Build widget
+
+- [x] T001 Design the API
+- [x] T002 Implement the handler
+- [ ] T003 Write tests
+
+## WP02 — Ship widget
+
+- [x] T004 Ship it
+"""
+
+
+class TestMtUncheckRollbackSubtasks:
+    """_mt_uncheck_rollback_subtasks unchecks the target WP's rows in tasks.md."""
+
+    def test_unchecks_checked_rows_in_wp_section(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        tasks_md = feature_dir / "tasks.md"
+        tasks_md.write_text(TASKS_WITH_CHECKED, encoding="utf-8")
+
+        st = _make_state(tmp_path, task_id="WP01")
+        ports = _make_ports(feature_dir)
+
+        _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+
+        result = tasks_md.read_text(encoding="utf-8")
+        assert "- [ ] T001" in result
+        assert "- [ ] T002" in result
+        assert "- [ ] T003" in result  # already unchecked — preserved
+        # WP02 rows must NOT be touched
+        assert "- [x] T004" in result
+
+    def test_does_not_write_when_no_checked_rows(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        tasks_md = feature_dir / "tasks.md"
+        content = "## WP01\n\n- [ ] T001 Not done\n"
+        tasks_md.write_text(content, encoding="utf-8")
+
+        st = _make_state(tmp_path, task_id="WP01")
+        ports = _make_ports(feature_dir)
+
+        _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+
+        # content unchanged; commit not called
+        assert tasks_md.read_text(encoding="utf-8") == content
+        ports.coord.commit_artifact.assert_not_called()
+
+    def test_skips_silently_when_tasks_md_absent(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        # No tasks.md created
+
+        st = _make_state(tmp_path, task_id="WP01")
+        ports = _make_ports(feature_dir)
+
+        _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+
+        ports.coord.commit_artifact.assert_not_called()
+
+    def test_commits_when_resolved_auto_commit_true(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        tasks_md = feature_dir / "tasks.md"
+        tasks_md.write_text(TASKS_WITH_CHECKED, encoding="utf-8")
+
+        st = _make_state(tmp_path, task_id="WP01", resolved_auto_commit=True)
+        ports = _make_ports(feature_dir)
+        # Patch ProtectionPolicy.resolve so it doesn't need a real repo
+        with patch("specify_cli.cli.commands.agent.tasks.ProtectionPolicy") as mock_pp:
+            mock_pp.resolve.return_value = MagicMock()
+            _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+
+        ports.coord.commit_artifact.assert_called_once()
+        call_kwargs = ports.coord.commit_artifact.call_args
+        assert call_kwargs.kwargs.get("kind") is not None or call_kwargs.args
+
+    def test_skips_commit_when_resolved_auto_commit_false(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        tasks_md = feature_dir / "tasks.md"
+        tasks_md.write_text(TASKS_WITH_CHECKED, encoding="utf-8")
+
+        st = _make_state(tmp_path, task_id="WP01", resolved_auto_commit=False)
+        ports = _make_ports(feature_dir)
+
+        _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+
+        # File must still be written (the uncheck itself), but no commit
+        result = tasks_md.read_text(encoding="utf-8")
+        assert "- [ ] T001" in result
+        ports.coord.commit_artifact.assert_not_called()
+
+    def test_commit_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        from specify_cli.cli.commands.agent.tasks_move_task import _mt_uncheck_rollback_subtasks
+
+        feature_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        feature_dir.mkdir(parents=True)
+        tasks_md = feature_dir / "tasks.md"
+        tasks_md.write_text(TASKS_WITH_CHECKED, encoding="utf-8")
+
+        st = _make_state(tmp_path, task_id="WP01", resolved_auto_commit=True)
+        ports = _make_ports(feature_dir)
+        ports.coord.commit_artifact.side_effect = RuntimeError("disk full")
+
+        with patch("specify_cli.cli.commands.agent.tasks.ProtectionPolicy") as mock_pp:
+            mock_pp.resolve.return_value = MagicMock()
+            _mt_uncheck_rollback_subtasks(st, ports)  # type: ignore[arg-type]
+        # must not raise — the write still happened
+        assert "- [ ] T001" in tasks_md.read_text(encoding="utf-8")

--- a/tests/specify_cli/cli/commands/agent/test_tasks_move_task_seam.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_move_task_seam.py
@@ -68,6 +68,7 @@ _MOVE_SET: tuple[str, ...] = (
     "_mt_commit_wp_file",
     "_mt_persist_tracker_refs",
     "_mt_persist_wp_file",
+    "_mt_uncheck_rollback_subtasks",
     "_mt_release_review_lock",
     "_mt_execute",
     "_mt_output",

--- a/tests/specify_cli/core/test_uncheck_wp_section_subtask_rows.py
+++ b/tests/specify_cli/core/test_uncheck_wp_section_subtask_rows.py
@@ -1,0 +1,104 @@
+"""Unit tests for uncheck_wp_section_subtask_rows (#2513).
+
+A rolled-back WP must have its subtask rows unchecked so the lane-transition
+gate does not pass immediately without the work being re-done.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.core.subtask_rows import uncheck_wp_section_subtask_rows
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+TASKS_MD = """\
+## WP01 — Build widget
+
+- [x] T001 Design the API
+- [x] T002 Implement the handler
+- [ ] T003 Write tests
+
+## WP02 — Ship widget
+
+- [x] T004 Create release notes
+- [x] T005 Tag the release
+"""
+
+
+def test_unchecks_checked_rows_in_target_wp() -> None:
+    result = uncheck_wp_section_subtask_rows(TASKS_MD, "WP01")
+    assert "- [ ] T001" in result
+    assert "- [ ] T002" in result
+
+
+def test_preserves_already_unchecked_rows() -> None:
+    result = uncheck_wp_section_subtask_rows(TASKS_MD, "WP01")
+    assert "- [ ] T003" in result
+
+
+def test_does_not_touch_other_wp_sections() -> None:
+    result = uncheck_wp_section_subtask_rows(TASKS_MD, "WP01")
+    assert "- [x] T004" in result
+    assert "- [x] T005" in result
+
+
+def test_returns_original_when_no_checked_rows() -> None:
+    tasks = "## WP03 — Empty\n\n- [ ] T006 Nothing done\n"
+    result = uncheck_wp_section_subtask_rows(tasks, "WP03")
+    assert result is tasks  # same object — no allocation
+
+
+def test_returns_original_when_wp_section_absent() -> None:
+    result = uncheck_wp_section_subtask_rows(TASKS_MD, "WP99")
+    assert result is TASKS_MD
+
+
+def test_ignores_rows_inside_code_fence() -> None:
+    tasks = """\
+## WP04 — Fenced example
+
+```
+- [x] T007 inside fence — must not be unchecked
+```
+- [x] T008 outside fence
+"""
+    result = uncheck_wp_section_subtask_rows(tasks, "WP04")
+    assert "- [x] T007 inside fence" in result   # preserved
+    assert "- [ ] T008 outside fence" in result  # unchecked
+
+
+def test_heading_with_dependency_mention_does_not_reenter_dep_section() -> None:
+    """WP03 heading mentioning WP01 must not re-enter WP01's section (#2346)."""
+    tasks = """\
+## WP01 — Base
+
+- [x] T001 Done
+
+## WP03 — Derived (depends: WP01)
+
+- [x] T002 Also done
+"""
+    result = uncheck_wp_section_subtask_rows(tasks, "WP01")
+    assert "- [ ] T001" in result   # WP01 row unchecked
+    assert "- [x] T002" in result   # WP03 row left alone
+
+
+def test_uppercase_x_also_unchecked() -> None:
+    tasks = "## WP05 — Mixed case\n\n- [X] T009 Uppercase X\n"
+    result = uncheck_wp_section_subtask_rows(tasks, "WP05")
+    assert "- [ ] T009" in result
+
+
+def test_heading_without_wp_token_does_not_end_section() -> None:
+    """A sub-heading with no WP token inside a WP section must not close it."""
+    tasks = """\
+## WP06 — Work
+
+### Details
+
+- [x] T010 Under sub-heading
+"""
+    result = uncheck_wp_section_subtask_rows(tasks, "WP06")
+    assert "- [ ] T010" in result


### PR DESCRIPTION
## Problem

When `move-task --to planned` rolls a WP back, the `- [x] T###` subtask rows in the WP's `tasks.md` section stay checked. The lane-transition gate then passes immediately on the next `for_review` submission — without any work being re-done. The checked rows lie about the state: a rolled-back WP must be fully re-implemented.

Fixes #2513.

## Solution

`_mt_execute` now calls `_mt_uncheck_rollback_subtasks(st, ports)` when `target_lane == Lane.PLANNED`, placed outside the status lock (same pattern as `_mt_release_review_lock`).

The helper:
1. Resolves `tasks.md` through the `TASKS_INDEX` primary-partition anchor (via `ports.fs.planning_read_dir(kind=TASKS_INDEX)`) so coord-topology missions read the correct surface — not the `-coord` husk (same anchor as `mark-status` and the subtask gate).
2. Calls `uncheck_wp_section_subtask_rows(text, wp_id)` (new `core/subtask_rows.py`) which applies the canonical `#2346` heading-boundary/fence semantics to flip `[x]` → `[ ]` only within the target WP's section.
3. Writes back the modified content.
4. Auto-commits via `ports.coord.commit_artifact(..., kind=TASKS_INDEX)` when `resolved_auto_commit` is set — same route as `mark-status`.

Failures are non-fatal: missing `tasks.md` is silently skipped; commit exceptions are logged as warnings, never `typer.Exit`.

## New module: `core/subtask_rows.py`

> **Note:** PR #2505 also creates `core/subtask_rows.py` with read-only utilities (`iter_wp_section_subtask_rows`, `count_wp_section_subtask_rows`). When both PRs land, the section-traversal logic should be unified into one canonical walk. The merge conflict is trivial (combine both functions into the file).

## Tests

15 new tests across 2 new files:
- `tests/specify_cli/core/test_uncheck_wp_section_subtask_rows.py` — 9 unit tests for the text-transform function (section boundaries, fences, case variants, dependency-mention heading rule, sub-headings without WP tokens, unchanged-text identity)
- `tests/specify_cli/cli/commands/agent/test_move_task_uncheck_rollback.py` — 6 unit tests for `_mt_uncheck_rollback_subtasks` (unchecks rows, no-write when nothing to uncheck, skips when tasks.md absent, commits when auto-commit enabled, skips commit when disabled, non-fatal commit failure)

`_mt_uncheck_rollback_subtasks` added to the WP05 move-set in `test_tasks_move_task_seam.py` and re-exported through `tasks.py` (seam-bridge rule).

## Test plan

- [x] 15 new tests pass
- [x] Existing move-task test suite green (66 tests)
- [x] `ruff check` — no issues
- [x] Full fast suite: 22,529+ passed (architectural shard-marker flakiness pre-existing, unrelated to this diff)