### PR TITLE
feat: expose structured review results to orchestrator API

### DIFF
--- a/docs/api/orchestrator-api.md
+++ b/docs/api/orchestrator-api.md
@@ -29,7 +29,7 @@ It is intentionally stricter than the human-facing CLI:
 
 ## Contract Version
 
-- `CONTRACT_VERSION`: `1.2.0`
+- `CONTRACT_VERSION`: `1.3.0`
 - `MIN_PROVIDER_VERSION`: `0.1.0`
 - Startup probe: `spec-kitty orchestrator-api contract-version`
 
@@ -41,6 +41,8 @@ constant in `src/specify_cli/orchestrator_api/envelope.py`):
   `workspace_path` means that lane worktree. New error code
   `LANE_ALLOCATION_FAILED`.
 - `1.2.0` — new read-only `resolve-workspace` command (#2337). Purely additive.
+- `1.3.0` — `transition` accepts structured `--review-result-json`, allowing
+  guarded `in_review` exits without recovery-only force overrides.
 
 ## Response Envelope
 
@@ -258,8 +260,8 @@ spec-kitty orchestrator-api transition \
 ```
 
 `in_progress -> for_review` requires evidence that the implementation handoff
-is ready. A provider may use `--force` with a clear `--note` when it has its own
-reviewable evidence model.
+is ready. Providers may supply the explicit guard hints shown above or omit them
+and let the host derive the facts. `--force` is reserved for recovery.
 
 ### Claim review
 
@@ -284,13 +286,13 @@ spec-kitty orchestrator-api transition \
   --actor spec-kitty-orchestrator \
   --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"codex","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
   --review-ref review/WP12/attempt-1 \
-  --force \
+  --review-result-json '{"reviewer":"codex","verdict":"approved","reference":"review/WP12/attempt-1"}' \
+  --evidence-json '{"review":{"reviewer":"codex","verdict":"approved","reference":"review/WP12/attempt-1"}}' \
   --note "Codex review approved"
 ```
 
-Use `--force` with an audit note for the current external-review completion
-path. The provider is responsible for keeping the review artifact reference in
-`--review-ref` stable enough for later audit.
+The structured review result satisfies the `in_review` exit guard; done evidence
+keeps the terminal event independently auditable. `--force` remains recovery-only.
 
 ### Send rejected review back to rework
 
@@ -302,7 +304,7 @@ spec-kitty orchestrator-api transition \
   --actor spec-kitty-orchestrator \
   --policy '{"orchestrator_id":"spec-kitty-orchestrator","orchestrator_version":"0.1.0","agent_family":"codex","approval_mode":"full_auto","sandbox_mode":"workspace_write","network_mode":"none","dangerous_flags":[]}' \
   --review-ref review/WP12/attempt-1 \
-  --force \
+  --review-result-json '{"reviewer":"codex","verdict":"changes_requested","reference":"review/WP12/attempt-1"}' \
   --note "Review rejected; rework required"
 ```
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -32,6 +32,11 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   validation** (`asset_mime_invalid`). A new totality guard asserts every
   `ArtifactKind`/`NodeKind`-keyed mapping table stays exhaustive. The 9 existing
   kinds are unchanged.
+- **External orchestrators can submit structured review outcomes without
+  forcing lane transitions.** `orchestrator-api transition` now accepts
+  `--review-result-json` with reviewer, verdict, and reference fields, allowing
+  guarded `in_review` exits to remain fully host-enforced. The additive contract
+  change bumps the orchestrator API to 1.3.0.
 
 ### 🐛 Fixed
 

--- a/docs/guides/build-custom-orchestrator.md
+++ b/docs/guides/build-custom-orchestrator.md
@@ -70,7 +70,8 @@ spec-kitty orchestrator-api transition \
   --actor my-orchestrator \
   --policy '<json>' \
   --review-ref review/WP01/attempt-1 \
-  --force \
+  --review-result-json '{"reviewer":"reviewer-bot","verdict":"approved","reference":"review/WP01/attempt-1"}' \
+  --evidence-json '{"review":{"reviewer":"reviewer-bot","verdict":"approved","reference":"review/WP01/attempt-1"}}' \
   --note "Approved by reviewer-bot"
 
 # review rejected -> rework
@@ -79,7 +80,7 @@ spec-kitty orchestrator-api transition \
   --actor my-orchestrator \
   --policy '<json>' \
   --review-ref review/WP01/attempt-1 \
-  --force \
+  --review-result-json '{"reviewer":"reviewer-bot","verdict":"changes_requested","reference":"review/WP01/attempt-1"}' \
   --note "Rejected by reviewer-bot; rework required"
 ```
 
@@ -130,8 +131,8 @@ while true:
     transition(wp, for_review)
     run reviewer
     start-review(wp, review_ref)
-    if approved: transition(wp, done, force=True)
-    else: transition(wp, in_progress, force=True)
+    if approved: transition(wp, done, review_result, done_evidence)
+    else: transition(wp, in_progress, review_result)
 accept-mission(mission)
 merge-mission(mission)
 ```

--- a/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
+++ b/src/doctrine/skills/spec-kitty-orchestrator-api-operator/references/orchestrator-api-contract.md
@@ -6,7 +6,7 @@ Every command returns a canonical JSON envelope:
 
 ```json
 {
-  "contract_version": "1.2.0",
+  "contract_version": "1.3.0",
   "command": "orchestrator-api.<subcommand-name>",
   "timestamp": "2026-03-21T08:00:00Z",
   "correlation_id": "uuid-v4",
@@ -226,7 +226,8 @@ Perform an explicit lane transition on a work package.
 ```bash
 spec-kitty orchestrator-api transition \
   --mission TEXT --wp TEXT --to TEXT --actor TEXT \
-  [--note TEXT] [--policy TEXT] [--force] [--review-ref TEXT]
+  [--note TEXT] [--policy TEXT] [--force] [--review-ref TEXT] \
+  [--review-result-json TEXT] [--evidence-json TEXT]
 ```
 
 **Flags:**
@@ -241,6 +242,8 @@ spec-kitty orchestrator-api transition \
 | `--policy` | TEXT | none | JSON policy metadata (required for run-affecting lanes) |
 | `--force` | FLAG | off | Override guard checks (recovery only) |
 | `--review-ref` | TEXT | none | Review artifact reference |
+| `--review-result-json` | TEXT | none | Structured review outcome required for transitions from `in_review` |
+| `--evidence-json` | TEXT | none | Structured evidence for `done` transitions |
 
 **Valid target lanes:**
 
@@ -466,11 +469,13 @@ spec-kitty orchestrator-api transition \
 
 # 7. (Reviewer reviews the work)
 
-# 8. Transition to done (requires --force because the transition command
-#    does not accept reviewer evidence payloads)
+# 8. Transition to done with structured review result and terminal evidence
 spec-kitty orchestrator-api transition \
   --mission 017-my-mission --wp WP01 --to done --actor "reviewer-bot" \
-  --force --note "Approved in PR #42"
+  --review-ref "PR #42" \
+  --review-result-json '{"reviewer":"reviewer-bot","verdict":"approved","reference":"PR #42"}' \
+  --evidence-json '{"review":{"reviewer":"reviewer-bot","verdict":"approved","reference":"PR #42"}}' \
+  --note "Approved in PR #42"
 
 # 9. When all WPs are approved or done, accept and merge
 spec-kitty orchestrator-api accept-mission --mission 017-my-mission --actor "ci-bot"

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -486,6 +486,7 @@ def _prepare_event(
             reason=request.reason,
             review_ref=request.review_ref,
             evidence=done_evidence,
+            review_result=request.review_result,
             policy_metadata=request.policy_metadata,
         ),
         resolved_lane,
@@ -855,6 +856,7 @@ def emit_status_transition_transactional(
                 execution_mode=request.execution_mode,
                 reason=request.reason,
                 review_ref=request.review_ref,
+                review_result=request.review_result,
                 policy_metadata=request.policy_metadata,
             )
         txn.append_event(event)

--- a/src/specify_cli/orchestrator_api/commands.py
+++ b/src/specify_cli/orchestrator_api/commands.py
@@ -54,6 +54,7 @@ from specify_cli.git.commit_helpers import (
 from specify_cli.mission_metadata import resolve_mission_identity
 from specify_cli.status import wp_state_for
 from specify_cli.status import Lane
+from specify_cli.status import ReviewResult
 
 from .envelope import (
     CONTRACT_VERSION,
@@ -1293,6 +1294,40 @@ def _enforce_for_review_commit_gate(
         )
 
 
+def _parse_review_result_json(raw: str) -> ReviewResult:
+    """Parse the external review outcome accepted by the transition command."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in --review-result-json: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("--review-result-json must decode to a JSON object")
+
+    reviewer = parsed.get("reviewer")
+    verdict = parsed.get("verdict")
+    reference = parsed.get("reference")
+    if not all(
+        isinstance(value, str) and value.strip()
+        for value in (reviewer, verdict, reference)
+    ):
+        raise ValueError(
+            "--review-result-json requires non-empty reviewer, verdict, and reference strings"
+        )
+    if verdict not in {"approved", "changes_requested"}:
+        raise ValueError(
+            "--review-result-json verdict must be 'approved' or 'changes_requested'"
+        )
+    feedback_path = parsed.get("feedback_path")
+    if feedback_path is not None and not isinstance(feedback_path, str):
+        raise ValueError("--review-result-json feedback_path must be a string")
+    return ReviewResult(
+        reviewer=reviewer,
+        verdict=verdict,
+        reference=reference,
+        feedback_path=feedback_path,
+    )
+
+
 @app.command(name="transition")
 def transition(
     mission: str = typer.Option(..., "--mission", help=_HELP_MISSION_SLUG),
@@ -1303,6 +1338,11 @@ def transition(
     policy: str = typer.Option(None, "--policy", help="Policy metadata JSON (required for run-affecting lanes)"),
     force: bool = typer.Option(False, "--force", help="Force the transition"),
     review_ref: str = typer.Option(None, "--review-ref", help="Review reference"),
+    review_result_json: str = typer.Option(
+        None,
+        "--review-result-json",
+        help="JSON structured review outcome for transitions from in_review",
+    ),
     evidence_json: str = typer.Option(None, "--evidence-json", help="JSON string with done evidence"),
     subtasks_complete: bool = typer.Option(None, "--subtasks-complete", help="Whether required subtasks are complete for in_progress->for_review"),
     implementation_evidence_present: bool = typer.Option(
@@ -1353,6 +1393,14 @@ def transition(
             return
         evidence = parsed_evidence
 
+    review_result: ReviewResult | None = None
+    if review_result_json is not None:
+        try:
+            review_result = _parse_review_result_json(review_result_json)
+        except ValueError as exc:
+            _fail(cmd, "USAGE_ERROR", str(exc))
+            return
+
     main_repo_root = _get_main_repo_root()
     mission_dir = _resolve_mission_dir_or_fail(cmd, main_repo_root, mission)
 
@@ -1380,6 +1428,7 @@ def transition(
                 force=force,
                 evidence=evidence,
                 review_ref=review_ref,
+                review_result=review_result,
                 subtasks_complete=subtasks_complete,
                 implementation_evidence_present=implementation_evidence_present,
                 execution_mode="worktree",

--- a/src/specify_cli/orchestrator_api/envelope.py
+++ b/src/specify_cli/orchestrator_api/envelope.py
@@ -23,7 +23,9 @@ from specify_cli.core.time_utils import now_utc_iso
 # 1.2.0: added read-only ``resolve-workspace`` (#2337) — resolves a WP's lane
 # workspace_path / prompt_path / lane_branch WITHOUT allocating or transitioning,
 # so an external orchestrator can resume a for_review WP. Purely additive.
-CONTRACT_VERSION = "1.2.0"
+# 1.3.0: ``transition`` accepts structured ``--review-result-json`` so normal
+# in_review exits satisfy host guards without using the recovery-only force flag.
+CONTRACT_VERSION = "1.3.0"
 MIN_PROVIDER_VERSION = "0.1.0"
 
 # Banned flags: enforced by parse_and_validate_policy() below (a policy whose

--- a/src/specify_cli/status/emit.py
+++ b/src/specify_cli/status/emit.py
@@ -44,6 +44,7 @@ from .models import (
     Lane,
     RepoEvidence,
     ReviewApproval,
+    ReviewResult,
     StatusEvent,
     TransitionRequest,
     VerificationResult,
@@ -139,6 +140,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
     reason: str | None = None,
     review_ref: str | None = None,
     evidence: DoneEvidence | None = None,
+    review_result: ReviewResult | None = None,
     policy_metadata: dict[str, Any] | None = None,
 ) -> StatusEvent:
     """Construct a fresh :class:`StatusEvent` with a new ULID and timestamp.
@@ -160,6 +162,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
         reason: Optional human reason (required for force).
         review_ref: Optional review-feedback reference.
         evidence: Optional :class:`DoneEvidence` for done transitions.
+        review_result: Optional structured review outcome for review exits.
         policy_metadata: Optional orchestrator policy metadata dict.
 
     Returns:
@@ -178,6 +181,7 @@ def build_status_event(  # noqa: PLR0913 -- pass-through to a dataclass construc
         reason=reason,
         review_ref=review_ref,
         evidence=evidence,
+        review_result=review_result,
         policy_metadata=policy_metadata,
         mission_id=mission_id,
     )
@@ -554,6 +558,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
                 reason=reason,
                 review_ref=review_ref,
                 evidence=None,
+                review_result=review_result,
                 policy_metadata=policy_metadata,
                 mission_id=mission_id,
             )
@@ -599,6 +604,7 @@ def emit_status_transition(  # NOSONAR — central orchestration hub; 15 of 20 p
             reason=reason,
             review_ref=review_ref,
             evidence=done_evidence,
+            review_result=review_result,
             policy_metadata=policy_metadata,
             mission_id=mission_id,
         )
@@ -724,6 +730,7 @@ def emit_status_transition_batch(  # noqa: C901 — composite transition orchest
             reason=request.reason,
             review_ref=request.review_ref,
             evidence=done_evidence,
+            review_result=request.review_result,
             policy_metadata=request.policy_metadata,
             mission_id=mission_id,
         )

--- a/src/specify_cli/status/models.py
+++ b/src/specify_cli/status/models.py
@@ -184,6 +184,25 @@ class ReviewResult:
     reference: str  # Approval ref or feedback:// URI
     feedback_path: str | None = None  # Resolved path to feedback file (rejection only)
 
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "reviewer": self.reviewer,
+            "verdict": self.verdict,
+            "reference": self.reference,
+        }
+        if self.feedback_path is not None:
+            data["feedback_path"] = self.feedback_path
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReviewResult:
+        return cls(
+            reviewer=data["reviewer"],
+            verdict=data["verdict"],
+            reference=data["reference"],
+            feedback_path=data.get("feedback_path"),
+        )
+
 
 @dataclass(frozen=True)
 class StatusEvent:
@@ -211,6 +230,7 @@ class StatusEvent:
     reason: str | None = None
     review_ref: str | None = None
     evidence: DoneEvidence | None = None
+    review_result: ReviewResult | None = None
     policy_metadata: dict[str, Any] | None = None
     # mission_id (ULID) added in WP05; None for legacy events read from disk
     # before the migration, or for missions that pre-date mission_id minting.
@@ -232,6 +252,8 @@ class StatusEvent:
             "evidence": self.evidence.to_dict() if self.evidence else None,
             "policy_metadata": self.policy_metadata,
         }
+        if self.review_result is not None:
+            d["review_result"] = self.review_result.to_dict()
         if self.mission_id is not None:
             d["mission_id"] = self.mission_id
         return d
@@ -248,6 +270,7 @@ class StatusEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> StatusEvent:
         evidence_data = data.get("evidence")
+        review_result_data = data.get("review_result")
         return cls(
             event_id=data["event_id"],
             mission_slug=data.get("mission_slug") or data.get("feature_slug", ""),
@@ -261,6 +284,11 @@ class StatusEvent:
             reason=data.get("reason"),
             review_ref=data.get("review_ref"),
             evidence=DoneEvidence.from_dict(evidence_data) if evidence_data else None,
+            review_result=(
+                ReviewResult.from_dict(review_result_data)
+                if review_result_data
+                else None
+            ),
             policy_metadata=data.get("policy_metadata"),
             mission_id=data.get("mission_id"),  # None for legacy events
         )

--- a/src/specify_cli/status/wp_state.py
+++ b/src/specify_cli/status/wp_state.py
@@ -403,7 +403,14 @@ class InReviewState(WPState):
 
     def guard_for(self, _target: Lane, ctx: TransitionInputs) -> tuple[bool, str | None]:
         # FR-012c: ALL outbound transitions from in_review require ReviewResult.
-        return _check_review_result(ctx)
+        ok, error = _check_review_result(ctx)
+        if not ok:
+            return ok, error
+        if _target in {Lane.APPROVED, Lane.DONE}:
+            ok, error = _check_in_review_approval(ctx)
+            if not ok:
+                return ok, error
+        return _check_review_result_consistency(ctx)
 
     def progress_bucket(self) -> str:
         return "review"
@@ -525,12 +532,29 @@ def _check_reviewer_approval(ctx: TransitionInputs) -> tuple[bool, str | None]:
         return False, _REVIEWER_APPROVAL_REQUIRED
     review = getattr(evidence, "review", None)
     reviewer = getattr(review, "reviewer", None) if review is not None else None
+    verdict = getattr(review, "verdict", None) if review is not None else None
     reference = getattr(review, "reference", None) if review is not None else None
     if not reviewer or not str(reviewer).strip():
         return False, _REVIEWER_APPROVAL_REQUIRED
     if not reference or not str(reference).strip():
         return False, _REVIEWER_APPROVAL_REQUIRED
+    if verdict != "approved":
+        return False, _REVIEWER_APPROVAL_REQUIRED
     return True, None
+
+
+def _check_in_review_approval(ctx: TransitionInputs) -> tuple[bool, str | None]:
+    """Accept review-result approval when no separate done evidence is needed."""
+    if ctx.evidence is not None:
+        return _check_reviewer_approval(ctx)
+    review_result = ctx.review_result
+    if (
+        getattr(review_result, "reviewer", None)
+        and getattr(review_result, "verdict", None) == "approved"
+        and getattr(review_result, "reference", None)
+    ):
+        return True, None
+    return False, _REVIEWER_APPROVAL_REQUIRED
 
 
 def _check_no_review_conflict(ctx: TransitionInputs) -> tuple[bool, str | None]:
@@ -565,6 +589,36 @@ def _check_review_result(ctx: TransitionInputs) -> tuple[bool, str | None]:
         return False, "Transition from in_review requires review_result with verdict"
     if not reference or not str(reference).strip():
         return False, "Transition from in_review requires review_result with reference"
+    return True, None
+
+
+def _check_review_result_consistency(
+    ctx: TransitionInputs,
+) -> tuple[bool, str | None]:
+    """Reject contradictory structured, evidence, and legacy review fields."""
+    rr = ctx.review_result
+    if rr is None:
+        return False, "Transition from in_review requires review_result"
+
+    if ctx.review_ref is not None and ctx.review_ref != getattr(rr, "reference", None):
+        return False, "review_ref must match review_result.reference"
+
+    evidence = ctx.evidence
+    if evidence is None:
+        return True, None
+    review = getattr(evidence, "review", None)
+    expected = (
+        getattr(rr, "reviewer", None),
+        getattr(rr, "verdict", None),
+        getattr(rr, "reference", None),
+    )
+    actual = (
+        getattr(review, "reviewer", None),
+        getattr(review, "verdict", None),
+        getattr(review, "reference", None),
+    )
+    if actual != expected:
+        return False, "Review evidence must match review_result"
     return True, None
 
 

--- a/tests/agent/test_orchestrator_commands_integration.py
+++ b/tests/agent/test_orchestrator_commands_integration.py
@@ -915,6 +915,8 @@ class TestTransition:
                     "reviewer",
                     "--review-ref",
                     "review-001",
+                    "--review-result-json",
+                    '{"reviewer":"reviewer","verdict":"approved","reference":"review-001"}',
                     "--evidence-json",
                     '{"review":{"reviewer":"reviewer","verdict":"approved","reference":"review-001"}}',
                 ],
