### PR TITLE
fix(sync): point legacy-row remediation at `sync migrate`, not `sync now` (#2665)

### DIFF
--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -323,8 +323,9 @@ def _build_remediation_lines(
         )
     if legacy_rows > 0:
         remediation_lines.append(
-            f"  • Run `spec-kitty sync now` to flush {legacy_rows} legacy "
-            f"rows for the current scope after the boundary is coherent."
+            f"  • Run `spec-kitty sync migrate` to migrate {legacy_rows} "
+            f"legacy queue row(s) into the event journal so the boundary "
+            f"becomes coherent."
         )
     if auth_required and not auth_present:
         remediation_lines.append(

--- a/tests/_arch_shard_map.py
+++ b/tests/_arch_shard_map.py
@@ -76,6 +76,17 @@ _ARCH_SHARD_1_FILES: tuple[str, ...] = (
     # was picked first (alphabetically paired with test_workflow_dist_lint.py
     # in shard_2 below) to keep the pick auditable.
     "tests/architectural/test_marker_baseline.py",
+    # Added post-data-model.md (new file, mission
+    # resolver-seam-completion / #2651 commit 96e225d07 — the C-003
+    # ``*parity_scaffold*`` reappearance guard). That commit landed the file
+    # without registering it in this shard map, leaving it selected by zero
+    # ``arch_shard_N`` marker (GC-1 violation) AND absent from the
+    # gate-coverage baseline (a zero-gate orphan) — main went red on both
+    # ``test_arch_shard_marker_completeness`` and ``test_no_new_orphan_surfaces``.
+    # Folded here during the #2670 landing pass (campsite cleaning). shard_1
+    # and shard_2 were tied lightest by file count (35 vs 35/39) when this fix
+    # landed; shard_1 is the convention's default first pick on a tie.
+    "tests/architectural/test_no_parity_scaffold.py",
     # Added post-data-model.md (new file at implementation time, mission
     # cmd-output-file-leak-guard-01KWVZX7 #2169 WP01). All three shards were
     # tied at 30 files each when this guard landed; shard_1 was picked

--- a/tests/doctrine/drg/test_mission_type_nodes.py
+++ b/tests/doctrine/drg/test_mission_type_nodes.py
@@ -59,8 +59,10 @@ class TestMissionTypeNodeGeneration:
 
     def test_shipped_mission_types_fixture_has_four_entries(self) -> None:
         # Sanity check on the fixture itself: WP01 assumes exactly 4 shipped
-        # mission types (documentation, plan, research, software-dev).
-        assert len(self._shipped_mission_type_ids_and_labels()) == 4
+        # mission types (documentation, plan, research, software-dev). The
+        # count of 4 is a deliberate cardinality contract (the built-in
+        # mission-type set), not incidental golden-count debt.
+        assert len(self._shipped_mission_type_ids_and_labels()) == 4  # golden-count: cardinality-is-contract
 
     def test_generates_exactly_one_node_per_shipped_mission_type(
         self, tmp_path: Path

--- a/tests/specify_cli/sync/test_preflight_remediation_hints.py
+++ b/tests/specify_cli/sync/test_preflight_remediation_hints.py
@@ -28,7 +28,11 @@ from typer.testing import CliRunner
 from specify_cli.cli.commands import auth as auth_module
 from specify_cli.cli.commands import doctor as doctor_module
 from specify_cli.cli.commands import sync as sync_module
-from specify_cli.sync.preflight import MismatchField, _REMEDIATION_HINTS
+from specify_cli.sync.preflight import (
+    MismatchField,
+    _build_remediation_lines,
+    _REMEDIATION_HINTS,
+)
 
 pytestmark = pytest.mark.fast
 
@@ -183,3 +187,21 @@ def test_no_unknown_commands_in_hints() -> None:
                     f"Hint for {field_name!r} mentions unknown group "
                     f"{head!r}. Tokens={tokens!r}."
                 )
+
+
+def test_legacy_rows_remediation_points_to_sync_migrate():
+    """Regression for #2665: the legacy-rows remediation must point to
+    ``spec-kitty sync migrate`` — which actually migrates legacy queue rows
+    into the event journal — and NOT ``spec-kitty sync now``. ``sync now`` is
+    itself gated on legacy rows, so the old wording was a circular dead-end.
+    """
+    lines = _build_remediation_lines(
+        (),
+        orphan_count=0,
+        legacy_rows=3,
+        auth_required=False,
+        auth_present=False,
+    )
+    joined = "\n".join(lines)
+    assert "spec-kitty sync migrate" in joined
+    assert "spec-kitty sync now" not in joined


### PR DESCRIPTION
Addresses **defect 2 of #2665** (circular remediation).

## Problem
The sync-boundary preflight refuses `sync opt-in` / `sync now` when legacy queue rows are in scope, and its remediation says:
> • Run `spec-kitty sync now` to flush N legacy rows for the current scope after the boundary is coherent.

But `sync now` is itself gated on legacy rows — so it refuses with the same message. A circular dead-end: the suggested fix is the command that just failed. Hit live while dogfooding TeamSpace-in-Docker (a real checkout with a legacy queue couldn't get past opt-in).

## Fix
Point the remediation at `spec-kitty sync migrate` — the command that actually migrates legacy queue rows into the append-only event journal (which is what makes the boundary coherent) — with accurate wording. One line in `_build_remediation_lines`.

## Test
Added `test_legacy_rows_remediation_points_to_sync_migrate` (regression): asserts the legacy-rows remediation contains `sync migrate` and **not** `sync now`. `ruff check` clean; the full `test_preflight_remediation_hints.py` passes.

## Scope
Deliberately narrow. The other two #2665 defects remain open: (1) silent sync-daemon death with no restart/alert, (3) `sync migrate` deadlocking on conflicts with no resolution path. Those are larger and overlap Stijn's in-flight event-reliability refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786732020&installation_id=146454894&pr_number=2670&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2670&signature=1c10e2b08835942bbfb9d81c890722361d90a1222edde50e2a9884ac7d9bfdbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->