### PR TITLE
test(arch): allow pr:deferred/pr:skip-ci full-CI-block labels on always-on jobs

### DIFF
--- a/tests/architectural/_gate_coverage.py
+++ b/tests/architectural/_gate_coverage.py
@@ -115,6 +115,66 @@ _PYTEST_HEAD_RE = re.compile(r"^pytest\b")
 _GHA_EXPR_RE = re.compile(r"\$\{\{(.*?)\}\}")
 _SEGMENT_SPLIT_RE = re.compile(r"&&|;|\|\|?|\bthen\b|\bdo\b")
 
+# The two operator-facing "full CI block" labels: a PR explicitly labeled
+# ``pr:deferred`` / ``pr:skip-ci`` blocks ALL PR-triggered workflows (added in
+# ``ddac71ebc``). An always-on job may carry ONLY these two label guards and
+# still count as "runs unconditionally"; ANY other conjunct (a
+# ``needs.changes.outputs`` path filter, a status/draft/event-name check) would
+# silently mask the job and is rejected -- that is the mask the arch pole and
+# the residual gate exist to forbid.
+FULL_CI_BLOCK_LABELS: tuple[str, ...] = ("pr:deferred", "pr:skip-ci")
+
+
+def _normalize_conjunct(text: str) -> str:
+    """Collapse all whitespace so gate conjuncts compare canonically."""
+    return "".join(text.split())
+
+
+def _full_ci_block_conjuncts() -> frozenset[str]:
+    return frozenset(
+        f"!contains(github.event.pull_request.labels.*.name,'{label}')"
+        for label in FULL_CI_BLOCK_LABELS
+    )
+
+
+def gate_is_always_on_modulo_full_ci_block(
+    if_value: str | None, *, require_always: bool
+) -> bool:
+    """Whether a job runs unconditionally EXCEPT for the full-CI-block labels.
+
+    Accepts either an absent ``if:`` (truly unconditional) or an ``if:`` whose
+    only conjuncts are ``always()`` (optional in general, mandatory when
+    *require_always* -- e.g. the arch pole must run even when upstream jobs
+    fail) plus BOTH ``pr:deferred`` / ``pr:skip-ci`` label guards. Any other
+    conjunct -- a path/status/needs/draft/event filter -- returns ``False``,
+    because it could silently mask the job (the pre-WP03 mask this forbids).
+    """
+    if if_value is None:
+        # No gate at all is unconditional, but a job that must survive upstream
+        # failure needs an explicit ``always()`` -- absence is a regression there.
+        return not require_always
+    expr_match = _GHA_EXPR_RE.search(if_value)
+    inner = expr_match.group(1) if expr_match else if_value
+    conjuncts = [c for c in inner.split("&&") if c.strip()]
+    if not conjuncts:
+        return False
+    has_always = False
+    label_conjuncts = _full_ci_block_conjuncts()
+    seen_labels: set[str] = set()
+    for conjunct in conjuncts:
+        normalized = _normalize_conjunct(conjunct)
+        if normalized in ("always()", "(always())"):
+            has_always = True
+        elif normalized in label_conjuncts:
+            seen_labels.add(normalized)
+        else:
+            return False  # a masking condition -- reject
+    # Labels are all-or-nothing: a bare ``always()`` (no labels) is the original,
+    # strictest form; ``always()`` + BOTH labels is the sanctioned full-CI-block
+    # form. A single label (asymmetric) is a malformed gate and is rejected.
+    labels_ok = seen_labels in (frozenset(), label_conjuncts)
+    return labels_ok and (has_always or not require_always)
+
 # Runner prefixes that may precede the literal ``pytest`` command token. After
 # stripping leading env-assignments and these, a real pytest *command* segment
 # begins with ``pytest`` — so ``pipx inject ... pytest`` and ``git grep ...

--- a/tests/architectural/test_ci_architectural_gate_coverage.py
+++ b/tests/architectural/test_ci_architectural_gate_coverage.py
@@ -27,6 +27,8 @@ from typing import Any
 import pytest
 import yaml
 
+from tests.architectural import _gate_coverage as gc
+
 pytestmark = [pytest.mark.architectural]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -187,12 +189,14 @@ def test_arch_suite_runs_unconditionally_cannot_be_masked() -> None:
     data = _load_workflow()
     arch_job = data["jobs"]["arch-adversarial"]
 
-    # Gate is exactly always() — not a filter-conditioned expression.
+    # Gate is always() — optionally AND-ed with ONLY the pr:deferred /
+    # pr:skip-ci full-CI-block labels (ddac71ebc) — never a path/status filter.
     gate = str(arch_job["if"]).strip()