@@ -923,6 +925,9 @@ class TestTransition:
         assert result.exit_code == 0, result.output
         req = emit_mock.call_args.args[0]
         assert req.review_ref == "review-001"
+        assert req.review_result.reviewer == "reviewer"
+        assert req.review_result.verdict == "approved"
+        assert req.review_result.reference == "review-001"
         assert req.evidence == {
             "review": {
                 "reviewer": "reviewer",
@@ -953,6 +958,43 @@ class TestTransition:
                     "reviewer",
                     "--evidence-json",
                     '{"review":',
+                ],
+            )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["error_code"] == "USAGE_ERROR"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"reviewer":',
+            '[]',
+            '{"reviewer":"reviewer","verdict":"approved"}',
+            '{"reviewer":"reviewer","verdict":"maybe","reference":"review-001"}',
+        ],
+    )
+    def test_transition_rejects_invalid_review_result_json(self, tmp_path, payload):
+        repo_root, _ = _make_mission(tmp_path, "099-test-feature")
+
+        with patch(
+            "specify_cli.orchestrator_api.commands._get_main_repo_root",
+            return_value=repo_root,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "transition",
+                    "--mission",
+                    "099-test-feature",
+                    "--wp",
+                    "WP01",
+                    "--to",
+                    "done",
+                    "--actor",
+                    "reviewer",
+                    "--review-result-json",
+                    payload,
                 ],
             )
 

