### PR TITLE
fix: auto-commit during agent action review fails on missions using a coordination worktree

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 from specify_cli.core.constants import (
     KITTY_SPECS_DIR,
     MISSION_TYPE_RESEARCH,
+    WORKTREES_DIR,
 )
 from specify_cli.missions._read_path_resolver import (
     _canonicalize_primary_read_handle,
@@ -538,9 +539,27 @@ def _resolve_workflow_read_dir(
     return read_dir
 
 
+def _worktree_root_for_feature_dir(repo_root: Path, feature_dir: Path) -> Path:
+    """Return the correct worktree_root for safe_commit, derived from feature_dir.
+
+    When feature_dir lives inside .worktrees/<name>/..., returns
+    .worktrees/<name> so that absolute paths under that worktree normalize
+    correctly (preventing SafeCommitPathPolicyError on paths whose first
+    component is .worktrees/).  For primary-checkout feature_dirs, returns
+    repo_root unchanged.
+    """
+    worktrees_parent = repo_root / WORKTREES_DIR
+    try:
+        rel = feature_dir.resolve().relative_to(worktrees_parent.resolve())
+        return worktrees_parent / rel.parts[0]
+    except ValueError:
+        return repo_root
+
+
 def _commit_via_legacy_safe_commit(
     *,
     repo_root: Path,
+    worktree_root: Path,
     target_branch: str,
     paths: list[Path],
     message: str,
@@ -553,7 +572,7 @@ def _commit_via_legacy_safe_commit(
     # tracking ``main``) is REFUSED by the guard, never waived (FR-008).
     result = safe_commit(
         repo_root=repo_root,
-        worktree_root=repo_root,
+        worktree_root=worktree_root,
         target=CommitTarget(ref=target_branch),
         message=message,
         paths=tuple(paths),
@@ -694,9 +713,11 @@ def _commit_workflow_change(
         return
 
     # Legacy fallback (TODO(WP08): replace with the legacy bridge).
+    legacy_worktree_root = _worktree_root_for_feature_dir(repo_root, feature_dir)
     try:
         _commit_via_legacy_safe_commit(
             repo_root=repo_root,
+            worktree_root=legacy_worktree_root,
             target_branch=placement.ref,
             paths=paths,
             message=message,

--- a/tests/architectural/test_no_write_side_rederivation.py
+++ b/tests/architectural/test_no_write_side_rederivation.py
@@ -163,7 +163,9 @@ _ALLOW_LIST_SEED: tuple[tuple[str, int], ...] = (
     # _render_wp_prompt_wrapper + routing) shifted _review_feedback_root's
     # ``return feature_dir.parent.parent`` 838 -> 872 (same READ-side helper,
     # verified by re-scan, not a new offender).
-    ("src/specify_cli/cli/commands/agent/workflow.py", 872),
+    # post-merge re-anchor (worktree_root fix #2607): _worktree_root_for_feature_dir
+    # insertion shifted _review_feedback_root's return line 872 -> 893.
+    ("src/specify_cli/cli/commands/agent/workflow.py", 893),
     # tracked: #2453 - _status_commit_destination_branch's
     # ``get_current_branch(repo_root) or fallback_branch`` git-HEAD selector.
     # It ONLY predicts the pre-lane status-commit branch for the protected-branch
@@ -657,13 +659,12 @@ _CHECKOUT_GRAMMAR_ALLOW_LIST_SEED: tuple[tuple[str, int, str], ...] = (
     ),
     (
         "src/specify_cli/cli/commands/agent/workflow.py",
-        557,
+        576,
         "tracked: #2453 - _commit_via_legacy_safe_commit's target_branch "
         "parameter is a pre-coordination-topology legacy mission's "
         "checked-out branch; same deferred bucket as the other #2453 "
-        "residuals. post-merge re-anchor (coord-primary-partition-lock "
-        "aggregate landing): cumulative cross-lane line drift shifted this "
-        "524 -> 523 (same construction, verified by re-scan).",
+        "residuals. post-merge re-anchor (worktree_root fix #2607): "
+        "_worktree_root_for_feature_dir helper insertion shifted line to 576.",
     ),
     (
         "src/specify_cli/cli/commands/agent/tasks_move_task.py",

--- a/tests/git/test_guard_capability_regression.py
+++ b/tests/git/test_guard_capability_regression.py
@@ -258,6 +258,7 @@ def test_legacy_workflow_commit_refused_on_protected_target(
     with pytest.raises(ProtectedBranchRefused):
         workflow._commit_via_legacy_safe_commit(
             repo_root=repo.repo_root,
+            worktree_root=repo.repo_root,
             target_branch=repo.target_branch,
             paths=[changed],
             message="chore: workflow status bookkeeping",

--- a/tests/specify_cli/cli/commands/agent/test_workflow_placement_routing.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_placement_routing.py
@@ -347,6 +347,98 @@ def test_commit_workflow_change_legacy_path_routes_through_the_seam(
     )
 
 
+def test_worktree_root_for_feature_dir_inside_worktrees(tmp_path: Path) -> None:
+    """_worktree_root_for_feature_dir returns the worktree root for coord dirs."""
+    from specify_cli.cli.commands.agent.workflow import _worktree_root_for_feature_dir
+
+    worktree_dir = tmp_path / ".worktrees" / "my-mission-abc123-coord"
+    feature_dir = worktree_dir / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+
+    result = _worktree_root_for_feature_dir(tmp_path, feature_dir)
+
+    assert result == worktree_dir
+
+
+def test_worktree_root_for_feature_dir_in_primary_checkout(tmp_path: Path) -> None:
+    """_worktree_root_for_feature_dir returns repo_root for primary-checkout dirs."""
+    from specify_cli.cli.commands.agent.workflow import _worktree_root_for_feature_dir
+
+    feature_dir = tmp_path / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+
+    result = _worktree_root_for_feature_dir(tmp_path, feature_dir)
+
+    assert result == tmp_path
+
+
+def test_commit_workflow_change_legacy_path_uses_coord_worktree_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy path passes the coord worktree root (not repo_root) to safe_commit.
+
+    When feature_dir is inside .worktrees/<name>/..., the legacy fallback must
+    supply worktree_root=.worktrees/<name> so that absolute paths under the coord
+    worktree normalise correctly and do not trigger SafeCommitPathPolicyError.
+    """
+    import mission_runtime
+    from mission_runtime import CommitTarget, MissionArtifactKind
+    from specify_cli.cli.commands.agent import workflow
+
+    worktree_name = "001-demo-abc123-coord"
+    coord_worktree = tmp_path / ".worktrees" / worktree_name
+    feature_dir = coord_worktree / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+    events_path = feature_dir / "status.events.jsonl"
+    status_path = feature_dir / "status.json"
+    events_path.write_text('{"event_id":"before"}\n', encoding="utf-8")
+    status_path.write_text('{"before":true}\n', encoding="utf-8")
+
+    class _StubSeam:
+        def __init__(self, repo_root: Path, mission_slug: str) -> None:
+            del repo_root, mission_slug
+
+        def write_target(self, kind: MissionArtifactKind) -> CommitTarget:
+            assert kind is MissionArtifactKind.STATUS_STATE
+            return CommitTarget(ref="lane-branch")
+
+    monkeypatch.setattr(mission_runtime, "placement_seam", _StubSeam)
+    monkeypatch.setattr(workflow, "_load_coord_branch_meta", lambda _fd: (None, None, None))
+
+    captured: dict[str, object] = {}
+
+    class _StubResult:
+        sha = "cafebabe"
+
+    def _fake_safe_commit(**kwargs: object) -> _StubResult:
+        captured.update(kwargs)
+        return _StubResult()
+
+    monkeypatch.setattr(workflow, "safe_commit", _fake_safe_commit)
+    workflow._reset_workflow_receipts()
+
+    workflow._commit_workflow_change(
+        repo_root=tmp_path,
+        feature_dir=feature_dir,
+        mission_slug="001-demo",
+        target_branch="lane-branch",
+        paths=[events_path, status_path],
+        message="chore: WP01 in_review [claude]",
+        operation="for_review -> in_review for WP01",
+        wp_id="WP01",
+        pre_emit_event_size=len('{"event_id":"before"}\n'),
+        pre_emit_status_bytes=b'{"before":true}\n',
+    )
+
+    assert "worktree_root" in captured, "safe_commit was never invoked"
+    assert captured["worktree_root"] == coord_worktree, (
+        f"legacy path passed worktree_root={captured['worktree_root']!r}; "
+        f"expected coord worktree root {coord_worktree!r}. "
+        "Paths under .worktrees/ will raise SafeCommitPathPolicyError when "
+        "normalised against repo_root."
+    )
+
+
 # ---------------------------------------------------------------------------
 # T021 campsite regression anchor — empty except at the dossier-sync site
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

Running `spec-kitty agent action review WP01` on a mission with a coordination topology would silently fail to commit the status update. The error — `SafeCommitPathPolicyError` — appeared only if you looked closely at the output, and the practical symptom was that `spec-kitty merge` would refuse to proceed because the workspace had uncommitted tracking files.

## The fix in plain terms

When the review command writes its status artifacts, those files live inside a sub-workspace (a git worktree). The code was telling git "these files are relative to the main repo root" — but they weren't, they were relative to the sub-workspace root. Git's safety policy correctly rejected the mismatch. We now detect whether the files are in a sub-workspace and pass the right root.

## Technical details

`_commit_via_legacy_safe_commit` hardcoded `worktree_root=repo_root`. Added `_worktree_root_for_feature_dir(repo_root, feature_dir)` which walks the path: if `feature_dir` is inside `.worktrees/<name>/`, return `.worktrees/<name>` as the root; otherwise return `repo_root`. The derived root is passed as `worktree_root` to `safe_commit`.

## Why this approach

The legacy fallback path (`_commit_via_legacy_safe_commit`) exists as a bridge until WP08 replaces it with a proper legacy bridge. Rather than changing *when* the code takes this path, making the path itself robust is the right defensive move — it honours the existing `worktree_root` contract that `safe_commit` already enforces, and shrinks the blast radius of the WP08 TODO instead of widening it.

## Test plan

- `test_worktree_root_for_feature_dir_inside_worktrees` — unit-tests the new helper for a coord worktree path
- `test_worktree_root_for_feature_dir_in_primary_checkout` — unit-tests the helper returns `repo_root` for primary-checkout paths
- `test_commit_workflow_change_legacy_path_uses_coord_worktree_root` — integration-level: verifies `safe_commit` receives the coord worktree root (not `repo_root`) when `feature_dir` is inside `.worktrees/`
- Updated `test_legacy_workflow_commit_refused_on_protected_target` to pass the new required `worktree_root` parameter
- Updated architectural allow-list line anchors (`test_no_write_side_rederivation.py`) for the line shift introduced by the new helper function