### PR TITLE
feat(dashboard): surface next-action hint and mission lifecycle status

### DIFF
--- a/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
+++ b/kitty-specs/unified-charter-bundle-chokepoint-01KP5Q2G/baseline/pre-wp23-dashboard-typed.json
@@ -122,7 +122,9 @@
         "mission_id": "01HXBASELINEDEMO000000000Z",
         "mission_number": 1
       },
+      "mission_status": "active",
       "name": "Demo Feature",
+      "next_action": null,
       "path": "kitty-specs/001-demo-feature",
       "workflow": {
         "implement": "in_progress",

--- a/src/specify_cli/dashboard/api_types.py
+++ b/src/specify_cli/dashboard/api_types.py
@@ -220,6 +220,8 @@ class FeatureItem(TypedDict):
     artifacts: dict[str, ArtifactInfo]
     workflow: WorkflowStatus
     kanban_stats: KanbanStats
+    mission_status: str  # "active" | "planned" | "done" | "draft"
+    next_action: NotRequired[str | None]
     meta: dict[str, Any]
     worktree: WorktreeInfo
     is_legacy: bool  # added by handler, not scanner

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -211,8 +211,56 @@ def _coerce_sort_mission_number(value: object) -> int | None:
     return None
 
 
-def _feature_recency_sort_key(feature: dict[str, Any]) -> tuple[bool, float, bool, str, bool, int, str]:
-    """Sort dashboard selector rows newest-first with deterministic legacy fallbacks."""
+# Higher priority = sorted first (list uses reverse=True).
+_MISSION_STATUS_PRIORITY: dict[str, int] = {"active": 3, "planned": 2, "done": 1, "draft": 0}
+
+
+def _derive_mission_status(kanban_stats: dict[str, Any]) -> str:
+    """Derive mission lifecycle status from WP lane counts.
+
+    Returns one of ``"active"``, ``"planned"``, ``"done"``, or ``"draft"``.
+
+    - ``"active"``  — at least one WP is in ``doing``, ``for_review``, or ``approved``
+    - ``"planned"`` — WPs exist but none have been started
+    - ``"done"``    — WPs exist and all are in terminal lanes (done/canceled)
+    - ``"draft"``   — no WPs yet, or the event log is unreadable
+    """
+    if kanban_stats.get("error") or not kanban_stats.get("total", 0):
+        return "draft"
+    if kanban_stats.get("doing", 0) or kanban_stats.get("for_review", 0) or kanban_stats.get("approved", 0):
+        return "active"
+    if kanban_stats.get("planned", 0):
+        return "planned"
+    return "done"
+
+
+def _derive_next_action(meta_data: dict[str, Any], kanban_stats: dict[str, Any]) -> str | None:
+    """Derive the next operator action from mission lifecycle markers in meta.json.
+
+    spec-kitty merge writes ``baseline_merge_commit``; spec-kitty accept writes
+    ``accepted_at``.  Together they let the dashboard surface what's still needed
+    without calling the decision engine.
+    """
+    if not isinstance(meta_data, dict):
+        return None
+    if meta_data.get("accepted_at"):
+        return None
+    slug = meta_data.get("mission_slug") or meta_data.get("slug") or "<mission>"
+    if meta_data.get("baseline_merge_commit"):
+        return f"Run /spec-kitty.review, then: spec-kitty accept --mission {slug}"
+    if not kanban_stats.get("error") and kanban_stats.get("total", 0) > 0:
+        in_flight = kanban_stats.get("doing", 0) + kanban_stats.get("for_review", 0) + kanban_stats.get("approved", 0) + kanban_stats.get("planned", 0)
+        if in_flight == 0 and kanban_stats.get("done", 0) > 0:
+            return f"Run: spec-kitty merge --mission {slug}"
+    return None
+
+
+def _feature_recency_sort_key(feature: dict[str, Any]) -> tuple[int, bool, float, bool, str, bool, int, str]:
+    """Sort selector rows: active first, then planned, then done/draft; newest-first within each bucket."""
+    status = feature.get("mission_status", "draft")
+    status_priority = _MISSION_STATUS_PRIORITY.get(status, 0)
+
+
     meta = feature.get("meta")
     if not isinstance(meta, dict):
         meta = {}
@@ -223,6 +271,7 @@ def _feature_recency_sort_key(feature: dict[str, Any]) -> tuple[bool, float, boo
     mission_number = _coerce_sort_mission_number(meta.get("mission_number"))
 
     return (
+        status_priority,
         created_at is not None,
         created_at if created_at is not None else float("-inf"),
         bool(mission_id_key),
@@ -866,6 +915,8 @@ def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
                 "artifacts": artifacts,
                 "workflow": workflow,
                 "kanban_stats": kanban_stats,
+                "mission_status": _derive_mission_status(kanban_stats),
+                "next_action": _derive_next_action(meta_data or {}, kanban_stats),
                 "meta": meta_data or {},
                 "worktree": worktree,
             }

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.paths import assert_safe_path_segment
 import contextlib
 import logging
 import os
@@ -248,7 +249,13 @@ def _derive_next_action(meta_data: dict[str, Any], kanban_stats: dict[str, Any])
         return None
     if meta_data.get("accepted_at"):
         return None
-    slug = meta_data.get("mission_slug") or meta_data.get("slug") or "<mission>"
+    slug = meta_data.get("mission_slug") or meta_data.get("slug")
+    if not isinstance(slug, str):
+        return None
+    try:
+        slug = assert_safe_path_segment(slug)
+    except ValueError:
+        return None
     if meta_data.get("baseline_merge_commit"):
         return f"Run /spec-kitty.review, then: spec-kitty accept --mission {slug}"
     if not kanban_stats.get("error") and kanban_stats.get("total", 0) > 0:

--- a/src/specify_cli/dashboard/scanner.py
+++ b/src/specify_cli/dashboard/scanner.py
@@ -215,14 +215,14 @@ def _coerce_sort_mission_number(value: object) -> int | None:
 _MISSION_STATUS_PRIORITY: dict[str, int] = {"active": 3, "planned": 2, "done": 1, "draft": 0}
 
 
-def _derive_mission_status(kanban_stats: dict[str, Any]) -> str:
-    """Derive mission lifecycle status from WP lane counts.
+def _derive_mission_status(kanban_stats: dict[str, Any], meta_data: dict[str, Any] | None = None) -> str:
+    """Derive mission lifecycle status from WP lane counts and lifecycle markers.
 
     Returns one of ``"active"``, ``"planned"``, ``"done"``, or ``"draft"``.
 
-    - ``"active"``  — at least one WP is in ``doing``, ``for_review``, or ``approved``
-    - ``"planned"`` — WPs exist but none have been started
-    - ``"done"``    — WPs exist and all are in terminal lanes (done/canceled)
+    - ``"active"``  — WPs in flight, OR all WPs terminal but mission not yet accepted
+    - ``"planned"`` — no WP is active and planned work remains
+    - ``"done"``    — all WPs terminal AND ``accepted_at`` is set in meta.json
     - ``"draft"``   — no WPs yet, or the event log is unreadable
     """
     if kanban_stats.get("error") or not kanban_stats.get("total", 0):
@@ -231,6 +231,9 @@ def _derive_mission_status(kanban_stats: dict[str, Any]) -> str:
         return "active"
     if kanban_stats.get("planned", 0):
         return "planned"
+    # All WPs terminal — only "done" once the operator has accepted the mission
+    if meta_data and not meta_data.get("accepted_at"):
+        return "active"
     return "done"
 
 
@@ -915,7 +918,7 @@ def scan_all_features(project_dir: Path) -> list[dict[str, Any]]:
                 "artifacts": artifacts,
                 "workflow": workflow,
                 "kanban_stats": kanban_stats,
-                "mission_status": _derive_mission_status(kanban_stats),
+                "mission_status": _derive_mission_status(kanban_stats, meta_data),
                 "next_action": _derive_next_action(meta_data or {}, kanban_stats),
                 "meta": meta_data or {},
                 "worktree": worktree,

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -406,6 +406,29 @@ body {
     margin-top: 6px;
 }
 
+.next-action-callout {
+    margin-top: 20px;
+    padding: 12px 16px;
+    background: #fffbeb;
+    border-left: 4px solid #f59e0b;
+    border-radius: 6px;
+    font-size: 0.95em;
+    color: #92400e;
+}
+
+.next-action-callout .next-action-icon {
+    margin-right: 6px;
+    color: #f59e0b;
+}
+
+.next-action-callout code {
+    background: #fef3c7;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 0.9em;
+}
+
 .progress-bar {
     width: 100%;
     height: 6px;

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -416,6 +416,14 @@ function loadOverview() {
     progressBar.appendChild(progressFill);
     completedCard.appendChild(progressBar);
 
+    const nextAction = feature.next_action;
+    const nextActionEl = nextAction ? (() => {
+        const el = document.createElement('div');
+        el.className = 'next-action-callout';
+        el.innerHTML = `<span class="next-action-icon">▶</span> <strong>Next step:</strong> <code>${nextAction}</code>`;
+        return el;
+    })() : null;
+
     const artifactsHeading = document.createElement('h3');
     artifactsHeading.style.marginTop = '30px';
     artifactsHeading.style.marginBottom = '15px';
@@ -436,7 +444,10 @@ function loadOverview() {
         artifactsGrid.appendChild(item);
     });
 
-    overviewContent.replaceChildren(header, statusSummary, artifactsHeading, artifactsGrid);
+    const overviewChildren = [header, statusSummary];
+    if (nextActionEl) overviewChildren.push(nextActionEl);
+    overviewChildren.push(artifactsHeading, artifactsGrid);
+    overviewContent.replaceChildren(...overviewChildren);
 }
 
 function loadKanban() {

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -420,7 +420,14 @@ function loadOverview() {
     const nextActionEl = nextAction ? (() => {
         const el = document.createElement('div');
         el.className = 'next-action-callout';
-        el.innerHTML = `<span class="next-action-icon">▶</span> <strong>Next step:</strong> <code>${nextAction}</code>`;
+        const icon = document.createElement('span');
+        icon.className = 'next-action-icon';
+        icon.textContent = '▶';
+        const label = document.createElement('strong');
+        label.textContent = 'Next step:';
+        const command = document.createElement('code');
+        command.textContent = nextAction;
+        el.append(icon, document.createTextNode(' '), label, document.createTextNode(' '), command);
         return el;
     })() : null;
 

--- a/src/specify_cli/dashboard/static/dashboard/dashboard.js
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.js
@@ -1336,11 +1336,16 @@ function updateFeatureListSilent(features) {
     }
     updateSidebarState();
 
-    // Detect artifact changes and reload overview if artifacts changed
+    // Refresh every value rendered by the overview. Lifecycle markers can
+    // change without changing artifacts (for example merge or acceptance).
     if (currentPage === 'overview' && oldFeature && feature) {
-        const oldArtifacts = JSON.stringify(oldFeature.artifacts);
-        const newArtifacts = JSON.stringify(feature.artifacts);
-        if (oldArtifacts !== newArtifacts) {
+        const overviewState = item => JSON.stringify({
+            artifacts: item.artifacts,
+            next_action: item.next_action,
+            mission_status: item.mission_status,
+            kanban_stats: item.kanban_stats,
+        });
+        if (overviewState(oldFeature) !== overviewState(feature)) {
             loadOverview();
         }
     }

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -392,10 +392,15 @@ class TestDeriveNextAction:
         assert result is not None
         assert "042-bar" in result
 
-    def test_placeholder_slug_when_no_slug_in_meta(self):
-        result = scanner._derive_next_action({}, self._stats(total=1, done=1))
-        assert result is not None
-        assert "<mission>" in result
+    def test_none_when_no_slug_in_meta(self):
+        assert scanner._derive_next_action({}, self._stats(total=1, done=1)) is None
+
+    def test_none_when_slug_is_not_shell_safe(self):
+        result = scanner._derive_next_action(
+            {"mission_slug": "demo; rm -rf data"},
+            self._stats(total=1, done=1),
+        )
+        assert result is None
 
     def test_none_when_meta_is_not_dict(self):
         assert scanner._derive_next_action(None, self._stats(total=2, done=2)) is None  # type: ignore[arg-type]

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -322,12 +322,28 @@ class TestDeriveMissionStatus:
     def test_planned_when_all_planned(self):
         assert scanner._derive_mission_status(self._stats(total=4, planned=4)) == "planned"
 
-    def test_done_when_all_done(self):
-        assert scanner._derive_mission_status(self._stats(total=3, done=3)) == "done"
+    def test_active_when_all_wps_done_but_not_accepted(self):
+        # All WPs done but operator hasn't run spec-kitty accept — still needs attention
+        meta = {"mission_slug": "042-foo"}
+        assert scanner._derive_mission_status(self._stats(total=3, done=3), meta) == "active"
 
-    def test_done_when_mix_of_done_and_canceled(self):
+    def test_active_when_merged_but_not_accepted(self):
+        meta = {"baseline_merge_commit": "abc123", "mission_slug": "042-foo"}
+        assert scanner._derive_mission_status(self._stats(total=3, done=3), meta) == "active"
+
+    def test_done_when_accepted(self):
+        meta = {"accepted_at": "2026-07-12T00:00:00+00:00", "mission_slug": "042-foo"}
+        assert scanner._derive_mission_status(self._stats(total=3, done=3), meta) == "done"
+
+    def test_done_when_no_meta(self):
+        # Legacy missions with no meta.json fall through to done
+        assert scanner._derive_mission_status(self._stats(total=3, done=3)) == "done"
+        assert scanner._derive_mission_status(self._stats(total=3, done=3), None) == "done"
+
+    def test_done_when_mix_of_done_and_canceled_and_accepted(self):
         # canceled WPs are not counted in total; total==done means mission is done
-        assert scanner._derive_mission_status(self._stats(total=2, done=2)) == "done"
+        meta = {"accepted_at": "2026-07-12T00:00:00+00:00"}
+        assert scanner._derive_mission_status(self._stats(total=2, done=2), meta) == "done"
 
 
 class TestDeriveNextAction:

--- a/tests/test_dashboard/test_scanner.py
+++ b/tests/test_dashboard/test_scanner.py
@@ -277,7 +277,7 @@ def test_feature_recency_helpers_cover_timestamp_and_legacy_fallbacks():
     assert scanner._coerce_sort_mission_number("WP42") is None
 
     fallback_key = scanner._feature_recency_sort_key({"id": "legacy-mission", "meta": "not-a-dict"})
-    assert fallback_key == (False, float("-inf"), False, "", False, -1, "legacy-mission")
+    assert fallback_key == (0, False, float("-inf"), False, "", False, -1, "legacy-mission")
 
 
 def test_read_dashboard_feature_meta_ignores_malformed_and_non_object_json(tmp_path):
@@ -292,6 +292,133 @@ def test_read_dashboard_feature_meta_ignores_malformed_and_non_object_json(tmp_p
     (non_object / "meta.json").write_text('["not", "an", "object"]', encoding="utf-8")
 
     assert scanner._read_dashboard_feature_meta(non_object) == ("002-non-object-meta", None)
+
+
+class TestDeriveMissionStatus:
+    """_derive_mission_status returns the correct lifecycle bucket."""
+
+    def _stats(self, **kwargs: int) -> dict:
+        base = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
+        base.update(kwargs)
+        return base
+
+    def test_draft_when_total_zero(self):
+        assert scanner._derive_mission_status(self._stats()) == "draft"
+
+    def test_draft_when_error_key_present(self):
+        s = self._stats(total=3, planned=3)
+        s["error"] = "Event log not found"
+        assert scanner._derive_mission_status(s) == "draft"
+
+    def test_active_when_doing(self):
+        assert scanner._derive_mission_status(self._stats(total=2, doing=1, planned=1)) == "active"
+
+    def test_active_when_for_review(self):
+        assert scanner._derive_mission_status(self._stats(total=2, for_review=1, done=1)) == "active"
+
+    def test_active_when_approved(self):
+        assert scanner._derive_mission_status(self._stats(total=3, approved=1, done=2)) == "active"
+
+    def test_planned_when_all_planned(self):
+        assert scanner._derive_mission_status(self._stats(total=4, planned=4)) == "planned"
+
+    def test_done_when_all_done(self):
+        assert scanner._derive_mission_status(self._stats(total=3, done=3)) == "done"
+
+    def test_done_when_mix_of_done_and_canceled(self):
+        # canceled WPs are not counted in total; total==done means mission is done
+        assert scanner._derive_mission_status(self._stats(total=2, done=2)) == "done"
+
+
+class TestDeriveNextAction:
+    """_derive_next_action returns the right hint at each lifecycle stage."""
+
+    def _stats(self, **kwargs: int) -> dict:
+        base = {"total": 0, "planned": 0, "doing": 0, "for_review": 0, "approved": 0, "done": 0}
+        base.update(kwargs)
+        return base
+
+    def test_none_when_accepted(self):
+        meta = {"accepted_at": "2026-07-12T00:00:00+00:00", "baseline_merge_commit": "abc123", "mission_slug": "042-foo"}
+        assert scanner._derive_next_action(meta, self._stats(total=2, done=2)) is None
+
+    def test_review_and_accept_when_merged_not_accepted(self):
+        meta = {"baseline_merge_commit": "abc123", "mission_slug": "042-foo"}
+        result = scanner._derive_next_action(meta, self._stats(total=2, done=2))
+        assert result is not None
+        assert "spec-kitty.review" in result
+        assert "spec-kitty accept" in result
+        assert "042-foo" in result
+
+    def test_merge_hint_when_all_wps_done_not_yet_merged(self):
+        meta = {"mission_slug": "042-foo"}
+        result = scanner._derive_next_action(meta, self._stats(total=4, done=4))
+        assert result is not None
+        assert "spec-kitty merge" in result
+        assert "042-foo" in result
+
+    def test_none_when_wps_still_in_flight(self):
+        meta = {"mission_slug": "042-foo"}
+        assert scanner._derive_next_action(meta, self._stats(total=4, done=2, doing=2)) is None
+
+    def test_none_when_no_wps_yet(self):
+        assert scanner._derive_next_action({}, self._stats()) is None
+
+    def test_none_when_kanban_error(self):
+        meta = {"mission_slug": "042-foo"}
+        stats = self._stats(total=4, done=4)
+        stats["error"] = "Event log not found"
+        assert scanner._derive_next_action(meta, stats) is None
+
+    def test_falls_back_to_slug_field(self):
+        meta = {"slug": "042-bar"}
+        result = scanner._derive_next_action(meta, self._stats(total=2, done=2))
+        assert result is not None
+        assert "042-bar" in result
+
+    def test_placeholder_slug_when_no_slug_in_meta(self):
+        result = scanner._derive_next_action({}, self._stats(total=1, done=1))
+        assert result is not None
+        assert "<mission>" in result
+
+    def test_none_when_meta_is_not_dict(self):
+        assert scanner._derive_next_action(None, self._stats(total=2, done=2)) is None  # type: ignore[arg-type]
+
+
+class TestFeatureStatusSortOrder:
+    """Active missions sort before planned, planned before done/draft."""
+
+    def _feature(self, status: str, created_at: str = "2026-01-01T00:00:00+00:00") -> dict:
+        return {
+            "id": f"mission-{status}",
+            "mission_status": status,
+            "meta": {"created_at": created_at},
+        }
+
+    def test_active_sorts_before_planned(self):
+        features = [self._feature("planned"), self._feature("active")]
+        features.sort(key=scanner._feature_recency_sort_key, reverse=True)
+        assert features[0]["mission_status"] == "active"
+
+    def test_planned_sorts_before_done(self):
+        features = [self._feature("done"), self._feature("planned")]
+        features.sort(key=scanner._feature_recency_sort_key, reverse=True)
+        assert features[0]["mission_status"] == "planned"
+
+    def test_done_sorts_before_draft(self):
+        features = [self._feature("draft"), self._feature("done")]
+        features.sort(key=scanner._feature_recency_sort_key, reverse=True)
+        assert features[0]["mission_status"] == "done"
+
+    def test_within_bucket_newest_first(self):
+        features = [
+            self._feature("active", "2026-01-01T00:00:00+00:00"),
+            self._feature("active", "2026-06-01T00:00:00+00:00"),
+        ]
+        features[0]["id"] = "mission-a"
+        features[1]["id"] = "mission-b"
+        features.sort(key=scanner._feature_recency_sort_key, reverse=True)
+        assert features[0]["id"] == "mission-b"  # newer
 
 
 def test_build_legacy_kanban_stats_counts_lane_directories(tmp_path):

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -68,7 +68,7 @@ def test_dashboard_overview_mission_copy_uses_text_nodes():
     assert "titleEl.textContent = `Mission Run: ${feature.name}`;" in source
     assert "introEl.textContent = purposeTldr;" in source
     assert "contextEl.textContent = purposeContext;" in source
-    assert "overviewContent.replaceChildren(header, statusSummary, artifactsHeading, artifactsGrid);" in source
+    assert "overviewContent.replaceChildren(...overviewChildren);" in source
     assert "overviewContent.innerHTML" not in source
     assert "<h3>Mission Run: ${feature.name}" not in source
     assert "${purposeTldr}</p>" not in source

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -60,6 +60,14 @@ def test_dashboard_features_polling_guards_malformed_payloads():
     assert "response.ok" in source
 
 
+def test_dashboard_overview_polling_includes_lifecycle_state():
+    source = DASHBOARD_JS.read_text(encoding="utf-8")
+
+    assert "next_action: item.next_action" in source
+    assert "mission_status: item.mission_status" in source
+    assert "kanban_stats: item.kanban_stats" in source
+
+
 def test_dashboard_overview_mission_copy_uses_text_nodes():
     source = DASHBOARD_JS.read_text(encoding="utf-8")
 

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -70,6 +70,8 @@ def test_dashboard_overview_mission_copy_uses_text_nodes():
     assert "contextEl.textContent = purposeContext;" in source
     assert "overviewContent.replaceChildren(...overviewChildren);" in source
     assert "overviewContent.innerHTML" not in source
+    assert "command.textContent = nextAction;" in source
+    assert "el.innerHTML" not in source
     assert "<h3>Mission Run: ${feature.name}" not in source
     assert "${purposeTldr}</p>" not in source
     assert "${purposeContext}</p>" not in source


### PR DESCRIPTION
## Summary

- Adds an amber callout to the mission overview when there's an obvious next operator action (all WPs done but not yet merged, or merged but not yet accepted). The hint includes the exact command to run.
- Adds `mission_status` to the `FeatureItem` API response and sorts the mission selector by lifecycle status so active missions appear first.

## Motivation

After `spec-kitty merge` completes, the dashboard showed the mission as "active" with all WPs in `done` — no indication of what to do next.

What we really want is for the dashboard to show where a mission sits in its overall lifecycle — not just WP implementation progress, but the full arc: planning → implementation → merge → review → acceptance. Right now the dashboard has no concept of any of that post-implementation state.

## Design question for review

We're unsure about the right path forward and would love direction before going further.

The concern is avoiding duplicated logic: `spec-kitty next` already knows what the next step is for any mission state, but it's designed for the agent loop — it manages run state and isn't safe to call read-only from the dashboard. So this PR takes a lightweight shortcut: reading two `meta.json` markers written by existing commands (`baseline_merge_commit` from `spec-kitty merge`, `accepted_at` from `spec-kitty accept`).

That works for the immediate problem, but a full lifecycle stage tracker would need a proper solution. Is there a canonical, lightweight way the dashboard should be determining mission lifecycle stage? Should there be a dedicated read-only query surface for this? Or is the meta.json marker approach the right pattern to extend?

## Test plan

- [ ] 9 new unit tests in `TestDeriveNextAction` covering: accepted (no hint), post-merge (review+accept hint), all-WPs-done pre-merge (merge hint), in-flight WPs (no hint), no WPs yet, kanban error, slug fallbacks, non-dict meta
- [ ] `TestFeatureStatusSortOrder` verifies active missions sort before planned/done/draft
- [ ] `test_api_contract.py` passes — `next_action` key visible to the contract scanner
- [ ] `mypy` and `ruff` clean on changed files