### PR TITLE
fix(doctor): add --fix to doctor coordination for dangling coord branches

### DIFF
--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -572,6 +572,13 @@ def _fix_never_created_branches(findings: list[DoctorFinding]) -> list[str]:
         if "coordination_branch" not in meta:
             continue
         del meta["coordination_branch"]
+        # Clear the stale stored topology so backfill_topology_repo re-derives it:
+        # backfill never overwrites an existing topology (migration/backfill_topology.py),
+        # and every mission minted post-#2069 stores `topology` at create time — leaving it
+        # would keep the mission routed through coordination (false-green flatten). Record the
+        # flatten via the provenance flag. (#2614 adversarial-squad remediation)
+        meta.pop("topology", None)
+        meta["flattened"] = True
         write_meta(mission_dir, meta, validate=False)
         fixed.append(mission_dir.name)
     return fixed

--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -538,9 +538,43 @@ def _collect_coordination_findings(repo_root: Path) -> list[DoctorFinding]:
         meta = load_meta(mission_dir, on_malformed="none")
         if meta is None:
             continue
-        findings.extend(_check_coordination_worktree_health(repo_root, meta))
+        coord_findings = _check_coordination_worktree_health(repo_root, meta)
+        for f in coord_findings:
+            if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED":
+                f.extra["meta_path"] = str(mission_dir / "meta.json")
+        findings.extend(coord_findings)
         findings.extend(_check_lane_sparse_checkout_drift(repo_root, meta))
     return findings
+
+
+def _fix_never_created_branches(findings: list[DoctorFinding]) -> list[str]:
+    """Remove stale ``coordination_branch`` keys from meta.json.
+
+    Targets only ``COORDINATION_WORKTREE_NEVER_CREATED`` findings that carry
+    a ``meta_path`` in their ``extra`` dict (populated by
+    :func:`_collect_coordination_findings`). After removal, call
+    :func:`~specify_cli.migration.backfill_topology.backfill_topology_repo` so
+    topology is re-derived from the now-absent key.
+
+    Returns a list of mission slugs that were modified.
+    """
+    from specify_cli.mission_metadata import load_meta_or_empty, write_meta
+
+    fixed: list[str] = []
+    for f in findings:
+        if f.error_code != "COORDINATION_WORKTREE_NEVER_CREATED":
+            continue
+        meta_path_str = f.extra.get("meta_path")
+        if not meta_path_str:
+            continue
+        mission_dir = Path(str(meta_path_str)).parent
+        meta = load_meta_or_empty(mission_dir)
+        if "coordination_branch" not in meta:
+            continue
+        del meta["coordination_branch"]
+        write_meta(mission_dir, meta, validate=False)
+        fixed.append(mission_dir.name)
+    return fixed
 
 
 def _emit_coordination_findings(findings: list[DoctorFinding], json_output: bool) -> None:
