### PR TITLE
fix: setup-plan leaks raw FileNotFoundError text instead of translating to 'P...

### DIFF
--- a/src/specify_cli/cli/commands/agent/mission_setup_plan.py
+++ b/src/specify_cli/cli/commands/agent/mission_setup_plan.py
@@ -958,7 +958,10 @@ def setup_plan(
         ):
             return
 
-        plan_template = _resolve_plan_template(repo_root, plan_read_dir)
+        try:
+            plan_template = _resolve_plan_template(repo_root, plan_read_dir)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError("Plan template not found in repository or package") from exc
         _scaffold_plan_template(plan_file, plan_template)
         _emit_spec_plan_phase_events(feature_dir, mission_slug, spec_file, repo_root)
 


### PR DESCRIPTION
Fixes #2754.

## Summary

setup-plan leaks raw FileNotFoundError text instead of translating to 'Plan template not found' (pre-existing main regression)

## Validation

- Mechanical gate: +4/-1, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786879429&installation_id=146454894&pr_number=2756&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2756&signature=6c6eb9917f87035761be1034808ca25bef8059f043d6d50548edb80b87f7e5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->