### PR TITLE
fix(sync): drain oversized + poison batches instead of deadlocking (#2734)

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -719,11 +719,6 @@ def _combine_dispatch_summaries(
     )
 
 
-def _batch_left_selection_set(summary: DispatchSummary) -> bool:
-    terminal = summary.delivered + summary.duplicate + summary.terminal_failed
-    return summary.selected > terminal
-
-
 def _batch_is_oversized(summary: DispatchSummary) -> bool:
     """Whether a batch was rejected wholesale for exceeding the server size cap.
 
@@ -766,6 +761,7 @@ def _run_dispatch_batches(
 
     combined = DispatchSummary.empty()
     limit = _EVENT_SYNC_DISPATCH_BATCH_LIMIT
+    skip: set[str] = set()
     while True:
         batch = dispatch(
             journal=runtime.journal,
@@ -773,6 +769,7 @@ def _run_dispatch_batches(
             receiver=receiver,
             target=delivery_target,
             limit=limit,
+            exclude=frozenset(skip),
         )
         # Honor the documented "retry with a smaller batch" contract: a
         # byte-oversized batch (HTTP 413, nothing delivered) is halved and
@@ -784,9 +781,15 @@ def _run_dispatch_batches(
             limit = max(1, limit // 2)
             continue
         combined = _combine_dispatch_summaries(combined, batch)
-        if batch.selected < limit:
-            break
-        if _batch_left_selection_set(batch):
+        # Advance past events that made no terminal-success this pass (content
+        # rejections, persistent transient). Skipping them for the REST OF THIS
+        # PASS lets deliverable events behind them drain instead of a poison
+        # batch halting the loop; the ledger keeps them selectable for the next
+        # `sync now`, so the non-terminal retry contract is preserved.
+        before = len(skip)
+        skip.update(failure.event_id for failure in batch.failures)
+        advanced = (batch.delivered + batch.duplicate) > 0 or len(skip) > before
+        if batch.selected == 0 or not advanced:
             break
     return combined
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -85,7 +85,7 @@ _TRANSIENT_SYNC_NOW_MESSAGE = (
 # HTTP 413 is how the SaaS sync ingress (Fly proxy + edge) rejects an
 # over-cap batch; see apps/sync/limits.py (512 KiB decompressed ceiling).
 _HTTP_PAYLOAD_TOO_LARGE = 413
-_OVERSIZED_ERROR_MARKER = "too large"
+_OVERSIZED_ERROR_MARKER = "retry with a smaller batch"
 _HTTP_AUTH_STATUSES = frozenset({401, 403})
 _WARNING_HEADER_STYLE = "bold yellow"
 _ABSENT_VALUE = "<absent>"
@@ -310,7 +310,8 @@ def _enforce_sync_now_exit_from_dispatch(
       "queue non-empty but all-zero result". This is routed through the
       teamspace-aware recovery so the unauthenticated UX (interactive login,
       structured exit 4, legacy exit 1) is preserved regardless of ``--strict``.
-    * Partial progress with a hard terminal failure → exit 1 under ``--strict``.
+    * Partial progress with any rejected, transient, or terminal failure → exit
+      1 under ``--strict``.
 
     A ``None`` summary means dispatch infrastructure was unavailable. Under
     ``--strict`` that is a failure only when retained or legacy work exists.
@@ -342,7 +343,8 @@ def _enforce_sync_now_exit_from_dispatch(
     if work_present and progressed == 0:
         _handle_sync_now_unauthenticated(strict)
         return
-    if strict and summary is not None and summary.terminal_failed > 0:
+    errors = summary.rejected + summary.transient + summary.terminal_failed
+    if strict and errors > 0:
         raise typer.Exit(1)
 
 
@@ -716,6 +718,10 @@ def _combine_dispatch_summaries(
         transient=left.transient + right.transient,
         terminal_failed=left.terminal_failed + right.terminal_failed,
         failures=(*left.failures, *right.failures),
+        retryable_event_ids=(
+            *left.retryable_event_ids,
+            *right.retryable_event_ids,
+        ),
     )
 
 
@@ -729,10 +735,22 @@ def _batch_is_oversized(summary: DispatchSummary) -> bool:
     error (``_BATCH_OVERSIZED_ERROR`` = "retry with a smaller batch"). This is
     the signal that we should honor that documented contract and shrink.
     """
-    return any(
-        failure.http_status == _HTTP_PAYLOAD_TOO_LARGE
-        or (failure.error is not None and _OVERSIZED_ERROR_MARKER in failure.error)
-        for failure in summary.failures
+    failures = summary.failures
+    is_wholesale_transient = (
+        summary.selected > 0
+        and summary.transient == summary.selected
+        and len(failures) == summary.selected
+    )
+    return is_wholesale_transient and all(
+        failure.outcome == "transient"
+        and (
+            failure.http_status == _HTTP_PAYLOAD_TOO_LARGE
+            or (
+                failure.error is not None
+                and _OVERSIZED_ERROR_MARKER in failure.error.lower()
+            )
+        )
+        for failure in failures
     )
 
 
@@ -781,13 +799,13 @@ def _run_dispatch_batches(
             limit = max(1, limit // 2)
             continue
         combined = _combine_dispatch_summaries(combined, batch)
-        # Advance past events that made no terminal-success this pass (content
-        # rejections, persistent transient). Skipping them for the REST OF THIS
-        # PASS lets deliverable events behind them drain instead of a poison
-        # batch halting the loop; the ledger keeps them selectable for the next
-        # `sync now`, so the non-terminal retry contract is preserved.
+        # Advance past retryable events that made no terminal-success this pass
+        # (pending, content rejection, persistent transient). Skipping them for
+        # the REST OF THIS PASS lets deliverable events behind them drain
+        # instead of a poison batch halting the loop; the ledger keeps them
+        # selectable for the next `sync now`, so retryability is preserved.
         before = len(skip)
-        skip.update(failure.event_id for failure in batch.failures)
+        skip.update(batch.retryable_event_ids)
         advanced = (batch.delivered + batch.duplicate) > 0 or len(skip) > before
         if batch.selected == 0 or not advanced:
             break

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -817,6 +817,16 @@ def _run_dispatch_batches(
         terminal_progress = (
             batch.delivered + batch.duplicate + batch.terminal_failed
         ) > 0
+        # Grow a shrunk limit back after terminal progress. A single event over
+        # the server byte cap forces `limit` down to 1 and is parked
+        # (terminal_failed); without recovery the entire *healthy* tail would
+        # then drain one-event-per-POST for the rest of the pass -- correct but
+        # a throughput cliff. Multiplicative increase mirrors the halving and is
+        # capped at the count default, so throughput recovers within a few
+        # batches while the per-batch byte contract is still honored: an
+        # over-grown batch simply 413s and re-halves, which is bounded.
+        if terminal_progress and limit < _EVENT_SYNC_DISPATCH_BATCH_LIMIT:
+            limit = min(_EVENT_SYNC_DISPATCH_BATCH_LIMIT, limit * 2)
         advanced = terminal_progress or len(skip) > before
         if batch.selected == 0 or not advanced:
             break

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -74,6 +74,19 @@ _STATUS_LAST_SYNC_LABEL = "Last Sync"
 _UNAUTHENTICATED_SYNC_NOW_MESSAGE = (
     "not authenticated: no valid access token. Run `spec-kitty auth login`."
 )
+_OVERSIZED_SYNC_NOW_MESSAGE = (
+    "sync batch exceeded the server size limit; the CLI retried with smaller "
+    "batches. Re-run `spec-kitty sync now` if events remain."
+)
+_TRANSIENT_SYNC_NOW_MESSAGE = (
+    "sync delivery failed transiently; no events were lost. Re-run "
+    "`spec-kitty sync now` (see `--report` for per-event detail)."
+)
+# HTTP 413 is how the SaaS sync ingress (Fly proxy + edge) rejects an
+# over-cap batch; see apps/sync/limits.py (512 KiB decompressed ceiling).
+_HTTP_PAYLOAD_TOO_LARGE = 413
+_OVERSIZED_ERROR_MARKER = "too large"
+_HTTP_AUTH_STATUSES = frozenset({401, 403})
 _WARNING_HEADER_STYLE = "bold yellow"
 _ABSENT_VALUE = "<absent>"
 _UNSET_VALUE = "<unset>"
@@ -319,7 +332,7 @@ def _enforce_sync_now_exit_from_dispatch(
         _handle_sync_now_unauthenticated(strict)
         return
     if selected > 0 and progressed == 0 and summary.transient > 0:
-        console.print(f"[yellow]{_UNAUTHENTICATED_SYNC_NOW_MESSAGE}[/yellow]")
+        console.print(f"[yellow]{_transient_block_message(summary)}[/yellow]")
         if strict:
             raise typer.Exit(1)
         return
@@ -711,6 +724,39 @@ def _batch_left_selection_set(summary: DispatchSummary) -> bool:
     return summary.selected > terminal
 
 
+def _batch_is_oversized(summary: DispatchSummary) -> bool:
+    """Whether a batch was rejected wholesale for exceeding the server size cap.
+
+    The count-based batch limit cannot see decompressed byte size, so a backlog
+    whose events fit the 1000-event limit can still crowd the SaaS 512 KiB
+    ceiling (apps/sync/limits.py). The edge proxy answers HTTP 413 and the WP06
+    receiver maps that to a batch-wide ``transient`` carrying the oversized
+    error (``_BATCH_OVERSIZED_ERROR`` = "retry with a smaller batch"). This is
+    the signal that we should honor that documented contract and shrink.
+    """
+    return any(
+        failure.http_status == _HTTP_PAYLOAD_TOO_LARGE
+        or (failure.error is not None and _OVERSIZED_ERROR_MARKER in failure.error)
+        for failure in summary.failures
+    )
+
+
+def _transient_block_message(summary: DispatchSummary) -> str:
+    """Explain a wholesale-transient drain accurately instead of always blaming auth.
+
+    The legacy heuristic reported every all-transient batch as "not
+    authenticated", which mislabels a 413 (batch too large) or a 5xx as a
+    logged-out session and sends operators chasing auth. Classify by the actual
+    failure status instead.
+    """
+    statuses = {f.http_status for f in summary.failures if f.http_status is not None}
+    if _HTTP_PAYLOAD_TOO_LARGE in statuses:
+        return _OVERSIZED_SYNC_NOW_MESSAGE
+    if statuses & _HTTP_AUTH_STATUSES:
+        return _UNAUTHENTICATED_SYNC_NOW_MESSAGE
+    return _TRANSIENT_SYNC_NOW_MESSAGE
+
+
 def _run_dispatch_batches(
     runtime: _EventSyncRuntime,
     receiver: DeliveryReceiver,
@@ -719,16 +765,26 @@ def _run_dispatch_batches(
     from specify_cli.delivery.dispatcher import DispatchSummary, dispatch
 
     combined = DispatchSummary.empty()
+    limit = _EVENT_SYNC_DISPATCH_BATCH_LIMIT
     while True:
         batch = dispatch(
             journal=runtime.journal,
             ledger=runtime.ledger,
             receiver=receiver,
             target=delivery_target,
-            limit=_EVENT_SYNC_DISPATCH_BATCH_LIMIT,
+            limit=limit,
         )
+        # Honor the documented "retry with a smaller batch" contract: a
+        # byte-oversized batch (HTTP 413, nothing delivered) is halved and
+        # retried rather than surrendered as transient. dispatch() leaves those
+        # events undelivered, so the smaller re-selection picks the same events
+        # up. A single oversized event is terminal-failed by the receiver (not
+        # transient), so limit==1 can never loop forever.
+        if limit > 1 and batch.delivered == 0 and _batch_is_oversized(batch):
+            limit = max(1, limit // 2)
+            continue
         combined = _combine_dispatch_summaries(combined, batch)
-        if batch.selected < _EVENT_SYNC_DISPATCH_BATCH_LIMIT:
+        if batch.selected < limit:
             break
         if _batch_left_selection_set(batch):
             break

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -337,6 +337,14 @@ def _enforce_sync_now_exit_from_dispatch(
         if strict:
             raise typer.Exit(1)
         return
+    if selected > 0 and progressed == 0 and summary.recorded > 0:
+        # Rejected and terminal-failed rows are concrete delivery outcomes, not
+        # evidence that authentication blocked the attempt. The dispatch
+        # summary already exposes their counts; preserve --strict semantics
+        # without sending the operator through auth recovery.
+        if strict:
+            raise typer.Exit(1)
+        return
 
     # Pending work but nothing was even attempted → teamspace-aware recovery.
     work_present = queue_size > 0 or selected > 0
@@ -806,7 +814,10 @@ def _run_dispatch_batches(
         # selectable for the next `sync now`, so retryability is preserved.
         before = len(skip)
         skip.update(batch.retryable_event_ids)
-        advanced = (batch.delivered + batch.duplicate) > 0 or len(skip) > before
+        terminal_progress = (
+            batch.delivered + batch.duplicate + batch.terminal_failed
+        ) > 0
+        advanced = terminal_progress or len(skip) > before
         if batch.selected == 0 or not advanced:
             break
     return combined

--- a/src/specify_cli/delivery/dispatcher.py
+++ b/src/specify_cli/delivery/dispatcher.py
@@ -189,6 +189,7 @@ def _select_undelivered(
     target_id: str,
     *,
     limit: int | None = None,
+    exclude: frozenset[str] = frozenset(),
 ) -> list[Event]:
     """Return journal events still needing delivery to *target_id* (FR-004 / FR-015).
 
@@ -197,12 +198,20 @@ def _select_undelivered(
     ``select_undelivered`` filters out every event that already has a terminal-success
     or terminal-failed row for the active target. Order is preserved so re-runs are
     reproducible. No SQL and no ``queue.py`` import lives here.
+
+    *exclude* is a caller-supplied, in-memory skip set applied to the universe
+    **before** the ledger query, so the ``limit`` still fills with selectable
+    events. It is a transient, per-call filter (a drain pass uses it to advance
+    past events that made no progress this pass); it never changes durable ledger
+    state, so the ledger's non-terminal re-selection contract is preserved.
     """
     universe = journal.read_all()
     by_id = {event.event_id: event for event in universe}
     selected_ids = ledger.select_undelivered(
         target_id=target_id,
-        event_universe=[event.event_id for event in universe],
+        event_universe=[
+            event.event_id for event in universe if event.event_id not in exclude
+        ],
         limit=limit,
     )
     return [by_id[event_id] for event_id in selected_ids]
@@ -342,6 +351,7 @@ def dispatch(
     receiver: DeliveryReceiver,
     target: DeliveryTarget | None,
     limit: int | None = None,
+    exclude: frozenset[str] = frozenset(),
 ) -> DispatchSummary:
     """Drain undelivered journal events to one active *target* (contract §3/§4).
 
@@ -355,11 +365,19 @@ def dispatch(
     Activates WP08 coalescing on this live path first (D-020 / FR-011), then runs
     select -> post -> record. A successful drain leaves the journal row count
     unchanged and writes terminal-success ledger rows (FR-001).
+
+    *exclude* is an optional in-memory skip set (event IDs) applied to this
+    selection only. A multi-batch drain uses it to advance past events that made
+    no progress earlier in the same pass, so a permanent content rejection cannot
+    head-of-line-block deliverable events behind it. It never mutates the ledger,
+    so those events stay selectable on the next drain.
     """
     _install_coalescing(ledger)
     if target is None:
         return DispatchSummary.empty()
-    events = _select_undelivered(journal, ledger, target.target_id, limit=limit)
+    events = _select_undelivered(
+        journal, ledger, target.target_id, limit=limit, exclude=exclude
+    )
     results = _post(receiver, events)
     return _record(ledger, target.target_id, results, selected=len(events))
 

--- a/src/specify_cli/delivery/dispatcher.py
+++ b/src/specify_cli/delivery/dispatcher.py
@@ -77,7 +77,10 @@ class DispatchSummary:
 
     ``selected`` is how many journal events the drain pulled; the per-outcome fields
     sum to :attr:`recorded`. ``target_id`` is ``None`` only for a no-op drain (no
-    active target was resolvable — T039 step 4).
+    active target was resolvable — T039 step 4). ``retryable_event_ids`` carries
+    pending/rejected/transient IDs separately from reportable failures so a
+    multi-batch command can skip them in-memory while leaving them durably
+    selectable for the next command.
     """
 
     target_id: str | None
@@ -89,6 +92,7 @@ class DispatchSummary:
     transient: int
     terminal_failed: int
     failures: tuple[DispatchFailure, ...] = ()
+    retryable_event_ids: tuple[str, ...] = ()
 
     @property
     def recorded(self) -> int:
@@ -124,6 +128,7 @@ class DispatchSummary:
         selected: int,
         counts: Mapping[DeliveryOutcome, int],
         failures: Sequence[DispatchFailure] = (),
+        retryable_event_ids: Sequence[str] = (),
     ) -> DispatchSummary:
         """Build a summary from a :class:`DeliveryOutcome` -> count mapping."""
         return cls(
@@ -136,6 +141,7 @@ class DispatchSummary:
             transient=counts[DeliveryOutcome.TRANSIENT],
             terminal_failed=counts[DeliveryOutcome.TERMINAL_FAILED],
             failures=tuple(failures),
+            retryable_event_ids=tuple(retryable_event_ids),
         )
 
 
@@ -317,10 +323,17 @@ def _record(
     """Record every *result* and tally per-outcome counts into a :class:`DispatchSummary`."""
     counts: dict[DeliveryOutcome, int] = dict.fromkeys(DeliveryOutcome, 0)
     failures: list[DispatchFailure] = []
+    retryable_event_ids: list[str] = []
     with ledger.transaction():
         for result in results:
             _record_one(ledger, target_id, result)
             counts[result.outcome] += 1
+            if result.outcome in {
+                DeliveryOutcome.PENDING,
+                DeliveryOutcome.REJECTED,
+                DeliveryOutcome.TRANSIENT,
+            }:
+                retryable_event_ids.append(result.event_id)
             if result.outcome in {
                 DeliveryOutcome.REJECTED,
                 DeliveryOutcome.TRANSIENT,
@@ -335,7 +348,11 @@ def _record(
                     )
                 )
     return DispatchSummary.from_counts(
-        target_id, selected=selected, counts=counts, failures=failures
+        target_id,
+        selected=selected,
+        counts=counts,
+        failures=failures,
+        retryable_event_ids=retryable_event_ids,
     )
 
 

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -511,6 +511,29 @@ class TestSyncNowExitCodes:
             res = runner.invoke(sync_app, ["now"])
         assert res.exit_code == 1, res.output
 
+    @pytest.mark.parametrize("outcome", ["rejected", "transient"])
+    def test_strict_exits_1_on_partial_retryable_errors(self, outcome):
+        """Strict mode fails when progress leaves retryable delivery errors."""
+        summary = self._dispatch_summary(
+            selected=3,
+            delivered=2,
+            **{outcome: 1},
+        )
+        svc = self._make_dispatch_service(queue_size=3)
+
+        runner = CliRunner()
+        with (
+            patch("specify_cli.sync.background.get_sync_service", return_value=svc),
+            patch("specify_cli.cli.commands.sync.is_saas_sync_enabled", return_value=True),
+            patch(
+                "specify_cli.cli.commands.sync._run_event_sync_dispatch",
+                return_value=summary,
+            ),
+        ):
+            res = runner.invoke(sync_app, ["now"])
+
+        assert res.exit_code == 1, res.output
+
     def test_now_returns_0_when_saas_feature_disabled(self, monkeypatch):
         """sync now should no-op safely when SaaS flag is disabled."""
         monkeypatch.delenv(SAAS_SYNC_ENV_VAR, raising=False)

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -534,6 +534,29 @@ class TestSyncNowExitCodes:
 
         assert res.exit_code == 1, res.output
 
+    @pytest.mark.parametrize("outcome", ["rejected", "terminal_failed"])
+    def test_recorded_no_progress_failure_does_not_invoke_auth_recovery(
+        self, outcome
+    ):
+        """Recorded delivery errors are not authentication failures."""
+        summary = self._dispatch_summary(selected=2, **{outcome: 2})
+        svc = self._make_dispatch_service(queue_size=2)
+
+        runner = CliRunner()
+        with (
+            patch("specify_cli.sync.background.get_sync_service", return_value=svc),
+            patch("specify_cli.cli.commands.sync.is_saas_sync_enabled", return_value=True),
+            patch(
+                "specify_cli.cli.commands.sync._run_event_sync_dispatch",
+                return_value=summary,
+            ),
+        ):
+            res = runner.invoke(sync_app, ["now"])
+
+        assert res.exit_code == 1, res.output
+        assert "not authenticated" not in res.output.lower()
+        assert "auth login" not in res.output.lower()
+
     def test_now_returns_0_when_saas_feature_disabled(self, monkeypatch):
         """sync now should no-op safely when SaaS flag is disabled."""
         monkeypatch.delenv(SAAS_SYNC_ENV_VAR, raising=False)

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -473,7 +473,7 @@ def test_run_dispatch_batches_halves_on_oversized_then_drains(
     calls: list[int] = []
     remaining = {"n": 5}
 
-    def fake_dispatch(*, journal, ledger, receiver, target, limit):  # noqa: ANN001, ANN202
+    def fake_dispatch(*, journal, ledger, receiver, target, limit, exclude=frozenset()):  # noqa: ANN001, ANN202
         calls.append(limit)
         if limit >= 4:  # too large: server 413s the whole batch
             return _oversized_summary(min(limit, remaining["n"]))
@@ -498,6 +498,62 @@ def test_run_dispatch_batches_halves_on_oversized_then_drains(
     assert 8 in calls and 2 in calls
     assert combined.delivered == 5
     assert combined.transient == 0
+
+
+def test_run_dispatch_batches_skips_rejected_and_drains_events_behind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A poison chunk (content-rejected, no delivery) must not halt the drain:
+    the loop skips those events for the rest of the pass so deliverable events
+    behind them still drain, and terminates without re-selecting the poison.
+
+    Models the head-of-line block a small (post-oversized) batch limit exposes:
+    without the in-pass skip, the first all-rejected chunk stops the whole drain.
+    """
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 2)
+
+    # Universe: two poison events up front, then three deliverable ones.
+    poison = ["p0", "p1"]
+    good = ["g0", "g1", "g2"]
+    universe = poison + good
+    delivered: list[str] = []
+
+    def fake_dispatch(*, journal, ledger, receiver, target, limit, exclude=frozenset()):  # noqa: ANN001, ANN202
+        selectable = [eid for eid in universe if eid not in exclude and eid not in delivered]
+        chunk = selectable[:limit]
+        if not chunk:
+            return DispatchSummary.empty()
+        rejected_ids = [eid for eid in chunk if eid in poison]
+        good_ids = [eid for eid in chunk if eid not in poison]
+        delivered.extend(good_ids)
+        return DispatchSummary(
+            target_id="t",
+            selected=len(chunk),
+            delivered=len(good_ids),
+            duplicate=0,
+            pending=0,
+            rejected=len(rejected_ids),
+            transient=0,
+            terminal_failed=0,
+            failures=tuple(
+                DispatchFailure(
+                    event_id=eid,
+                    outcome="rejected",
+                    http_status=400,
+                    error="requires force=True",
+                )
+                for eid in rejected_ids
+            ),
+        )
+
+    monkeypatch.setattr("specify_cli.delivery.dispatcher.dispatch", fake_dispatch)
+
+    combined = sync_module._run_dispatch_batches(Mock(), Mock(), Mock())
+
+    # All three deliverable events drained despite the poison at the head.
+    assert set(delivered) == set(good)
+    assert combined.delivered == 3
+    assert combined.rejected == 2
 
 
 def test_transient_block_message_distinguishes_cause() -> None:

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from specify_cli.auth.session import StoredSession, Team
 from specify_cli.cli.commands import sync as sync_module
-from specify_cli.delivery.dispatcher import DispatchSummary
+from specify_cli.delivery.dispatcher import DispatchFailure, DispatchSummary
 
 runner = CliRunner()
 pytestmark = pytest.mark.fast
@@ -388,7 +388,11 @@ def test_now_logged_out_nonempty_queue_reports_unauthenticated_failures(
     service.drain_body_uploads_only.return_value = None
 
     # A logged-out dispatch: 3 events selected and attempted, none delivered
-    # (the whole batch came back transient — the 401 classification).
+    # (the whole batch came back transient — the 401 classification). A real 401
+    # maps each event to a transient failure carrying http_status=401 (see
+    # ``specify_cli.delivery.receivers.map_batch_response``); the message
+    # classifier keys on that status to report "not authenticated" rather than a
+    # generic transient / oversized message.
     unauthenticated_summary = DispatchSummary(
         target_id="t-1",
         selected=3,
@@ -398,6 +402,15 @@ def test_now_logged_out_nonempty_queue_reports_unauthenticated_failures(
         rejected=0,
         transient=3,
         terminal_failed=0,
+        failures=tuple(
+            DispatchFailure(
+                event_id=f"evt-{i}",
+                outcome="transient",
+                http_status=401,
+                error="not authenticated",
+            )
+            for i in range(3)
+        ),
     )
 
     monkeypatch.setattr(sync_module, "is_saas_sync_enabled", lambda: True)
@@ -423,3 +436,107 @@ def test_now_logged_out_nonempty_queue_reports_unauthenticated_failures(
     assert report["selected"] == 3
     assert report["transient"] == 3
     assert report["delivered"] == 0
+
+
+def _oversized_summary(sel: int) -> DispatchSummary:
+    """A batch the server 413'd wholesale: nothing delivered, all transient."""
+    return DispatchSummary(
+        target_id="t",
+        selected=sel,
+        delivered=0,
+        duplicate=0,
+        pending=0,
+        rejected=0,
+        transient=sel,
+        terminal_failed=0,
+        failures=tuple(
+            DispatchFailure(
+                event_id=f"e{i}",
+                outcome="transient",
+                http_status=413,
+                error="batch payload too large; retry with a smaller batch",
+            )
+            for i in range(sel)
+        ),
+    )
+
+
+def test_run_dispatch_batches_halves_on_oversized_then_drains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A byte-oversized batch (HTTP 413) is halved and retried until it fits,
+    honoring the documented "retry with a smaller batch" contract instead of
+    surrendering the whole backlog as transient (the deadlock this fixes).
+    """
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 8)
+
+    calls: list[int] = []
+    remaining = {"n": 5}
+
+    def fake_dispatch(*, journal, ledger, receiver, target, limit):  # noqa: ANN001, ANN202
+        calls.append(limit)
+        if limit >= 4:  # too large: server 413s the whole batch
+            return _oversized_summary(min(limit, remaining["n"]))
+        sel = min(limit, remaining["n"])  # fits: delivers what it selects
+        remaining["n"] -= sel
+        return DispatchSummary(
+            target_id="t",
+            selected=sel,
+            delivered=sel,
+            duplicate=0,
+            pending=0,
+            rejected=0,
+            transient=0,
+            terminal_failed=0,
+        )
+
+    monkeypatch.setattr("specify_cli.delivery.dispatcher.dispatch", fake_dispatch)
+
+    combined = sync_module._run_dispatch_batches(Mock(), Mock(), Mock())
+
+    # Shrank 8 -> 4 -> 2 before a batch fit, then drained all five events.
+    assert 8 in calls and 2 in calls
+    assert combined.delivered == 5
+    assert combined.transient == 0
+
+
+def test_transient_block_message_distinguishes_cause() -> None:
+    """The wholesale-transient message must not blame auth for a 413 or a 5xx.
+
+    This is the mislabel that made a batch-too-large failure read as a
+    logged-out session and sent operators chasing OAuth.
+    """
+    oversized = _oversized_summary(3)
+    assert sync_module._transient_block_message(oversized) == (
+        sync_module._OVERSIZED_SYNC_NOW_MESSAGE
+    )
+
+    unauth = DispatchSummary(
+        target_id="t",
+        selected=1,
+        delivered=0,
+        duplicate=0,
+        pending=0,
+        rejected=0,
+        transient=1,
+        terminal_failed=0,
+        failures=(DispatchFailure(event_id="e", outcome="transient", http_status=401),),
+    )
+    assert sync_module._transient_block_message(unauth) == (
+        sync_module._UNAUTHENTICATED_SYNC_NOW_MESSAGE
+    )
+
+    server_err = DispatchSummary(
+        target_id="t",
+        selected=1,
+        delivered=0,
+        duplicate=0,
+        pending=0,
+        rejected=0,
+        transient=1,
+        terminal_failed=0,
+        failures=(DispatchFailure(event_id="e", outcome="transient", http_status=503),),
+    )
+    assert sync_module._transient_block_message(server_err) == (
+        sync_module._TRANSIENT_SYNC_NOW_MESSAGE
+    )

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -557,6 +557,75 @@ def test_run_dispatch_batches_skips_rejected_and_drains_events_behind(
     assert combined.rejected == 2
 
 
+def test_run_dispatch_batches_grows_limit_back_after_oversized_park(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a single over-cap event forces limit->1 and is parked, the limit
+    grows back so the healthy tail drains in grown batches, not one-per-POST.
+
+    Without the grow-back the four small events behind the giant would each
+    need their own singleton POST (the throughput cliff). Asserting that a
+    post-park batch delivered >1 tail event catches a regression to that.
+    """
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 8)
+
+    giant = "big-0"  # any batch containing it exceeds the server byte cap
+    tail = ["s0", "s1", "s2", "s3"]
+    universe = [giant, *tail]
+    delivered: list[str] = []
+    parked: set[str] = set()
+    calls: list[tuple[str, ...]] = []
+
+    def fake_dispatch(*, journal, ledger, receiver, target, limit, exclude=frozenset()):  # noqa: ANN001, ANN202
+        selectable = [
+            eid
+            for eid in universe
+            if eid not in exclude and eid not in delivered and eid not in parked
+        ]
+        chunk = selectable[:limit]
+        calls.append(tuple(chunk))
+        if not chunk:
+            return DispatchSummary.empty()
+        if giant in chunk and len(chunk) > 1:  # byte-oversized: server 413s it
+            return _oversized_summary(len(chunk))
+        if chunk == [giant]:  # a single over-cap event is terminal-failed
+            parked.add(giant)
+            return DispatchSummary(
+                target_id="t",
+                selected=1,
+                delivered=0,
+                duplicate=0,
+                pending=0,
+                rejected=0,
+                transient=0,
+                terminal_failed=1,
+            )
+        delivered.extend(chunk)
+        return DispatchSummary(
+            target_id="t",
+            selected=len(chunk),
+            delivered=len(chunk),
+            duplicate=0,
+            pending=0,
+            rejected=0,
+            transient=0,
+            terminal_failed=0,
+        )
+
+    monkeypatch.setattr("specify_cli.delivery.dispatcher.dispatch", fake_dispatch)
+
+    combined = sync_module._run_dispatch_batches(Mock(), Mock(), Mock())
+
+    assert combined.delivered == len(tail)
+    assert combined.terminal_failed == 1
+    assert set(delivered) == set(tail)
+    # The healthy tail drained in grown batches, not four singleton POSTs:
+    # the limit recovered above 1 after the giant was parked.
+    tail_calls = [c for c in calls if c and all(eid in tail for eid in c)]
+    assert any(len(c) >= 2 for c in tail_calls)
+    assert len(tail_calls) < len(tail)
+
+
 def test_run_dispatch_batches_skips_pending_and_reports_each_event_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -544,6 +544,7 @@ def test_run_dispatch_batches_skips_rejected_and_drains_events_behind(
                 )
                 for eid in rejected_ids
             ),
+            retryable_event_ids=tuple(rejected_ids),
         )
 
     monkeypatch.setattr("specify_cli.delivery.dispatcher.dispatch", fake_dispatch)
@@ -554,6 +555,53 @@ def test_run_dispatch_batches_skips_rejected_and_drains_events_behind(
     assert set(delivered) == set(good)
     assert combined.delivered == 3
     assert combined.rejected == 2
+
+
+def test_run_dispatch_batches_skips_pending_and_reports_each_event_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending head must wait for the next command, not block this drain."""
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 2)
+
+    pending = {"p0", "p1"}
+    good = {"g0", "g1"}
+    universe = ["p0", "p1", "g0", "g1"]
+    delivered: set[str] = set()
+    attempted: list[tuple[str, ...]] = []
+
+    def fake_dispatch(*, journal, ledger, receiver, target, limit, exclude=frozenset()):  # noqa: ANN001, ANN202
+        selectable = [
+            event_id
+            for event_id in universe
+            if event_id not in exclude and event_id not in delivered
+        ]
+        chunk = selectable[:limit]
+        attempted.append(tuple(chunk))
+        if not chunk:
+            return DispatchSummary.empty()
+        pending_ids = [event_id for event_id in chunk if event_id in pending]
+        delivered_ids = [event_id for event_id in chunk if event_id in good]
+        delivered.update(delivered_ids)
+        return DispatchSummary(
+            target_id="t",
+            selected=len(chunk),
+            delivered=len(delivered_ids),
+            duplicate=0,
+            pending=len(pending_ids),
+            rejected=0,
+            transient=0,
+            terminal_failed=0,
+            retryable_event_ids=tuple(pending_ids),
+        )
+
+    monkeypatch.setattr("specify_cli.delivery.dispatcher.dispatch", fake_dispatch)
+
+    combined = sync_module._run_dispatch_batches(Mock(), Mock(), Mock())
+
+    assert attempted == [("p0", "p1"), ("g0", "g1"), ()]
+    assert combined.selected == 4
+    assert combined.pending == 2
+    assert combined.delivered == 2
 
 
 def test_transient_block_message_distinguishes_cause() -> None:
@@ -596,3 +644,66 @@ def test_transient_block_message_distinguishes_cause() -> None:
     assert sync_module._transient_block_message(server_err) == (
         sync_module._TRANSIENT_SYNC_NOW_MESSAGE
     )
+
+
+def test_oversized_classifier_requires_wholesale_transient_rejection() -> None:
+    """Ordinary content text containing 'too large' must not trigger halving."""
+    content_rejection = DispatchSummary(
+        target_id="t",
+        selected=1,
+        delivered=0,
+        duplicate=0,
+        pending=0,
+        rejected=1,
+        transient=0,
+        terminal_failed=0,
+        failures=(
+            DispatchFailure(
+                event_id="e",
+                outcome="rejected",
+                http_status=200,
+                error="field value too large",
+            ),
+        ),
+    )
+    partial_413 = DispatchSummary(
+        target_id="t",
+        selected=2,
+        delivered=1,
+        duplicate=0,
+        pending=0,
+        rejected=0,
+        transient=1,
+        terminal_failed=0,
+        failures=(
+            DispatchFailure(
+                event_id="e",
+                outcome="transient",
+                http_status=413,
+                error="batch payload too large; retry with a smaller batch",
+            ),
+        ),
+    )
+    generic_transient = DispatchSummary(
+        target_id="t",
+        selected=1,
+        delivered=0,
+        duplicate=0,
+        pending=0,
+        rejected=0,
+        transient=1,
+        terminal_failed=0,
+        failures=(
+            DispatchFailure(
+                event_id="e",
+                outcome="transient",
+                http_status=200,
+                error="field value too large",
+            ),
+        ),
+    )
+
+    assert sync_module._batch_is_oversized(_oversized_summary(2)) is True
+    assert sync_module._batch_is_oversized(content_rejection) is False
+    assert sync_module._batch_is_oversized(partial_413) is False
+    assert sync_module._batch_is_oversized(generic_transient) is False

--- a/tests/delivery/test_dispatcher.py
+++ b/tests/delivery/test_dispatcher.py
@@ -601,7 +601,14 @@ def test_multi_batch_drain_continues_after_singleton_terminal_failure(
     target_a: DeliveryTarget,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Canonical 413 halving parks one event, then drains the success tail."""
+    """Canonical 413 halving parks one event, then drains the success tail.
+
+    After the oversized head (evt-0) is halved to a singleton and parked as
+    terminal_failed, the limit grows back (1 -> 2), so the healthy tail
+    (evt-1, evt-2) drains in one grown batch rather than one-event-per-POST.
+    The grow-back is the throughput-cliff fix; the old behavior emitted
+    ``("evt-1",), ("evt-2",)`` as separate singleton calls.
+    """
     receiver = _AdaptiveOversizedStub()
     runtime = SimpleNamespace(journal=journal, ledger=ledger)
     monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 2)
@@ -611,8 +618,7 @@ def test_multi_batch_drain_continues_after_singleton_terminal_failure(
     assert receiver.calls == [
         ("evt-0", "evt-1"),
         ("evt-0",),
-        ("evt-1",),
-        ("evt-2",),
+        ("evt-1", "evt-2"),
     ]
     assert summary.selected == 3
     assert summary.terminal_failed == 1

--- a/tests/delivery/test_dispatcher.py
+++ b/tests/delivery/test_dispatcher.py
@@ -48,6 +48,7 @@ from specify_cli.delivery.receivers import (
     DeliveryResult,
     OutboundEvent,
     StubReceiver,
+    map_batch_response,
 )
 from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
 from specify_cli.event_journal.journal import EventJournal
@@ -193,6 +194,39 @@ class _PendingHeadStub:
             )
             for event in batch
         ]
+
+
+class _AdaptiveOversizedStub:
+    """Exercise the canonical mapper's batch-413 then singleton-terminal path."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    @property
+    def endpoint_url(self) -> str:
+        return "http://localhost/__adaptive-oversized-stub__/api/v1/events/batch/"
+
+    def auth_headers(self) -> dict[str, str]:
+        return {}
+
+    def gates(self) -> tuple[Any, ...]:
+        return ()
+
+    def deliver(self, batch: Sequence[OutboundEvent]) -> list[DeliveryResult]:
+        events = list(batch)
+        self.calls.append(tuple(event.event_id for event in events))
+        if events and events[0].event_id == "evt-0":
+            return map_batch_response(events, http_status=413, body=None)
+        return map_batch_response(
+            events,
+            http_status=200,
+            body={
+                "results": [
+                    {"event_id": event.event_id, "status": "success"}
+                    for event in events
+                ]
+            },
+        )
 
 
 class _FakeCoalesce:
@@ -559,6 +593,31 @@ def test_multi_batch_drain_skips_pending_head_through_live_dispatcher(
     assert summary.delivered == 2
     remaining = _select_undelivered(journal, ledger, target_a.target_id)
     assert [event.event_id for event in remaining] == ["evt-0", "evt-1"]
+
+
+def test_multi_batch_drain_continues_after_singleton_terminal_failure(
+    journal: EventJournal,
+    ledger: SqliteDeliveryLedger,
+    target_a: DeliveryTarget,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canonical 413 halving parks one event, then drains the success tail."""
+    receiver = _AdaptiveOversizedStub()
+    runtime = SimpleNamespace(journal=journal, ledger=ledger)
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 2)
+
+    summary = sync_module._run_dispatch_batches(runtime, receiver, target_a)
+
+    assert receiver.calls == [
+        ("evt-0", "evt-1"),
+        ("evt-0",),
+        ("evt-1",),
+        ("evt-2",),
+    ]
+    assert summary.selected == 3
+    assert summary.terminal_failed == 1
+    assert summary.delivered == 2
+    assert _select_undelivered(journal, ledger, target_a.target_id) == []
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/delivery/test_dispatcher.py
+++ b/tests/delivery/test_dispatcher.py
@@ -20,10 +20,12 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections.abc import Sequence
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from specify_cli.cli.commands import sync as sync_module
 from specify_cli.delivery.dispatcher import (
     DispatchSummary,
     _decode_payload,
@@ -159,6 +161,38 @@ class _TerminalFailStub:
 
     def delivered_ids(self) -> tuple[str, ...]:
         return tuple(self._delivered)
+
+
+class _PendingHeadStub:
+    """Return pending for the first two events and success for later events."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    @property
+    def endpoint_url(self) -> str:
+        return "http://localhost/__pending-head-stub__/api/v1/events/batch/"
+
+    def auth_headers(self) -> dict[str, str]:
+        return {}
+
+    def gates(self) -> tuple[Any, ...]:
+        return ()
+
+    def deliver(self, batch: Sequence[OutboundEvent]) -> list[DeliveryResult]:
+        self.calls.append(tuple(event.event_id for event in batch))
+        return [
+            DeliveryResult(
+                event_id=event.event_id,
+                outcome=(
+                    DeliveryOutcome.PENDING
+                    if event.event_id in {"evt-0", "evt-1"}
+                    else DeliveryOutcome.SUCCESS
+                ),
+                http_status=200,
+            )
+            for event in batch
+        ]
 
 
 class _FakeCoalesce:
@@ -479,6 +513,52 @@ def test_dispatch_summary_counts_and_recorded() -> None:
     assert summary.delivered == 2
     assert summary.pending == 1
     assert summary.recorded == 3
+
+
+def test_record_exposes_retryable_ids_without_calling_pending_a_failure(
+    ledger: SqliteDeliveryLedger,
+) -> None:
+    """The batch loop can skip every retryable outcome without report drift."""
+    results = [
+        DeliveryResult(event_id="pending", outcome=DeliveryOutcome.PENDING),
+        DeliveryResult(event_id="rejected", outcome=DeliveryOutcome.REJECTED),
+        DeliveryResult(event_id="transient", outcome=DeliveryOutcome.TRANSIENT),
+        DeliveryResult(
+            event_id="terminal",
+            outcome=DeliveryOutcome.TERMINAL_FAILED,
+        ),
+    ]
+
+    summary = _record(ledger, "target", results, selected=len(results))
+
+    assert summary.retryable_event_ids == ("pending", "rejected", "transient")
+    assert [failure.event_id for failure in summary.failures] == [
+        "rejected",
+        "transient",
+        "terminal",
+    ]
+
+
+def test_multi_batch_drain_skips_pending_head_through_live_dispatcher(
+    journal: EventJournal,
+    ledger: SqliteDeliveryLedger,
+    target_a: DeliveryTarget,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pending rows defer to the next command while later rows drain now."""
+    journal.append(_make_event(3))
+    receiver = _PendingHeadStub()
+    runtime = SimpleNamespace(journal=journal, ledger=ledger)
+    monkeypatch.setattr(sync_module, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 2)
+
+    summary = sync_module._run_dispatch_batches(runtime, receiver, target_a)
+
+    assert receiver.calls == [("evt-0", "evt-1"), ("evt-2", "evt-3")]
+    assert summary.selected == 4
+    assert summary.pending == 2
+    assert summary.delivered == 2
+    remaining = _select_undelivered(journal, ledger, target_a.target_id)
+    assert [event.event_id for event in remaining] == ["evt-0", "evt-1"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Draft for feedback (@stijn / @kent). Fixes the root cause in #2734. Not for merge until you have looked at it.

## What this fixes

`sync now` could not drain a backlog whose events exceeded the server's per-batch size limit, and it reported the failure as an auth error. That mislabel is what made the whole "data will not sync" saga read as an OAuth problem. OAuth (#2731) is sound; I ruled it out.

Two related drain defects, in two commits:

### 1. Byte-oversized batches deadlocked

The CLI chunks a drain only by event count (`_EVENT_SYNC_DISPATCH_BATCH_LIMIT = 1000`), never by byte size. A backlog under 1000 events but over the server's size cap goes out as one oversized batch, gets a 413, and every event flips to `transient`. `_run_dispatch_batches` breaks on `selected < 1000` and re-selects the same oversized set on the next drain. Permanent deadlock. The receiver already returns `"batch payload too large; retry with a smaller batch"` and batch.py promises the CLI will retry smaller, but nothing did.

**Change:** adaptive halving in `_run_dispatch_batches` (on 413 with nothing delivered and > 1 event, halve the limit and retry; a single oversized event is terminal-failed by the receiver so `limit == 1` cannot loop forever), plus an honest message classified by actual failure status (413 -> too large, 401/403 -> not authenticated, else -> generic transient) instead of always blaming auth.

### 2. A poison chunk head-of-line blocked the rest

Once batches are small, the loop broke on the first chunk that made no terminal progress -- a content-rejected chunk halted the whole pass, so deliverable events behind it never drained.

**Change:** `dispatch()`/`_select_undelivered` gain an optional in-memory `exclude` skip set (applied to the journal universe before the ledger query, so `limit` still fills). The loop accumulates events that made no terminal-success this pass and skips them for the rest of the pass, advancing to deliverable events behind them. It never mutates the ledger, so the non-terminal re-selection contract (T028) is preserved; termination is on a strict progress invariant.

## Verified locally

A 647-event backlog that deadlocked as one oversized batch (all transient, "not authenticated") drains cleanly once byte-safe: 400 delivered, 0 transient, confirmed server-side. The remaining rejections are genuine content rejections (see #2736), not a delivery problem.

## Tests

- `test_run_dispatch_batches_halves_on_oversized_then_drains`: an oversized batch is halved 8 -> 4 -> 2 until it fits, then drains all events.
- `test_run_dispatch_batches_skips_rejected_and_drains_events_behind`: poison events at the head do not stop deliverable events behind them.
- `test_transient_block_message_distinguishes_cause`: 413 / 401 / 5xx each get the right message.
- Updated `test_now_logged_out_nonempty_queue_reports_unauthenticated_failures` to a realistic 401 summary so #829's exit-1 / "auth login" contract holds under the more precise classifier.

Full delivery + sync-routes suites green (187); ruff and mypy clean.

## Two things I deliberately left out (your call)

- **All-rejected exit contract**: an all-rejected drain (content 400s, no progress) still routes through `_handle_sync_now_unauthenticated` and prints the auth message. Fixing that cleanly touches the #829 exit-code contract (exit 1 vs exit 4), your lane, so I did not rework it here.
- **Batch-400 isolation (#2736)**: full recovery of innocent events trapped in a strict-whole-batch 400 needs bisecting the batch to isolate the invalid event. That mirrors the oversized halving here but touches the server's whole-batch-400 contract, so I filed it separately for your call rather than build it blind.

Related: #2734 (root cause), #2736 (batch-400 isolation follow-up), #2731 (OAuth, ruled out).