-    assert gate == "always()", (
-        f"arch-adversarial gate must be exactly 'always()', got {gate!r}. A "
-        "filter-conditioned gate would let a status/path change mask the "
-        "architectural suite (the pre-WP03 mask this mission removed)."
+    assert gc.gate_is_always_on_modulo_full_ci_block(gate, require_always=True), (
+        f"arch-adversarial gate must be 'always()' (optionally guarded only by "
+        f"the pr:deferred / pr:skip-ci full-CI-block labels), got {gate!r}. A "
+        "path/status-conditioned gate would let a change mask the architectural "
+        "suite (the pre-WP03 mask this mission removed)."
     )
     assert "needs.changes.outputs" not in gate, (
         "arch-adversarial gained a dorny filter-output gate — that re-opens the "

--- a/tests/architectural/test_ci_quality_path_filters.py
+++ b/tests/architectural/test_ci_quality_path_filters.py
@@ -280,8 +280,13 @@ def test_execution_context_parity_ratchet_runs_unconditionally() -> None:
     data = _load_workflow()
     arch_job = _job(data, "arch-adversarial")
 
-    # Always-on: no result-gated or filter-gated skip can drop the ratchet.
-    assert str(arch_job["if"]).strip() == "always()"
+    # Always-on: no result-gated or path/status-gated skip can drop the ratchet.
+    # The only permitted guards are the pr:deferred / pr:skip-ci full-CI-block
+    # labels (ddac71ebc), which block ALL PR workflows but cannot mask this pole
+    # via a change filter.
+    assert gc.gate_is_always_on_modulo_full_ci_block(
+        str(arch_job["if"]), require_always=True
+    ), f"arch-adversarial pole gained a masking filter: if={arch_job['if']!r}"
 
     # Every matrix leg collects the tests/architectural tree, which owns
     # test_execution_context_parity.py — so the parity ratchet is in-scope no

--- a/tests/architectural/test_unit_contract_residual_gate.py
+++ b/tests/architectural/test_unit_contract_residual_gate.py
@@ -73,16 +73,24 @@ def _load_jobs(path: Path) -> dict[str, Any]:
 
 
 def residual_job_is_always_on(jobs: dict[str, Any], job_name: str) -> bool:
-    """``True`` iff ``job_name`` EXISTS and carries no ``if:`` key.
+    """``True`` iff ``job_name`` EXISTS and runs unconditionally.
 
-    An absent job is explicitly a violation (``False``), never a vacuous pass
-    — guards the ``.get(key, empty)`` mis-key trap called out in the module
-    docstring.
+    "Unconditionally" means no ``if:`` key at all, OR an ``if:`` whose only
+    conjuncts are the ``pr:deferred`` / ``pr:skip-ci`` full-CI-block label
+    guards (``ddac71ebc``): those let an operator block ALL PR workflows but
+    cannot silently mask this job via a path/status change. Any other filter is
+    a violation. An absent job is explicitly a violation (``False``), never a
+    vacuous pass — guards the ``.get(key, empty)`` mis-key trap called out in
+    the module docstring.
     """
     if job_name not in jobs:
         return False
     job = jobs[job_name]
-    return isinstance(job, dict) and job.get("if") is None
+    if not isinstance(job, dict):
+        return False
+    return gc.gate_is_always_on_modulo_full_ci_block(
+        job.get("if"), require_always=False
+    )
 
 
 def residual_job_is_gate_member(
@@ -116,8 +124,9 @@ def test_unit_contract_residual_is_always_on_live() -> None:
     """
     jobs = _load_jobs(_CI_QUALITY)
     assert residual_job_is_always_on(jobs, _RESIDUAL_JOB), (
-        f"{_RESIDUAL_JOB!r} must carry NO `if:` key (always-on); found "
-        f"if={jobs.get(_RESIDUAL_JOB, {}).get('if')!r}"
+        f"{_RESIDUAL_JOB!r} must run unconditionally — no `if:`, or an `if:` "
+        "guarded ONLY by the pr:deferred / pr:skip-ci full-CI-block labels; "
+        f"found if={jobs.get(_RESIDUAL_JOB, {}).get('if')!r}"
     )
 
 


### PR DESCRIPTION
## What

`ddac71ebc` ("ci: skip PR-triggered workflows on pr:deferred / pr:skip-ci labels") added the two **full-CI-block** labels to every PR-triggered job's `if:` gate — including the always-on `arch-adversarial` pole and `unit-contract-residual`. That left three architectural gates **red on `main`**, because they assert those jobs must be *exactly* `if: always()` (or carry no `if:`):

- `test_ci_architectural_gate_coverage.py` — arch-adversarial pole gate
- `test_ci_quality_path_filters.py::test_execution_context_parity_ratchet_runs_unconditionally`
- `test_unit_contract_residual_gate.py::test_unit_contract_residual_is_always_on_live`

## Why the tests, not the workflow

These gates exist to forbid **masking** the architectural/residual suites via a path/status filter (the pre-WP03 mask). The `pr:deferred`/`pr:skip-ci` labels are a sanctioned operator opt-out that blocks *all* PR workflows — categorically different from a silent path-conditioned mask. So the workflow is correct; the assertions were stale.

## Change

One shared validator `gate_is_always_on_modulo_full_ci_block()` in `tests/architectural/_gate_coverage.py`, used at all three sites. It accepts:
- an absent `if:` (truly unconditional), **or**
- a bare `always()`, **or**
- `always()` AND-ed with **both** full-CI-block label guards (mandatory-`always()` for the arch pole; optional for the residual job).

It still **rejects** any `needs.changes.outputs` / status / draft / event-name conjunct (the real mask), and treats the labels as all-or-nothing so an asymmetric single-label gate remains a violation.

## Verification

- Full `tests/architectural/` suite: **1016 passed, 4 skipped** locally.
- Validator unit-checked against arch/residual/mask/single-label/None forms.
- Workflow file unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786874412&installation_id=146454894&pr_number=2753&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2753&signature=8a531fa5fb6effd3a3b0854fb4e75ca222eef722847dd8fecfc419d66617361d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->