### PR TITLE
docs(adr): red main is honest signal; CI is the release authority (Accepted by consensus)

### DIFF
--- a/.kittify/charter/charter.md
+++ b/.kittify/charter/charter.md
@@ -43,8 +43,8 @@ These bind every action; detail lives in the referenced doctrine and the section
 
 ## Quality & Tech-Debt Standing Orders
 
-Eight standing practices that keep spec-driven missions honest, now activated
-doctrine (14 artifacts) and compiled into this charter. Each rule below is
+Nine standing practices that keep spec-driven missions honest, now activated
+doctrine (15 artifacts) and compiled into this charter. Each rule below is
 binding actionable guidance; the full how-to lives in the referenced doctrine
 artifact. **Throughline:** never trust a green check, a clean diff, or a confident
 summary — verify against live code, witness the bug in a real run, and let
@@ -88,8 +88,16 @@ the cheapest point in the lifecycle.
    give implementers ownership-map leeway (no-overlap is the real guard); apply
    tiered rigour. → `planning-and-tracking` styleguide,
    `reviewer-implementer-role-separation`, `ownership-map-leeway`.
+9. **Red-main & release discipline.** A red mainline is an honest signal of a
+   known release-blocking (P0) defect — never green-wash it (no reverting an
+   honest red, no declining a bug's reproduction test). Mainline CI status is the
+   authoritative release gate: **red CI == no release**. When a P0 is filed or
+   accepted, land a failing reproduction test; do not spend expensive QA or manual
+   testing on a red base; work red main down as top priority. Transparency over
+   convenience — it's broken, we hate it, but it's the truth, so we do not hide it.
+   → `red-main-release-discipline` procedure, ADR `2026-07-17-1`.
 
-All 14 catfooding artifacts are activated (`.kittify/config.yaml`) and
+All 15 catfooding artifacts are activated (`.kittify/config.yaml`) and
 directive-reachable, so each resolves in the compiled reference set
 (`references.yaml`). This section states the rules; the referenced artifacts carry
 the detailed procedures, examples, and anti-patterns.

--- a/.kittify/config.yaml
+++ b/.kittify/config.yaml
@@ -184,6 +184,7 @@ activated_procedures:
 - adversarial-squad-deployment
 - post-merge-arch-gate-adjudication
 - mission-wrap-up-sequence
+- red-main-release-discipline
 activated_paradigms:
 - atomic-design
 - behaviour-driven-development

--- a/docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
+++ b/docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
@@ -1,0 +1,65 @@
+---
+title: 'Red main is honest signal; CI status is the release authority'
+status: Accepted
+date: '2026-07-17'
+---
+
+# Red main is honest signal; CI status is the release authority
+
+**Status:** Accepted (by consensus) · **Deciders:** Robert Douglass (CEO / product owner), Kent (QA lead), maintainers · **Date:** 2026-07-17 · **Related:** [`docs/guides/red-main-and-release-readiness.md`](../../guides/red-main-and-release-readiness.md), [`docs/guides/testing-flakiness.md`](../../guides/testing-flakiness.md), [`docs/guides/pr-landing.md`](../../guides/pr-landing.md), the charter's red-first / test-remediation standing order.
+
+## Context and Problem Statement
+
+Our `main` branch runs a large CI suite whose result the team reads as the truth about the product. Two pressures pull against each other:
+
+- **The convenience pull** — a green `main` feels good, so there is a standing temptation to keep it green by reverting anything that goes red, or by declining to merge a test that reproduces a known bug. That produces a *green-washed* mainline: green because the failures are hidden, not because the product works.
+- **The honesty pull** — the whole point of CI is to be a trustworthy signal. A P0 defect that exists in the product but is invisible on `main` is a lie the whole team then builds on: releases ship on a false green, expensive QA runs validate a base that is secretly broken, and the same bug gets rediscovered downstream.
+
+The precipitating events: #2752 was merged with known reds (a CI-guard change whose companion arch-gate fix, #2753, landed right after), and #2754 (a pre-existing `setup-plan` error-translation regression) was filed *because* it was surfaced honestly during a landing pass rather than papered over. Both cases raised the same question — **is a red `main` a process failure to be hidden, or a true signal to be honoured?** — and the team needed a single, written answer.
+
+## Decision Drivers
+
+* **Honest signal over convenience.** A false green is worse than an honest red: it moves the cost of a defect downstream and destroys trust in CI.
+* **CI must mean one thing.** If CI status is sometimes decorative (kept green by hiding failures) and sometimes authoritative, it is authoritative for nothing.
+* **Protect expensive verification.** Manual QA and long/expensive automated runs are wasted if they execute against a base that is already known-broken.
+* **Reproduce, don't just assert.** A P0 that carries a failing test is unambiguous, self-documenting, and un-loseable; a P0 described only in prose drifts and gets forgotten.
+* **Recovery is the priority.** Red `main` is not acceptable as a resting state; it is an alarm that pulls maintainer attention to the front of the queue.
+
+## Considered Options
+
+* **Option A — Always-green mainline (green-washing).** Keep `main` green at all times: revert anything that reds it, and refuse to merge failing reproduction tests. *Rejected* — it hides P0s, lets releases ship on a false green, wastes QA on a secretly-broken base, and contradicts the transparency value.
+* **Option B — Honest mainline; CI is the release authority (chosen).** `main` is allowed to be red when it carries accepted release-blocking (P0) defects; CI status is the single authoritative release gate; failing reproduction tests for P0s are encouraged; expensive QA is gated on green; maintainers prioritize red recovery.
+* **Option C — Separate always-green release branch, `main` allowed red.** Maintain a parallel release line that is kept green while `main` may be red. *Rejected* — it splits the source of truth into two CI signals, adds branch-management overhead, and dilutes exactly the "CI means one thing" property Option B is designed to protect.
+
+## Decision Outcome
+
+**Chosen option: "Option B — Honest mainline; CI is the release authority."** The five binding rules:
+
+1. **`main` may be red.** A red `main` is legitimate and expected when it reflects known release-blocking (P0) defects. It is a *true signal*, not a workflow violation. (This is orthogonal to the no-direct-push / Protect-Main policy, which is unchanged — see [Consequences](#consequences).)
+2. **Mainline CI status is authoritative for release readiness.** **Red CI means no release.** No release proceeds on a red mainline, full stop. There is no "known-red, ship anyway" path.
+3. **P0 filing/acceptance may (and should) add a failing test.** When a P0 bug is filed or accepted, the reporter/accepter is free and **encouraged** to land a test that reproduces the defect — a red-first reproduction at mainline scope. Turning `main` red this way is honouring the process, not breaking it.
+4. **Expensive QA and internal manual testing do not run on a red mainline.** There is no value in validating a base that is already known-broken; QA effort waits for green.
+5. **Maintainers prioritize red builds.** Green `main` is the goal; a red `main` is not an acceptable resting state and pulls to the front of the maintainer queue. We favour transparency and honest reporting over convenience: *it's broken, we hate it, but it's the truth, so we do not hide it.*
+
+### Consequences
+
+#### Positive
+
+* Release readiness has a single, trustworthy gate — CI — that cannot be green-washed.
+* P0 defects are visible on `main` and, when reproduced by a test, self-documenting and un-loseable.
+* Expensive QA and manual-test effort is never spent validating a known-broken base.
+* The policy reinforces the existing red-first / never-retry-to-green discipline (see [testing-flakiness](../../guides/testing-flakiness.md) and the landing-pass bin classification in [pr-landing](../../guides/pr-landing.md)) by extending it from the PR scope to the mainline scope.
+
+#### Negative
+
+* A red `main` is psychologically uncomfortable and can alarm contributors who read it as "the project is broken" rather than "a known P0 is being worked." Mitigation: the accompanying guide states the meaning plainly, and P0s that red `main` carry a filed issue.
+* The policy depends on maintainer discipline to actually prioritize recovery; without it, "red is allowed" could erode into "red is tolerated." The "not an acceptable resting state" rule and the QA-gating consequence are the counter-pressures.
+
+#### Neutral
+
+* **No-direct-push is unchanged.** Changes still reach `main` only through pull requests and the Protect-Main workflow; this ADR governs what a red CI *means*, not how commits arrive.
+* A P0 reproduction test that reds `main` is expected to be tracked by its P0 issue, so the red is always traceable to an accepted defect.
+
+### Confirmation
+
+The decision is confirmed in practice by two observable invariants: (a) no release is cut while mainline CI is red, and (b) an accepted P0 either carries a failing reproduction test or a filed issue (ideally both). A release cut on red, or an accepted P0 silently reverted to keep `main` green, is a violation of this ADR. The operational runbook lives in [`docs/guides/red-main-and-release-readiness.md`](../../guides/red-main-and-release-readiness.md).

--- a/docs/adr/3.x/README.md
+++ b/docs/adr/3.x/README.md
@@ -82,3 +82,4 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-07-14 | [Doctrine → Charter → Core Mission-Type Resolution Unification (governance first)](2026-07-14-2-doctrine-to-core-mission-type-resolution-unification.md) |
 | 2026-07-16 | [WP runtime-state authority — evict runtime-mutable state from tasks/WP##.md into the canonical event log](2026-07-16-1-wp-runtime-state-authority-event-log-eviction.md) |
 | 2026-07-16 | [Steps are the mission-type building block; "template" is a doctrine artefact kind](2026-07-16-2-mission-type-step-authority-and-template-vocabulary.md) |
+| 2026-07-17 | [Red main is honest signal; CI status is the release authority](2026-07-17-1-red-main-is-honest-ci-is-release-authority.md) |

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -794,6 +794,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none
@@ -2055,6 +2061,12 @@
   current_target: true
   notes: null
 - path: docs/guides/recover-from-interrupted-merge.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/guides/red-main-and-release-readiness.md
   tag: current
   divio_type: none
   owning_workstream: none

--- a/docs/guides/how-to-toc.yml
+++ b/docs/guides/how-to-toc.yml
@@ -48,6 +48,8 @@
   href: merge-feature.md
 - name: Troubleshoot Merge Issues
   href: troubleshoot-merge.md
+- name: Red Main and Release Readiness
+  href: red-main-and-release-readiness.md
 - name: Handle Dependencies
   href: handle-dependencies.md
 - name: Sync Workspaces

--- a/docs/guides/red-main-and-release-readiness.md
+++ b/docs/guides/red-main-and-release-readiness.md
@@ -1,0 +1,59 @@
+---
+title: 'Red Main and Release Readiness'
+description: 'What a red main branch means, why CI status is the authoritative release gate, how P0 bugs carry failing reproduction tests, and how maintainers prioritize recovery.'
+doc_status: active
+updated: '2026-07-17'
+related:
+- docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
+- docs/guides/testing-flakiness.md
+- docs/guides/pr-landing.md
+- docs/guides/keep-main-clean.md
+---
+
+# Red Main and Release Readiness
+
+This guide states, in operational terms, what a red `main` means and how the team acts on it. The governing decision is [ADR 2026-07-17-1](../adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md), accepted by consensus (CEO/product owner, QA lead, maintainers).
+
+The one-line stance: **it's broken, we hate it, but it's the truth, so we do not hide it.** An honest red is worth more than a convenient green.
+
+## What a red main means
+
+A red `main` is a **true signal**, not a workflow violation. It means mainline CI has found one or more known release-blocking (**P0**) defects. We do **not** keep `main` green by hiding failures — reverting an honest red or declining to merge a bug's reproduction test would produce a *green-washed* mainline that lies to everyone building on it.
+
+A red `main` should always be **traceable to an accepted P0**: a filed issue, ideally with a failing test that reproduces the defect.
+
+## CI status is the release authority
+
+**Mainline CI status is authoritative for release readiness. Red CI means no release.**
+
+- No release is cut while mainline CI is red — there is no "known-red, ship anyway" path.
+- Because CI is the single gate, it must mean one thing. That is exactly why we refuse to green-wash: a CI signal that is sometimes decorative is authoritative for nothing.
+
+See the release process in [CONTRIBUTING](../../CONTRIBUTING.md); this guide governs *whether* a release may proceed, which is gated on green mainline CI.
+
+## Filing or accepting a P0: add a failing test
+
+When you file or accept a P0 bug, you are **free and encouraged** to land a test that reproduces it — a red-first reproduction at mainline scope.
+
+- A P0 that carries a failing test is unambiguous, self-documenting, and impossible to lose track of. A P0 described only in prose drifts and gets rediscovered downstream.
+- Turning `main` red this way is **honouring the process, not breaking it.** The red is the point: it makes the defect visible until it is fixed.
+- This is the mainline-scope extension of the red-first / never-retry-to-green discipline already applied per-PR — see [test-flakiness handling](testing-flakiness.md) and the red classification bins in the [PR-landing runbook](pr-landing.md).
+
+## Expensive QA and manual testing wait for green
+
+**Expensive QA runs and internal manual testing do not execute on a red mainline build.** There is no value in validating a base that is already known-broken; that effort waits until `main` is green. This protects scarce QA and human-tester time from being spent certifying a base whose result is already known.
+
+## Maintainers prioritize red builds
+
+Green `main` is the goal. A red `main` is **not an acceptable resting state** — it is an alarm that pulls to the front of the maintainer queue.
+
+- Treat mainline recovery as top priority; do not let "red is allowed" erode into "red is tolerated."
+- Land the fix through the normal PR flow (no-direct-push is unchanged — see [Keep Main Clean](keep-main-clean.md)); this policy governs what a red CI *means*, not how commits arrive.
+- The landing-pass runbook's [red-classification step](pr-landing.md#4-classify-every-red-check) tells you how to tell a genuine P0 red from a flake or a pre-existing breakage while you work the queue.
+
+## See also
+
+- [ADR 2026-07-17-1 — Red main is honest signal; CI status is the release authority](../adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md) — the governing decision.
+- [Test-flakiness handling policy](testing-flakiness.md) — the never-retry-to-green rule and budget-gate tuning.
+- [Landing Contributor PRs: The Maintainer Runbook](pr-landing.md) — red classification and the merge-ready hand-off.
+- [How to Keep Main Clean](keep-main-clean.md) — the branch and no-direct-push discipline.

--- a/src/doctrine/procedures/built-in/red-main-release-discipline.procedure.yaml
+++ b/src/doctrine/procedures/built-in/red-main-release-discipline.procedure.yaml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+id: red-main-release-discipline
+name: Red Main & Release Discipline
+purpose: >
+  Keep the mainline CI signal honest and authoritative for release. A red main
+  is a true signal of known release-blocking (P0) defects, never something to
+  hide by reverting an honest failure or declining a bug's reproduction test.
+  Mainline CI status is the single authoritative release gate; expensive QA and
+  manual testing are not spent on a known-broken base; and red main is worked
+  down as top priority. Consensus policy (CEO/product owner, QA lead,
+  maintainers); governing decision ADR 2026-07-17-1, operational guide
+  docs/guides/red-main-and-release-readiness.md.
+entry_condition: >
+  A development mission is running, or a P0 bug is being filed or accepted, or
+  a release is being considered, or mainline CI has gone red.
+exit_condition: >
+  Either main is green, or its red is traceable to an accepted P0 with a filed
+  issue (ideally a failing reproduction test); no release has been cut while
+  mainline CI is red; and expensive QA / manual testing has been deferred until
+  main is green.
+steps:
+  - title: Read a red main as honest signal, not a violation
+    description: >
+      Treat a red mainline as a true signal that a known release-blocking (P0)
+      defect exists. Do NOT green-wash: never revert an honest red or decline to
+      merge a bug's reproduction test just to keep main green — a false green
+      moves the defect downstream and destroys trust in CI. A red main should
+      always be traceable to an accepted P0 (a filed issue, ideally with a
+      failing test). It's broken, we hate it, but it's the truth, so we do not
+      hide it.
+    actor: agent
+  - title: On filing or accepting a P0, add a failing reproduction test
+    description: >
+      When you file or accept a P0 bug, you are free and encouraged to land a
+      test that reproduces it — a red-first reproduction at mainline scope. A P0
+      that carries a failing test is unambiguous, self-documenting, and
+      impossible to lose track of. Turning main red this way honours the
+      process; the red is the point until the defect is fixed. This is the
+      mainline-scope extension of the per-PR red-first / never-retry-to-green
+      discipline.
+    actor: agent
+  - title: Gate release on green mainline CI
+    description: >
+      Mainline CI status is authoritative for release readiness: red CI means
+      no release. Do not cut a release while mainline CI is red — there is no
+      "known-red, ship anyway" path. Because CI is the single release gate, it
+      must mean one thing, which is exactly why green-washing is refused.
+    actor: agent
+  - title: Defer expensive QA and manual testing until green
+    description: >
+      Do not run expensive QA suites or internal manual testing against a red
+      mainline build — there is no value in validating a base that is already
+      known-broken. That effort waits until main is green, protecting scarce QA
+      and human-tester time.
+    actor: agent
+  - title: Prioritize red recovery
+    description: >
+      Green main is the goal; a red main is not an acceptable resting state — it
+      pulls to the front of the maintainer queue. Land the fix through the normal
+      PR flow (no-direct-push is unchanged). Use the landing-pass red
+      classification (docs/guides/pr-landing.md) to distinguish a genuine P0 red
+      from a flake or pre-existing breakage while working the queue.
+    actor: agent


### PR DESCRIPTION
## What

Formalizes the newly-agreed release/CI policy as an **ADR (Accepted by consensus)** plus an operational guide.

Aligned with **Robert Douglass** (CEO / product owner), **Kent** (QA lead), and maintainers:

1. **`main` may be red** — a red mainline is an honest signal of known release-blocking (P0) defects, not a workflow violation.
2. **Mainline CI status is authoritative for release readiness** — **red CI == no release** (no "known-red, ship anyway" path).
3. **P0 filing/acceptance is encouraged to add a failing reproduction test** — red-first at mainline scope; turning `main` red this way honours the process.
4. **Expensive QA + internal manual tests do not run on a red mainline** — no value validating a known-broken base.
5. **Maintainers prioritize red builds** — green `main` is the goal, red is not an acceptable resting state; transparency over convenience: *"it's broken, we hate it, but it's the truth, so we do not hide it."*

## Files

- **`docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md`** — the decision record (Status: **Accepted** by consensus; Deciders listed). Context, drivers, considered options (incl. the rejected green-washing and separate-release-branch alternatives), decision, consequences, confirmation.
- **`docs/guides/red-main-and-release-readiness.md`** — the operational runbook, registered in the how-to TOC.
- README ADR index row + page-inventory lockfile updated via `freshen_adr_inventory`.

## Notes

- No-direct-push / Protect-Main is **unchanged** — this ADR governs what a red CI *means*, not how commits arrive.
- Reinforces the existing red-first / never-retry-to-green discipline (testing-flakiness, pr-landing) by extending it from PR scope to mainline scope.
- Docs-only. All docs-freshness gates (anti-sprawl, related-edge, description-length, relative-link, `check_docs_freshness --ci`) and the terminology guard pass locally.
- Opened for review; **the operator merges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAFBwqsfQkmYVSvRWu8t2R

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786880104&installation_id=146454894&pr_number=2757&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2757&signature=596e5b9f88d2034efefd5c7712b57081875a8143cc7a1310fdceac820b3aa52e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->