### PR TITLE
fix: implement-loop friction quick-wins (topology default, pre-review-gate escape hatch, finalize per-branch hashes, charter first-run) — #2581/#2573/#2549/#2577

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -76,6 +76,30 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **Implement-loop friction quick-wins (#2581, #2573, #2549, #2577).** Four independent
+  loop-friction fixes: `mission create` / `spec-kitty specify` now derive the create-time
+  topology from context — a non-primary feature branch without `--pr-bound` defaults to
+  `single_branch` instead of minting a coordination branch the operator must manually flatten
+  (primary branch, `--pr-bound`, and explicit `--topology` still default to `coord`);
+  `move-task --to for_review` gains a `--skip-pre-review-gate` flag, honors the
+  `SPEC_KITTY_SYNC_DISABLE` / `SPEC_KITTY_SYNC_MINIMAL_IMPORT` disable env, and surfaces a
+  progress notice so the scoped-test gate no longer reads as a hang (the full async redesign
+  stays deferred on #2573); `finalize-tasks --json` reports per-branch commit hashes
+  (`commit_hashes`) for the two-branch coord-topology commit set instead of a single
+  `commit_hash` that omitted the coordination-branch commit (#2549 facet B; facet A deferred);
+  and `charter synthesize` no longer fails closed on an empty/first-run config demanding a
+  companion tactic for every built-in directive — first-run parity restored (#2526 regression).
+
+- **Coord-shadows follow-ups: canonical-source consolidation + gate/liveness robustness
+  (#2574, #2575, #2576, #2567, #2568).** The triplicated subtask-gate-dir resolver is unified
+  onto one `resolve_subtasks_gate_dir` seam with the strong git-ancestry fallback (the weak
+  `status_transition` site no longer reads a stale coordination husk); `core/process_liveness`
+  guards against PID reuse via a persisted creation-time baseline co-written at every claim site
+  (a recycled PID no longer reads as a live claim); the rollback-uncheck write routes through the
+  house path-guard and surfaces failures instead of silently leaving checked rows; the acceptance
+  gate's stray checkbox parser is migrated onto the canonical `core/subtask_rows`; and the review
+  lock folds onto the canonical `is_process_alive` (last stray `os.kill` liveness probe removed).
+
 - **Coord-shadows-primary read/gate arm closed (#2502, #2504, #2510, #2512, #2513, #1231).**
   The `for_review` subtask gate no longer fails open: `_infer_subtasks_complete` reads the
   PRIMARY planning surface at every emit-layer caller and blocks on unchecked rows on both the

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -3104,6 +3104,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/plans/loop-friction-fastfollow-spec.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/plans/next-mission-mappings/README.md
   tag: current
   divio_type: none

--- a/docs/plans/loop-friction-fastfollow-spec.md
+++ b/docs/plans/loop-friction-fastfollow-spec.md
@@ -1,0 +1,119 @@
+# Mission Spec (materialization-ready): Implement-Loop Friction Quick-Wins
+
+**Status**: Draft spec — ready to materialize via `spec-kitty agent mission create` in a clean project-root checkout.
+**Created**: 2026-07-12
+**Origin**: friction logged live during mission `coord-shadows-followups-01KXBCZ1` (`traces/tooling-friction-trace.md`), then investigated (planner-priti lens, code-verified) into a scoped fast-follow.
+**Parent epics**: #2017 (workflow-guard friction — primary) + #2160 (coord-topology authority — co-parent).
+
+> **Why a doc, not a live mission:** at authoring time the shared project-root checkout was in active use by a concurrent `ci-test-topology-performance` mission (a cross-mission collision that itself is one of the friction lessons). `spec-kitty agent mission create` refuses to run from a worktree, so this spec is authored as a document to be dropped into a real mission once a clean checkout/clone is available. Content is mission-spec quality (issue matrix + FR/NFR/C + WP outline).
+
+## Context
+
+The `coord-shadows-followups` mission repeatedly hit implement/review-loop friction. A code-verified investigation mapped each witnessed friction to an existing or new ticket and scoped a **quick-wins** fast-follow — deliberately excluding the hard async redesign. The goal: clear the highest-friction, low-risk points so the next larger slices run against a smoother loop.
+
+## Tracked Issues (Issue Matrix)
+
+| Item | Issue | Surface | Verdict | Linkage |
+|------|-------|---------|---------|---------|
+| Topology default mints coord husk on a non-primary feature branch without `--pr-bound` | #2581 | `cli/commands/agent/mission_create.py:~401`, `core/mission_creation.py:~215` | in-mission | Closes #2581; child #2160, sibling #2533 |
+| Pre-review gate runs a synchronous multi-minute pytest that reads as a hang | #2573 | `cli/commands/agent/tasks_move_task.py::_mt_run_pre_review_gate`, `review/pre_review_gate.py:388` | in-mission (partial) | Closes #2573 (env+flag+progress; full async redesign deferred, noted on #2573) |
+| `finalize-tasks --json` reports one `commit_hash` for a two-branch commit set (facet B) | #2549 | `cli/commands/agent/mission_finalize.py:1296-1332,1406-1407`, `coordination/commit_router.py` | in-mission | Closes #2549 (facet B; facet A — lane mis-route — deferred, follow-up on #2549) |
+| `charter synthesize` over-demands companion tactics on empty config (#2526 regression) | #2577 | `cli/commands/charter/_synthesis.py:61` `_build_synthesis_request` | in-mission | Closes #2577; relates #2526 |
+| Sync-daemon deaf to `SPEC_KITTY_SYNC_DISABLE` (dup across #2573/#2555/#2570) | #2573 | consolidate onto #2573 | note | consolidate — do not spawn a 4th tracker |
+| Surface `/spec-kitty.analyze` in tasks→implement handoff | #2582 | doc/skill | **EXCLUDED — post-mission op** | operator-directed |
+| First-approval issue-matrix scope-conflation | #2583 | approve gate | **EXCLUDED — post-mission op** | operator-directed (touches approve-gate semantics — treat carefully) |
+| Approve clean-tree check scoped to WP code, not all `kitty-specs/` | #2017 | approve pre-flight | **OPTIONAL stretch** | #2017 Class A2/A3; include only if capacity |
+
+Epics #2017 / #2160 stay open. #2582/#2583 are handled as post-mission ops per operator direction.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — A feature-branch mission doesn't force a coord husk (Priority: P1)
+
+A maintainer runs `spec-kitty agent mission create` on a dedicated feature/fork branch without `--pr-bound`. The mission should default to a coord-less topology (`single_branch`) rather than minting a coordination branch that must be manually flattened.
+
+**Acceptance**: create on a non-primary branch without `--pr-bound` → `topology: single_branch`, no `coordination_branch` minted; primary-branch / `--pr-bound` / explicit-coord paths still get `coord`; a red-first test pins the feature-branch default.
+
+### User Story 2 — The pre-review gate is skippable and legible (Priority: P1)
+
+A maintainer runs `move-task --to for_review` and either sees streamed progress (not a silent multi-minute hang) or can skip the gate with an explicit flag / honored env var.
+
+**Acceptance**: `--skip-pre-review-gate` flag skips the gate; `SPEC_KITTY_SYNC_DISABLE` (and the minimal-import env) are honored; when the gate runs, progress is surfaced. The full async redesign is out of scope (deferred on #2573). Tests: flag skips; env honored; gate still enforceable by default.
+
+### User Story 3 — finalize-tasks reports the full commit set (Priority: P2)
+
+An automated caller reads `finalize-tasks --json` and gets **per-branch** commit hashes for a two-branch (coord-topology) commit set, so `commit_hash` + `files_committed` are consistent.
+
+**Acceptance**: under coord topology, the JSON reports the feature-branch AND coordination-branch commit hashes (a mapping or list), not a single `commit_hash` that omits the placement-partition commit; a flat/single-branch mission still reports its single commit; a test pins both shapes. Facet A (lane mis-route) is out of scope.
+
+### User Story 4 — charter synthesize works on an empty/first-run config (Priority: P2)
+
+A maintainer runs `charter synthesize` on an empty/first-run project. It must not fail-closed demanding a `how-we-apply-<directive>` companion tactic for every built-in directive.
+
+**Acceptance**: empty config → 0 companion-tactic demands (first-run parity with pre-#2526), per a charter/doctrine-owner decision (NOT the spec-forbidden test-seeding anti-pattern); a red-first empty-config parity test. Fix surface: the three-state fallback in `_build_synthesis_request` resolving `config_roots.directives` to all built-ins.
+
+### Edge Cases
+
+- Topology default must not regress primary-branch / `--pr-bound` / multi-agent coord creation.
+- `--skip-pre-review-gate` must not become the silent default — the gate stays enforceable.
+- finalize per-branch reporting must be backward-compatible for flat missions (single commit).
+- charter empty-config fix must not suppress genuinely-required companion tactics on a NON-empty config.
+
+## Requirements
+
+### Functional Requirements
+
+| ID | Title | Priority | Status |
+|----|-------|----------|--------|
+| FR-001 | Derive create-time topology default from branch/pr-bound context (feature-branch + no `--pr-bound` → `single_branch`, no coord branch) | High | Open |
+| FR-002 | `--skip-pre-review-gate` flag + honor `SPEC_KITTY_SYNC_DISABLE`/minimal-import env on the pre-review gate | High | Open |
+| FR-003 | Surface pre-review-gate progress (no silent multi-minute hang) | Medium | Open |
+| FR-004 | `finalize-tasks --json` reports per-branch commit hashes for a two-branch commit set (facet B) | Medium | Open |
+| FR-005 | `charter synthesize` empty/first-run config demands 0 companion tactics (first-run parity) | Medium | Open |
+| FR-006 | Consolidate the sync-daemon env-deafness fix onto #2573 (one home, retire dup framing in #2555/#2570) | Low | Open |
+
+### Non-Functional Requirements
+
+| ID | Requirement | Category | Status |
+|----|-------------|----------|--------|
+| NFR-001 | Every behavior change (topology default, gate skip, finalize JSON shape, charter empty-config) carries a red-first or characterization test | Maintainability | Open |
+| NFR-002 | 0 new ruff/mypy findings; terminology + arch gates green | Maintainability | Open |
+| NFR-003 | Backward compatibility: primary/coord create, default gate enforcement, flat-mission finalize JSON, non-empty charter synth all unchanged | Reliability | Open |
+
+### Constraints
+
+| ID | Constraint | Status |
+|----|------------|--------|
+| C-001 | Pre-review-gate async redesign is OUT (deferred on #2573) — this mission does env+flag+progress only | Open |
+| C-002 | #2549 facet A (lane mis-route of `status.*`) is OUT (deferred) | Open |
+| C-003 | charter empty-config fix requires a charter/doctrine-owner decision; the naive test-seed fix is spec-forbidden | Open |
+| C-004 | #2582/#2583 are post-mission ops, NOT WPs of this mission | Open |
+| C-005 | Fork PR to Priivacy-ai/main; operator merges | Open |
+
+## Success Criteria
+
+- **SC-001**: A feature-branch create without `--pr-bound` yields `single_branch` (no manual flatten); primary/coord paths unchanged (red-first pinned).
+- **SC-002**: The pre-review gate is skippable via flag + honors the disable env; default enforcement intact.
+- **SC-003**: `finalize-tasks --json` reports the full two-branch commit set under coord topology; flat missions unchanged.
+- **SC-004**: `charter synthesize` on an empty config demands 0 companion tactics (first-run parity restored).
+- **SC-005**: Full gate green; #2581/#2573/#2549(B)/#2577 addressed; #2582/#2583 tracked as ops; epics stay open.
+
+## Proposed Work Package Outline (for /tasks materialization)
+
+- **WP01 — Topology default (FR-001)**: `mission_create.py` + `core/mission_creation.py`; red-first feature-branch test. Independent. Closes #2581.
+- **WP02 — Pre-review-gate skip/env/progress (FR-002/003, C-001)**: `tasks_move_task.py::_mt_run_pre_review_gate` + `review/pre_review_gate.py`; flag + env + progress tests. Closes #2573 (partial). *Owned-files note: overlaps the #2576 rollback seam module — coordinate if coord-shadows PR #2584 unmerged.*
+- **WP03 — finalize-tasks per-branch hashes (FR-004, C-002)**: `mission_finalize.py` result builder + `coordination/commit_router.py`; two-branch + flat JSON-shape tests. Closes #2549 (facet B).
+- **WP04 — charter empty-config parity (FR-005, C-003)**: `charter/_synthesis.py::_build_synthesis_request`; red-first empty-config parity test; charter/doctrine-owner decision. Closes #2577.
+- **WP05 (optional stretch) — approve clean-tree scope (F6)**: scope the approve pre-flight to WP code, not all `kitty-specs/`; #2017.
+
+DAG: all WPs independent (disjoint surfaces). WP02 has an external merge-coordination note vs coord-shadows PR #2584 (both touch `tasks_move_task.py`, different functions).
+
+## Post-mission ops (operator-directed, NOT WPs)
+
+- **#2582** — surface `/spec-kitty.analyze` as a required tasks→implement handoff step (doc/skill).
+- **#2583** — don't gate the FIRST per-WP approval on whole-mission issue-matrix completeness (move to accept/merge). Note: touches approve-gate semantics — needs a targeted test even as an op.
+
+## Assumptions
+
+- Filed pre-spec: #2581 (topology default), #2582/#2583 (ops). #2573/#2549/#2577 pre-exist.
+- Materialize via `spec-kitty agent mission create` in a clean checkout; if it defaults to coord on the feature branch, flatten per the documented procedure (this mission's FR-001 fixes that going forward).

--- a/docs/plans/loop-friction-fastfollow-spec.md
+++ b/docs/plans/loop-friction-fastfollow-spec.md
@@ -1,3 +1,10 @@
+---
+title: 'Fast-Follow Spec: Implement-Loop Friction Quick-Wins'
+description: 'Fast-follow spec for the implement-loop friction quick-wins: topology default, pre-review-gate escape hatch, finalize per-branch hashes, and charter first-run parity.'
+doc_status: active
+updated: '2026-07-12'
+---
+
 # Mission Spec (materialization-ready): Implement-Loop Friction Quick-Wins
 
 **Status**: Draft spec — ready to materialize via `spec-kitty agent mission create` in a clean project-root checkout.

--- a/src/specify_cli/cli/commands/agent/mission_create.py
+++ b/src/specify_cli/cli/commands/agent/mission_create.py
@@ -195,6 +195,37 @@ def _enforce_branch_strategy_gate_phase(
         raise typer.Exit(1)
 
 
+def _resolve_default_topology_phase(
+    *,
+    explicit_topology: MissionTopology | None,
+    repo_root: Path | None,
+    current_branch: str | None,
+    pr_bound: bool,
+) -> MissionTopology:
+    """Derive the create-time topology default from branch/pr-bound context (#2581).
+
+    An explicit ``--topology`` always wins. Otherwise: PR-bound missions and
+    missions created on the repository's primary branch keep the historical
+    ``coord`` default (a coordination branch is minted). A mission created on
+    a non-primary feature/fork branch without ``--pr-bound`` defaults to
+    ``single_branch`` instead — minting a coordination branch there just to
+    have the operator manually flatten it is the exact friction #2581 closes.
+    """
+    if explicit_topology is not None:
+        return explicit_topology
+    if pr_bound:
+        return MissionTopology.COORD
+    if repo_root is None or current_branch is None:
+        return MissionTopology.COORD
+
+    from specify_cli.core.git_ops import resolve_primary_branch
+
+    primary_branch = resolve_primary_branch(repo_root)
+    if current_branch == primary_branch:
+        return MissionTopology.COORD
+    return MissionTopology.SINGLE_BRANCH
+
+
 def _print_worktree_navigation_hint(mission_slug: str, error_msg: str) -> None:
     """Print the 'run from main repo' hint when a worktree error blocked creation."""
     if "worktree" not in error_msg.lower():
@@ -388,17 +419,20 @@ def create_mission(
     purpose_context: Annotated[str | None, typer.Option("--purpose-context", help="Short stakeholder-facing paragraph for the mission")] = None,
     pr_bound: Annotated[bool, typer.Option("--pr-bound/--no-pr-bound", help="Mark mission as PR-bound (gate fires on merge_target_branch)")] = False,
     topology: Annotated[
-        MissionTopology,
+        MissionTopology | None,
         typer.Option(
             "--topology",
             help=(
                 "Create-time mission shape: single_branch | lanes | coord | "
                 "lanes_with_coord. Coordination-bearing shapes (coord, "
                 "lanes_with_coord) mint a coordination branch; branch-flat "
-                "shapes (single_branch, lanes) do not. Default: coord."
+                "shapes (single_branch, lanes) do not. Default: context-derived "
+                "(#2581) — coord on the primary branch, with --pr-bound, or "
+                "when explicitly requested; single_branch on a non-primary "
+                "feature/fork branch without --pr-bound."
             ),
         ),
-    ] = MissionTopology.COORD,
+    ] = None,
     branch_strategy: Annotated[
         str | None,
         typer.Option(
@@ -463,6 +497,13 @@ def create_mission(
         json_output=json_output,
     )
 
+    resolved_topology = _resolve_default_topology_phase(
+        explicit_topology=topology,
+        repo_root=repo_root,
+        current_branch=current_branch,
+        pr_bound=pr_bound,
+    )
+
     # Import the tracker package here (NOT at module scope) so ``tracker/__init__.py``
     # registers ``consume_pending_origin_impl`` with ``core.adapters`` BEFORE
     # ``create_mission_core`` runs ``consume_pending_origin`` (register-before-use,
@@ -480,7 +521,7 @@ def create_mission(
         friendly_name=friendly_name,
         purpose_tldr=purpose_tldr,
         purpose_context=purpose_context,
-        topology=topology,
+        topology=resolved_topology,
         force_recreate_coordination_branch=force_recreate_coordination_branch,
         json_output=json_output,
     )

--- a/src/specify_cli/cli/commands/agent/mission_finalize.py
+++ b/src/specify_cli/cli/commands/agent/mission_finalize.py
@@ -1263,10 +1263,21 @@ def _scaffold_acceptance_matrix_if_lane_based(
 
 @dataclass
 class _CommitOutcome:
-    """Outcome of the finalize commit phase."""
+    """Outcome of the finalize commit phase.
+
+    ``commit_hash`` remains the historical single-value projection (the
+    feature-branch commit for the common case) for backward compatibility.
+    ``commit_hashes`` (#2549 facet B) additionally carries the FULL per-branch
+    commit set the router actually issued — under coord topology this includes
+    BOTH the feature-branch commit (primary-partition artifacts: tasks.md,
+    lanes.json, tasks/WP*) AND the coordination-branch commit (placement-
+    partition artifacts: status.events.jsonl, status.json, acceptance-
+    matrix.json, issue-matrix.md), which ``commit_hash`` alone cannot express.
+    """
 
     commit_created: bool = False
     commit_hash: str | None = None
+    commit_hashes: list[dict[str, str]] = field(default_factory=list)
     files_committed: list[str] = field(default_factory=list)
 
 
@@ -1331,6 +1342,9 @@ def _commit_finalize_artifacts(
         if router_result.status == "committed":
             outcome.commit_hash = router_result.commit_hash
             outcome.commit_created = True
+            outcome.commit_hashes = [
+                {"branch": ref, "hash": commit_hash} for ref, commit_hash in router_result.commit_hashes
+            ]
             if not json_output:
                 console.print(f"[green]✓[/green] Tasks committed to {router_result.placement_ref}")
                 if outcome.commit_hash:
@@ -1404,6 +1418,7 @@ def _emit_success_report(
             "tasks_dir": str(tasks_dir),
             "commit_created": commit_outcome.commit_created,
             "commit_hash": commit_outcome.commit_hash,
+            "commit_hashes": commit_outcome.commit_hashes,
             "files_committed": commit_outcome.files_committed,
             "dependencies_parsed": dep_resolution.wp_dependencies,
             "requirement_refs_parsed": dep_resolution.wp_requirement_refs,

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -431,7 +431,11 @@ from specify_cli.cli.commands.agent.tasks_move_task import (
     _mt_pre_review_changed_files as _mt_pre_review_changed_files,
     _mt_pre_review_gate_block_message as _mt_pre_review_gate_block_message,
     _mt_pre_review_gate_console_warning as _mt_pre_review_gate_console_warning,
+    # #2573 fast-follow (FR-002): the --skip-pre-review-gate flag + disable-env
+    # skip-reason resolution join the family surface like every other def.
+    _mt_pre_review_gate_env_disable_reason as _mt_pre_review_gate_env_disable_reason,
     _mt_pre_review_gate_metadata as _mt_pre_review_gate_metadata,
+    _mt_pre_review_gate_skip_reason as _mt_pre_review_gate_skip_reason,
     _mt_pre_review_gate_verdict as _mt_pre_review_gate_verdict,
     _mt_pre_review_gate_with_override_scope as _mt_pre_review_gate_with_override_scope,
     _mt_pre_review_scope_override as _mt_pre_review_scope_override,
@@ -606,6 +610,18 @@ def move_task(
         bool | None, typer.Option("--auto-commit/--no-auto-commit", help="Automatically commit WP file changes to target branch (default: from project config)")
     ] = None,
     json_output: Annotated[bool, typer.Option("--json", help="Output JSON format")] = False,
+    skip_pre_review_gate: Annotated[
+        bool,
+        typer.Option(
+            "--skip-pre-review-gate",
+            help=(
+                "Skip the pre-review regression gate on a --to for_review move "
+                "(also honored via the SPEC_KITTY_SYNC_DISABLE / "
+                "SPEC_KITTY_SYNC_MINIMAL_IMPORT env vars). The gate still runs "
+                "and enforces by default."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Move task between lanes (planned → doing → for_review → approved → done).
 
@@ -639,6 +655,7 @@ def move_task(
         skip_review_artifact_check=skip_review_artifact_check,
         auto_commit=auto_commit,
         json_output=json_output,
+        skip_pre_review_gate=skip_pre_review_gate,
     )
 
 

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import traceback
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -86,6 +87,7 @@ from specify_cli.cli.commands.agent.tasks_transition_core import (
 )
 from specify_cli.core.commit_guard import GuardCapability
 from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.env import is_truthy
 from specify_cli.core.paths import is_worktree_context
 from specify_cli.core.subtask_rows import uncheck_wp_section_subtask_rows
 from specify_cli.core.utils import write_text_within_directory
@@ -167,6 +169,7 @@ class _MoveTaskState:
     skip_review_artifact_check: bool
     auto_commit: bool | None
     json_output: bool
+    skip_pre_review_gate: bool = False
     # --- phase A: resolved targets ---
     target_lane: Lane = Lane.PLANNED
     repo_root: Path = field(default_factory=Path)
@@ -722,6 +725,21 @@ _PRE_REVIEW_CONFIG_KEY_BLOCK = "fail_on_pre_review_regression"
 _PRE_REVIEW_CONFIG_KEY_TEST_COMMAND = "pre_review_test_command"
 _PRE_REVIEW_FRONTMATTER_KEY = "pre_review_test_scope"
 
+#: #2573 fast-follow (FR-002): env vars the gate honors as a "skip the
+#: subprocess" signal, ordered by precedence for the skip-reason message.
+#: ``SPEC_KITTY_SYNC_DISABLE`` is the sync layer's existing "keep this
+#: process light" toggle (also consumed by the sync daemon per
+#: ``docs/plans/loop-friction-fastfollow-spec.md`` FR-002/FR-006);
+#: ``SPEC_KITTY_SYNC_MINIMAL_IMPORT`` is the sibling "minimal import, no
+#: heavy registration" signal (``sync/__init__.py``, ``sync/daemon.py``,
+#: ``specify_cli/__init__.py``). Neither was ever wired to the gate's own
+#: multi-minute subprocess before this fix — the gate reuses the SAME
+#: signals rather than inventing a third env var.
+_PRE_REVIEW_GATE_DISABLE_ENV_VARS: tuple[str, ...] = (
+    "SPEC_KITTY_SYNC_DISABLE",
+    "SPEC_KITTY_SYNC_MINIMAL_IMPORT",
+)
+
 
 def _pre_review_gate_filter_groups() -> Mapping[str, tuple[str, ...]] | None:
     """Test seam: production always returns ``None``.
@@ -772,6 +790,29 @@ def _mt_review_config_section(main_repo_root: Path) -> Mapping[str, Any]:
 def _mt_pre_review_block_enabled(main_repo_root: Path) -> bool:
     """FR-001/NFR-001: opt-in block toggle — ``review.fail_on_pre_review_regression``."""
     return bool(_mt_review_config_section(main_repo_root).get(_PRE_REVIEW_CONFIG_KEY_BLOCK, False))
+
+
+def _mt_pre_review_gate_env_disable_reason() -> str | None:
+    """#2573 FR-002: the first honored disable env var, or ``None`` if none set."""
+    for env_var in _PRE_REVIEW_GATE_DISABLE_ENV_VARS:
+        if is_truthy(os.environ.get(env_var)):
+            return f"{env_var} is set"
+    return None
+
+
+def _mt_pre_review_gate_skip_reason(st: _MoveTaskState) -> str | None:
+    """#2573 FR-002: why the gate should be skipped this move, or ``None`` to run it.
+
+    The ``--skip-pre-review-gate`` flag is checked first (an explicit, per-
+    invocation opt-out); the disable env vars are checked second (a
+    process-wide opt-out already used by the sync layer). Either one skips
+    the gate WITHOUT ever resolving a workspace or spawning the scoped
+    pytest subprocess — the default (neither set) still runs/enforces the
+    gate exactly as before this fix.
+    """
+    if st.skip_pre_review_gate:
+        return "--skip-pre-review-gate flag"
+    return _mt_pre_review_gate_env_disable_reason()
 
 
 def _mt_pre_review_scope_override(wp_frontmatter: str, main_repo_root: Path) -> tuple[str, ...] | None:
@@ -1024,6 +1065,20 @@ def _mt_run_pre_review_gate(st: _MoveTaskState) -> None:
         return
     from specify_cli.cli.commands.agent import tasks as _tasks
 
+    # #2573 FR-002: the opt-out escape hatch — checked BEFORE touching the
+    # workspace or WP frontmatter, so a skip never resolves a lane workspace,
+    # diffs changed files, or spawns the scoped pytest subprocess. Default
+    # behavior (neither the flag nor an env var set) is untouched below.
+    skip_reason = _mt_pre_review_gate_skip_reason(st)
+    if skip_reason is not None:
+        verdict = _mt_empty_scope_verdict(f"gate skipped — {skip_reason}")
+        st.pre_review_gate_metadata = _mt_pre_review_gate_metadata(
+            verdict, block_enabled=False, blocked=False, force_bypassed=False,
+        )
+        if not st.json_output:
+            _tasks.console.print(f"[yellow]Pre-review regression gate: SKIPPED ({skip_reason})[/yellow]")
+        return
+
     assert st.wp is not None
     try:
         worktree_path = _mt_resolve_pre_review_workspace(st)
@@ -1037,6 +1092,17 @@ def _mt_run_pre_review_gate(st: _MoveTaskState) -> None:
         wp_slug = _resolve_wp_slug(st.main_repo_root, st.mission_slug, st.task_id)
         baseline_path = st.feature_dir / "tasks" / wp_slug / "baseline-tests.json"
         baseline = BaselineTestResult.load(baseline_path)
+        # #2573 FR-003: a non-empty scope means the gate is about to spawn a
+        # (potentially multi-minute) scoped pytest subprocess — surface that
+        # BEFORE the run so it never reads as a silent hang. An empty scope
+        # (no override, no changed files) stays silent here; it degrades to
+        # the cheap ``_mt_empty_scope_verdict`` path below without running
+        # anything.
+        if (override_targets is not None or changed_files) and not st.json_output:
+            _tasks.console.print(
+                "[cyan]Pre-review regression gate: running scoped tests at head "
+                "(may take a few minutes)...[/cyan]"
+            )
         verdict = _mt_pre_review_gate_verdict(
             changed_files=changed_files,
             override_targets=override_targets,
@@ -1705,6 +1771,7 @@ def _do_move_task(
     skip_review_artifact_check: bool,
     auto_commit: bool | None,
     json_output: bool,
+    skip_pre_review_gate: bool = False,
     *,
     ports: TasksPorts | None = None,
 ) -> None:
@@ -1737,6 +1804,7 @@ def _do_move_task(
         skip_review_artifact_check=skip_review_artifact_check,
         auto_commit=auto_commit,
         json_output=json_output,
+        skip_pre_review_gate=skip_pre_review_gate,
     )
     try:
         _mt_resolve_targets(st, ports)

--- a/src/specify_cli/cli/commands/charter/_synthesis.py
+++ b/src/specify_cli/cli/commands/charter/_synthesis.py
@@ -32,6 +32,7 @@ def _build_synthesis_request(
 
     from charter.compiler import resolve_config_activated_roots
     from charter.interview import read_interview_answers
+    from charter.pack_context import PackContext
     from charter.synthesizer.fixture_adapter import FixtureAdapter
     from charter.synthesizer.generated_artifact_adapter import GeneratedArtifactAdapter
     from charter.synthesizer.request import SynthesisRequest, SynthesisTarget
@@ -55,10 +56,32 @@ def _build_synthesis_request(
     # ``charter.compiler.compile_charter``, so both derivation paths agree.
     config_roots = resolve_config_activated_roots(repo_root=repo_root)
 
+    # #2577 (fast-follow fix of the #2526 regression): `config_roots.directives`
+    # already applied the three-state absent-key fallback documented on
+    # `PackContext` -- when `.kittify/config.yaml` has no `activated_directives`
+    # key at all, `resolve_config_activated_roots()` returns EVERY built-in
+    # directive (the correct default for the `compile_charter`/references.yaml
+    # consumer, see `test_no_pack_context_and_no_repo_root_defaults_to_all_
+    # builtins_active`). Feeding that same "all built-ins" list into
+    # `interview_snapshot["selected_directives"]` is wrong for THIS consumer:
+    # `resolve_sections()` expands one `how-we-apply-<directive>` companion-
+    # tactic target per entry, so a first-run project with no explicit
+    # activation yet demanded ~25 companion tactics nobody asked for and
+    # failed `charter synthesize` closed on the first missing YAML. Read the
+    # raw three-state signal directly so the absent-key case (first run) is
+    # distinguished from an explicit (possibly empty) activation list -- only
+    # the latter should drive companion-tactic expansion, matching the
+    # pre-#2526 behavior where this field was sourced from
+    # `answers.selected_directives` and defaulted to `[]` on a fresh interview.
+    pack_context = PackContext.from_config(repo_root)
+    directives_for_synthesis: list[str] = (
+        [] if pack_context.activated_directives is None else config_roots.directives
+    )
+
     # Build a minimal interview snapshot, config-activated selections + answers
     interview_snapshot: dict[str, Any] = {
         "mission_id": interview_data.mission,
-        "selected_directives": config_roots.directives,
+        "selected_directives": directives_for_synthesis,
         "selected_paradigms": config_roots.paradigms,
     }
     interview_snapshot.update(dict(interview_data.answers))
@@ -70,9 +93,13 @@ def _build_synthesis_request(
         "styleguides": {},
     }
 
-    # Build a minimal DRG snapshot with config-activated directives as nodes
+    # Build a minimal DRG snapshot with config-activated directives as nodes.
+    # Sourced from the SAME `directives_for_synthesis` list as
+    # `selected_directives` above (rather than the raw `config_roots.directives`
+    # fallback) so the two never drift into an inconsistent state where nodes
+    # exist for directives no target references.
     drg_nodes = []
-    for directive_id in config_roots.directives:
+    for directive_id in directives_for_synthesis:
         drg_nodes.append({
             "urn": f"directive:{directive_id}",
             "kind": "directive",

--- a/src/specify_cli/cli/commands/lifecycle.py
+++ b/src/specify_cli/cli/commands/lifecycle.py
@@ -64,7 +64,7 @@ def _emit_scaffold_only_guidance(mission_slug: str) -> None:
     _console.print(f"[cyan]Next:[/cyan] {_scaffold_next_action(mission_slug)}")
 
 
-def _create_mission_for_specify_json(slug: str, mission_type: str | None, topology: MissionTopology) -> None:
+def _create_mission_for_specify_json(slug: str, mission_type: str | None, topology: MissionTopology | None) -> None:
     """Run mission creation and enrich its single JSON payload for direct specify."""
     capture = io.StringIO()
     try:
@@ -131,14 +131,16 @@ def specify(
     mission: str = typer.Argument(..., help="Mission name or slug (e.g., user-authentication)"),
     mission_type: str | None = typer.Option(None, "--mission-type", help="Mission type (e.g., software-dev, research)"),
     mission_type_alias: str | None = typer.Option(None, "--mission", hidden=True, help="(deprecated) Use --mission-type"),
-    topology: MissionTopology = typer.Option(
-        MissionTopology.COORD,
+    topology: MissionTopology | None = typer.Option(
+        None,
         "--topology",
         help=(
             "Create-time mission shape: single_branch | lanes | coord | "
             "lanes_with_coord. Coordination-bearing shapes (coord, "
             "lanes_with_coord) mint a coordination branch; branch-flat shapes "
-            "(single_branch, lanes) do not. Default: coord."
+            "(single_branch, lanes) do not. Default: context-derived (#2581) — "
+            "coord on the primary branch or with --pr-bound, single_branch on a "
+            "non-primary feature branch."
         ),
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit JSON result"),

--- a/src/specify_cli/coordination/commit_router.py
+++ b/src/specify_cli/coordination/commit_router.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Final, Literal, Protocol, runtime_checkable
 
@@ -93,11 +93,23 @@ class CommitRouterResult:
     - ``_STATUS_UNCHANGED``        — benign no-op: artifact present + already committed.
     - ``_STATUS_NO_OP_WRONG_SURFACE`` — artifact absent at resolved placement.
     - ``_STATUS_ERROR``            — commit failed unexpectedly.
+
+    ``commit_hash`` / ``placement_ref`` remain the historical single-commit
+    projection (the CALLER-partition outcome — see :func:`_merge_group_results`)
+    for backward compatibility. ``commit_hashes`` (#2549 facet B) additionally
+    carries the FULL commit set as ``(placement_ref, commit_hash)`` pairs, one
+    per partition group that actually committed. For the common single-group
+    case this holds exactly the same one entry as ``commit_hash`` /
+    ``placement_ref``; for a genuinely split (mixed-partition, coord-topology)
+    batch it also carries the second commit — e.g. the coordination-branch
+    commit alongside the caller-partition (feature-branch) one — that the
+    single-value fields alone cannot express.
     """
 
     status: Literal["committed", "unchanged", "no_op_wrong_surface", "error"]
     placement_ref: str
     commit_hash: str | None = None
+    commit_hashes: tuple[tuple[str, str], ...] = ()
     diagnostic: str | None = None
 
 
@@ -326,6 +338,7 @@ def _commit_partition_group(
         status=_STATUS_COMMITTED,
         placement_ref=placement.ref,
         commit_hash=commit_hash,
+        commit_hashes=((placement.ref, commit_hash),) if commit_hash else (),
     )
 
 
@@ -437,17 +450,25 @@ def _merge_group_results(
     3. If no group matches the caller's own partition (should not happen once
        :func:`_group_files_by_partition` always includes it when present),
        fall back to the first group's result deterministically.
+
+    #2549 facet B: regardless of which group is authoritative for the legacy
+    single-value ``commit_hash`` / ``placement_ref`` fields, the returned
+    result's ``commit_hashes`` is always the UNION of every committed group's
+    ``commit_hashes`` — so a genuinely split commit (e.g. feature-branch +
+    coordination-branch) reports BOTH hashes, not just the caller-partition one.
     """
     for result in results:
         if result.status == _STATUS_ERROR:
             return result
 
+    all_commit_hashes = tuple(pair for result in results for pair in result.commit_hashes)
+
     caller_is_primary = is_primary_artifact_kind(caller_kind)
     for (group_kind, _group_files), result in zip(groups, results, strict=True):
         if is_primary_artifact_kind(group_kind) == caller_is_primary:
-            return result
+            return replace(result, commit_hashes=all_commit_hashes)
 
-    return results[0]
+    return replace(results[0], commit_hashes=all_commit_hashes)
 
 
 def _resolve_primary_target_branch(repo_root: Path, mission_slug: str) -> str:

--- a/tests/charter/test_config_sourced_derivation.py
+++ b/tests/charter/test_config_sourced_derivation.py
@@ -321,17 +321,93 @@ def test_build_synthesis_request_sources_selections_from_config_not_answers(tmp_
     ]
 
 
-def test_build_synthesis_request_with_no_config_defaults_to_all_builtin_directives(tmp_path: Path) -> None:
-    """No `.kittify/config.yaml` at all -> absent-key default, all built-ins active."""
+def test_build_synthesis_request_first_run_empty_config_selects_zero_directives(tmp_path: Path) -> None:
+    """#2577: No ``.kittify/config.yaml`` at all -- first-run / empty-config parity.
+
+    ``PackContext.activated_directives is None`` (absent key) is the shared
+    three-state signal for "no explicit activation yet". ``compile_charter``
+    (the ``references.yaml`` consumer) legitimately treats that as "all
+    built-ins active" -- see
+    ``test_no_pack_context_and_no_repo_root_defaults_to_all_builtins_active``
+    above, a *different, still-correct* consumer of the same fallback.
+
+    ``_build_synthesis_request`` must NOT inherit that fallback for
+    ``interview_snapshot["selected_directives"]``: that field drives
+    ``resolve_sections()``'s ``how-we-apply-<directive>`` companion-tactic
+    expansion (one target per selected directive), so feeding it "all ~25
+    built-in directives" on a project that has activated nothing yet demands
+    ~25 companion tactics nobody asked for and fails ``charter synthesize``
+    closed on the first missing YAML (the #2526 regression of pre-#2526
+    parity, where this field was sourced from ``answers.selected_directives``
+    and defaulted to ``[]`` on a fresh interview). First run must demand
+    ZERO companion tactics, matching pre-#2526 behavior.
+    """
     from specify_cli.cli.commands.charter._synthesis import _build_synthesis_request
 
     answers_path = tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml"
     write_interview_answers(answers_path, _interview_with(selected_directives=["DIRECTIVE_003"]))
+    # Deliberately no .kittify/config.yaml -- the genuine first-run signal.
 
     request, _adapter = _build_synthesis_request(tmp_path, "fixture")
 
-    catalog = load_doctrine_catalog()
-    assert sorted(request.interview_snapshot["selected_directives"]) == sorted(catalog.directives)
+    assert request.interview_snapshot["selected_directives"] == []
+    assert request.drg_snapshot["nodes"] == []
+
+
+def test_build_synthesis_request_first_run_demands_zero_companion_tactics(tmp_path: Path) -> None:
+    """#2577 RED-FIRST: first-run request resolves to ZERO companion-tactic targets.
+
+    Exercises the real downstream consumer (``resolve_sections()``) rather
+    than only inspecting the snapshot, so the assertion is pinned to the
+    actual fail-closed surface the bug report described.
+    """
+    from charter.synthesizer.interview_mapping import normalize_interview_snapshot, resolve_sections
+
+    from specify_cli.cli.commands.charter._synthesis import _build_synthesis_request
+
+    answers_path = tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml"
+    write_interview_answers(answers_path, _interview_with(selected_directives=["DIRECTIVE_003"]))
+    # Deliberately no .kittify/config.yaml -- the genuine first-run signal.
+
+    request, _adapter = _build_synthesis_request(tmp_path, "fixture")
+    snapshot = normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = resolve_sections(snapshot)
+
+    companion_tactic_sections = [label for label, _ctx in sections if label == "selected_directives"]
+    assert companion_tactic_sections == []
+
+
+def test_build_synthesis_request_explicit_activation_still_demands_companion_tactics(tmp_path: Path) -> None:
+    """Regression guard: an EXPLICIT ``config.activated_directives`` selection
+    still expands into one ``how-we-apply-<directive>`` companion-tactic
+    target per activated directive -- the #2577 fix must not silence the
+    intended (non-empty) expansion, only the first-run/absent-key case."""
+    from charter.synthesizer.interview_mapping import normalize_interview_snapshot, resolve_sections
+
+    from specify_cli.cli.commands.charter._synthesis import _build_synthesis_request
+
+    answers_path = tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml"
+    write_interview_answers(answers_path, _interview_with(selected_directives=[]))
+
+    config_path = tmp_path / ".kittify" / "config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "activated_directives:\n"
+        "  - 010-specification-fidelity-requirement\n"
+        "  - 024-locality-of-change\n",
+        encoding="utf-8",
+    )
+
+    request, _adapter = _build_synthesis_request(tmp_path, "fixture")
+
+    assert sorted(request.interview_snapshot["selected_directives"]) == ["DIRECTIVE_010", "DIRECTIVE_024"]
+
+    snapshot = normalize_interview_snapshot(dict(request.interview_snapshot))
+    sections = resolve_sections(snapshot)
+    demanded_directive_ids = sorted(
+        ctx["directive_id"] for label, ctx in sections if label == "selected_directives"
+    )
+    assert demanded_directive_ids == ["DIRECTIVE_010", "DIRECTIVE_024"]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/specify_cli/cli/commands/agent/fixtures/tasks_cli/help/move-task.help
+++ b/tests/specify_cli/cli/commands/agent/fixtures/tasks_cli/help/move-task.help
@@ -57,6 +57,13 @@
 │                                                              changes to target branch (default:  │
 │                                                              from project config)                │
 │    --json                                                    Output JSON format                  │
+│    --skip-pre-review-gate                                    Skip the pre-review regression gate │
+│                                                              on a --to for_review move (also     │
+│                                                              honored via the                     │
+│                                                              SPEC_KITTY_SYNC_DISABLE /           │
+│                                                              SPEC_KITTY_SYNC_MINIMAL_IMPORT env  │
+│                                                              vars). The gate still runs and      │
+│                                                              enforces by default.                │
 │    --help                                                    Show this message and exit.         │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -75,6 +75,21 @@ def _mission_summary(slug: str) -> dict[str, str]:
     }
 
 
+def _mission_summary_args(title: str) -> list[str]:
+    """CLI-flag form of ``_mission_summary`` for driving the typer entry point."""
+    return [
+        "--friendly-name",
+        title,
+        "--purpose-tldr",
+        f"Deliver {title} cleanly for the team.",
+        "--purpose-context",
+        (
+            f"This mission delivers {title} so product and engineering can move "
+            "forward with a clear outcome and shared understanding."
+        ),
+    ]
+
+
 def _patch_repo_environment(repo: Path) -> list[AbstractContextManager[Any]]:
     """Common patch stack for ``create_mission_core`` against ``repo``."""
     return [
@@ -341,6 +356,165 @@ def test_create_json_output_contains_coordination_branch(tmp_path: Path) -> None
     assert payload["scaffold_only"] is True
     assert payload["requires_agent_authoring"] is True
     assert payload["plan_guard"] == "SPEC_NOT_SUBSTANTIVE_OR_UNCOMMITTED"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2581 — context-derived topology default
+#
+# Coordination-bearing topology (coord) mints a coordination branch that a
+# non-primary-branch mission (created without --pr-bound) has to be manually
+# flattened out of afterwards. The default must instead be derived from
+# context: single_branch on a non-primary feature/fork branch with no
+# --pr-bound; coord everywhere else (primary branch, --pr-bound, or an
+# explicit --topology choice).
+# ---------------------------------------------------------------------------
+
+
+def test_create_on_non_primary_branch_without_pr_bound_defaults_to_single_branch(
+    tmp_path: Path,
+) -> None:
+    """RED before #2581: a feature-branch create with no ``--topology``/``--pr-bound``
+    must default to ``single_branch`` and mint NO coordination branch.
+
+    The on-disk repo stays on ``main`` (``resolve_primary_branch`` falls back to
+    the real current branch when no ``origin`` is configured); the CLI's view of
+    "current branch" is mocked to a feature branch so the derivation sees a
+    genuine primary/non-primary mismatch.
+    """
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="feature/my-fix"),
+        patch("specify_cli.status.fire_dossier_sync"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="feature/my-fix"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "feature-branch-default",
+                "--json",
+                "--target-branch",
+                "feature/my-fix",
+                *_mission_summary_args("Feature Branch Default"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["topology"] == "single_branch", payload
+    assert payload.get("coordination_branch") is None, payload
+    assert payload.get("coordination_branch_created") is False, payload
+
+
+def test_create_on_primary_branch_still_defaults_to_coord(tmp_path: Path) -> None:
+    """Non-regression: a primary-branch create with no ``--topology`` still gets ``coord``."""
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
+        patch("specify_cli.status.fire_dossier_sync"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "primary-branch-default",
+                "--json",
+                "--target-branch",
+                "main",
+                *_mission_summary_args("Primary Branch Default"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["topology"] == "coord", payload
+    assert payload["coordination_branch"].startswith("kitty/mission-primary-branch-default-")
+    assert payload["coordination_branch_created"] is True
+
+
+def test_create_pr_bound_on_non_primary_branch_still_defaults_to_coord(tmp_path: Path) -> None:
+    """Non-regression: ``--pr-bound`` keeps the ``coord`` default even off the primary branch."""
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="feature/my-fix"),
+        patch("specify_cli.status.fire_dossier_sync"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="feature/my-fix"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "pr-bound-non-primary",
+                "--pr-bound",
+                "--json",
+                "--target-branch",
+                "main",
+                *_mission_summary_args("PR Bound Non Primary"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["topology"] == "coord", payload
+    assert payload["coordination_branch"].startswith("kitty/mission-pr-bound-non-primary-")
+    assert payload["coordination_branch_created"] is True
+
+
+def test_create_explicit_topology_overrides_context_derivation(tmp_path: Path) -> None:
+    """An explicit ``--topology single_branch`` wins even on the primary branch."""
+    _init_repo(tmp_path)
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
+        patch("specify_cli.status.fire_dossier_sync"),
+        patch(f"{_CORE_MODULE}._commit_feature_file"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main"),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "explicit-topology-override",
+                "--json",
+                "--target-branch",
+                "main",
+                "--topology",
+                "single_branch",
+                *_mission_summary_args("Explicit Topology Override"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["topology"] == "single_branch", payload
+    assert payload.get("coordination_branch") is None, payload
 
 
 def test_pr_bound_create_json_refuses_with_json_instead_of_prompt_abort(tmp_path: Path) -> None:

--- a/tests/specify_cli/cli/commands/agent/test_tasks_compat_surface.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_compat_surface.py
@@ -141,7 +141,7 @@ _TASKS_STATUS_CMD: tuple[str, ...] = (  # WP07 (wave2) — 21 symbols
     "_render_stale_status",
 )
 
-_TASKS_MOVE_TASK: tuple[str, ...] = (  # WP05 (wave2) — 54 symbols (#2513/#2160: +uncheck/clear-markers/reset-rollback)
+_TASKS_MOVE_TASK: tuple[str, ...] = (  # WP05 (wave2) — 56 symbols (#2513/#2160: +uncheck/clear-markers/reset-rollback; #2573: +gate skip-reason pair)
     "_default_move_task_ports",
     "_MoveTaskState",
     "_mt_warn_worktree_kitty_specs",
@@ -192,6 +192,9 @@ _TASKS_MOVE_TASK: tuple[str, ...] = (  # WP05 (wave2) — 54 symbols (#2513/#216
     "_mt_pre_review_gate_block_message",
     "_mt_review_config_section",
     "_mt_pre_review_block_enabled",
+    # #2573 fast-follow: the --skip-pre-review-gate flag + disable-env seam.
+    "_mt_pre_review_gate_env_disable_reason",
+    "_mt_pre_review_gate_skip_reason",
     "_mt_pre_review_scope_override",
     "_pre_review_gate_filter_groups",
     "_pre_review_gate_composite_routing",
@@ -356,12 +359,14 @@ def test_no_required_symbol_duplicated_in_survey() -> None:
     assert total_declared == len(SYMBOL_TO_MODULE)
 
 
-def test_guard_covers_full_132_symbol_surface() -> None:
+def test_guard_covers_full_134_symbol_surface() -> None:
     """Traceability pin: the guard's total symbol count matches the sum of
     the 6 seams' counts recorded in the seam files' own docstrings at
-    authoring time (8 + 15 + 21 + 21 + 54 + 13 = 132). A change here is
+    authoring time (8 + 15 + 21 + 21 + 56 + 13 = 134). A change here is
     expected when a future WP relocates symbols; it should be a deliberate,
     reviewed edit — not a silent drift. #2513/#2160 added
     ``_mt_uncheck_rollback_subtasks``, ``_mt_clear_rollback_claim_markers`` and
-    ``_mt_reset_for_planned_rollback`` to the tasks_move_task seam (51 -> 54)."""
-    assert len(SYMBOL_TO_MODULE) == 132
+    ``_mt_reset_for_planned_rollback`` to the tasks_move_task seam (51 -> 54).
+    #2573 fast-follow added ``_mt_pre_review_gate_env_disable_reason`` and
+    ``_mt_pre_review_gate_skip_reason`` (54 -> 56)."""
+    assert len(SYMBOL_TO_MODULE) == 134

--- a/tests/specify_cli/cli/commands/agent/test_tasks_move_task_pre_review_gate_escape_hatch.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_move_task_pre_review_gate_escape_hatch.py
@@ -1,0 +1,349 @@
+"""#2573 fast-follow (partial): ``--skip-pre-review-gate`` flag + disable-env
+honoring + running-progress legibility on ``_mt_run_pre_review_gate``.
+
+``move-task --to for_review`` runs a synchronous, potentially multi-minute
+scoped pytest subprocess (``pre_review_gate.run_scoped_tests_at_head``) with
+no way to skip it — the loop-friction fast-follow spec
+(``docs/plans/loop-friction-fastfollow-spec.md`` FR-002/FR-003) adds:
+
+1. an explicit ``--skip-pre-review-gate`` CLI flag (``st.skip_pre_review_gate``),
+2. honoring the sync layer's existing ``SPEC_KITTY_SYNC_DISABLE`` /
+   ``SPEC_KITTY_SYNC_MINIMAL_IMPORT`` env vars as a process-wide opt-out,
+3. a console notice before the scoped run starts, so it never reads as a
+   silent hang.
+
+Every skip scenario below proves the workspace is NEVER touched (no
+``_mt_resolve_pre_review_workspace`` call, so no diff/subprocess can follow)
+— the escape hatch must short-circuit BEFORE any I/O, not merely suppress
+the eventual verdict. The default-behavior test proves the opposite: with
+neither the flag nor an env var set, the gate still attempts to resolve the
+workspace exactly as before this fix (NFR-003 backward compatibility).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import click
+import pytest
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.agent import tasks_move_task
+from specify_cli.cli.commands.agent.tasks import app
+from specify_cli.cli.commands.agent.tasks_move_task import _MoveTaskState
+from specify_cli.review import pre_review_gate
+from specify_cli.status import Lane
+
+pytestmark = pytest.mark.fast
+
+_TASKS = "specify_cli.cli.commands.agent.tasks"
+_MODULE = "specify_cli.cli.commands.agent.tasks_move_task"
+
+runner = CliRunner()
+
+
+class _WorkspaceTouched(Exception):
+    """Raised by the sentinel workspace resolver to prove it was reached."""
+
+
+def _make_state(**overrides: Any) -> _MoveTaskState:
+    kwargs: dict[str, Any] = {
+        "task_id": "WP01",
+        "to": "for_review",
+        "mission": "test-pre-review-escape",
+        "agent": "claude",
+        "assignee": None,
+        "shell_pid": None,
+        "note": None,
+        "review_feedback_file": None,
+        "approval_ref": None,
+        "reviewer": None,
+        "self_review_fallback": False,
+        "intended_reviewer": None,
+        "reviewer_failure_reason": None,
+        "done_override_reason": None,
+        "force": False,
+        "tracker_ref": None,
+        "skip_review_artifact_check": False,
+        "auto_commit": None,
+        "json_output": False,
+        "skip_pre_review_gate": False,
+    }
+    field_names = set(_MoveTaskState.__dataclass_fields__)
+    field_overrides = {k: v for k, v in overrides.items() if k in kwargs}
+    kwargs.update(field_overrides)
+    st = _MoveTaskState(**kwargs)
+    for key, value in overrides.items():
+        if key not in field_overrides:
+            assert key in field_names, f"unknown _MoveTaskState field: {key!r}"
+            setattr(st, key, value)
+    st.target_lane = Lane.FOR_REVIEW
+    st.main_repo_root = Path("/tmp/does-not-need-to-exist-for-skip")
+    st.target_branch = "main"
+    st.mission_slug = "test-pre-review-escape"
+    st.wp = SimpleNamespace(path=Path("WP01-x.md"), frontmatter="")
+    return st
+
+
+# --------------------------------------------------------------------------- #
+# Skip escape hatches (FR-002) — must short-circuit BEFORE any workspace I/O.
+# --------------------------------------------------------------------------- #
+
+
+def test_skip_flag_skips_gate_without_touching_workspace() -> None:
+    """``--skip-pre-review-gate`` never resolves a workspace or runs pytest."""
+    st = _make_state(skip_pre_review_gate=True)
+    with patch(
+        f"{_MODULE}._mt_resolve_pre_review_workspace", side_effect=_WorkspaceTouched
+    ) as workspace_mock:
+        tasks_move_task._mt_run_pre_review_gate(st)
+    workspace_mock.assert_not_called()
+    assert st.pre_review_gate_metadata is not None
+    assert st.pre_review_gate_metadata["outcome"] == pre_review_gate.GateOutcome.NO_COVERAGE.value
+    assert "--skip-pre-review-gate flag" in (st.pre_review_gate_metadata["reason"] or "")
+    assert st.pre_review_gate_metadata["blocked"] is False
+
+
+@pytest.mark.parametrize("env_var", ["SPEC_KITTY_SYNC_DISABLE", "SPEC_KITTY_SYNC_MINIMAL_IMPORT"])
+def test_disable_env_var_skips_gate_without_touching_workspace(
+    env_var: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Either sync-layer disable env var short-circuits the gate the same way
+    as the explicit flag — no workspace resolution, no subprocess."""
+    monkeypatch.setenv(env_var, "1")
+    st = _make_state()
+    with patch(
+        f"{_MODULE}._mt_resolve_pre_review_workspace", side_effect=_WorkspaceTouched
+    ) as workspace_mock:
+        tasks_move_task._mt_run_pre_review_gate(st)
+    workspace_mock.assert_not_called()
+    assert st.pre_review_gate_metadata is not None
+    assert env_var in (st.pre_review_gate_metadata["reason"] or "")
+
+
+@pytest.mark.parametrize("falsy_value", ["0", "false", "", "no"])
+def test_falsy_env_value_does_not_skip_gate(
+    falsy_value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A present-but-falsy env var must NOT trip the skip — only recognized
+    truthy tokens (the ``core.env.is_truthy`` grammar) do."""
+    monkeypatch.setenv("SPEC_KITTY_SYNC_DISABLE", falsy_value)
+    st = _make_state()
+    with patch(
+        f"{_MODULE}._mt_resolve_pre_review_workspace", return_value=None
+    ) as workspace_mock:
+        tasks_move_task._mt_run_pre_review_gate(st)
+    workspace_mock.assert_called_once()
+
+
+def test_skip_prints_explicit_skip_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FR-003 legibility: a skip is announced, not silent."""
+    st = _make_state(skip_pre_review_gate=True, json_output=False)
+    with (
+        patch(f"{_MODULE}._mt_resolve_pre_review_workspace", side_effect=_WorkspaceTouched),
+        patch(f"{_TASKS}.console") as console_mock,
+    ):
+        tasks_move_task._mt_run_pre_review_gate(st)
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list)
+    assert "SKIPPED" in printed
+    assert "--skip-pre-review-gate flag" in printed
+
+
+def test_skip_prints_nothing_under_json_output() -> None:
+    """``--json`` output stays machine-readable — no console noise on skip."""
+    st = _make_state(skip_pre_review_gate=True, json_output=True)
+    with (
+        patch(f"{_MODULE}._mt_resolve_pre_review_workspace", side_effect=_WorkspaceTouched),
+        patch(f"{_TASKS}.console") as console_mock,
+    ):
+        tasks_move_task._mt_run_pre_review_gate(st)
+    console_mock.print.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Default behavior (NFR-003) — neither flag nor env set: gate still runs.
+# --------------------------------------------------------------------------- #
+
+
+def test_default_still_attempts_to_resolve_workspace_and_run_gate() -> None:
+    """With no flag and no env var set, the gate is NOT skipped — it still
+    resolves the workspace exactly as before this fix."""
+    st = _make_state()
+    with patch(
+        f"{_MODULE}._mt_resolve_pre_review_workspace", return_value=None
+    ) as workspace_mock:
+        tasks_move_task._mt_run_pre_review_gate(st)
+    workspace_mock.assert_called_once()
+    assert st.pre_review_gate_metadata is not None
+    reason = st.pre_review_gate_metadata["reason"] or ""
+    assert "gate skipped" not in reason
+    assert "--skip-pre-review-gate" not in reason
+    assert "SPEC_KITTY_SYNC_DISABLE" not in reason
+    assert "SPEC_KITTY_SYNC_MINIMAL_IMPORT" not in reason
+
+
+def test_default_does_not_print_skip_notice() -> None:
+    """The ordinary (non-skip) console line must not claim SKIPPED."""
+    st = _make_state()
+    with (
+        patch(f"{_MODULE}._mt_resolve_pre_review_workspace", return_value=None),
+        patch(f"{_TASKS}.console") as console_mock,
+    ):
+        tasks_move_task._mt_run_pre_review_gate(st)
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list)
+    assert "SKIPPED" not in printed
+
+
+# --------------------------------------------------------------------------- #
+# Progress legibility (FR-003) — a non-empty scope prints a running notice
+# BEFORE the (mocked) scoped test run, so it never reads as a silent hang.
+# --------------------------------------------------------------------------- #
+
+
+def test_progress_notice_printed_before_running_nonempty_scope() -> None:
+    """An explicit override scope (frontmatter ``pre_review_test_scope``) is a
+    non-empty scope — the gate prints a running notice before evaluating it.
+    ``pre_review_gate.evaluate_with_scope`` is mocked so no real subprocess
+    ever spawns; the assertion is purely about notice-before-evaluate
+    ordering + content.
+    """
+    st = _make_state()
+    st.wp = SimpleNamespace(
+        path=Path("WP01-x.md"), frontmatter="pre_review_test_scope: tests/foo/test_bar.py\n"
+    )
+    call_order: list[str] = []
+    fake_verdict = pre_review_gate.GateVerdict(
+        outcome=pre_review_gate.GateOutcome.NO_COVERAGE,
+        scope=pre_review_gate.ScopeResult(
+            test_targets=("tests/foo/test_bar.py",),
+            matched_shard_groups=(),
+            matched_composite_dirs=(),
+            empty_cone_composite_dirs=(),
+            excluded_scope_files=(),
+        ),
+        reason="mocked — no real run",
+    )
+
+    def _fake_evaluate_with_scope(*args: Any, **kwargs: Any) -> pre_review_gate.GateVerdict:
+        call_order.append("evaluate")
+        return fake_verdict
+
+    with (
+        patch(f"{_MODULE}._mt_resolve_pre_review_workspace", return_value=None),
+        patch(f"{_MODULE}._resolve_wp_slug", return_value="WP01-fake"),
+        patch(
+            "specify_cli.review.baseline.BaselineTestResult.load", return_value=None
+        ),
+        patch.object(
+            pre_review_gate, "evaluate_with_scope", side_effect=_fake_evaluate_with_scope
+        ),
+        patch(f"{_TASKS}.console") as console_mock,
+    ):
+        console_mock.print.side_effect = lambda *a, **k: call_order.append("print")
+        tasks_move_task._mt_run_pre_review_gate(st)
+
+    assert call_order[0] == "print", "the progress notice must print BEFORE the scoped run"
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list)
+    assert "running scoped tests at head" in printed
+    assert "may take a few minutes" in printed
+
+
+def test_no_progress_notice_when_scope_is_empty() -> None:
+    """No override, no changed files -> the cheap empty-scope path never
+    claims it's "running" anything (it isn't)."""
+    st = _make_state()
+    with (
+        patch(f"{_MODULE}._mt_resolve_pre_review_workspace", return_value=None),
+        patch(f"{_TASKS}.console") as console_mock,
+    ):
+        tasks_move_task._mt_run_pre_review_gate(st)
+    printed = " ".join(str(call.args[0]) for call in console_mock.print.call_args_list)
+    assert "running scoped tests at head" not in printed
+
+
+# --------------------------------------------------------------------------- #
+# Not-a-for_review-move: the gate does not even reach the skip check.
+# --------------------------------------------------------------------------- #
+
+
+def test_non_for_review_lane_returns_before_any_skip_logic() -> None:
+    st = _make_state(skip_pre_review_gate=True)
+    st.target_lane = Lane.IN_PROGRESS
+    with patch(
+        f"{_MODULE}._mt_resolve_pre_review_workspace", side_effect=_WorkspaceTouched
+    ) as workspace_mock:
+        tasks_move_task._mt_run_pre_review_gate(st)
+    workspace_mock.assert_not_called()
+    assert st.pre_review_gate_metadata is None
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring — the ``move-task`` Typer command declares ``--skip-pre-review-gate``
+# and forwards it to ``_do_move_task`` (the orchestrator this module tests
+# above). These prove the flag actually reaches the seam, not just that the
+# seam behaves correctly once fed it.
+# --------------------------------------------------------------------------- #
+
+
+def test_skip_pre_review_gate_flag_is_registered_on_move_task_help() -> None:
+    result = runner.invoke(app, ["move-task", "--help"], terminal_width=160)
+
+    assert result.exit_code == 0, result.output
+    group = get_command(app)
+    assert isinstance(group, click.Group)
+    click_command = group.commands["move-task"]
+    option = next(
+        param
+        for param in click_command.params
+        if isinstance(param, click.Option) and param.name == "skip_pre_review_gate"
+    )
+    assert "--skip-pre-review-gate" in option.opts
+    assert option.default is False
+    assert "SPEC_KITTY_SYNC_DISABLE" in (option.help or "")
+    assert "SPEC_KITTY_SYNC_MINIMAL_IMPORT" in (option.help or "")
+
+
+def test_move_task_cli_forwards_skip_flag_to_orchestrator() -> None:
+    """The Typer wrapper passes ``--skip-pre-review-gate`` through as
+    ``skip_pre_review_gate=True`` — proving the CLI-declared flag actually
+    reaches ``_do_move_task`` (not just that it parses)."""
+    with patch(f"{_TASKS}._do_move_task") as do_move_task_mock:
+        result = runner.invoke(
+            app,
+            [
+                "move-task",
+                "WP01",
+                "--to",
+                "for_review",
+                "--skip-pre-review-gate",
+                "--mission",
+                "test-mission",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    do_move_task_mock.assert_called_once()
+    assert do_move_task_mock.call_args.kwargs["skip_pre_review_gate"] is True
+
+
+def test_move_task_cli_default_omits_skip_flag() -> None:
+    """Without the flag, the orchestrator receives ``skip_pre_review_gate=False``
+    — the default stays the enforcing behavior (NFR-003)."""
+    with patch(f"{_TASKS}._do_move_task") as do_move_task_mock:
+        result = runner.invoke(
+            app,
+            [
+                "move-task",
+                "WP01",
+                "--to",
+                "for_review",
+                "--mission",
+                "test-mission",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    do_move_task_mock.assert_called_once()
+    assert do_move_task_mock.call_args.kwargs["skip_pre_review_gate"] is False

--- a/tests/specify_cli/coordination/test_commit_router_partition.py
+++ b/tests/specify_cli/coordination/test_commit_router_partition.py
@@ -315,3 +315,134 @@ def test_single_partition_batch_keeps_the_fast_path(
         "data-model.md",
     }
     assert result.status == "committed"
+
+
+# ---------------------------------------------------------------------------
+# #2549 facet B — CommitRouterResult.commit_hashes reports the FULL commit set
+# ---------------------------------------------------------------------------
+
+
+class _SequencedCommitResult:
+    """A ``safe_commit`` stand-in that returns a distinct sha per invocation.
+
+    ``_FakeCommitResult`` above returns the SAME constant sha for every call,
+    which cannot prove that a mixed-partition (coord-topology) batch reports
+    TWO *different* commit hashes -- the exact defect #2549 facet B closes
+    (finalize-tasks --json reported one commit_hash, silently dropping the
+    coordination-branch commit). This stub hands out ``feature-branch-sha`` /
+    ``coord-branch-sha`` in call order so the assertions below can pin that the
+    two hashes actually differ, not just that two calls happened.
+    """
+
+    def __init__(self, shas: list[str]) -> None:
+        self._shas = iter(shas)
+
+    def __call__(self, **kwargs: object) -> object:
+        class _Result:
+            sha = next(self._shas)  # noqa: B023 - captured per-instance, not per-loop
+
+        return _Result()
+
+
+def test_mixed_batch_result_reports_commit_hashes_for_both_partitions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#2549 facet B: a split (coord-topology) commit reports BOTH commit hashes.
+
+    Pre-fix, ``_merge_group_results`` discarded every group's result except the
+    caller-partition one -- the coordination-branch commit landed for real
+    (``_group_files_by_partition`` already splits and commits it, proven by
+    ``test_mixed_batch_routes_each_file_to_its_own_partition_ref`` above) but its
+    sha was never surfaced on the returned ``CommitRouterResult``. This pins the
+    fix: ``commit_hashes`` carries a ``(ref, sha)`` pair for EACH partition group
+    that committed, and the two shas are genuinely distinct (proving the second
+    commit's identity survives the merge, not just its ref).
+    """
+    mission_slug = "001-demo"
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    feature_dir.mkdir(parents=True)
+
+    tasks_file = feature_dir / "tasks.md"
+    tasks_file.write_text("# Tasks\n", encoding="utf-8")
+    matrix_file = feature_dir / "acceptance-matrix.json"
+    matrix_file.write_text("{}", encoding="utf-8")
+
+    coord_worktree = tmp_path / ".worktrees" / "coord"
+    coord_worktree.mkdir(parents=True)
+
+    _install_common_fakes(monkeypatch, coord_worktree=coord_worktree)
+    monkeypatch.setattr(
+        commit_router,
+        "safe_commit",
+        _SequencedCommitResult(["feature-branch-sha-0001", "coord-branch-sha-0002"]),
+    )
+    policy = _make_policy(protected=False)
+
+    result = commit_router.commit_for_mission(
+        tmp_path,
+        mission_slug,
+        (tasks_file, matrix_file),
+        "chore: finalize tasks",
+        policy,
+        kind=MissionArtifactKind.TASKS_INDEX,
+    )
+
+    assert result.status == "committed"
+    hashes_by_ref = dict(result.commit_hashes)
+    assert len(result.commit_hashes) == 2, (
+        f"expected one commit hash per partition group, got {result.commit_hashes!r}"
+    )
+    assert hashes_by_ref[_PRIMARY_REF] == "feature-branch-sha-0001"
+    assert hashes_by_ref[_COORD_REF] == "coord-branch-sha-0002"
+    assert hashes_by_ref[_PRIMARY_REF] != hashes_by_ref[_COORD_REF], (
+        "the feature-branch and coordination-branch commits are genuinely "
+        "distinct commits and must report distinct hashes"
+    )
+    # Backward compatibility: the legacy single-value fields still describe the
+    # caller-partition (TASKS_INDEX -> PRIMARY -> feature-branch) commit.
+    assert result.commit_hash == "feature-branch-sha-0001"
+    assert result.placement_ref == _PRIMARY_REF
+
+
+def test_single_partition_batch_commit_hashes_matches_legacy_single_commit_hash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backward compatibility: a flat/single-partition commit reports ONE hash.
+
+    Under a topology with no coordination routing (``SINGLE_BRANCH`` / flat
+    missions), every artifact lands in ONE partition group, so
+    ``commit_hashes`` must carry exactly the one ``(ref, hash)`` pair that
+    ``commit_hash`` / ``placement_ref`` already describe -- no caller depending
+    on the historical single-value fields sees any change.
+    """
+    mission_slug = "001-demo"
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    feature_dir.mkdir(parents=True)
+
+    spec_file = feature_dir / "spec.md"
+    spec_file.write_text("# Spec\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        commit_router, "resolve_placement_only", lambda *_a, **_kw: CommitTarget(ref=_PRIMARY_REF)
+    )
+    monkeypatch.setattr(
+        commit_router, "resolve_topology", lambda *_a, **_kw: MissionTopology.SINGLE_BRANCH
+    )
+    monkeypatch.setattr(
+        commit_router, "_resolve_primary_target_branch", lambda *_a, **_kw: _PRIMARY_REF
+    )
+    monkeypatch.setattr(commit_router, "safe_commit", lambda **_kw: _FakeCommitResult())
+    policy = _make_policy(protected=False)
+
+    result = commit_router.commit_for_mission(
+        tmp_path,
+        mission_slug,
+        (spec_file,),
+        "chore: spec",
+        policy,
+        kind=MissionArtifactKind.SPEC,
+    )
+
+    assert result.status == "committed"
+    assert result.commit_hashes == ((_PRIMARY_REF, result.commit_hash),)
+    assert result.commit_hash == _FakeCommitResult.sha

--- a/tests/specify_cli/test_specify_topology_flag.py
+++ b/tests/specify_cli/test_specify_topology_flag.py
@@ -237,6 +237,42 @@ def test_specify_omitted_topology_defaults_to_coord_and_mints_branch(
     assert coord_branch in refs, f"minted coordination branch {coord_branch!r} is not a real ref"
 
 
+def _add_origin_on_main(repo: Path, tmp_path: Path) -> None:
+    """Give *repo* an ``origin`` whose HEAD is ``main`` so ``resolve_primary_branch``
+    resolves the primary branch from ``origin/HEAD`` independently of the branch
+    currently checked out (Method 1 in ``core.git_ops.resolve_primary_branch``)."""
+    bare = tmp_path / "origin.git"
+    _run(["git", "init", "-qb", "main", "--bare", str(bare)], repo)
+    _git(repo, "remote", "add", "origin", str(bare))
+    _git(repo, "push", "-q", "origin", "main")
+    _git(repo, "remote", "set-head", "origin", "main")
+
+
+def test_specify_omitted_topology_on_non_primary_branch_derives_single_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#2581: omitting ``--topology`` on a NON-primary feature branch now derives
+    ``single_branch`` (no coordination branch minted) through the shared
+    context-derivation — closing the gotcha at the ``/spec-kitty.specify`` entry
+    point, not just ``agent mission create``. On the primary branch (T010) the
+    default stays ``coord``; here, with ``origin/HEAD -> main`` and HEAD on a
+    feature branch, the derivation sees a genuine primary/non-primary mismatch."""
+    repo = _init_project(tmp_path)
+    _add_origin_on_main(repo, tmp_path)
+    _git(repo, "checkout", "-qb", "feat/non-primary-change")
+    with _in_project(repo, monkeypatch):
+        result = _invoke_specify(["non-primary-demo", "--json"])
+
+    assert result.exit_code == 0, f"exit {result.exit_code}:\n{result.output}"
+    feature_dir = _only_feature_dir(repo)
+    meta = _read_meta(feature_dir)
+    assert meta["topology"] == "single_branch", meta
+    assert "coordination_branch" not in meta, (
+        f"a non-primary-branch specify without --pr-bound must NOT mint a "
+        f"coordination branch (got {meta.get('coordination_branch')!r})"
+    )
+
+
 # ---------------------------------------------------------------------------
 # T009 — mandatory end-to-end non-coord proof
 #

--- a/tests/tasks/test_finalize_tasks_json_output_unit.py
+++ b/tests/tasks/test_finalize_tasks_json_output_unit.py
@@ -42,10 +42,36 @@ def _committed_router_result(*, commit_success: bool = True) -> CommitRouterResu
     """
     if commit_success:
         return CommitRouterResult(
-            status="committed", placement_ref="main", commit_hash=_FAKE_SHA
+            status="committed",
+            placement_ref="main",
+            commit_hash=_FAKE_SHA,
+            commit_hashes=(("main", _FAKE_SHA),),
         )
     return CommitRouterResult(
         status="error", placement_ref="main", diagnostic="safe_commit: git commit failed"
+    )
+
+
+_FAKE_COORD_SHA = "b" * 40
+_COORD_BRANCH = "kitty/mission-001-test-A1B2C3D4"
+
+
+def _committed_router_result_coord_split() -> CommitRouterResult:
+    """Build the split-commit CommitRouterResult a coord-topology finalize returns.
+
+    #2549 facet B: under coord topology, ``commit_for_mission`` issues TWO
+    commits -- one for primary-partition artifacts (tasks.md, lanes.json,
+    tasks/WP*) landing on the feature branch, one for placement-partition
+    artifacts (status.events.jsonl, status.json, acceptance-matrix.json,
+    issue-matrix.md) landing on the coordination branch. The legacy single
+    ``commit_hash`` still names the feature-branch commit (the caller
+    partition); ``commit_hashes`` carries BOTH.
+    """
+    return CommitRouterResult(
+        status="committed",
+        placement_ref="main",
+        commit_hash=_FAKE_SHA,
+        commit_hashes=(("main", _FAKE_SHA), (_COORD_BRANCH, _FAKE_COORD_SHA)),
     )
 
 
@@ -340,6 +366,93 @@ class TestFinalizeTasks:
         assert isinstance(payload["files_committed"], list)
         assert isinstance(payload["updated_wp_count"], int)
         assert isinstance(payload["tasks_dir"], str)
+
+    def test_json_output_commit_hashes_reports_both_branches_under_coord_topology(
+        self, tmp_path: Path
+    ) -> None:
+        """#2549 facet B: under coord topology, JSON reports BOTH commit hashes.
+
+        A coord-topology finalize issues two commits (feature branch + coord
+        branch) as separate commits on separate branches. Pre-fix, the JSON
+        payload named only the feature-branch ``commit_hash`` while
+        ``files_committed`` listed files from BOTH partitions -- misleading
+        automated callers. This pins the fix: the new ``commit_hashes`` field
+        carries an entry per branch, and the coord-branch hash is present and
+        genuinely differs from the feature-branch hash.
+        """
+        feature_dir, _ = _build_feature(tmp_path)
+
+        with (
+            patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+            patch("specify_cli.cli.commands.agent.mission._find_feature_directory", return_value=feature_dir),
+            patch("specify_cli.cli.commands.agent.mission._show_branch_context", return_value=(None, "main")),
+            patch(
+                "specify_cli.coordination.commit_router.commit_for_mission",
+                return_value=_committed_router_result_coord_split(),
+            ),
+            patch("specify_cli.cli.commands.agent.mission.run_command", side_effect=_make_run_command("M tasks.md")),
+            patch("specify_cli.cli.commands.agent.mission.get_emitter"),
+        ):
+            result = runner.invoke(app, ["finalize-tasks", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        import json as _json
+
+        lines = [l for l in result.stdout.splitlines() if l.strip().startswith("{")]
+        payload = _json.loads(lines[-1])
+
+        # Backward-compatible single-value field still names the feature-branch commit.
+        assert payload["commit_hash"] == _FAKE_SHA
+
+        assert "commit_hashes" in payload, "JSON must include commit_hashes"
+        commit_hashes = payload["commit_hashes"]
+        assert isinstance(commit_hashes, list)
+        assert len(commit_hashes) == 2, f"expected 2 branch commits, got {commit_hashes!r}"
+
+        hashes_by_branch = {entry["branch"]: entry["hash"] for entry in commit_hashes}
+        assert hashes_by_branch["main"] == _FAKE_SHA
+        assert hashes_by_branch[_COORD_BRANCH] == _FAKE_COORD_SHA
+        assert hashes_by_branch[_COORD_BRANCH] is not None
+        assert hashes_by_branch[_COORD_BRANCH] != hashes_by_branch["main"], (
+            "the coordination-branch commit hash must be reported and must "
+            "differ from the feature-branch commit hash"
+        )
+
+    def test_json_output_commit_hashes_single_entry_for_flat_topology(self, tmp_path: Path) -> None:
+        """#2549 facet B backward compat: a flat/single_branch finalize reports one hash.
+
+        A flat/single_branch mission has no coordination partition -- everything
+        commits in one commit on one branch. ``commit_hashes`` must carry exactly
+        that one ``{branch, hash}`` entry, matching the legacy ``commit_hash``
+        field, so existing single-commit callers see no behavioural change.
+        """
+        feature_dir, _ = _build_feature(tmp_path)
+
+        with (
+            patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+            patch("specify_cli.cli.commands.agent.mission._find_feature_directory", return_value=feature_dir),
+            patch("specify_cli.cli.commands.agent.mission._show_branch_context", return_value=(None, "main")),
+            patch(
+                "specify_cli.coordination.commit_router.commit_for_mission",
+                return_value=_committed_router_result(),
+            ),
+            patch("specify_cli.cli.commands.agent.mission.run_command", side_effect=_make_run_command("M tasks.md")),
+            patch("specify_cli.cli.commands.agent.mission.get_emitter"),
+        ):
+            result = runner.invoke(app, ["finalize-tasks", "--json"])
+
+        assert result.exit_code == 0, result.stdout
+        import json as _json
+
+        lines = [l for l in result.stdout.splitlines() if l.strip().startswith("{")]
+        payload = _json.loads(lines[-1])
+
+        commit_hashes = payload["commit_hashes"]
+        assert isinstance(commit_hashes, list)
+        assert commit_hashes == [{"branch": "main", "hash": _FAKE_SHA}], (
+            f"flat topology must report exactly one branch commit, got {commit_hashes!r}"
+        )
+        assert payload["commit_hash"] == commit_hashes[0]["hash"]
 
     def test_json_reports_modified_unchanged_preserved(self, tmp_path: Path) -> None:
         """Success JSON output must include modified_wps, unchanged_wps, preserved_wps (T008/T009)."""


### PR DESCRIPTION
## Why

The `coord-shadows-followups` mission (#2584) logged live implement-loop friction that repeatedly interrupted the workflow. This fast-follow clears the **quick-win subset** — config-default / output-shape / escape-hatch fixes, deliberately excluding the hard async redesign — so the next larger slices run against a smoother loop. Scope was investigated (code-verified) from the mission's `tooling-friction-trace`.

## What

Four independent fixes, each with a red-first/characterization test:

| Fix | Issue | Change |
|-----|-------|--------|
| Topology default is context-derived | **Closes #2581** | `mission create` **and** `spec-kitty specify` now default topology from branch context: a non-primary feature branch without `--pr-bound` → `single_branch` (no coordination branch to manually flatten). Primary branch, `--pr-bound`, and explicit `--topology` still default to `coord`. Reuses the canonical `resolve_primary_branch`. |
| Pre-review-gate escape hatches | Relates **#2573** | `move-task --to for_review` gains `--skip-pre-review-gate`, honors the `SPEC_KITTY_SYNC_DISABLE` / `SPEC_KITTY_SYNC_MINIMAL_IMPORT` disable env (via canonical `core.env.is_truthy`), and prints a progress notice so the scoped-test gate no longer reads as a silent hang. Default enforcement is unchanged. **The full async redesign stays deferred on #2573.** |
| Per-branch commit hashes in finalize JSON | Relates **#2549** | `finalize-tasks --json` reports `commit_hashes: [{branch, hash}]` for the two-branch coord-topology commit set (the merge step previously discarded the coordination-branch hash); `commit_hash` is retained for backward compatibility. **Facet B only — facet A (lane mis-route) stays deferred on #2549.** |
| Charter first-run parity | **Closes #2577** | `charter synthesize` on an empty/first-run config no longer fails closed demanding a `how-we-apply-<directive>` companion tactic for every built-in directive — the fix distinguishes first-run (`None`) from explicit activation and leaves the "all built-ins" fallback intact for the other consumer that legitimately needs it (#2526 regression). |

## For whom

Anyone running the Spec Kitty implement/review loop on a fork or feature branch: no more manual topology flatten, a skippable/legible pre-review gate, honest `finalize-tasks` JSON for automation, and a working `charter synthesize` on a first run.

## Not in scope (tracked)

- **#2573 async redesign** and **#2549 facet A** remain open (only the quick-win halves land here).
- **#2582** (surface `/spec-kitty.analyze` in the tasks→implement handoff) and **#2583** (don't gate the first per-WP approval on whole-mission issue-matrix completeness) are handled separately as post-mission ops.

## Verification

- Full gate green: `ruff` + `mypy` clean on all changed files; arch (trio-seam / dead-code / terminology / marker-correctness / compat-surface) + the four WPs' functional suites all pass; the topology-default derivation, the gate escape hatches, the two-branch commit-hash reporting, and the charter first-run parity are each pinned by red-first or characterization tests.
- Rebased onto current `main` (post-#2584); an opus reviewer LAND'd the aggregate.
- **CHANGELOG** updated (this cycle's friction quick-wins + a retroactive entry for #2584, which merged without one).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017epsBKV8kvJdVrc8Zh9Qtf
