### PR TITLE
fix(sync): converge legacy-row boundary after a clean queue→journal migrate (#2665)

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1396,7 +1396,8 @@ def _auto_converge_legacy_on_enable() -> None:
     surfaced with the explicit ``sync migrate --resolve-conflicts keep-journal``
     recovery, and the coherence gate that follows still refuses until they are
     resolved. Idempotent and lossless: a no-op on an already-converged runtime.
-    Any runtime-open failure is swallowed so the coherence gate handles it.
+    Any failure opening the runtime OR converging is swallowed so the coherence
+    gate that follows handles it, rather than aborting opt-in with a traceback.
     """
     from specify_cli.paths import get_runtime_root
     from specify_cli.sync.migrate_journal import (
@@ -1420,10 +1421,13 @@ def _auto_converge_legacy_on_enable() -> None:
             resolve_conflicts=False,
             cleanup=True,
         )
+    except Exception:  # converge failed — let the coherence gate report it
+        return
     finally:
         with contextlib.suppress(Exception):
             audit.close()
-        runtime.close()
+        with contextlib.suppress(Exception):
+            runtime.close()
 
     deleted = converge.cleanup.total_deleted if converge.cleanup is not None else 0
     if deleted:

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1386,6 +1386,58 @@ def opt_out(
     )
 
 
+def _auto_converge_legacy_on_enable() -> None:
+    """Converge any legacy queue residue into the journal when enabling sync (#2665).
+
+    Turning sync on for a checkout should make it coherent, not refuse. Runs the
+    clean-path convergence (import + cleanup) so the legacy-row boundary clears.
+    Divergent-duplicate conflicts are deliberately NOT auto-resolved here (that
+    would discard superseded source data, even if quarantined) — they are
+    surfaced with the explicit ``sync migrate --resolve-conflicts keep-journal``
+    recovery, and the coherence gate that follows still refuses until they are
+    resolved. Idempotent and lossless: a no-op on an already-converged runtime.
+    Any runtime-open failure is swallowed so the coherence gate handles it.
+    """
+    from specify_cli.paths import get_runtime_root
+    from specify_cli.sync.migrate_journal import (
+        AUDIT_DB_NAME,
+        MigrationAudit,
+        converge_legacy_runtime,
+    )
+
+    spec_kitty_dir = get_runtime_root().base
+    try:
+        runtime = _open_event_sync_runtime()
+    except Exception:  # runtime unavailable — let the coherence gate report it
+        return
+    audit = MigrationAudit(spec_kitty_dir / AUDIT_DB_NAME)
+    try:
+        converge = converge_legacy_runtime(
+            spec_kitty_dir,
+            journal=runtime.journal,
+            audit=audit,
+            resolved_target=runtime.target,
+            resolve_conflicts=False,
+            cleanup=True,
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            audit.close()
+        runtime.close()
+
+    deleted = converge.cleanup.total_deleted if converge.cleanup is not None else 0
+    if deleted:
+        console.print(
+            f"[green]✓[/green] Converged {deleted} legacy queue row(s) into the event journal."
+        )
+    if converge.blocked_conflicts:
+        console.print(
+            f"[yellow]{converge.blocked_conflicts} divergent-duplicate conflict(s) remain. "
+            "Run `spec-kitty sync migrate --resolve-conflicts keep-journal` to resolve them, "
+            "then re-run opt-in.[/yellow]"
+        )
+
+
 @app.command(name="opt-in")
 def opt_in(
     checkout_only: bool = typer.Option(
@@ -1397,14 +1449,20 @@ def opt_in(
     """Enable SaaS sync for this checkout."""
     from specify_cli.sync.routing import enable_checkout_sync
 
-    _require_daemon_owner_coherence("spec-kitty sync opt-in")
-
     if not is_saas_sync_enabled():
         # Non-green + non-zero (#2264 item 3): opt-in cannot take effect while
         # the rollout flag is off, so a dim exit-0 "success" is misleading.
         # Surface the disabled state clearly and exit non-zero.
         console.print(f"[yellow]{saas_sync_disabled_message()}[/yellow]")
         raise typer.Exit(1)
+
+    # Turning sync on converges any legacy queue residue into the journal so the
+    # boundary is coherent instead of refusing (#2665). Conservative: clean-path
+    # only; divergent-duplicate conflicts are surfaced for an explicit
+    # `sync migrate --resolve-conflicts keep-journal` before opt-in can proceed.
+    _auto_converge_legacy_on_enable()
+
+    _require_daemon_owner_coherence("spec-kitty sync opt-in")
 
     enforce_teamspace_mission_state_ready(
         console=console,

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from specify_cli.delivery.retention import RetentionResult
     from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
     from specify_cli.event_journal.journal import EventJournal
-    from specify_cli.sync.migrate_journal import MigrationAudit, MigrationResult
+    from specify_cli.sync.migrate_journal import CleanupResult, MigrationAudit, MigrationResult
     from specify_cli.sync.target_authority import ResolvedSyncTarget
 
 from specify_cli.cli.commands._auth_recovery import (
@@ -834,6 +834,23 @@ def _print_migration_result(result: MigrationResult) -> None:
                 f"[red]Source {source.digest} failed[/red]: {source.error}"
             )
     console.print(f"[dim]{result.note}[/dim]")
+
+
+def _print_cleanup_result(cleanup: CleanupResult) -> None:
+    """Render the post-migration source-queue cleanup (#2665)."""
+    if not cleanup.ran:
+        return
+    console.print(
+        "Source cleanup: "
+        f"[green]deleted {cleanup.total_deleted}[/green] migrated row(s) "
+        f"from {cleanup.sources_cleaned} source queue(s) "
+        "(boundary now converges; sync now / opt-in no longer refuse)."
+    )
+    for outcome in cleanup.outcomes:
+        if outcome.error:
+            console.print(
+                f"[red]Cleanup error on source {outcome.digest}[/red]: {outcome.error}"
+            )
 
 
 def _run_event_sync_dispatch() -> DispatchSummary | None:
@@ -1973,28 +1990,46 @@ def archive() -> None:
 
 
 @app.command()
-def migrate() -> None:
+def migrate(
+    no_cleanup: bool = typer.Option(
+        False,
+        "--no-cleanup",
+        help=(
+            "Import into the journal but do NOT delete the migrated rows from the "
+            "source queues. Use to inspect the migration before the legacy-row "
+            "boundary is converged; re-run `sync migrate` (without the flag) to clean up."
+        ),
+    ),
+) -> None:
     """Migrate legacy hash-scoped queue DBs into the append-only event journal.
 
     Lifts every currently-queued payload from the legacy ``queue.db`` and each
     scoped ``queues/queue-<digest>.db`` into the WP03 event journal, recording
     per-source provenance and quarantining divergent-duplicate collisions into
-    the migration-audit store. Source DBs are opened read-only and are never
-    modified. Exits non-zero when an unresolved conflict blocks cleanup (SC-011).
+    the migration-audit store. Import opens source DBs read-only.
+
+    On a clean migration (no conflicts, no source errors) the migrated rows are
+    then deleted from their source queues so the legacy-row boundary converges
+    and ``sync now`` / ``sync opt-in`` stop refusing (#2665). Pass
+    ``--no-cleanup`` to skip that step and inspect first. Exits non-zero when an
+    unresolved conflict blocks cleanup (SC-011).
 
     Examples:
         spec-kitty sync migrate
+        spec-kitty sync migrate --no-cleanup
     """
     from specify_cli.paths import get_runtime_root
     from specify_cli.sync.migrate_journal import (
         AUDIT_DB_NAME,
         MigrationAudit,
+        cleanup_migrated_sources,
         migrate_queues_to_journal,
     )
 
     spec_kitty_dir = get_runtime_root().base
     runtime = _open_event_sync_runtime()
     audit = MigrationAudit(spec_kitty_dir / AUDIT_DB_NAME)
+    cleanup = None
     try:
         result = migrate_queues_to_journal(
             spec_kitty_dir,
@@ -2002,11 +2037,20 @@ def migrate() -> None:
             audit=audit,
             resolved_target=runtime.target,
         )
+        if not no_cleanup and not result.cleanup_blocked:
+            cleanup = cleanup_migrated_sources(
+                spec_kitty_dir,
+                journal=runtime.journal,
+                audit=audit,
+                result=result,
+            )
     finally:
         with contextlib.suppress(Exception):
             audit.close()
         runtime.close()
     _print_migration_result(result)
+    if cleanup is not None:
+        _print_cleanup_result(cleanup)
     if result.exit_code != 0:
         raise typer.Exit(result.exit_code)
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from specify_cli.sync.migrate_journal import (
         CleanupResult,
         ConflictResolution,
+        ConvergeResult,
         MigrationAudit,
         MigrationResult,
     )
@@ -2059,9 +2060,7 @@ def migrate(
     from specify_cli.sync.migrate_journal import (
         AUDIT_DB_NAME,
         MigrationAudit,
-        cleanup_migrated_sources,
-        migrate_queues_to_journal,
-        resolve_conflicts_keep_journal,
+        converge_legacy_runtime,
     )
 
     if resolve_conflicts is not None and resolve_conflicts != "keep-journal":
@@ -2074,47 +2073,26 @@ def migrate(
     spec_kitty_dir = get_runtime_root().base
     runtime = _open_event_sync_runtime()
     audit = MigrationAudit(spec_kitty_dir / AUDIT_DB_NAME)
-    cleanup = None
-    resolution = None
     try:
-        result = migrate_queues_to_journal(
+        converge: ConvergeResult = converge_legacy_runtime(
             spec_kitty_dir,
             journal=runtime.journal,
             audit=audit,
             resolved_target=runtime.target,
+            resolve_conflicts=(resolve_conflicts == "keep-journal"),
+            cleanup=not no_cleanup,
         )
-        if resolve_conflicts == "keep-journal" and result.conflicts:
-            resolution = resolve_conflicts_keep_journal(
-                spec_kitty_dir,
-                journal=runtime.journal,
-                audit=audit,
-            )
-            # Re-run the migration now the conflicts are resolved so the result
-            # (and the cleanup gate below) reflects the converged state.
-            result = migrate_queues_to_journal(
-                spec_kitty_dir,
-                journal=runtime.journal,
-                audit=audit,
-                resolved_target=runtime.target,
-            )
-        if not no_cleanup and not result.cleanup_blocked:
-            cleanup = cleanup_migrated_sources(
-                spec_kitty_dir,
-                journal=runtime.journal,
-                audit=audit,
-                result=result,
-            )
     finally:
         with contextlib.suppress(Exception):
             audit.close()
         runtime.close()
-    _print_migration_result(result)
-    if resolution is not None:
-        _print_resolution_result(resolution)
-    if cleanup is not None:
-        _print_cleanup_result(cleanup)
-    if result.exit_code != 0:
-        raise typer.Exit(result.exit_code)
+    _print_migration_result(converge.migration)
+    if converge.resolution is not None:
+        _print_resolution_result(converge.resolution)
+    if converge.cleanup is not None:
+        _print_cleanup_result(converge.cleanup)
+    if converge.migration.exit_code != 0:
+        raise typer.Exit(converge.migration.exit_code)
 
 
 @app.command()

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -31,7 +31,12 @@ if TYPE_CHECKING:
     from specify_cli.delivery.retention import RetentionResult
     from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
     from specify_cli.event_journal.journal import EventJournal
-    from specify_cli.sync.migrate_journal import CleanupResult, MigrationAudit, MigrationResult
+    from specify_cli.sync.migrate_journal import (
+        CleanupResult,
+        ConflictResolution,
+        MigrationAudit,
+        MigrationResult,
+    )
     from specify_cli.sync.target_authority import ResolvedSyncTarget
 
 from specify_cli.cli.commands._auth_recovery import (
@@ -851,6 +856,21 @@ def _print_cleanup_result(cleanup: CleanupResult) -> None:
             console.print(
                 f"[red]Cleanup error on source {outcome.digest}[/red]: {outcome.error}"
             )
+
+
+def _print_resolution_result(resolution: ConflictResolution) -> None:
+    """Render keep-journal conflict resolution (#2665)."""
+    console.print(
+        "Conflict resolution (keep-journal): "
+        f"[green]resolved {resolution.resolved_count}[/green] (archived to quarantine)  "
+        f"[yellow]skipped {len(resolution.skipped)}[/yellow]  "
+        f"already-absent {len(resolution.already_absent)}"
+    )
+    if resolution.skipped:
+        console.print(
+            "[yellow]Skipped conflicts are not yet canonical in the journal or their "
+            "source is gone — left intact.[/yellow]"
+        )
 
 
 def _run_event_sync_dispatch() -> DispatchSummary | None:
@@ -2000,6 +2020,16 @@ def migrate(
             "boundary is converged; re-run `sync migrate` (without the flag) to clean up."
         ),
     ),
+    resolve_conflicts: str = typer.Option(
+        None,
+        "--resolve-conflicts",
+        help=(
+            "Resolve divergent-duplicate conflicts so the boundary can converge. "
+            "Only `keep-journal` is supported: the journal payload is canonical, so "
+            "each conflicting source row is archived (quarantined) then removed. "
+            "Explicit operator recovery; never overwrites the journal."
+        ),
+    ),
 ) -> None:
     """Migrate legacy hash-scoped queue DBs into the append-only event journal.
 
@@ -2011,12 +2041,19 @@ def migrate(
     On a clean migration (no conflicts, no source errors) the migrated rows are
     then deleted from their source queues so the legacy-row boundary converges
     and ``sync now`` / ``sync opt-in`` stop refusing (#2665). Pass
-    ``--no-cleanup`` to skip that step and inspect first. Exits non-zero when an
-    unresolved conflict blocks cleanup (SC-011).
+    ``--no-cleanup`` to skip that step and inspect first.
+
+    Divergent-duplicate conflicts (same ``event_id``, different payload than the
+    journal) block cleanup by default. Pass ``--resolve-conflicts keep-journal``
+    to resolve them journal-wins: each conflicting source payload is archived to
+    the audit quarantine and the source row removed, so the boundary can
+    converge. The journal is never overwritten. Exits non-zero when unresolved
+    conflicts still block cleanup (SC-011).
 
     Examples:
         spec-kitty sync migrate
         spec-kitty sync migrate --no-cleanup
+        spec-kitty sync migrate --resolve-conflicts keep-journal
     """
     from specify_cli.paths import get_runtime_root
     from specify_cli.sync.migrate_journal import (
@@ -2024,12 +2061,21 @@ def migrate(
         MigrationAudit,
         cleanup_migrated_sources,
         migrate_queues_to_journal,
+        resolve_conflicts_keep_journal,
     )
+
+    if resolve_conflicts is not None and resolve_conflicts != "keep-journal":
+        console.print(
+            f"[red]Unknown --resolve-conflicts strategy '{resolve_conflicts}'. "
+            "Only 'keep-journal' is supported.[/red]"
+        )
+        raise typer.Exit(2)
 
     spec_kitty_dir = get_runtime_root().base
     runtime = _open_event_sync_runtime()
     audit = MigrationAudit(spec_kitty_dir / AUDIT_DB_NAME)
     cleanup = None
+    resolution = None
     try:
         result = migrate_queues_to_journal(
             spec_kitty_dir,
@@ -2037,6 +2083,20 @@ def migrate(
             audit=audit,
             resolved_target=runtime.target,
         )
+        if resolve_conflicts == "keep-journal" and result.conflicts:
+            resolution = resolve_conflicts_keep_journal(
+                spec_kitty_dir,
+                journal=runtime.journal,
+                audit=audit,
+            )
+            # Re-run the migration now the conflicts are resolved so the result
+            # (and the cleanup gate below) reflects the converged state.
+            result = migrate_queues_to_journal(
+                spec_kitty_dir,
+                journal=runtime.journal,
+                audit=audit,
+                resolved_target=runtime.target,
+            )
         if not no_cleanup and not result.cleanup_blocked:
             cleanup = cleanup_migrated_sources(
                 spec_kitty_dir,
@@ -2049,6 +2109,8 @@ def migrate(
             audit.close()
         runtime.close()
     _print_migration_result(result)
+    if resolution is not None:
+        _print_resolution_result(resolution)
     if cleanup is not None:
         _print_cleanup_result(cleanup)
     if result.exit_code != 0:

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -166,6 +166,15 @@ CREATE TABLE IF NOT EXISTS migration_conflicts (
     recorded_at   TEXT NOT NULL,
     PRIMARY KEY (event_id, source_digest)
 );
+CREATE TABLE IF NOT EXISTS quarantined_conflicts (
+    event_id      TEXT NOT NULL,
+    source_digest TEXT NOT NULL,
+    payload       BLOB NOT NULL,
+    existing_sha  TEXT NOT NULL,
+    incoming_sha  TEXT NOT NULL,
+    resolved_at   TEXT NOT NULL,
+    PRIMARY KEY (event_id, source_digest)
+);
 """
 
 
@@ -296,6 +305,40 @@ class MigrationAudit:
     def has_conflicts(self) -> bool:
         row = self._conn.execute("SELECT 1 FROM migration_conflicts LIMIT 1").fetchone()
         return row is not None
+
+    def quarantine_conflict(
+        self,
+        *,
+        event_id: str,
+        source_digest: str,
+        payload: bytes,
+        existing_sha: str,
+        incoming_sha: str,
+    ) -> None:
+        """Archive a divergent source payload before its source row is deleted.
+
+        Idempotent on ``(event_id, source_digest)`` so a re-run never duplicates
+        the archive. This preserves the superseded source copy — keep-journal
+        resolution converges the boundary without ever losing data.
+        """
+        self._conn.execute(
+            "INSERT OR IGNORE INTO quarantined_conflicts "
+            "(event_id, source_digest, payload, existing_sha, incoming_sha, resolved_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (event_id, source_digest, payload, existing_sha, incoming_sha, now_utc_iso()),
+        )
+
+    def clear_conflict(self, event_id: str, source_digest: str) -> None:
+        """Remove a resolved conflict from the active conflict table."""
+        self._conn.execute(
+            "DELETE FROM migration_conflicts WHERE event_id = ? AND source_digest = ?",
+            (event_id, source_digest),
+        )
+
+    def quarantined_count(self) -> int:
+        """Return the number of archived (quarantined) conflict payloads."""
+        row = self._conn.execute("SELECT COUNT(*) FROM quarantined_conflicts").fetchone()
+        return int(row[0]) if row else 0
 
 
 # --- per-source outcomes + overall result ---------------------------------
@@ -757,12 +800,95 @@ def cleanup_migrated_sources(
     return cleanup
 
 
+# --- keep-journal conflict resolution (#2665, explicit operator recovery) --
+
+
+@dataclass
+class ConflictResolution:
+    """Outcome of one :func:`resolve_conflicts_keep_journal` run."""
+
+    resolved: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    already_absent: list[str] = field(default_factory=list)
+
+    @property
+    def resolved_count(self) -> int:
+        return len(self.resolved)
+
+
+def _read_row_payload(source_path: Path, event_id: str) -> bytes | None:
+    """Return one queued row's canonical payload from *source_path* (read-only)."""
+    for row in _read_queued_rows(source_path):
+        if row.event_id == event_id:
+            return _canonical_payload(row.data)
+    return None
+
+
+def resolve_conflicts_keep_journal(
+    spec_kitty_dir: Path,
+    *,
+    journal: EventJournal,
+    audit: MigrationAudit,
+) -> ConflictResolution:
+    """Resolve divergent-duplicate conflicts by keeping the journal (canonical).
+
+    An explicit operator recovery path for the migrate-conflict deadlock: when a
+    source row and the journal disagree on the canonical payload for the same
+    ``event_id``, the migration quarantines it and blocks cleanup (FR-018), and
+    there is otherwise no way to converge the boundary. This resolves each such
+    conflict *journal-wins*:
+
+    1. only when the ``event_id`` is durable in the journal (the journal copy is
+       canonical/delivered; a conflict whose id is not in the journal is left
+       intact — never dropped);
+    2. archive the divergent SOURCE payload to the audit quarantine (nothing is
+       lost — the superseded copy is recoverable);
+    3. delete that row from its source queue by id; and
+    4. clear the conflict record so cleanup is no longer blocked.
+
+    The journal payload is never overwritten and no ``event_id`` is rewritten
+    (C-005/FR-018) — only the superseded source copy is removed, after it is
+    preserved. This is the only contract-legal resolution direction.
+    """
+    resolution = ConflictResolution()
+    conflicts = audit.conflicts()
+    if not conflicts:
+        return resolution
+    sources = {source.digest: source for source in discover_source_dbs(spec_kitty_dir)}
+    for conflict in conflicts:
+        if journal.read_by_id(conflict.event_id) is None:
+            resolution.skipped.append(conflict.event_id)  # not canonical yet — keep it
+            continue
+        source = sources.get(conflict.source_digest)
+        if source is None:
+            resolution.skipped.append(conflict.event_id)  # source gone from disk
+            continue
+        payload = _read_row_payload(source.path, conflict.event_id)
+        if payload is None:  # row already absent from source — just clear the record
+            audit.clear_conflict(conflict.event_id, conflict.source_digest)
+            resolution.already_absent.append(conflict.event_id)
+            continue
+        audit.quarantine_conflict(
+            event_id=conflict.event_id,
+            source_digest=conflict.source_digest,
+            payload=payload,
+            existing_sha=conflict.existing_sha,
+            incoming_sha=conflict.incoming_sha,
+        )
+        _delete_migrated_rows(source.path, [conflict.event_id])
+        audit.clear_conflict(conflict.event_id, conflict.source_digest)
+        resolution.resolved.append(conflict.event_id)
+    audit.commit()
+    return resolution
+
+
 __all__ = [
     "AUDIT_DB_NAME",
     "KNOWN_PREFIX",
     "LEGACY_DIGEST",
     "MIGRATION_NOTE",
     "CleanupResult",
+    "ConflictResolution",
     "MigrationAudit",
     "MigrationConflict",
     "MigrationResult",
@@ -773,4 +899,5 @@ __all__ = [
     "discover_source_dbs",
     "migrate_queues_to_journal",
     "migration_target_token",
+    "resolve_conflicts_keep_journal",
 ]

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -762,7 +762,6 @@ __all__ = [
     "KNOWN_PREFIX",
     "LEGACY_DIGEST",
     "MIGRATION_NOTE",
-    "CleanupOutcome",
     "CleanupResult",
     "MigrationAudit",
     "MigrationConflict",

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -32,7 +32,17 @@ Guarantees pinned by ``tests/sync/test_migrate_journal.py``:
 Per **C-001** this module writes only through the WP03 journal public API and its
 own migration-audit store (provenance/conflicts are migration metadata that have
 no home on a delivery-state ledger row); it never re-implements those tables.
-Source DBs are opened **read-only** so they are structurally untouched.
+During **import** (:func:`migrate_queues_to_journal`) source DBs are opened
+**read-only** so they are structurally untouched.
+
+**Cleanup (#2665).** Import alone never converges the legacy-row boundary: the
+rows stay in the source queues, so ``sync now`` / ``sync opt-in`` refuse forever.
+:func:`cleanup_migrated_sources` is the separate, gated follow-up that deletes
+the confirmed-migrated rows (provenance ∩ journal) from each source once a
+migration is clean (no conflicts, no source errors) — by id, never a blanket
+clear. It is safe because delivery reads solely from the journal (the legacy
+offline-queue drain is retired), so a row proven durable in the journal remains
+deliverable after its source copy is removed.
 """
 from __future__ import annotations
 
@@ -250,6 +260,21 @@ class MigrationAudit:
             (event_id,),
         ).fetchone()
         return None if row is None else str(row["target_id"])
+
+    def event_ids_for_source(self, source_digest: str) -> list[str]:
+        """Return the distinct ``event_id``s migrated from *source_digest*.
+
+        Only imported/deduped rows record provenance (divergent duplicates go to
+        the conflict table instead), so this is exactly the set that is safe to
+        delete from that source once the migration is clean — conflicted ids are
+        never returned here. Ordered for reproducibility.
+        """
+        rows = self._conn.execute(
+            "SELECT DISTINCT event_id FROM migration_provenance "
+            "WHERE source_digest = ? ORDER BY event_id",
+            (source_digest,),
+        ).fetchall()
+        return [str(row["event_id"]) for row in rows]
 
     def conflicts(self) -> list[MigrationConflict]:
         """Return every recorded migration conflict (ordered for reproducibility)."""
@@ -623,17 +648,129 @@ def migrate_queues_to_journal(
     return result
 
 
+# --- source cleanup after a clean migration (#2665) -----------------------
+
+
+@dataclass
+class CleanupOutcome:
+    """Per-source outcome of the post-migration source-queue cleanup."""
+
+    digest: str
+    is_legacy: bool
+    deleted: int = 0
+    error: str | None = None
+
+
+@dataclass
+class CleanupResult:
+    """Observable outcome of one :func:`cleanup_migrated_sources` run.
+
+    ``ran`` is ``False`` when cleanup was blocked (a no-op), so callers can
+    distinguish "nothing to clean" from "cleanup was gated off".
+    """
+
+    ran: bool = False
+    outcomes: list[CleanupOutcome] = field(default_factory=list)
+
+    @property
+    def total_deleted(self) -> int:
+        return sum(outcome.deleted for outcome in self.outcomes)
+
+    @property
+    def sources_cleaned(self) -> int:
+        return sum(1 for outcome in self.outcomes if outcome.deleted)
+
+    @property
+    def had_errors(self) -> bool:
+        return any(outcome.error for outcome in self.outcomes)
+
+
+def _delete_migrated_rows(source_path: Path, event_ids: list[str]) -> int:
+    """Delete *event_ids* from a source queue DB via the canonical queue class.
+
+    Imported lazily to avoid a queue<->migrate import cycle.
+    """
+    from specify_cli.sync.queue import OfflineQueue  # noqa: PLC0415 - avoid import cycle
+
+    deleted: int = OfflineQueue(db_path=source_path).remove_events(event_ids)
+    return deleted
+
+
+def cleanup_migrated_sources(
+    spec_kitty_dir: Path,
+    *,
+    journal: EventJournal,
+    audit: MigrationAudit,
+    result: MigrationResult,
+) -> CleanupResult:
+    """Delete confirmed-migrated rows from source queues after a CLEAN migration.
+
+    :func:`migrate_queues_to_journal` is deliberately read-only — it copies
+    queued events into the journal but never deletes the source rows. Without a
+    follow-up delete the legacy ``queue.db`` rows persist forever, the preflight
+    boundary keeps counting them, and ``sync now`` / ``sync opt-in`` refuse
+    indefinitely (#2665). This is that follow-up, and it is **gated and safe**:
+
+    * **No-op when cleanup is blocked** (``result.cleanup_blocked`` — any
+      divergent-duplicate conflict or source read/import error). Nothing is
+      deleted until an operator resolves the blockers, so a conflicted event is
+      never dropped from its source.
+    * **Per-source error isolation** — a source that errored during import is
+      skipped individually (its rows are left intact).
+    * **Delete only confirmed-migrated ids** — an ``event_id`` is removed only
+      when it carries migration *provenance* (imported/deduped, never
+      conflicted) **and** is present in the journal, and it is deleted *by id*,
+      never via a blanket clear, so a row enqueued after the migration snapshot
+      is preserved.
+
+    Deleting is safe because delivery reads from the journal, not the queues:
+    the legacy offline-queue drain is retired (``sync now`` delivers solely from
+    the journal), so a row proven durable in the journal remains fully
+    deliverable after its source copy is removed.
+    """
+    cleanup = CleanupResult()
+    if result.cleanup_blocked:
+        # Any conflict or source import error blocks ALL cleanup, so by the time
+        # we get past this guard every source imported cleanly — no per-source
+        # error handling is needed inside the loop below.
+        return cleanup
+    cleanup.ran = True
+    for source in discover_source_dbs(spec_kitty_dir):
+        migrated = [
+            event_id
+            for event_id in audit.event_ids_for_source(source.digest)
+            if journal.read_by_id(event_id) is not None
+        ]
+        if not migrated:
+            cleanup.outcomes.append(CleanupOutcome(digest=source.digest, is_legacy=source.is_legacy))
+            continue
+        try:
+            deleted = _delete_migrated_rows(source.path, migrated)
+        except sqlite3.Error as exc:  # a locked/corrupt source — report, keep going
+            cleanup.outcomes.append(
+                CleanupOutcome(digest=source.digest, is_legacy=source.is_legacy, error=str(exc))
+            )
+            continue
+        cleanup.outcomes.append(
+            CleanupOutcome(digest=source.digest, is_legacy=source.is_legacy, deleted=deleted)
+        )
+    return cleanup
+
+
 __all__ = [
     "AUDIT_DB_NAME",
     "KNOWN_PREFIX",
     "LEGACY_DIGEST",
     "MIGRATION_NOTE",
+    "CleanupOutcome",
+    "CleanupResult",
     "MigrationAudit",
     "MigrationConflict",
     "MigrationResult",
     "SourceDb",
     "SourceOutcome",
     "UNKNOWN_PREFIX",
+    "cleanup_migrated_sources",
     "discover_source_dbs",
     "migrate_queues_to_journal",
     "migration_target_token",

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -882,6 +882,69 @@ def resolve_conflicts_keep_journal(
     return resolution
 
 
+# --- one-shot legacy convergence (the migration engine, #2665/#2180) -------
+
+
+@dataclass
+class ConvergeResult:
+    """Observable outcome of one :func:`converge_legacy_runtime` run."""
+
+    migration: MigrationResult
+    resolution: ConflictResolution | None = None
+    cleanup: CleanupResult | None = None
+
+    @property
+    def converged(self) -> bool:
+        """True iff the boundary is coherent after the run (cleanup ran clean)."""
+        return not self.migration.cleanup_blocked and self.cleanup is not None and self.cleanup.ran
+
+    @property
+    def blocked_conflicts(self) -> int:
+        """Conflicts still blocking convergence (e.g. resolution disabled/partial)."""
+        return len(self.migration.conflicts)
+
+
+def converge_legacy_runtime(
+    spec_kitty_dir: Path,
+    *,
+    journal: EventJournal,
+    audit: MigrationAudit,
+    resolved_target: ResolvedSyncTarget | None = None,
+    resolve_conflicts: bool = False,
+    cleanup: bool = True,
+) -> ConvergeResult:
+    """Converge a legacy runtime into the journal in one idempotent pass.
+
+    The single orchestration shared by ``sync migrate`` and the auto-migration:
+
+    1. import queued events into the journal (read-only on sources);
+    2. optionally resolve divergent-duplicate conflicts journal-wins (archiving
+       each divergent source payload to the quarantine), then re-import so the
+       result reflects the converged state;
+    3. optionally delete the confirmed-migrated rows from their sources so the
+       legacy-row boundary converges.
+
+    Idempotent: on an already-converged runtime every step is a no-op. Nothing
+    is ever lost — import is read-only, conflict resolution quarantines before
+    removing, and cleanup deletes only journal-confirmed rows by id.
+    """
+    result = migrate_queues_to_journal(
+        spec_kitty_dir, journal=journal, audit=audit, resolved_target=resolved_target
+    )
+    resolution: ConflictResolution | None = None
+    if resolve_conflicts and result.conflicts:
+        resolution = resolve_conflicts_keep_journal(spec_kitty_dir, journal=journal, audit=audit)
+        result = migrate_queues_to_journal(
+            spec_kitty_dir, journal=journal, audit=audit, resolved_target=resolved_target
+        )
+    cleanup_result: CleanupResult | None = None
+    if cleanup and not result.cleanup_blocked:
+        cleanup_result = cleanup_migrated_sources(
+            spec_kitty_dir, journal=journal, audit=audit, result=result
+        )
+    return ConvergeResult(migration=result, resolution=resolution, cleanup=cleanup_result)
+
+
 __all__ = [
     "AUDIT_DB_NAME",
     "KNOWN_PREFIX",
@@ -889,15 +952,14 @@ __all__ = [
     "MIGRATION_NOTE",
     "CleanupResult",
     "ConflictResolution",
+    "ConvergeResult",
     "MigrationAudit",
     "MigrationConflict",
     "MigrationResult",
     "SourceDb",
     "SourceOutcome",
     "UNKNOWN_PREFIX",
-    "cleanup_migrated_sources",
+    "converge_legacy_runtime",
     "discover_source_dbs",
-    "migrate_queues_to_journal",
     "migration_target_token",
-    "resolve_conflicts_keep_journal",
 ]

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -875,6 +875,13 @@ def resolve_conflicts_keep_journal(
             existing_sha=conflict.existing_sha,
             incoming_sha=conflict.incoming_sha,
         )
+        # Write-ahead: the quarantine archive MUST be durable before the source
+        # row is destroyed (the delete below commits queue.db immediately). A
+        # crash between the two would otherwise leave the row deleted but the
+        # archive rolled back — losing the superseded payload the docstring
+        # promises is recoverable. Mirrors the import path's provenance-first
+        # commit ordering (see ``audit.commit()`` before ``txn.commit()`` above).
+        audit.commit()
         _delete_migrated_rows(source.path, [conflict.event_id])
         audit.clear_conflict(conflict.event_id, conflict.source_digest)
         resolution.resolved.append(conflict.event_id)

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -1671,6 +1671,34 @@ class OfflineQueue:
         with self._row_count_lock:
             self._row_count = 0
 
+    def remove_events(self, event_ids: list[str]) -> int:
+        """Remove queued events by ``event_id``; return the number deleted.
+
+        Used by the queue->journal migration cleanup (#2665) to delete rows
+        that have been confirmed durable in the event journal. Deletes only the
+        given ids — never a blanket clear — so events enqueued after the
+        migration snapshot are preserved. Ids absent from the queue are simply
+        not counted (the return value is the *actual* number of rows removed).
+        """
+        if not event_ids:
+            return 0
+        conn = sqlite3.connect(self.db_path)
+        try:
+            placeholders = ",".join("?" * len(event_ids))
+            cursor = conn.execute(
+                f"DELETE FROM queue WHERE event_id IN ({placeholders})",  # noqa: S608  # nosec B608 - placeholders are count-derived only
+                list(event_ids),
+            )
+            removed = cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
+            conn.commit()
+        finally:
+            conn.close()
+        if removed > 0:
+            with self._row_count_lock:
+                if self._row_count is not None:
+                    self._row_count = max(0, self._row_count - removed)
+        return removed
+
     def remove_project_events(self, project_uuid: str) -> int:
         """Remove queued events that belong to one project UUID."""
         if not project_uuid:

--- a/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
+++ b/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
@@ -17,6 +17,8 @@ from specify_cli.sync.migrate_journal import (
     MigrationResult,
 )
 
+pytestmark = pytest.mark.fast
+
 
 class _FakeRuntime:
     journal = object()

--- a/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
+++ b/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
@@ -1,0 +1,72 @@
+"""#2665 — `sync opt-in` auto-converges legacy queue residue on enable.
+
+These unit tests pin the reporting branches of
+``_auto_converge_legacy_on_enable`` with the runtime open and the convergence
+engine mocked, so the CLI wiring is covered without a live runtime.
+"""
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.cli.commands import sync as sync_cmd
+from specify_cli.sync.migrate_journal import (
+    CleanupOutcome,
+    CleanupResult,
+    ConvergeResult,
+    MigrationConflict,
+    MigrationResult,
+)
+
+
+class _FakeRuntime:
+    journal = object()
+    target = None
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+def test_auto_converge_reports_converged_rows(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setattr(sync_cmd, "_open_event_sync_runtime", lambda *a, **k: _FakeRuntime())
+
+    def _fake_converge(*_a, **_k):
+        return ConvergeResult(
+            migration=MigrationResult(),
+            cleanup=CleanupResult(
+                ran=True,
+                outcomes=[CleanupOutcome(digest="legacy", is_legacy=True, deleted=7)],
+            ),
+        )
+
+    monkeypatch.setattr("specify_cli.sync.migrate_journal.converge_legacy_runtime", _fake_converge)
+
+    sync_cmd._auto_converge_legacy_on_enable()
+
+    out = capsys.readouterr().out
+    assert "Converged 7 legacy queue row" in out
+
+
+def test_auto_converge_surfaces_conflicts(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setattr(sync_cmd, "_open_event_sync_runtime", lambda *a, **k: _FakeRuntime())
+    conflict = MigrationConflict(
+        event_id="dup", source_digest="legacy", existing_sha="a", incoming_sha="b"
+    )
+
+    def _fake_converge(*_a, **_k):
+        return ConvergeResult(migration=MigrationResult(conflicts=[conflict]), cleanup=None)
+
+    monkeypatch.setattr("specify_cli.sync.migrate_journal.converge_legacy_runtime", _fake_converge)
+
+    sync_cmd._auto_converge_legacy_on_enable()
+
+    out = capsys.readouterr().out
+    assert "resolve-conflicts keep-journal" in out
+
+
+def test_auto_converge_swallows_runtime_open_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a, **_k):
+        raise RuntimeError("runtime unavailable")
+
+    monkeypatch.setattr(sync_cmd, "_open_event_sync_runtime", _boom)
+    # Must not raise — the coherence gate downstream reports the incoherence.
+    sync_cmd._auto_converge_legacy_on_enable()

--- a/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
+++ b/tests/specify_cli/cli/commands/test_sync_opt_in_converge.py
@@ -72,3 +72,17 @@ def test_auto_converge_swallows_runtime_open_failure(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(sync_cmd, "_open_event_sync_runtime", _boom)
     # Must not raise — the coherence gate downstream reports the incoherence.
     sync_cmd._auto_converge_legacy_on_enable()
+
+
+def test_auto_converge_swallows_converge_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure INSIDE converge (not just opening the runtime) is swallowed too,
+    so opt-in defers to the coherence gate instead of aborting with a traceback.
+    """
+    monkeypatch.setattr(sync_cmd, "_open_event_sync_runtime", lambda *a, **k: _FakeRuntime())
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("journal API contract error mid-converge")
+
+    monkeypatch.setattr("specify_cli.sync.migrate_journal.converge_legacy_runtime", _boom)
+    # Must not raise — the runtime is still closed and control returns cleanly.
+    sync_cmd._auto_converge_legacy_on_enable()

--- a/tests/sync/test_migrate_journal.py
+++ b/tests/sync/test_migrate_journal.py
@@ -629,7 +629,7 @@ def test_resolve_conflicts_skips_when_source_gone(tmp_path: Path) -> None:
     resolution = resolve_conflicts_keep_journal(home, journal=journal, audit=audit)
 
     assert resolution.resolved_count == 0
-    assert len(resolution.skipped) == 1
+    assert resolution.skipped == ["dup"]  # the vanished-source conflict, left intact
     assert audit.quarantined_count() == 0
 
 

--- a/tests/sync/test_migrate_journal.py
+++ b/tests/sync/test_migrate_journal.py
@@ -30,6 +30,7 @@ from specify_cli.sync.migrate_journal import (
     MigrationResult,
     SourceDb,
     cleanup_migrated_sources,
+    converge_legacy_runtime,
     discover_source_dbs,
     migrate_queues_to_journal,
     migration_target_token,
@@ -656,3 +657,51 @@ def test_resolve_then_remigrate_and_cleanup_converges(tmp_path: Path) -> None:
     # every source drained → boundary converges
     assert OfflineQueue(db_path=_scoped_path(home, _digest("a"))).size() == 0
     assert OfflineQueue(db_path=_scoped_path(home, _digest("b"))).size() == 0
+
+
+# ----------------------------------------------------------------------
+# #2665 — converge_legacy_runtime (the one-shot migration engine)
+# ----------------------------------------------------------------------
+
+
+def test_converge_legacy_runtime_converges_and_is_idempotent(tmp_path: Path) -> None:
+    """One converge pass drains a conflicted runtime; a second pass is a no-op."""
+    home = tmp_path / "home"
+    _seed_queue(
+        _scoped_path(home, _digest("a")),
+        [_event("dup", payload={"v": 1}), _event("clean1")],
+    )
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    converge = converge_legacy_runtime(
+        home, journal=journal, audit=audit, resolve_conflicts=True, cleanup=True
+    )
+
+    assert converge.converged is True
+    assert OfflineQueue(db_path=_scoped_path(home, _digest("a"))).size() == 0
+    assert OfflineQueue(db_path=_scoped_path(home, _digest("b"))).size() == 0
+
+    again = converge_legacy_runtime(
+        home, journal=journal, audit=audit, resolve_conflicts=True, cleanup=True
+    )
+    assert again.converged is True
+    assert again.migration.imported_event_ids == []  # nothing new — idempotent no-op
+
+
+def test_converge_without_resolve_leaves_conflicts_blocked(tmp_path: Path) -> None:
+    """Without resolve_conflicts a divergent duplicate blocks convergence."""
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("a")), [_event("dup", payload={"v": 1})])
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    converge = converge_legacy_runtime(
+        home, journal=journal, audit=audit, resolve_conflicts=False, cleanup=True
+    )
+
+    assert converge.converged is False
+    assert converge.blocked_conflicts == 1
+    assert converge.cleanup is None  # cleanup gated off while the conflict blocks

--- a/tests/sync/test_migrate_journal.py
+++ b/tests/sync/test_migrate_journal.py
@@ -29,6 +29,7 @@ from specify_cli.sync.migrate_journal import (
     MigrationAudit,
     MigrationResult,
     SourceDb,
+    cleanup_migrated_sources,
     discover_source_dbs,
     migrate_queues_to_journal,
     migration_target_token,
@@ -476,3 +477,101 @@ def test_non_json_payload_migrates_as_raw_bytes(tmp_path: Path) -> None:
     raw = journal.read_by_id("e_raw")
     assert raw is not None
     assert raw.payload == b"not-json{"
+
+
+# ----------------------------------------------------------------------
+# #2665 — post-migration source cleanup converges the legacy-row boundary
+# ----------------------------------------------------------------------
+
+
+def test_cleanup_deletes_migrated_rows_and_leaves_journal_intact(tmp_path: Path) -> None:
+    """A clean migration + cleanup drains every source but keeps the journal."""
+    home = tmp_path / "home"
+    legacy = _seed_queue(home / "queue.db", [_event("e1"), _event("e2")])
+    scoped = _seed_queue(_scoped_path(home, _digest("s")), [_event("e3")])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert result.cleanup_blocked is False
+    # import is read-only: sources are still full after the migration proper
+    assert legacy.size() == 2
+    assert scoped.size() == 1
+
+    cleanup = cleanup_migrated_sources(home, journal=journal, audit=audit, result=result)
+
+    assert cleanup.ran is True
+    assert cleanup.total_deleted == 3
+    assert cleanup.had_errors is False
+    # sources drained (boundary converges)
+    assert OfflineQueue(db_path=home / "queue.db").size() == 0
+    assert OfflineQueue(db_path=_scoped_path(home, _digest("s"))).size() == 0
+    # journal keeps every migrated payload
+    stored = {event.event_id for event in journal.read_all()}
+    assert {"e1", "e2", "e3"} <= stored
+
+
+def test_cleanup_is_noop_when_blocked_by_conflict(tmp_path: Path) -> None:
+    """A divergent-duplicate conflict blocks cleanup entirely — nothing is dropped."""
+    home = tmp_path / "home"
+    a = _seed_queue(_scoped_path(home, _digest("a")), [_event("dup", payload={"v": 1})])
+    b = _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert result.cleanup_blocked is True
+
+    cleanup = cleanup_migrated_sources(home, journal=journal, audit=audit, result=result)
+
+    assert cleanup.ran is False
+    assert cleanup.total_deleted == 0
+    # both sources left fully intact while the conflict is unresolved
+    assert a.size() == 1
+    assert b.size() == 1
+
+
+def test_cleanup_is_idempotent(tmp_path: Path) -> None:
+    """Re-running cleanup after the sources are drained deletes nothing more."""
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("s")), [_event("e1")])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+
+    first = cleanup_migrated_sources(home, journal=journal, audit=audit, result=result)
+    assert first.total_deleted == 1
+
+    second = cleanup_migrated_sources(home, journal=journal, audit=audit, result=result)
+    assert second.ran is True
+    assert second.total_deleted == 0
+
+
+def test_cleanup_reports_error_without_crashing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A locked/corrupt source at cleanup time is reported, not fatal."""
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("s")), [_event("e1")])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+
+    import specify_cli.sync.migrate_journal as mj
+
+    def _boom(*_args: Any, **_kwargs: Any) -> int:
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(mj, "_delete_migrated_rows", _boom)
+
+    cleanup = mj.cleanup_migrated_sources(home, journal=journal, audit=audit, result=result)
+
+    assert cleanup.ran is True
+    assert cleanup.total_deleted == 0
+    assert cleanup.had_errors is True
+
+
+def test_remove_events_deletes_only_named_ids(tmp_path: Path) -> None:
+    """OfflineQueue.remove_events deletes exactly the named ids, by id."""
+    queue = _seed_queue(tmp_path / "queue.db", [_event("e1"), _event("e2"), _event("e3")])
+    removed = queue.remove_events(["e1", "e3", "absent"])
+    assert removed == 2
+    assert queue.size() == 1

--- a/tests/sync/test_migrate_journal.py
+++ b/tests/sync/test_migrate_journal.py
@@ -33,6 +33,7 @@ from specify_cli.sync.migrate_journal import (
     discover_source_dbs,
     migrate_queues_to_journal,
     migration_target_token,
+    resolve_conflicts_keep_journal,
 )
 from specify_cli.sync.queue import OfflineQueue
 from specify_cli.sync.target_authority import (
@@ -575,3 +576,83 @@ def test_remove_events_deletes_only_named_ids(tmp_path: Path) -> None:
     removed = queue.remove_events(["e1", "e3", "absent"])
     assert removed == 2
     assert queue.size() == 1
+
+
+# ----------------------------------------------------------------------
+# #2665 — keep-journal conflict resolution (explicit operator recovery)
+# ----------------------------------------------------------------------
+
+
+def test_resolve_conflicts_keep_journal_archives_and_removes_source(tmp_path: Path) -> None:
+    """A divergent duplicate is archived, its source row removed, conflict cleared."""
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("a")), [_event("dup", payload={"v": 1})])
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert result.cleanup_blocked is True
+    assert len(result.conflicts) == 1
+
+    resolution = resolve_conflicts_keep_journal(home, journal=journal, audit=audit)
+
+    assert resolution.resolved_count == 1
+    assert audit.quarantined_count() == 1  # divergent payload preserved, not lost
+    assert audit.has_conflicts() is False  # boundary can converge now
+    # the conflicting source is drained; the canonical source keeps its row
+    sizes = sorted(
+        [
+            OfflineQueue(db_path=_scoped_path(home, _digest("a"))).size(),
+            OfflineQueue(db_path=_scoped_path(home, _digest("b"))).size(),
+        ]
+    )
+    assert sizes == [0, 1]
+    # journal payload is untouched — the event is still present
+    assert journal.read_by_id("dup") is not None
+
+
+def test_resolve_conflicts_skips_when_source_gone(tmp_path: Path) -> None:
+    """A conflict whose source DB has vanished is left intact (never fabricated away)."""
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("a")), [_event("dup", payload={"v": 1})])
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert len(result.conflicts) == 1
+    # delete the conflicting source DB so resolution can't find it
+    _scoped_path(home, result.conflicts[0].source_digest).unlink()
+
+    resolution = resolve_conflicts_keep_journal(home, journal=journal, audit=audit)
+
+    assert resolution.resolved_count == 0
+    assert len(resolution.skipped) == 1
+    assert audit.quarantined_count() == 0
+
+
+def test_resolve_then_remigrate_and_cleanup_converges(tmp_path: Path) -> None:
+    """End-to-end: resolve conflicts, re-migrate clean, cleanup drains every source."""
+    home = tmp_path / "home"
+    _seed_queue(
+        _scoped_path(home, _digest("a")),
+        [_event("dup", payload={"v": 1}), _event("clean1")],
+    )
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit = MigrationAudit(home / "migration_audit.db")
+
+    first = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert first.cleanup_blocked is True  # conflict blocks
+
+    resolve_conflicts_keep_journal(home, journal=journal, audit=audit)
+
+    second = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert second.cleanup_blocked is False  # conflicts resolved → clean
+
+    cleanup = cleanup_migrated_sources(home, journal=journal, audit=audit, result=second)
+    assert cleanup.ran is True
+    # every source drained → boundary converges
+    assert OfflineQueue(db_path=_scoped_path(home, _digest("a"))).size() == 0
+    assert OfflineQueue(db_path=_scoped_path(home, _digest("b"))).size() == 0

--- a/tests/sync/test_migrate_journal.py
+++ b/tests/sync/test_migrate_journal.py
@@ -613,6 +613,42 @@ def test_resolve_conflicts_keep_journal_archives_and_removes_source(tmp_path: Pa
     assert journal.read_by_id("dup") is not None
 
 
+def test_resolve_quarantine_is_durable_before_source_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The divergent payload is committed to the audit store BEFORE the source
+    row is destroyed — a crash at the delete boundary must never lose it.
+
+    Regression for the write-ahead ordering: the source delete commits queue.db
+    immediately, so the quarantine archive has to be durable first. We inject a
+    failure at the delete boundary and assert the archive is already on disk
+    (visible to a fresh audit connection), i.e. the superseded copy is
+    recoverable exactly as the contract promises.
+    """
+    home = tmp_path / "home"
+    _seed_queue(_scoped_path(home, _digest("a")), [_event("dup", payload={"v": 1})])
+    _seed_queue(_scoped_path(home, _digest("b")), [_event("dup", payload={"v": 2})])
+    journal = _journal(home)
+    audit_path = home / "migration_audit.db"
+    audit = MigrationAudit(audit_path)
+
+    result = migrate_queues_to_journal(home, journal=journal, audit=audit)
+    assert len(result.conflicts) == 1
+
+    import specify_cli.sync.migrate_journal as mj
+
+    def _boom(*_args: Any, **_kwargs: Any) -> int:
+        raise sqlite3.OperationalError("crash at the delete boundary")
+
+    monkeypatch.setattr(mj, "_delete_migrated_rows", _boom)
+    with pytest.raises(sqlite3.OperationalError):
+        resolve_conflicts_keep_journal(home, journal=journal, audit=audit)
+
+    # A FRESH audit connection sees the archive → it was committed before the
+    # (failed) delete, so the divergent payload survives the crash window.
+    assert MigrationAudit(audit_path).quarantined_count() == 1
+
+
 def test_resolve_conflicts_skips_when_source_gone(tmp_path: Path) -> None:
     """A conflict whose source DB has vanished is left intact (never fabricated away)."""
     home = tmp_path / "home"


### PR DESCRIPTION
Fixes the **clean-path** half of the #2665 migrate deadlock, found dogfooding the CLI→TeamSpace back-prop.

## The bug
`spec-kitty sync migrate` imports queued events into the journal **read-only** and never deletes them from the source queues (by design — "source DBs are opened read-only"). The `cleanup_blocked` gate and the "resolve them before deleting source queues" message anticipate a cleanup step **that was never implemented**. So legacy `queue.db` rows persist, `preflight.legacy_rows_for_scope` keeps counting them, and `sync now` / `sync opt-in` refuse forever — no operator path to a coherent boundary.

## The fix (gated, safe)
- `OfflineQueue.remove_events(ids)` — delete queued rows by `event_id`, never a blanket clear.
- `MigrationAudit.event_ids_for_source()` — the imported/deduped (non-conflict) ids for a source.
- `cleanup_migrated_sources()` — on a **clean** migration (`cleanup_blocked == False`), delete from each source the ids provably present in the journal. **No-op when blocked**; deletes only confirmed-migrated ids, by id.
- `sync migrate` runs cleanup automatically on a clean migration; **`--no-cleanup`** preserves inspect-first.

**Why deletion is safe:** delivery reads solely from the journal (the legacy offline-queue drain is retired), so a row proven durable in the journal remains deliverable after its source copy is removed. Import stays read-only — the existing FR-013/T058 import-phase guarantees are untouched; cleanup is a *separate*, gated, post-commit step.

## Tests
`tests/sync/test_migrate_journal.py` (+5): convergence (sources drain to 0, journal intact), blocked no-op (conflict → nothing deleted), idempotency, the DB-error branch (reported, non-fatal), and `remove_events`. Full suite green; ruff + mypy clean.

## Verified live
Ran against the local dogfood runtime: on a clean migration the sources drain and the boundary converges; under conflicts cleanup **correctly no-ops** and leaves every source intact.

## Known follow-up (the *other* #2665 dimension — needs a decision)
The live rig also surfaced the **migrate-conflict deadlock**: divergent-duplicate conflicts (same `event_id`, divergent payload vs the per-target journal) quarantine correctly but have **no operator resolution path**, so cleanup stays blocked and the boundary can't converge. Import can't overwrite (C-005/FR-018) and cleanup won't force-delete conflicted rows, so there's no way out today. Proposed resolution: a `--resolve-conflicts=keep-journal` that discards source rows whose `event_id` is already durable in the journal (journal = canonical/delivered; the source copy is a stale supersede). Tracked under #2665 / #2180.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786791628&installation_id=146454894&pr_number=2682&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2682&signature=7fff46795d87336514250faeb9597f08385665bb8e6a5e0a94980af8c71d0e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->