### PR TITLE
refactor: route remaining specify_cli datetime stamp sites onto now_utc_iso() (#2496)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -629,6 +629,14 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   (create-if-absent); an existing curated companion is left byte-for-byte untouched,
   preserving the #2772 never-clobber invariant. `charter.md` remains display-only, never a
   resolving input. ADR 2026-07-18-1 amended.
+- **Internal: remaining `specify_cli` datetime stamp sites consolidated onto
+  `now_utc_iso()` (#2496).** Follow-up to #2494's clock-consolidation sweep; routes the
+  remaining byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in
+  `specify_cli` (14 sites, 11 files) onto the single canonical `now_utc_iso()` helper.
+  Behaviour-preserving: the `UTC` / `timezone.utc` spellings serialize byte-identically
+  under `requires-python >=3.11`. Boundary packages (`charter`/`glossary`, blocked by the
+  architectural layer contract) and non-`now` sites (`timespec=`, naive, subprocess-string)
+  are left as-is by design.
 - **Internal: the coord-authority trio is decomposed into ports + pure cores
   (#2464, #2465).** The three coord-authority god-modules are restructured
   behaviour-preservingly into the shipped Typer-shell + request-dataclass + pure-cores

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -629,25 +629,19 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   (create-if-absent); an existing curated companion is left byte-for-byte untouched,
   preserving the #2772 never-clobber invariant. `charter.md` remains display-only, never a
   resolving input. ADR 2026-07-18-1 amended.
-- **Internal: remaining `specify_cli` datetime stamp sites consolidated onto
-  `now_utc_iso()` (#2496).** Follow-up to #2494's clock-consolidation sweep; routes the
-  remaining byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in
-  `specify_cli` (14 sites, 11 files) onto the single canonical `now_utc_iso()` helper.
-  Behaviour-preserving: the `UTC` / `timezone.utc` spellings serialize byte-identically
-  under `requires-python >=3.11`. Boundary packages (`charter`/`glossary`, blocked by the
-  architectural layer contract) and non-`now` sites (`timespec=`, naive, subprocess-string)
-  are left as-is by design.
-- **Internal: the coord-authority trio is decomposed into ports + pure cores
-  (#2464, #2465).** The three coord-authority god-modules are restructured
-  behaviour-preservingly into the shipped Typer-shell + request-dataclass + pure-cores
-  (ports injected) + executor pattern — following `MissionResolver` (#2494) and
-  `tasks.py` (#2308): `workflow.py` → `workflow_cores.py` + `workflow_executor.py`,
-  `implement.py` → `implement_cores.py` (a `GitPort` injected and two `# noqa: C901`
-  suppressions removed), and `acceptance/` → `summary_core.py` + `gates_core.py`. The
-  trio's leaf resolvers now consume the kind-aware placement seam, preserving all three
-  (lenient) read contracts (#2465). No user-facing behaviour change; pinned by
-  seam-only + cores-no-I/O architectural tests and a characterization safety net over
-  implement / review / accept / next.
+- **Internal: the `specify_cli` aware-UTC clock contract is now enforced structurally
+  (#2496).** Follow-up to #2494's clock-consolidation sweep. Routes the remaining
+  byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in `specify_cli`
+  onto the single canonical `now_utc_iso()` helper, so that helper is the sole permitted
+  producer of the form. Behaviour-preserving: the `UTC` / `timezone.utc` spellings
+  serialize byte-identically under `requires-python >=3.11`. Replaces the previous
+  owned-file inventory with an **AST negative gate** over the whole `src/specify_cli`
+  tree (`tests/specify_cli/test_clock_consolidation.py`), so a module added later is
+  covered the moment it lands rather than silently regressing while the suite stays
+  green; the gate ships a self-mutant non-vacuity test and a stale-exemption check.
+  Distinct contracts are deliberately out of scope and are not flagged: the
+  second-precision `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`,
+  naive `now()`, and the datetime-returning family.
 
 ## [3.2.5] - 2026-07-08
 

--- a/src/specify_cli/charter_runtime/lint/engine.py
+++ b/src/specify_cli/charter_runtime/lint/engine.py
@@ -13,10 +13,11 @@ Zero LLM calls.  All checks are pure graph traversal.
 
 from __future__ import annotations
 
-import datetime
 import logging
 import time
 from pathlib import Path
+
+from specify_cli.core.time_utils import now_utc_iso
 
 from .findings import DecayReport, GraphState, LintFinding
 from .checks.orphan import OrphanChecker
@@ -106,7 +107,7 @@ class LintEngine:
             )
             empty = DecayReport(
                 findings=[],
-                scanned_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                scanned_at=now_utc_iso(),
                 feature_scope=feature_scope,
                 duration_seconds=0.0,
                 drg_node_count=0,
@@ -139,7 +140,7 @@ class LintEngine:
 
         report = DecayReport(
             findings=all_findings,
-            scanned_at=datetime.datetime.now(datetime.UTC).isoformat(),
+            scanned_at=now_utc_iso(),
             feature_scope=feature_scope,
             duration_seconds=round(duration, 3),
             drg_node_count=len(list(getattr(drg, "nodes", []))),

--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -27,6 +26,7 @@ from typing_extensions import Annotated
 from specify_cli.context.mission_resolver import AmbiguousHandleError, MissionNotFoundError, ResolvedMission, resolve_mission
 from specify_cli.coordination.surface_resolver import resolve_status_surface
 from specify_cli.core.paths import locate_project_root
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.doctrine_synthesizer import (
     SynthesisResult,
     apply_proposals,
@@ -178,7 +178,7 @@ def _build_json_envelope(
     envelope: dict[str, object] = {
         "schema_version": "1",
         "command": "agent.retrospect.synthesize",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": now_utc_iso(),
         "dry_run": dry_run,
         "status": status,
         "outcome": outcome,
@@ -280,7 +280,7 @@ def _create_empty_retrospective_record(
         gen_record directly without re-reading the YAML via the Pydantic reader.
     """
     del feature_dir
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_utc_iso()
     gen_actor = GenActor(kind=actor.kind, id=actor.id)
     record = GenRetrospectiveRecord(
         schema_version=1,

--- a/src/specify_cli/cli/commands/charter/lint.py
+++ b/src/specify_cli/cli/commands/charter/lint.py
@@ -9,6 +9,7 @@ from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
 from specify_cli.cli.commands.charter._common import _emit_error
+from specify_cli.core.time_utils import now_utc_iso
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
@@ -154,8 +155,6 @@ def charter_lint(
     # existing graph load remains authoritative for findings — but the
     # call enforces FR-005 hard-fails as a lint gate.
     if org_fragments:
-        import datetime as _dt
-
         from charter.drg import (
             DRGGraph,
             OrgDRGConflict,
@@ -165,7 +164,7 @@ def charter_lint(
 
         empty_built_in = DRGGraph(
             schema_version="1.0",
-            generated_at=_dt.datetime.now(_dt.UTC).isoformat(),
+            generated_at=now_utc_iso(),
             generated_by="charter-lint",
             nodes=[],
             edges=[],

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -13,6 +13,7 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -921,7 +922,7 @@ def _annotation_for_request(
         request.wp_id,
         request.annotation_delta,
         actor=request.actor,
-        at=at or datetime.now(UTC).isoformat(),
+        at=at or now_utc_iso(),
         event_id=_emit._generate_ulid(),
     )
 

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -13,7 +13,6 @@ import logging
 import re
 import shutil
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +26,7 @@ from specify_cli.core.mission_payload import (
     default_mission_purpose_context,
 )
 from specify_cli.core.paths import is_worktree_context, locate_project_root
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.git import safe_commit
 from specify_cli.lanes.branch_naming import mission_dir_name, resolve_mid8
 from specify_cli.mission_metadata import load_meta_or_empty, validate_purpose_summary
@@ -426,7 +426,7 @@ def create_mission_core(
     meta.setdefault("purpose_context", normalized_purpose_context)
     meta.setdefault(_META_KEY_MISSION_TYPE, mission or "software-dev")
     meta.setdefault("target_branch", planning_branch)
-    meta.setdefault(_META_KEY_CREATED_AT, datetime.now(timezone.utc).isoformat())  # noqa: UP017
+    meta.setdefault(_META_KEY_CREATED_AT, now_utc_iso())
 
     # ------------------------------------------------------------------
     # 6.5 Coordination branch (WP03 / issue #1348, #2218)

--- a/src/specify_cli/core/time_utils.py
+++ b/src/specify_cli/core/time_utils.py
@@ -1,8 +1,23 @@
 """Canonical clock helper for ISO-8601 UTC timestamps.
 
-This module hosts the single canonical `now_utc_iso()` helper that replaces
-12 byte-identical `datetime.now(UTC).isoformat()` copies scattered across
-`event_journal/`, `status/`, `retrospective/`, `delivery/`, and `dossier/`.
+This module hosts the single canonical `now_utc_iso()` helper.
+
+**The semantic clock contract**: every "now"-stamp in `specify_cli` that
+serializes an *aware-UTC* instant at `isoformat()`'s native precision routes
+through this helper. `now_utc_iso()` is the sole permitted producer of that
+form; a local `datetime.now(UTC).isoformat()` copy is a contract violation.
+This is enforced structurally rather than by inventory: an AST gate
+(`tests/specify_cli/test_clock_consolidation.py`) scans the whole
+`src/specify_cli` tree for the raw form and fails on any occurrence outside
+the exception families below, so a newly added module is covered the moment
+it lands. (A count of migrated copies is deliberately NOT recorded here — it
+decays on every migration.)
+
+Allowed exception families (each a genuinely *distinct contract*, not an
+escape hatch):
+
+- **This module itself** — the canonical implementation.
+- The **stamp** family and the **datetime-returning** family, below.
 
 Two distinct-contract families are deliberately NOT folded into this helper
 (see mission-resolver-port-01KX1C05 research.md D-04, NFR-004):
@@ -29,10 +44,11 @@ from datetime import UTC, datetime
 def now_utc_iso() -> str:
     """Return the current UTC time as an ISO 8601 string.
 
-    Canonical replacement for the 12 byte-identical
-    ``datetime.now(UTC).isoformat()`` copies. Do not use this for the
-    second-precision ``%Y-%m-%dT%H:%M:%SZ`` stamp format (see
-    ``task_utils.support.now_utc``) or for callers that need a ``datetime``
-    object back.
+    The canonical producer of the aware-UTC ``isoformat()`` form: a local
+    ``datetime.now(UTC).isoformat()`` copy anywhere in ``specify_cli`` is a
+    violation of the module's clock contract and is caught by the AST gate.
+    Do not use this for the second-precision ``%Y-%m-%dT%H:%M:%SZ`` stamp
+    format (see ``task_utils.support.now_utc``) or for callers that need a
+    ``datetime`` object back.
     """
     return datetime.now(UTC).isoformat()

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -10,7 +10,6 @@ The invocation executor must NEVER claim a first-load token.
 from __future__ import annotations
 
 import dataclasses
-import datetime
 import hashlib
 import json as _json_mod
 import logging
@@ -31,6 +30,7 @@ import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/missi
 from charter.context import build_charter_context
 from mission_runtime import CommitTarget
 from specify_cli.core.commit_guard import GuardCapability
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.git import safe_commit
 from specify_cli.invocation.errors import InvalidModeForEvidenceError, InvocationError
 from specify_cli.invocation.modes import ModeOfWork
@@ -303,7 +303,7 @@ class ProfileInvocationExecutor:
             bundle = GlossaryObservationBundle(matched_urns=(), high_severity=(), all_conflicts=(), tokens_checked=0, duration_ms=0.0, error_msg=repr(_exc))
 
         # 3. Write started record (raises InvocationWriteError on fs failure)
-        started_at = datetime.datetime.now(datetime.UTC).isoformat()
+        started_at = now_utc_iso()
         record = OpStartedEvent(
             invocation_id=invocation_id,
             profile_id=profile.profile_id,
@@ -385,7 +385,7 @@ class ProfileInvocationExecutor:
         # Step 3: Append completed event (existing behaviour).
         completed = OpCompletedEvent(
             invocation_id=invocation_id,
-            completed_at=datetime.datetime.now(datetime.UTC).isoformat(),
+            completed_at=now_utc_iso(),
             outcome=outcome,
             closed_by=closed_by,
             evidence_ref=evidence_ref,

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -34,6 +34,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.invocation.adapters import get_saas_client as _get_saas_client_from_seam
 from specify_cli.invocation.adapters import resolve_sync_routing
 from specify_cli.invocation.projection_policy import EventKind, ModeOfWork, resolve_projection
@@ -204,15 +205,13 @@ def _log_propagation_error(
 ) -> None:
     """Append propagation failure to the local error log.  Never raises."""
     try:
-        import datetime  # noqa: PLC0415
-
         error_log = repo_root / PROPAGATION_ERRORS_PATH
         error_log.parent.mkdir(parents=True, exist_ok=True)
         entry = {
             "invocation_id": record.invocation_id,
             "event": record.event,
             "error": error,
-            "at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "at": now_utc_iso(),
         }
         with error_log.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")

--- a/src/specify_cli/invocation/writer.py
+++ b/src/specify_cli/invocation/writer.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import json
 import os
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.core.utils import ensure_within_any
 from specify_cli.invocation.errors import AlreadyClosedError, InvocationError, InvocationWriteError
 from specify_cli.invocation.record import (
@@ -240,7 +240,7 @@ class InvocationWriter:
         if (ref is None) == (sha is None):
             raise ValueError("Exactly one of ref or sha must be provided")
         path = self.invocation_path(invocation_id)
-        at_ts = at or datetime.datetime.now(datetime.UTC).isoformat()
+        at_ts = at or now_utc_iso()
         entry: dict[str, object] = {
             "event": "artifact_link" if ref is not None else "commit_link",
             "invocation_id": invocation_id,

--- a/src/specify_cli/migration/rewrite_opposed_by.py
+++ b/src/specify_cli/migration/rewrite_opposed_by.py
@@ -90,7 +90,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any
 
@@ -325,7 +325,7 @@ def _load_graph(pack_root: Path, artifact_type: str) -> DRGGraph:
     if not path.exists():
         return DRGGraph(
             schema_version="1.0",
-            generated_at=datetime.now(UTC).isoformat(),
+            generated_at=now_utc_iso(),
             generated_by=_GENERATED_BY,
             nodes=[],
             edges=[],

--- a/src/specify_cli/mission_metadata.py
+++ b/src/specify_cli/mission_metadata.py
@@ -15,7 +15,6 @@ always either the old version or the new version, never a partial write.
 
 from __future__ import annotations
 
-import datetime as _dt
 import json
 import re
 from dataclasses import dataclass
@@ -24,6 +23,7 @@ from typing import Any, Literal, TypedDict
 
 from specify_cli.core.atomic import atomic_write
 from specify_cli.core.paths import safe_mission_slug
+from specify_cli.core.time_utils import now_utc_iso
 
 # Hoisted S1192 literals (campsite #1970) -- the meta.json filename and the two
 # decode encodings appear across this module and the legacy contracts it absorbs.
@@ -123,7 +123,7 @@ class MissionIdentity:
 
 def _now_iso() -> str:
     """Current UTC time in ISO 8601."""
-    return _dt.datetime.now(_dt.UTC).isoformat()
+    return now_utc_iso()
 
 
 def mission_number_from_slug(mission_slug: str) -> int | None:

--- a/src/specify_cli/missions/_archive.py
+++ b/src/specify_cli/missions/_archive.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any
 
@@ -130,7 +130,7 @@ class DeferralDisposition:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(UTC).isoformat()
+    return now_utc_iso()
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/retrospective/cli.py
+++ b/src/specify_cli/retrospective/cli.py
@@ -13,9 +13,10 @@ Source-of-truth:
 from __future__ import annotations
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.time_utils import now_utc_iso
 import json
 import sys
-from datetime import date, datetime, timezone
+from datetime import date
 from pathlib import Path
 from typing import Optional
 
@@ -56,7 +57,7 @@ def _build_json_envelope(snapshot: SummarySnapshot) -> dict[str, object]:
     return {
         "schema_version": "1",
         "command": "retrospect.summary",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": now_utc_iso(),
         "result": snapshot.model_dump(),
     }
 

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.git_ops import resolve_primary_branch
 from specify_cli.core.paths import read_target_branch_from_meta
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.lanes.branch_naming import resolve_mid8
 import contextlib
-import datetime
 import json
 import logging
 import re
@@ -1202,7 +1202,7 @@ def generate_retrospective(
         RecordValidationError: If the generator produces an invalid record (indicates a bug).
     """
     if invoked_at is None:
-        invoked_at = datetime.datetime.now(datetime.UTC).isoformat()
+        invoked_at = now_utc_iso()
 
     if actor is None:
         actor = GenActor(kind="runtime", id="spec-kitty-generator", display="Spec Kitty Generator")

--- a/src/specify_cli/retrospective/summary.py
+++ b/src/specify_cli/retrospective/summary.py
@@ -17,6 +17,7 @@ WP03 addition (T017):
 from __future__ import annotations
 
 from specify_cli.core.constants import RETROSPECTIVE_FILENAME
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.mission_metadata import load_meta_or_empty
 from specify_cli.missions._read_path_resolver import candidate_feature_dir_for_mission
 import json
@@ -350,7 +351,7 @@ def build_summary(
         A :class:`SummarySnapshot` (always — never raises on malformed
         records; they appear in ``snapshot.malformed``).
     """
-    generated_at = datetime.now(timezone.utc).isoformat()
+    generated_at = now_utc_iso()
 
     # Mutable accumulator state
     mission_count = 0

--- a/src/specify_cli/session_presence/upgrade_check.py
+++ b/src/specify_cli/session_presence/upgrade_check.py
@@ -16,7 +16,8 @@ import json
 import os
 import subprocess
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 
 from specify_cli.core.env import is_truthy
@@ -68,7 +69,7 @@ def refresh_cache_once() -> None:
         tmp.write_text(
             json.dumps(
                 {
-                    "checked_at": datetime.now(UTC).isoformat(),
+                    "checked_at": now_utc_iso(),
                     "latest_version": latest,
                 }
             ),

--- a/tests/specify_cli/test_clock_consolidation.py
+++ b/tests/specify_cli/test_clock_consolidation.py
@@ -183,3 +183,126 @@ class TestStampFamilyPreserved:
         assert stamp_value.endswith("Z")
         assert "." in iso_value  # microseconds retained
         assert "." not in stamp_value  # microseconds dropped (second precision)
+
+
+# ---------------------------------------------------------------------------
+# The structural ratchet (review #2611): a full-tree AST negative gate.
+#
+# The owned-file inventory above protects only the ORIGINAL 12 files, so every
+# newly migrated module could regress while this suite stayed green. That is an
+# inventory, not a gate. The scan below walks the WHOLE src/specify_cli tree for
+# the raw aware-UTC ``.isoformat()`` form, so a module added tomorrow is covered
+# the moment it lands -- no list to remember to update.
+# ---------------------------------------------------------------------------
+
+# Justified exceptions. Each is a genuinely DISTINCT CONTRACT, not an escape
+# hatch; anything added here needs the same standard.
+_RAW_FORM_EXEMPT: dict[str, str] = {
+    # The canonical implementation itself -- this IS the one permitted producer.
+    "specify_cli/core/time_utils.py": "hosts now_utc_iso(); the single canonical call site",
+}
+
+
+def _is_utc_alias(node: ast.expr) -> bool:
+    """``UTC`` / ``datetime.UTC`` / ``timezone.utc`` - the aware-UTC spellings."""
+    if isinstance(node, ast.Name):
+        return node.id == "UTC"
+    if isinstance(node, ast.Attribute):
+        base = node.value
+        if node.attr == "UTC" and isinstance(base, ast.Name) and base.id == "datetime":
+            return True
+        if node.attr == "utc" and isinstance(base, ast.Name) and base.id == "timezone":
+            return True
+    return False
+
+
+def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
+    """Line numbers of every raw ``datetime.now(<aware-UTC>).isoformat()``.
+
+    Deliberately NARROW - it flags only the byte-identical form that
+    ``now_utc_iso()`` replaces:
+
+    - ``.isoformat()`` must take NO arguments. ``isoformat(timespec=...)`` is a
+      different serialization (a distinct contract), not a violation.
+    - the ``now()`` argument must be an aware-UTC alias. A naive ``now()`` and
+      ``now(some_tz)`` are different contracts too.
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        outer = node.func
+        if not (isinstance(outer, ast.Attribute) and outer.attr == "isoformat"):
+            continue
+        if node.args or node.keywords:
+            continue  # timespec= etc. -> a distinct serialization contract
+        inner = outer.value
+        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
+            continue
+        if inner.func.attr != "now" or len(inner.args) != 1 or inner.keywords:
+            continue
+        if _is_utc_alias(inner.args[0]):
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_raw_aware_utc_isoformat_outside_the_canonical_helper() -> None:
+    """THE RATCHET: no module may mint the raw form locally.
+
+    Structural, not inventory-based - a module added after this test was
+    written is covered automatically.
+    """
+    offenders: list[str] = []
+    scanned = 0
+    for path in sorted((_SRC / "specify_cli").rglob("*.py")):
+        rel = path.relative_to(_SRC).as_posix()
+        if rel in _RAW_FORM_EXEMPT:
+            continue
+        scanned += 1
+        for lineno in _raw_utc_isoformat_lines(ast.parse(path.read_text(encoding="utf-8"))):
+            offenders.append(f"{rel}:{lineno}")
+
+    assert scanned > 100, f"the scan must actually cover the tree (only {scanned} files seen)"
+    assert not offenders, (
+        "raw aware-UTC isoformat() found outside the canonical helper - route these "
+        "onto specify_cli.core.time_utils.now_utc_iso():\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_ratchet_is_non_vacuous() -> None:
+    """SELF-MUTANT: prove the detector FIRES on a planted violation.
+
+    A gate that never exercised its failure path is theatre. This drives the
+    SAME detector the tree scan uses, so a future refactor that silently breaks
+    the matcher turns this red instead of passing an empty scan.
+    """
+    violations = (
+        "import datetime\nx = datetime.datetime.now(datetime.UTC).isoformat()\n",
+        "from datetime import UTC, datetime\nx = datetime.now(UTC).isoformat()\n",
+        "from datetime import datetime, timezone\nx = datetime.now(timezone.utc).isoformat()\n",
+    )
+    for src in violations:
+        assert _raw_utc_isoformat_lines(ast.parse(src)), f"detector MISSED a violation:\n{src}"
+
+    # ...and does NOT fire on the distinct contracts it must leave alone.
+    allowed = (
+        "from specify_cli.core.time_utils import now_utc_iso\nx = now_utc_iso()\n",
+        # a different serialization: second precision via timespec
+        "from datetime import UTC, datetime\nx = datetime.now(UTC).isoformat(timespec='seconds')\n",
+        # the datetime-returning family
+        "from datetime import UTC, datetime\nx = datetime.now(UTC)\n",
+        # naive now() - a different contract
+        "from datetime import datetime\nx = datetime.now().isoformat()\n",
+    )
+    for src in allowed:
+        assert not _raw_utc_isoformat_lines(ast.parse(src)), f"detector FALSE-POSITIVED on:\n{src}"
+
+
+def test_every_exemption_is_real_and_still_needed() -> None:
+    """No stale exemptions: each exempt file must exist AND still contain the form."""
+    for rel, why in _RAW_FORM_EXEMPT.items():
+        path = _SRC / rel
+        assert path.exists(), f"exempt file no longer exists, drop it: {rel}"
+        assert _raw_utc_isoformat_lines(ast.parse(path.read_text(encoding="utf-8"))), (
+            f"exemption is stale (file no longer contains the raw form) - remove it: {rel} ({why})"
+        )


### PR DESCRIPTION
Follow-up to #2494 (WP06 T024), which routed 12 byte-identical stamp copies onto `core/time_utils.now_utc_iso()` and deliberately scoped out the rest. This routes the remaining byte-identical `datetime.now(<UTC>).isoformat()` "now"-stamp sites **within `specify_cli`** — 14 sites across 11 files, using the same import+call idiom as #2494.

## Behaviour-preserving
`now_utc_iso()` is `datetime.now(UTC).isoformat()`; under `requires-python >=3.11`, `datetime.UTC is timezone.utc`, so the `UTC` / `timezone.utc` spellings serialize byte-identically. `test_clock_consolidation.py` tests the helpers (not the call sites), so it stays green untouched.

## Verified locally (Python 3.11, `uv sync --extra test`)
- `tests/specify_cli/test_clock_consolidation.py` — 9 passed (byte-identical clock guard)
- `tests/architectural/test_layer_rules.py` — 17 passed (no package-boundary regression)
- touched-module behaviour tests (executor, propagator, writer, charter-lint engine, mission_creation, retrospective generator/summary/writer, agent_retrospect) — 181 passed

## Deliberately left
- **`charter/` and `glossary/`** — forbidden from importing `specify_cli` by the `tests/architectural` layer contract; routing them would break the layer test or duplicate the very helper being consolidated.
- **`runtime/next` (4 sites)** — contract-*legal* to route (`runtime` may import `specify_cli.core`, and `runtime/next/discovery.py` already does), but deferred here to keep the change uniform and respect WP06 T025's no-new-reverse-edges intent. **Open question: want these included here, or as a follow-up?**
- **Non-`now` sites** — `timespec="seconds"` (different precision), naive `datetime.now()` (would flip naive→aware), the `python3 -c` subprocess script string in `session_presence/upgrade_check.py` (`now_utc_iso` isn't importable in that namespace), the datetime-returning family, and parse defaults.

## Note on the issue's WP06 T025 wording
The issue states `runtime/next` "cannot import `specify_cli.core.time_utils`". The enforced layer contract (`tests/architectural/test_layer_rules.py`) actually forbids only `specify_cli.cli`/`.next` from `runtime`; `runtime/next/discovery.py` already imports `specify_cli.core`. Only `charter`/`glossary` are genuinely blocked — flagging so the follow-up scope stays accurate.