@@ -567,8 +601,14 @@ def _emit_coordination_findings(findings: list[DoctorFinding], json_output: bool
             console.print(f"  → {f.next_step}")
 
 
-def run_coordination_health(json_output: bool) -> None:
-    """Entry point for ``doctor coordination`` (exit 1 iff any ``error`` finding)."""
+def run_coordination_health(json_output: bool, fix: bool = False) -> None:
+    """Entry point for ``doctor coordination`` (exit 1 iff any ``error`` finding).
+
+    When *fix* is ``True``, automatically removes stale ``coordination_branch``
+    keys from ``meta.json`` for any ``COORDINATION_WORKTREE_NEVER_CREATED``
+    findings, then re-runs :func:`~specify_cli.migration.backfill_topology.backfill_topology_repo`
+    to re-derive topology from the now-absent key.
+    """
     try:
         repo_root = locate_project_root()
     except Exception as exc:
@@ -579,5 +619,24 @@ def run_coordination_health(json_output: bool) -> None:
         raise typer.Exit(1)
 
     findings = _collect_coordination_findings(repo_root)
+
+    if fix:
+        fixable = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+        if fixable:
+            fixed_slugs = _fix_never_created_branches(fixable)
+            for slug in fixed_slugs:
+                console.print(
+                    f"[green]Flattened:[/green] removed coordination_branch from {slug}/meta.json"
+                )
+            if fixed_slugs:
+                from specify_cli.migration.backfill_topology import backfill_topology_repo
+                backfill_topology_repo(repo_root)
+                console.print(
+                    "[green]Topology backfilled.[/green] "
+                    "Run `spec-kitty doctor coordination` to verify."
+                )
+            # Re-collect findings after fix so the exit code reflects the new state.
+            findings = _collect_coordination_findings(repo_root)
+
     _emit_coordination_findings(findings, json_output)
     raise typer.Exit(1 if any(f.severity == "error" for f in findings) else 0)

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -1195,6 +1195,17 @@ def _render_unsanctioned_override_findings(report: DoctrineHealthReport) -> None
 
 @app.command(name="coordination")
 def coordination_health(
+    fix: Annotated[
+        bool,
+        typer.Option(
+            "--fix",
+            help=(
+                "Remove stale coordination_branch keys from meta.json for missions "
+                "whose coord branch was never created, then re-derive topology via "
+                "`migrate backfill-topology`."
+            ),
+        ),
+    ] = False,
     json_output: Annotated[
         bool, typer.Option("--json", help="Machine-readable JSON output"),
     ] = False,
@@ -1209,5 +1220,15 @@ def coordination_health(
 
     Exits with code 1 if any ``error`` finding is emitted; ``warning``
     findings exit 0 but are still printed.
+
+    With ``--fix``, automatically flattens missions that have a stale
+    ``coordination_branch`` key (branch never created or already deleted)
+    and re-derives topology. Safe to run on 100%-done missions before
+    ``spec-kitty next`` or ``spec-kitty merge``.
+
+    Examples:
+        spec-kitty doctor coordination
+        spec-kitty doctor coordination --fix
+        spec-kitty doctor coordination --json
     """
-    run_coordination_health(json_output)
+    run_coordination_health(json_output, fix)

--- a/src/specify_cli/coordination/surface_resolver.py
+++ b/src/specify_cli/coordination/surface_resolver.py
@@ -208,9 +208,9 @@ class CoordinationBranchDeleted(StatusReadPathNotFound):  # type: ignore[misc, u
         self.next_step = (
             f"The coordination branch {coordination_branch!r} declared in "
             f"meta.json does not exist in git (never created or deleted). "
-            f"Flatten the mission by removing the `coordination_branch` key from "
-            f"meta.json (if the coordination topology was never used or was torn down), "
-            f"or recreate the worktree by running `spec-kitty doctor workspaces --fix`."
+            f"Run `spec-kitty doctor coordination --fix` to repair automatically, "
+            f"or manually remove the `coordination_branch` key from meta.json and "
+            f"run `spec-kitty migrate backfill-topology`."
         )
         super().__init__(
             repo_root=repo_root,

--- a/src/specify_cli/coordination/surface_resolver.py
+++ b/src/specify_cli/coordination/surface_resolver.py
@@ -208,9 +208,10 @@ class CoordinationBranchDeleted(StatusReadPathNotFound):  # type: ignore[misc, u
         self.next_step = (
             f"The coordination branch {coordination_branch!r} declared in "
             f"meta.json does not exist in git (never created or deleted). "
-            f"Run `spec-kitty doctor coordination --fix` to repair automatically, "
-            f"or manually remove the `coordination_branch` key from meta.json and "
-            f"run `spec-kitty migrate backfill-topology`."
+            f"Flatten the mission — drop the `coordination_branch` key from "
+            f"meta.json — to recover: run `spec-kitty doctor coordination --fix` "
+            f"to flatten automatically, or remove the key manually and run "
+            f"`spec-kitty migrate backfill-topology`."
         )
         super().__init__(
             repo_root=repo_root,
@@ -405,7 +406,28 @@ def _coord_branch_exists(repo_root: Path, coord_branch: str) -> bool:
         )
     except OSError:
         return True
-    return result.returncode == 0
+    if result.returncode == 0:
+        return True
+    # Local head absent, but a coordination branch that lives only on a remote
+    # (fresh clone, CI checkout, pruned local branch) is NOT "never created".
+    # Firing R3 here lets `doctor coordination --fix` delete a genuinely-coord
+    # mission's coordination_branch and silently flatten it (#2614 data-loss vector).
+    try:
+        remotes = subprocess.run(
+            ["git", "-C", str(repo_root), "for-each-ref", "--format=%(refname)", "refs/remotes/"],
+            check=False, capture_output=True, text=True,
+        )
+    except OSError:
+        return True
+    if remotes.returncode == 0:
+        prefix = "refs/remotes/"
+        for line in remotes.stdout.splitlines():
+            if not line.startswith(prefix):
+                continue
+            _, _, branch = line[len(prefix):].partition("/")  # <remote>/<branch...>
+            if branch == coord_branch:
+                return True
+    return False
 
 
 @dataclass(frozen=True)

--- a/tests/specify_cli/cli/commands/test_coordination_doctor.py
+++ b/tests/specify_cli/cli/commands/test_coordination_doctor.py
@@ -383,3 +383,100 @@ def test_no_doctor_merge_import_cycle() -> None:
 
     importlib.import_module("specify_cli.cli.commands.doctor")
     importlib.import_module("specify_cli.cli.commands.merge")
+
+
+# --- _fix_never_created_branches ---------------------------------------------
+
+
+def test_fix_removes_coordination_branch_key(tmp_path: Path) -> None:
+    """_fix_never_created_branches deletes coordination_branch from meta.json."""
+    import json
+
+    mission_dir = tmp_path / "kitty-specs" / "my-mission-01AB"
+    mission_dir.mkdir(parents=True)
+    meta = {"mission_slug": "my-mission-01AB", "coordination_branch": "kitty/mission-my-mission-01AB"}
+    (mission_dir / "meta.json").write_text(json.dumps(meta))
+
+    finding = cd.DoctorFinding(
+        severity="warning",
+        message="branch absent",
+        error_code="COORDINATION_WORKTREE_NEVER_CREATED",
+        extra={"meta_path": str(mission_dir / "meta.json")},
+    )
+    fixed = cd._fix_never_created_branches([finding])
+    assert fixed == ["my-mission-01AB"]
+    written = json.loads((mission_dir / "meta.json").read_text())
+    assert "coordination_branch" not in written
+
+
+def test_fix_skips_unrelated_error_codes(tmp_path: Path) -> None:
+    """_fix_never_created_branches ignores findings with other error codes."""
+    finding = cd.DoctorFinding(
+        severity="warning",
+        message="worktree missing",
+        error_code="COORDINATION_WORKTREE_MISSING",
+        extra={"meta_path": str(tmp_path / "meta.json")},
+    )
+    assert cd._fix_never_created_branches([finding]) == []
+
+
+def test_fix_skips_finding_without_meta_path(tmp_path: Path) -> None:
+    """_fix_never_created_branches is safe when meta_path is absent from extra."""
+    finding = cd.DoctorFinding(
+        severity="warning",
+        message="branch absent",
+        error_code="COORDINATION_WORKTREE_NEVER_CREATED",
+    )
+    assert cd._fix_never_created_branches([finding]) == []
+
+
+def test_fix_is_idempotent_when_key_already_absent(tmp_path: Path) -> None:
+    """_fix_never_created_branches does not list missions that had no key to remove."""
+    import json
+
+    mission_dir = tmp_path / "kitty-specs" / "already-flat-01AB"
+    mission_dir.mkdir(parents=True)
+    (mission_dir / "meta.json").write_text(json.dumps({"mission_slug": "already-flat-01AB"}))
+
+    finding = cd.DoctorFinding(
+        severity="warning",
+        message="branch absent",
+        error_code="COORDINATION_WORKTREE_NEVER_CREATED",
+        extra={"meta_path": str(mission_dir / "meta.json")},
+    )
+    assert cd._fix_never_created_branches([finding]) == []
+
+
+# --- _collect_coordination_findings injects meta_path -----------------------
+
+
+def test_collect_injects_meta_path_for_never_created_findings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_collect_coordination_findings stamps meta_path on COORDINATION_WORKTREE_NEVER_CREATED."""
+    import json
+
+    specs = tmp_path / "kitty-specs" / "demo-01AB"
+    specs.mkdir(parents=True)
+    (specs / "meta.json").write_text(
+        json.dumps({"mission_slug": "demo-01AB", "coordination_branch": "kitty/mission-demo-01AB"})
+    )
+
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+    monkeypatch.setattr(
+        cd,
+        "_check_coordination_worktree_health",
+        lambda _r, _m: [cd.DoctorFinding(
+            severity="warning",
+            message="never created",
+            error_code="COORDINATION_WORKTREE_NEVER_CREATED",
+        )],
+    )
+    monkeypatch.setattr(cd, "_check_lane_sparse_checkout_drift", lambda _r, _m: [])
+
+    findings = cd._collect_coordination_findings(tmp_path)
+    never_created = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+    assert never_created, "expected NEVER_CREATED finding from monkeypatched check"
+    assert "meta_path" in never_created[0].extra
+    assert never_created[0].extra["meta_path"].endswith("meta.json")

--- a/tests/specify_cli/cli/commands/test_doctor_cli_surface_golden.py
+++ b/tests/specify_cli/cli/commands/test_doctor_cli_surface_golden.py
@@ -95,7 +95,7 @@ EXPECTED_OPTIONS: dict[str, dict[str, str]] = {
         "--allow-dirty": "flag",
     },
     "doctrine": {"--json": "flag"},
-    "coordination": {"--json": "flag"},
+    "coordination": {"--fix": "flag", "--json": "flag"},
 }
 
 # Golden ``--help`` snapshots (whitespace-normalized) per subcommand.
@@ -378,7 +378,18 @@ EXPECTED_HELP: dict[str, list[str]] = {
         'Also runs the minimum git-version (RR-01) check.',
         'Exits with code 1 if any ``error`` finding is emitted; ``warning``',
         'findings exit 0 but are still printed.',
+        'With ``--fix``, automatically flattens missions that have a stale',
+        '``coordination_branch`` key (branch never created or already deleted)',
+        'and re-derives topology. Safe to run on 100%-done missions before',
+        '``spec-kitty next`` or ``spec-kitty merge``.',
+        'Examples:',
+        'spec-kitty doctor coordination',
+        'spec-kitty doctor coordination --fix',
+        'spec-kitty doctor coordination --json',
         'Options',
+        '--fix           Remove stale coordination_branch keys from meta.json for missions whose coord',
+        'branch was never created, then re-derive topology via `migrate',
+        'backfill-topology`.',
         '--json          Machine-readable JSON output',
         '--help          Show this message and exit.',
     ],

--- a/tests/specify_cli/cli/commands/test_doctor_coordination.py
+++ b/tests/specify_cli/cli/commands/test_doctor_coordination.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import typer
 
 from specify_cli.cli.commands.doctor import (
     DoctorFinding,
@@ -494,3 +495,186 @@ def test_fix_removes_key_and_backfill_derives_topology(fresh_mission_repo: Path)
     assert results[0].topology in ("single_branch", "lanes"), (
         "flattened mission must resolve to a non-coord topology"
     )
+
+
+# ---------------------------------------------------------------------------
+# #2614 adversarial-squad remediation: Findings 1-3
+# ---------------------------------------------------------------------------
+
+
+def test_fix_clears_stale_coord_topology_so_backfill_flattens(
+    fresh_mission_repo: Path,
+) -> None:
+    """FINDING 1 (#2614, false-green flatten): a mission with a PRE-STORED
+    ``topology: "coord"`` AND a ``coordination_branch`` whose branch was never
+    created in git must be FULLY flattened by ``--fix``.
+
+    Pre-fix: ``_fix_never_created_branches`` only deletes ``coordination_branch``;
+    it never clears the pre-existing ``topology: "coord"`` key, and
+    ``backfill_topology_repo`` never overwrites an already-valid ``topology``
+    value (``migration/backfill_topology.py`` `action="skip"`) — so the mission
+    stays routed through coordination even after ``--fix`` runs. RED on
+    unmodified code (the ``written.get("topology") != "coord"`` assertion fails).
+    """
+    from mission_runtime import routes_through_coordination
+
+    from specify_cli.cli.commands import _coordination_doctor as cd
+    from specify_cli.migration.backfill_topology import (
+        backfill_topology_repo,
+        read_topology,
+    )
+
+    spec_dir = fresh_mission_repo / "kitty-specs" / MISSION_SLUG
+    stale_meta = {
+        **_meta(),
+        "coordination_branch": "kitty/mission-never-created-00000000",
+        "topology": "coord",
+        "flattened": False,
+    }
+    (spec_dir / "meta.json").write_text(json.dumps(stale_meta))
+
+    findings = cd._collect_coordination_findings(fresh_mission_repo)
+    fixable = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+    assert fixable, "expected a NEVER_CREATED finding for the stale coord mission"
+
+    fixed = cd._fix_never_created_branches(fixable)
+    assert MISSION_SLUG in fixed
+
+    backfill_topology_repo(fresh_mission_repo, mission_slug=MISSION_SLUG)
+
+    written = json.loads((spec_dir / "meta.json").read_text())
+    assert "coordination_branch" not in written, "key must be gone after fix"
+    assert written.get("topology") != "coord", (
+        "stale topology:'coord' must be cleared by the fix so backfill re-derives "
+        "a non-coord topology — leaving it stored is a false-green flatten (#2614)"
+    )
+    assert written.get("topology") == "single_branch"
+    assert written.get("flattened") is True
+
+    assert not routes_through_coordination(read_topology(spec_dir)), (
+        "a mission flattened via --fix must no longer route through coordination"
+    )
+
+
+def test_run_coordination_health_fix_end_to_end(
+    fresh_mission_repo: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FINDING 3 (#2614, coverage gap): drive ``run_coordination_health(fix=True)``
+    end-to-end through the real entry point (no internal-function shortcuts),
+    pinning both the "fix ran" behaviour and the exit-code-after-re-collect claim.
+
+    Case A: one fixable NEVER_CREATED mission and no other error finding →
+    exit code 0 after --fix, and the fix actually mutated meta.json.
+
+    Case B: an additional UNFIXABLE ``error`` finding (tracked content under
+    ``.worktrees/`` — ``TRACKED_WORKTREES_CONTENT``) survives the fix pass →
+    exit code 1, proving the post-fix re-collect is real (not a rubber stamp).
+    """
+    from specify_cli.cli.commands import _coordination_doctor as cd
+
+    spec_dir = fresh_mission_repo / "kitty-specs" / MISSION_SLUG
+    stale_meta = {
+        **_meta(),
+        "coordination_branch": "kitty/mission-never-created-00000000",
+    }
+    (spec_dir / "meta.json").write_text(json.dumps(stale_meta))
+
+    monkeypatch.setattr(cd, "locate_project_root", lambda: fresh_mission_repo)
+
+    # ---- Case A: fixable-only → exit 0, fix actually ran ------------------
+    with pytest.raises(typer.Exit) as exc_a:
+        cd.run_coordination_health(json_output=False, fix=True)
+    assert exc_a.value.exit_code == 0, "a fully-fixed mission with no other errors must exit 0"
+    written = json.loads((spec_dir / "meta.json").read_text())
+    assert "coordination_branch" not in written, (
+        "run_coordination_health(fix=True) must actually invoke the fix, "
+        "not merely report the finding"
+    )
+
+    # ---- Case B: add an unfixable error finding, re-run --------------------
+    stale_meta_b = {
+        **_meta(),
+        "mission_slug": "second-mission-01J6ZZ00",
+        "mission_id": "01J6ZZ00ABCDEFGHJKMNPQRSTV",
+        "coordination_branch": "kitty/mission-second-never-created-00000001",
+    }
+    spec_dir_b = fresh_mission_repo / "kitty-specs" / "second-mission-01J6ZZ00"
+    spec_dir_b.mkdir(parents=True)
+    (spec_dir_b / "meta.json").write_text(json.dumps(stale_meta_b))
+    (spec_dir_b / "status.events.jsonl").write_text("{}\n")
+
+    worktrees_dir = fresh_mission_repo / ".worktrees"
+    worktrees_dir.mkdir(exist_ok=True)
+    junk = worktrees_dir / "junk.txt"
+    junk.write_text("tracked scratch content\n")
+    _git(fresh_mission_repo, "add", "-f", str(junk), str(spec_dir_b))
+    _git(fresh_mission_repo, "commit", "-q", "-m", "add tracked worktrees junk + 2nd mission")
+
+    with pytest.raises(typer.Exit) as exc_b:
+        cd.run_coordination_health(json_output=False, fix=True)
+    assert exc_b.value.exit_code == 1, (
+        "an unfixable error finding (TRACKED_WORKTREES_CONTENT) must survive "
+        "the fix pass and force a non-zero exit code"
+    )
+    written_b = json.loads((spec_dir_b / "meta.json").read_text())
+    assert "coordination_branch" not in written_b, (
+        "the second mission's fixable NEVER_CREATED finding must still be fixed "
+        "even though an unrelated error finding keeps the overall exit non-zero"
+    )
+
+
+def test_never_created_check_treats_remote_only_branch_as_present(
+    fresh_mission_repo: Path,
+) -> None:
+    """FINDING 2 (#2614, data-loss vector): a coordination_branch that lives
+    ONLY as a remote-tracking ref (fresh clone / CI checkout / pruned local
+    branch) must NOT be classified NEVER_CREATED.
+
+    Pre-fix: ``_coord_branch_exists`` probes ``refs/heads/<branch>`` only, so a
+    remote-only branch reads as absent → NEVER_CREATED fires → ``--fix`` would
+    delete ``coordination_branch`` from a genuinely-coord mission and silently
+    flatten it. RED on unmodified code (the ``not never_created`` assertion
+    fails because a NEVER_CREATED finding IS produced).
+    """
+    remote_only_branch = "kitty/mission-remote-only-01J6XW9K"
+    spec_dir = fresh_mission_repo / "kitty-specs" / MISSION_SLUG
+    meta = {**_meta(), "coordination_branch": remote_only_branch}
+    (spec_dir / "meta.json").write_text(json.dumps(meta))
+
+    head_sha = subprocess.check_output(
+        ["git", "-C", str(fresh_mission_repo), "rev-parse", "HEAD"], text=True,
+    ).strip()
+    _git(
+        fresh_mission_repo, "update-ref",
+        f"refs/remotes/origin/{remote_only_branch}", head_sha,
+    )
+
+    from specify_cli.cli.commands import _coordination_doctor as cd
+
+    findings = cd._collect_coordination_findings(fresh_mission_repo)
+    never_created = [
+        f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"
+    ]
+    assert not never_created, (
+        "a coordination_branch present only as a remote-tracking ref must NOT be "
+        "treated as never-created — firing NEVER_CREATED here lets --fix delete "
+        "a genuinely-coord mission's coordination_branch and silently flatten it "
+        "(#2614 data-loss vector)"
+    )
+
+
+def test_coordination_branch_deleted_next_step_message_pin(tmp_path: Path) -> None:
+    """Pin the ``CoordinationBranchDeleted.next_step`` operator-recovery text so
+    a future reword cannot silently drop either recovery command (#2614)."""
+    from specify_cli.coordination.surface_resolver import CoordinationBranchDeleted
+
+    err = CoordinationBranchDeleted(
+        repo_root=tmp_path,
+        mission_slug=MISSION_SLUG,
+        mid8=MID8,
+        coordination_branch=COORD_BRANCH,
+        coord_candidate=tmp_path / ".worktrees" / f"{MISSION_SLUG}-coord",
+        primary_candidate=tmp_path / "kitty-specs" / MISSION_SLUG,
+    )
+    assert "spec-kitty doctor coordination --fix" in err.next_step
+    assert "spec-kitty migrate backfill-topology" in err.next_step

--- a/tests/specify_cli/cli/commands/test_doctor_coordination.py
+++ b/tests/specify_cli/cli/commands/test_doctor_coordination.py
@@ -434,3 +434,63 @@ def test_coord_worktree_needs_refresh_detached_head(
     stale, branch = wh._coord_worktree_needs_refresh(wt, fresh_mission_repo)
     assert stale is False
     assert branch == ""
+
+
+# ---------------------------------------------------------------------------
+# _fix_never_created_branches / --fix end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_collect_injects_meta_path_on_real_repo(fresh_mission_repo: Path) -> None:
+    """_collect_coordination_findings stamps meta_path for NEVER_CREATED findings."""
+    from specify_cli.cli.commands import _coordination_doctor as cd
+
+    spec_dir = fresh_mission_repo / "kitty-specs" / MISSION_SLUG
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    # Override meta with a branch that was never created.
+    stale_meta = {
+        **_meta(),
+        "coordination_branch": "kitty/mission-never-created-00000000",
+    }
+    (spec_dir / "meta.json").write_text(json.dumps(stale_meta))
+
+    findings = cd._collect_coordination_findings(fresh_mission_repo)
+    never_created = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+    assert never_created, "expected NEVER_CREATED finding for absent coord branch"
+    assert "meta_path" in never_created[0].extra, (
+        "_collect must inject meta_path so --fix knows which file to patch"
+    )
+
+
+def test_fix_removes_key_and_backfill_derives_topology(fresh_mission_repo: Path) -> None:
+    """_fix_never_created_branches removes stale key; backfill_topology_repo then
+    writes a non-coord topology for the mission.
+    """
+    from specify_cli.cli.commands import _coordination_doctor as cd
+    from specify_cli.migration.backfill_topology import backfill_topology_repo
+
+    spec_dir = fresh_mission_repo / "kitty-specs" / MISSION_SLUG
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    stale_meta = {
+        **_meta(),
+        "coordination_branch": "kitty/mission-never-created-00000000",
+    }
+    (spec_dir / "meta.json").write_text(json.dumps(stale_meta))
+
+    findings = cd._collect_coordination_findings(fresh_mission_repo)
+    fixable = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+    assert fixable
+
+    fixed = cd._fix_never_created_branches(fixable)
+    assert MISSION_SLUG in fixed
+
+    written = json.loads((spec_dir / "meta.json").read_text())
+    assert "coordination_branch" not in written, "key must be gone after fix"
+
+    # backfill-topology should now succeed (no stale key to block it).
+    results = backfill_topology_repo(fresh_mission_repo, mission_slug=MISSION_SLUG)
+    assert results, "backfill must visit the mission"
+    assert results[0].action == "wrote", f"expected 'wrote', got {results[0].action!r}"
+    assert results[0].topology in ("single_branch", "lanes"), (
+        "flattened mission must resolve to a non-coord topology"
+    )

--- a/tests/specify_cli/coordination/test_surface_resolver.py
+++ b/tests/specify_cli/coordination/test_surface_resolver.py
@@ -273,7 +273,7 @@ def test_coordination_branch_deleted_raised_when_branch_gone(tmp_path: Path) -> 
     err = excinfo.value
     assert err.error_code == "COORDINATION_BRANCH_DELETED"
     assert err.coordination_branch == "kitty/mission-my-mission-01KTDVHZ-coord"
-    assert "doctor workspaces --fix" in err.next_step
+    assert "doctor coordination --fix" in err.next_step
 
 
 def test_coord_mid8_derived_from_slug_when_meta_lacks_id(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Missions whose `meta.json` carries a `coordination_branch` key pointing to a git branch that was never created are completely unreachable. `spec-kitty next` hard-errors with `CoordinationBranchDeleted`, and there is no automated recovery path — `doctor coordination` correctly diagnoses the issue but has no `--fix` flag to act on it. Operators must manually edit `meta.json` and run `migrate backfill-topology`.

A consumer repo reported 7 missions stuck in this state, all 100% done but locked out of close/review/merge.

## Fix

`doctor coordination --fix` now automatically repairs missions with `COORDINATION_WORKTREE_NEVER_CREATED` findings:

1. Removes the stale `coordination_branch` key from `meta.json` (via `write_meta(validate=False)` to tolerate legacy missions).
2. Runs `backfill_topology_repo` so topology is re-derived from the now-absent key (`SINGLE_BRANCH` or `LANES`).
3. Re-collects findings so the exit code reflects the repaired state.

Also improves the `CoordinationBranchDeleted` error message to lead with `spec-kitty doctor coordination --fix` rather than the manual edit steps.

## Technical details

- `_collect_coordination_findings` now stamps `extra["meta_path"]` on every `COORDINATION_WORKTREE_NEVER_CREATED` finding so the fixer knows which file to patch without a second filesystem scan.
- New `_fix_never_created_branches(findings)` does the key removal.
- `run_coordination_health` gains a `fix: bool` param; `doctor.py` wires it to `--fix` with a clear help string and usage examples.

## Why this approach

The doctor already had full diagnosis. Adding `--fix` completes the feature rather than punting to a separate migrate subcommand. Using `write_meta(validate=False)` is the established pattern for tolerant writes to legacy meta files. Re-collecting findings after the fix (rather than filtering the original list) means the exit code is always ground-truth.

The upstream write-site bug (coordination_branch written before branch creation) was already fixed in the current codebase — `mission_creation.py:435` only writes after `ensure_coordination_branch()` succeeds. The stuck missions are a legacy artifact.

## Test plan

- [ ] 4 fast unit tests for `_fix_never_created_branches`: removes key, skips wrong error codes, skips missing `meta_path`, idempotent when key already absent
- [ ] 1 fast unit test: `_collect_coordination_findings` injects `meta_path` on `COORDINATION_WORKTREE_NEVER_CREATED` findings
- [ ] 1 git_repo integration test: `_collect` injects `meta_path` on a real repo with a stale coord branch
- [ ] 1 git_repo integration test: full fix+backfill round-trip — key removed, `backfill_topology_repo` writes `single_branch` topology