--- a/tests/status/test_transitions.py
+++ b/tests/status/test_transitions.py
@@ -22,6 +22,7 @@ from specify_cli.status.transitions import (
     resolve_lane_alias,
     validate_transition,
 )
+from specify_cli.status.wp_state import _check_review_result_consistency
 from tests._support.coverage_safety import Mutation, assert_mutation_caught
 
 pytestmark = pytest.mark.fast
@@ -321,6 +322,64 @@ class TestGuardConditions:
             GuardContext(review_result=ReviewResult(reviewer="r", verdict="approved", reference="PR#42")),
         )
         assert ok is True
+
+    def test_in_review_approval_requires_approved_verdict(self) -> None:
+        ok, error = validate_transition(
+            "in_review",
+            "approved",
+            GuardContext(
+                review_result=ReviewResult(
+                    reviewer="r", verdict="changes_requested", reference="feedback://1"
+                )
+            ),
+        )
+        assert ok is False
+        assert "approval" in error.lower()
+
+    def test_in_review_done_rejects_non_approval_evidence(self) -> None:
+        result = ReviewResult(reviewer="r", verdict="changes_requested", reference="feedback://1")
+        evidence = DoneEvidence(review=ReviewApproval(
+            reviewer="r", verdict="changes_requested", reference="feedback://1"
+        ))
+        ok, error = validate_transition(
+            "in_review",
+            "done",
+            GuardContext(review_result=result, evidence=evidence),
+        )
+        assert ok is False
+        assert "approval" in error.lower()
+
+    def test_in_review_review_ref_must_match_result(self) -> None:
+        ok, error = validate_transition(
+            "in_review",
+            "planned",
+            GuardContext(
+                review_ref="feedback://other",
+                review_result=ReviewResult(
+                    reviewer="r", verdict="changes_requested", reference="feedback://1"
+                ),
+            ),
+        )
+        assert ok is False
+        assert "match" in error.lower()
+
+    def test_in_review_evidence_must_match_result(self) -> None:
+        result = ReviewResult(reviewer="r", verdict="approved", reference="PR#42")
+        evidence = DoneEvidence(review=ReviewApproval(
+            reviewer="other", verdict="approved", reference="PR#42"
+        ))
+        ok, error = validate_transition(
+            "in_review",
+            "done",
+            GuardContext(review_result=result, evidence=evidence),
+        )
+        assert ok is False
+        assert "match" in error.lower()
+
+    def test_review_result_consistency_requires_result(self) -> None:
+        ok, error = _check_review_result_consistency(GuardContext())
+        assert ok is False
+        assert "review_result" in error
 
     def test_workspace_context_required_for_claimed_to_in_progress(self) -> None:
         ok, error = validate_transition("claimed", "in_progress", GuardContext())


### PR DESCRIPTION
## Summary

Adds the missing host-side contract needed for external orchestrators to complete review transitions without `--force`.

- `orchestrator-api transition` accepts `--review-result-json`
- validates reviewer, verdict, reference, and optional feedback path
- carries structured review results through transition requests and persisted events
- preserves host review guards and checks review-result/evidence consistency
- bumps the orchestrator API contract to 1.3.0
- updates external-orchestrator docs and integration coverage

## Validation

- `pytest tests/status/test_transitions.py tests/status/test_emit.py -q` -> 187 passed
- `pytest tests/agent/test_orchestrator_commands_integration.py -q` -> 67 passed
- `ruff check ...` -> passed
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/agent/cli/commands/test_sync.py::TestSyncNowExitCodes::test_empty_queue_exits_0 -q` -> 1 passed
- compileall -> passed

This is the host prerequisite for spec-kitty-orchestrator PR #17.