### PR TITLE
docs(hygiene): fix guides Tutorials cross-link + relocate 01KSMG8Y closeout to its mission dir

### DIFF
--- a/docs/guides/how-to-index.md
+++ b/docs/guides/how-to-index.md
@@ -54,5 +54,5 @@ have Spec Kitty installed and walks one task end to end.
 
 ## See also
 
-- [Tutorials](index.md) — learning-oriented walkthroughs.
+- [Tutorials](tutorials-index.md) — learning-oriented walkthroughs.
 - [Reference](../api/index.md) — authoritative command and schema references.


### PR DESCRIPTION
Two small, deploy-safe doc-hygiene fixes from a doc-structure review squad. (The squad's larger finding: most apparent flatness is *intentional* structure — versioned architecture tracks, Divio category indexes — so there is deliberately little here.)

## (a) Fix mislabeled cross-link in `docs/guides/how-to-index.md`
Its "See also" linked `[Tutorials](index.md)`, but `index.md` is the **Guides** (contributor/maintainer) landing — the learning-oriented **Tutorials** index is `tutorials-index.md`. Content-only, no URL change.

## (b) Relocate the `docs/01KSMG8Y-closeout/` orphan into its mission dir
An unpublished (not in `docfx.json` globs) closeout dir sat at the docs root. Its `retro.md`/`baseline.md` turned out to be **unique historical artifacts, not duplicated in kitty-specs** — so deletion was ruled out (delete-discipline). Instead moved them to where they belong:
- `retro.md` / `baseline.md` → `kitty-specs/pre-doctrine-test-stabilization-01KSMG8Y/`
- dropped `index.md` (docs-site nav wrapper; its only `related:` edges pointed at the two moved files).

**Deploy-safety:** files were unpublished + absent from the redirect baseline (no NFR-002 impact); the kitty-specs generator's `ARTIFACTS` allow-list excludes `retro`/`baseline`, so they stay unpublished in their new home. `related_validator` + inventory scope `docs/` only. Inventory lockfile regenerated (3 rows removed, 564→561).

## Gates (local, PR-equivalent) — all green
- `anti_sprawl_ratchet --strict` — 0 violations
- `relative_link_fixer --check` — 0 dead links
- `related_validator --strict` — 608 edges, 0 dangling
- `check_docs_freshness --ci` — exit=0, 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)