### PR TITLE
feat(doctrine): mission wrap-up procedure + readable-consistent-PRs directive (DIRECTIVE_046)

### DIFF
--- a/.kittify/charter/charter.md
+++ b/.kittify/charter/charter.md
@@ -285,6 +285,14 @@ The 1.x/2.x branch split was originally documented in [ADR-12: Two-Branch Strate
 - **CI checks must pass** (tests, type checking, linting)
 - **Pre-commit hooks** must pass (UTF-8 encoding validation)
 
+**Readable and consistent PRs are binding** (directive `046-readable-consistent-prs`, active). Every mission branch / PR an agent hands the operator must be:
+
+- **Linear** — rebased onto the current upstream base and compacted into a small set of logically-sliced commits (rebase over merge; a non-reordering, behaviour-preserving snapshot chain per the `clean-linear-commit-history` tactic, never an interactive reorder).
+- **Consistent / complete** — the intended scope is finished; only genuinely high-effort / mission-sized work is deferred, and only as a tracked follow-up with a rationale.
+- **Independently reviewed** — the aggregate diff has had an independent review before, or in parallel to, opening the draft PR, with real findings folded in while it is still a draft; an adversarial review squad is the recommended mechanism (not a mandated gate).
+
+The standing close-out sequence that produces such a PR — accept → resolve issue verdicts → aggregate review squad → local merge → compact history → rebase onto upstream → draft PR + pre-merge squad → hand off — is captured as the `mission-wrap-up-sequence` procedure (active). The operator, not the agent, performs the mainline merge (`045-prs-only-and-read-intent`).
+
 ### Code Review Checklist
 
 - Tests added for new functionality

--- a/.kittify/charter/interview/answers.yaml
+++ b/.kittify/charter/interview/answers.yaml
@@ -92,6 +92,8 @@ selected_directives:
   - DIRECTIVE_043
   - DIRECTIVE_044
   - DIRECTIVE_045
+  # Mission wrap-up + readable-PRs doctrine (mission-wrapup-doctrine):
+  - DIRECTIVE_046
 
 # Tactics: use canonical id: field (same as filename stem for tactics).
 # Includes catfooding tactics from WP02 (§5a arch-gate non-vacuity),

--- a/.kittify/charter/synthesis-manifest.yaml
+++ b/.kittify/charter/synthesis-manifest.yaml
@@ -1,10 +1,10 @@
 adapter_id: fresh-seed
-adapter_version: 3.2.0rc44
+adapter_version: 3.2.5
 artifacts: []
 built_in_only: true
 created_at: '1970-01-01T00:00:00+00:00'
-manifest_hash: 4ebbbea935999f82dc17b3ebedbb2065ad4bec4834304d3264617b531ea1d33a
+manifest_hash: a64245b83ca12da53f23b1ebdf4c2d1c68beae6cecfaa88698bff301adb6cd97
 mission_id:
 run_id: fresh-project-seed
 schema_version: '2'
-synthesizer_version: 3.2.0rc44
+synthesizer_version: 3.2.5

--- a/.kittify/config.yaml
+++ b/.kittify/config.yaml
@@ -41,6 +41,7 @@ activated_directives:
 - 045-prs-only-and-read-intent
 - 041-tests-as-scaffold-not-friction
 - 042-common-docs
+- 046-readable-consistent-prs
 activated_tactics:
 - acceptance-test-first
 - adr-drafting-workflow
@@ -182,6 +183,7 @@ activated_procedures:
 - mission-tracer-files
 - adversarial-squad-deployment
 - post-merge-arch-gate-adjudication
+- mission-wrap-up-sequence
 activated_paradigms:
 - atomic-design
 - behaviour-driven-development

--- a/src/doctrine/directives/built-in/046-readable-consistent-prs.directive.yaml
+++ b/src/doctrine/directives/built-in/046-readable-consistent-prs.directive.yaml
@@ -1,0 +1,85 @@
+schema_version: "1.0"
+id: DIRECTIVE_046
+title: Readable and Consistent Pull Requests
+intent: >
+  Every mission branch and pull request an agent prepares must be readable,
+  consistent, and independently reviewed before it is handed to the operator.
+  Concretely, three properties are required and must not be traded away for speed:
+  (1) LINEAR history — the branch is rebased onto the current upstream base and
+  carries a small set of logically-sliced commits, never a tangle of merge and
+  status commits (rebase over merge); (2) CONSISTENT and COMPLETE scope — the
+  branch finishes the work it set out to do and does not defer genuinely small
+  remaining items to a follow-up, deferring only work that is genuinely
+  high-effort or mission-sized; (3) INDEPENDENTLY REVIEWED — the aggregate diff
+  has had an independent review before, or in parallel to, opening the draft PR,
+  with real findings folded in while the PR is still a draft. The adversarial
+  review squad (adversarial-squad-deployment) is the RECOMMENDED review mechanism
+  — not a mandated gate; it stays optional per its own doctrine.
+enforcement: required
+scope: >
+  Applies to every agent-prepared mission branch and pull request in the SDD flow,
+  from the point the mission's work packages are approved through to hand-off. It
+  governs how the branch history is shaped, how completely the scope is finished,
+  and what review has run before the PR is presented. It does not change the
+  operator-merges rule (DIRECTIVE_045) — it constrains what the agent hands the
+  operator.
+procedures:
+  - Rebase the mission branch onto the current upstream mainline so it is
+    ahead-only, and compact it into a small set of readable, logically-sliced
+    commits (for example docs / surface / repoints) per the
+    clean-linear-commit-history tactic (a non-reordering, behaviour-preserving
+    snapshot chain) — never an interactive reorder. Prefer rebase over merge for
+    integrating the upstream base.
+  - Before opening the draft PR, confirm the intended scope is complete. If a
+    remaining item is small enough to finish now, finish it; only defer work that
+    is genuinely high-effort or mission-sized, and when deferring, record it as a
+    tracked follow-up with a one-line rationale.
+  - Obtain an independent review of the aggregate diff before or in parallel to
+    opening the draft PR — the adversarial review squad (adversarial-squad-deployment)
+    is the recommended mechanism. Synthesize a LAND / HOLD verdict and fold every
+    real finding in while the PR is still a draft. Per-WP green and green CI are
+    not, by themselves, the final gate.
+  - Write a PR body that states the change, the review evidence (per-WP plus the
+    aggregate squad verdict), and any remaining reviewer or Sonar work, so a later
+    reviewer does not re-derive the context.
+  - Verify the compacted, rebased tree is identical to the pre-compaction tree
+    except for intentionally-dropped ignored artefacts, and re-run the affected
+    tests on the rebased tip before force-pushing with lease.
+integrity_rules:
+  - A mission PR must not be presented as ready while its branch carries
+    merge-commit tangle or status/bookkeeping commits that a compaction would
+    remove; linear, logically-sliced history is required.
+  - Deferring genuinely small remaining work to a follow-up solely to close the
+    mission faster is prohibited. Deferral is reserved for genuinely high-effort
+    or mission-sized work and must be tracked with a rationale.
+  - A mission PR must not be presented as ready without an independent review of
+    the aggregate diff; per-WP green and green CI are not, by themselves, the
+    final gate. The adversarial squad is the recommended review mechanism but is
+    not itself a mandated gate (it stays optional per its own doctrine).
+  - History rewrites follow the clean-linear-commit-history tactic (a
+    non-reordering, behaviour-preserving snapshot chain) and force-push-with-lease;
+    an interactive reorder that risks losing or scrambling commits is not an
+    acceptable compaction method.
+validation_criteria:
+  - The mission branch at hand-off is ahead-only against the upstream base and
+    carries a small, logically-sliced commit set (not per-WP status noise).
+  - Any deferred work is recorded as a tracked follow-up with a rationale, and no
+    genuinely small item was punted to close the mission faster.
+  - An independent review of the aggregate diff was performed (the adversarial
+    squad being the recommended mechanism) and its confirmed findings were
+    addressed before the PR was presented as ready.
+  - The PR body records the change summary, the review evidence, and any
+    outstanding reviewer/Sonar work.
+references:
+  - type: procedure
+    id: mission-wrap-up-sequence
+  - type: tactic
+    id: clean-linear-commit-history
+  - type: tactic
+    id: reviewer-implementer-role-separation
+  - type: tactic
+    id: review-intent-and-risk-first
+  - type: procedure
+    id: adversarial-squad-deployment
+  - type: directive
+    id: DIRECTIVE_045

--- a/src/doctrine/graph.yaml
+++ b/src/doctrine/graph.yaml
@@ -188,6 +188,9 @@ nodes:
 - urn: directive:DIRECTIVE_045
   kind: directive
   label: PRs-Only and Read-Intent Before High-Risk Operations
+- urn: directive:DIRECTIVE_046
+  kind: directive
+  label: Readable and Consistent Pull Requests
 - urn: paradigm:anemic-domain-model
   kind: paradigm
 - urn: paradigm:atomic-design
@@ -271,6 +274,9 @@ nodes:
 - urn: procedure:mission-tracer-files
   kind: procedure
   label: Mission Tracer Files
+- urn: procedure:mission-wrap-up-sequence
+  kind: procedure
+  label: Mission Wrap-Up Sequence
 - urn: procedure:onboard-external-agent-to-pack
   kind: procedure
   label: Onboard an External Agent into the Pack
@@ -986,6 +992,9 @@ edges:
   target: directive:DIRECTIVE_037
   relation: scope
 - source: action:software-dev/implement
+  target: directive:DIRECTIVE_046
+  relation: scope
+- source: action:software-dev/implement
   target: paradigm:execution-lanes
   relation: scope
 - source: action:software-dev/implement
@@ -1142,6 +1151,9 @@ edges:
   target: directive:DIRECTIVE_037
   relation: scope
 - source: action:software-dev/review
+  target: directive:DIRECTIVE_046
+  relation: scope
+- source: action:software-dev/review
   target: paradigm:execution-lanes
   relation: scope
 - source: action:software-dev/review
@@ -1158,6 +1170,9 @@ edges:
   relation: scope
 - source: action:software-dev/review
   target: procedure:legacy-codebase-triage
+  relation: scope
+- source: action:software-dev/review
+  target: procedure:mission-wrap-up-sequence
   relation: scope
 - source: action:software-dev/review
   target: procedure:refactoring
@@ -1179,9 +1194,6 @@ edges:
   relation: scope
 - source: action:software-dev/review
   target: tactic:change-apply-smallest-viable-diff
-  relation: scope
-- source: action:software-dev/review
-  target: tactic:dependency-hygiene
   relation: scope
 - source: action:software-dev/review
   target: tactic:quality-gate-verification
@@ -1730,6 +1742,24 @@ edges:
 - source: directive:DIRECTIVE_045
   target: procedure:post-merge-arch-gate-adjudication
   relation: suggests
+- source: directive:DIRECTIVE_046
+  target: directive:DIRECTIVE_045
+  relation: requires
+- source: directive:DIRECTIVE_046
+  target: procedure:adversarial-squad-deployment
+  relation: suggests
+- source: directive:DIRECTIVE_046
+  target: procedure:mission-wrap-up-sequence
+  relation: suggests
+- source: directive:DIRECTIVE_046
+  target: tactic:clean-linear-commit-history
+  relation: suggests
+- source: directive:DIRECTIVE_046
+  target: tactic:review-intent-and-risk-first
+  relation: suggests
+- source: directive:DIRECTIVE_046
+  target: tactic:reviewer-implementer-role-separation
+  relation: suggests
 - source: paradigm:behaviour-driven-development
   target: directive:DIRECTIVE_034
   relation: requires
@@ -2023,6 +2053,21 @@ edges:
 - source: procedure:mission-tracer-files
   target: styleguide:adversarial-squad-cadence
   relation: suggests
+- source: procedure:mission-wrap-up-sequence
+  target: directive:DIRECTIVE_045
+  relation: requires
+- source: procedure:mission-wrap-up-sequence
+  target: procedure:adversarial-squad-deployment
+  relation: requires
+- source: procedure:mission-wrap-up-sequence
+  target: procedure:mission-tracer-files
+  relation: requires
+- source: procedure:mission-wrap-up-sequence
+  target: procedure:post-merge-arch-gate-adjudication
+  relation: requires
+- source: procedure:mission-wrap-up-sequence
+  target: tactic:clean-linear-commit-history
+  relation: requires
 - source: procedure:onboard-external-agent-to-pack
   target: directive:DIRECTIVE_003
   relation: requires

--- a/src/doctrine/missions/software-dev/actions/implement/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/implement/index.yaml
@@ -11,6 +11,7 @@ directives:
   - 034-test-first-development
   - 036-black-box-integration-testing
   - 037-living-documentation-sync
+  - 046-readable-consistent-prs
 tactics:
   - acceptance-test-first
   - tdd-red-green-refactor

--- a/src/doctrine/missions/software-dev/actions/review/index.yaml
+++ b/src/doctrine/missions/software-dev/actions/review/index.yaml
@@ -3,6 +3,7 @@ directives:
   - 010-specification-fidelity-requirement
   - 037-living-documentation-sync
   - 030-test-and-typecheck-quality-gate
+  - 046-readable-consistent-prs
 tactics:
   - usage-examples-sync
   - review-intent-and-risk-first
@@ -10,4 +11,5 @@ tactics:
   - stopping-conditions
 styleguides: []
 toolguides: []
-procedures: []
+procedures:
+  - mission-wrap-up-sequence

--- a/src/doctrine/procedures/built-in/mission-tracer-files.procedure.yaml
+++ b/src/doctrine/procedures/built-in/mission-tracer-files.procedure.yaml
@@ -40,11 +40,13 @@ steps:
     actor: agent
   - title: Assess — review and act at mission close
     description: >
-      Before marking the mission as done (or as part of the accept step),
-      review all three tracer files. Summarise the most significant insights
-      in the mission retrospective. File any unresolved tooling-friction items
-      in the tracker so they feed the tooling-gap backlog. Confirm the tracer
-      files are committed to the mission branch before closing.
+      Before marking the mission as done (or as part of the accept step and the
+      mission wrap-up sequence's hand-off), review all three tracer files.
+      Summarise the most significant insights in the mission retrospective. File
+      any unresolved tooling-friction items in the tracker so they feed the
+      tooling-gap backlog. Confirm the tracer files are committed to the mission
+      branch before closing — note that the wrap-up sequence compacts the branch,
+      so the tracer files must be part of the retained, logically-sliced history.
     actor: agent
 anti_patterns:
   - name: Retroactive fill-in

--- a/src/doctrine/procedures/built-in/mission-wrap-up-sequence.procedure.yaml
+++ b/src/doctrine/procedures/built-in/mission-wrap-up-sequence.procedure.yaml
@@ -1,0 +1,154 @@
+schema_version: "1.0"
+id: mission-wrap-up-sequence
+name: Mission Wrap-Up Sequence
+purpose: >
+  Drive a mission from "all work packages approved" to "a clean, reviewable draft
+  pull request handed to the operator" through one standing, repeatable close-out
+  sequence. The sequence makes the last mile deterministic: it verifies readiness,
+  resolves every tracked-issue verdict, subjects the aggregate diff to an
+  independent review, lands locally, compacts the branch into readable history,
+  and opens a draft PR — so no mission ends in an ad-hoc, unreviewed, or messy
+  state. It complements (does not replace) the per-work-package implement/review
+  loop.
+entry_condition: >
+  Every work package in the mission is approved (the per-WP implement/review loop
+  is complete). Acceptance has not yet been recorded and the mission branch has
+  not yet been merged locally.
+exit_condition: >
+  Acceptance is recorded; every tracker issue referenced by the spec carries a
+  terminal issue-matrix verdict; the aggregate diff has passed an independent
+  review (the adversarial squad being the recommended mechanism); the lanes are
+  merged into the mission branch; the branch
+  history is compacted into a small set of readable, logically-sliced commits
+  rebased onto the current upstream base; and a draft pull request is open and
+  handed to the operator. The operator — not the agent — performs the merge to
+  the protected mainline.
+steps:
+  - title: Confirm readiness and run acceptance
+    description: >
+      Verify all work packages are in the approved lane, then run the mission's
+      accept step (`spec-kitty accept --mission <slug>`) as the readiness nudge.
+      Resolve any blocker it reports (for example a missing acceptance-matrix)
+      before proceeding. Acceptance is a pre-merge check, not a substitute for
+      per-WP review or the merge gate.
+    actor: agent
+  - title: Resolve every tracked-issue verdict to terminal
+    description: >
+      For each issue referenced in the spec, set a terminal issue-matrix verdict
+      (fixed, verified-already-fixed, or deferred-with-followup). An in-mission
+      placeholder must be driven to a terminal state before the mission can reach
+      done. Record the evidence for each verdict.
+    actor: agent
+  - title: Independently review the aggregate diff before landing
+    description: >
+      The sum of the per-WP reviews is not the final gate — the WPs only coexist
+      once combined. Obtain an independent review of the aggregate diff — the
+      adversarial review squad (adversarial-squad-deployment) is the recommended
+      mechanism — to catch cross-WP integration issues, behaviour drift, and any
+      documented exception that no longer holds. Synthesize a LAND / HOLD verdict
+      and resolve anything real before landing.
+    actor: agent
+  - title: Merge the lanes locally
+    description: >
+      Merge the approved lanes into the mission branch with the host merge command
+      (`spec-kitty merge --mission <slug>`), which lands locally only. Resolve any
+      stale-lane conflicts on shared files. Do not push to the protected mainline
+      and never merge it yourself — the operator does that.
+    actor: agent
+  - title: Compact the branch into readable history
+    description: >
+      Rewrite the mission branch into a small set of readable, logically-sliced
+      commits (for example docs / surface / repoints), following the
+      clean-linear-commit-history tactic (a non-reordering, behaviour-preserving
+      snapshot chain) — never an interactive reorder. Verify the compacted tree is
+      identical to the pre-compaction tree except for intentionally-dropped ignored
+      artefacts.
+    actor: agent
+  - title: Rebase onto the current upstream base
+    description: >
+      Fetch the true upstream mainline and rebase the compacted commits onto it so
+      the branch is ahead-only (rebase over merge — linear history). Re-run the
+      affected tests on the rebased tip to confirm the newer base introduced no
+      break, then force-push with lease.
+    actor: agent
+    on_failure: >
+      If the rebase conflicts with new upstream work, resolve slice-by-slice and
+      re-verify; if the base has diverged unexpectedly, fetch and reconcile before
+      pushing rather than forcing over unseen commits.
+  - title: Open a draft pull request and run a pre-merge squad
+    description: >
+      Open a draft PR against the upstream mainline with a body that states the
+      change, the review evidence, and any remaining reviewer/Sonar work. Run (or,
+      for speed, run in parallel to opening the draft) a final adversarial review
+      squad on the branch; fold any real finding in while it is still a draft.
+    actor: agent
+  - title: Hand off to the operator
+    description: >
+      Summarise the outcome (what shipped, the review verdicts, open follow-ups)
+      and hand the draft PR to the operator to mark ready and merge. Capture
+      durable learnings in the mission retrospective and memory. Do not mark the
+      PR ready or merge to the mainline on the agent's own initiative.
+    actor: agent
+anti_patterns:
+  - name: Per-WP green treated as the final gate
+    description: >
+      Skipping the aggregate review because every work package already passed.
+      The WPs only coexist after merge; the aggregate diff is where cross-WP
+      integration breaks surface.
+  - name: Merge commits instead of a linear history
+    description: >
+      Landing the mission as a tangle of merge/status commits rather than a
+      compacted, rebased, linear branch. Readability and bisectability are lost.
+  - name: Deferring instead of finishing
+    description: >
+      Punting genuinely small remaining work to a follow-up to close the mission
+      faster. Only genuinely high-effort / mission-sized work is deferred; the
+      rest is completed before hand-off.
+  - name: Agent merges the mainline
+    description: >
+      Marking the PR ready and merging to the protected mainline on the agent's
+      own initiative. The operator merges; the agent prepares and hands off.
+  - name: Unresolved issue verdicts at close
+    description: >
+      Leaving in-mission or empty verdicts in the issue matrix at hand-off. Every
+      referenced issue must reach a terminal verdict before done.
+notes: |
+  Standing close-out sequence for the SDD flow. It is the "last mile" companion to
+  the per-work-package implement/review loop: the loop makes each WP correct, this
+  procedure makes the mission land cleanly and reviewably.
+
+  Sequence summary: accept -> resolve issue verdicts -> aggregate review squad ->
+  local merge -> compact history -> rebase onto upstream -> draft PR + pre-merge
+  squad -> hand off. The operator performs the mainline merge (DIRECTIVE_045).
+
+  The three quality pillars this enforces are captured as a standard in the
+  readable-consistent-prs directive (DIRECTIVE_046): linear, consistent/complete,
+  independently reviewed.
+references:
+  - type: procedure
+    id: adversarial-squad-deployment
+    reason: >
+      The aggregate pre-merge review and the draft-PR review are both instances of
+      the adversarial-squad-deployment procedure applied at the pre-merge point-cut.
+  - type: procedure
+    id: post-merge-arch-gate-adjudication
+    reason: >
+      When the aggregate review touches architectural gates or cross-base state, the
+      post-merge arch-gate adjudication procedure governs how those findings are
+      weighed before hand-off.
+  - type: procedure
+    id: mission-tracer-files
+    reason: >
+      The assess step of the tracer-files procedure feeds this sequence's hand-off:
+      tracer insights are summarised in the retrospective at close-out.
+  - type: tactic
+    id: clean-linear-commit-history
+    reason: >
+      The compact-history and rebase-onto-upstream steps follow the
+      clean-linear-commit-history tactic (non-reordering snapshot chain, rebase
+      over merge).
+  - type: directive
+    id: DIRECTIVE_045
+    reason: >
+      Landing and hand-off obey PRs-only and read-intent: the agent prepares the PR
+      and the operator merges the protected mainline.


### PR DESCRIPTION
## Summary

Adds two first-party doctrine artefacts and activates them in the project charter, plus a small extension to the existing tracer-files procedure. Authored directly against `src/doctrine/` (dogfooded).

- **`mission-wrap-up-sequence` procedure** — the standing close-out sequence (accept → resolve issue verdicts → aggregate review squad → local merge → compact history → rebase onto upstream → draft PR + pre-merge squad → hand off). Scoped to the software-dev `review` action.
- **`DIRECTIVE_046` (`046-readable-consistent-prs`)** — mission branches/PRs must be **linear** (rebase over merge), **consistent/complete** (defer only genuinely mission-sized work), and **self-reviewed** (adversarial squad before/parallel to the draft PR). Scoped to `review` + `implement`.
- **Extends `mission-tracer-files`** — the assess step now feeds the wrap-up hand-off and must survive the wrap-up's history compaction.

## Mechanics

- Registered in the DRG (`src/doctrine/graph.yaml`, **regenerated** via `extractor.generate_graph` — the freshness gate enforces this) via action-index scope edges (`missions/software-dev/actions/{review,implement}/index.yaml`) + reference edges from the artefacts.
- Activated in `.kittify/config.yaml` (`activated_directives` / `activated_procedures`) via `spec-kitty charter activate`; `charter.md` PR-requirements prose added; `charter sync` + `charter synthesize` run.

## Verification

- Full `tests/doctrine/` green (**2500 passed**) after fixing a cross-mission `retrospect` scope-symmetry regression (the wrap-up is scoped to `review`, not `retrospect`, so all three built-in missions keep identical retrospect scope).
- Terminology guard green; `requires` edges stay a DAG.

## Notes

Separate PR from #2517 (the merge-base/diff consolidation) **per the very DIRECTIVE_046 this PR adds** — single-concern branches. Surfaced follow-up gaps tracked under epic #2519 (charter authoring & lifecycle robustness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)