### PR TITLE
docs(landing)+test: fold-first red policy; pin 4 known DRG P0 reds as regression

### DIFF
--- a/docs/guides/pr-landing.md
+++ b/docs/guides/pr-landing.md
@@ -93,7 +93,7 @@ rebased tip and classify it into exactly one of four bins:
 |---|---|---|
 | **PR defect** | The PR's own change breaks a test or gate | Fix it on the branch (a "fold", [step 5](#5-folds-remediation-commits-on-the-contributor-branch)) |
 | **Contract the PR legitimately crosses** | A seam move-set completeness gate, a census tolerance band | Re-pin the contract **in the same PR**, with a dated rationale in the pin |
-| **Pre-existing main breakage** | The same red reproduces on an unrelated main-based branch | Prove it cross-branch, file an upstream issue (campsite-cleaning standing order); do **not** fix it inside the contributor PR and do **not** retry-to-green |
+| **Pre-existing main breakage** | The same red reproduces on an unrelated main-based branch | **Fold the fix in the same landing pass by default** (boyscout / campsite-clean): a stale generated artifact, a forgotten regen, a small unwired reference are all fixable inline. **Only** when the fix is genuinely mission-scope/size and cannot reasonably be boy-scouted (e.g. it needs an in-flight mission's own reconciliation) do you instead accept it as an honest **P0 red** — mark the failing test `regression`, pin it to the tracking issue/mission, and leave it red per [Red Main and Release Readiness](red-main-and-release-readiness.md). Never retry-to-green. |
 | **Perf-budget flake** | A budget gate trips without a correctness signal | Note it, watch for recurrence, tune the budget at the root if it repeats — never retry-to-green |
 
 The cross-branch reproduction for the third bin is cheap and decisive:
@@ -103,10 +103,17 @@ git worktree add /tmp/repro-main upstream/main
 cd /tmp/repro-main && PWHEADLESS=1 uv run pytest <failing test> -q
 ```
 
-If it is red there too, the PR does not wear the failure — the filed issue
-does. See the
+If it is red there too, it is a pre-existing breakage — but the default is to
+**fold the fix** into the landing pass (boyscout), not to file-and-defer. Fall
+back to an accepted-P0 `regression` mark + tracking issue **only** when the fix
+is genuinely mission-scope (it belongs to an in-flight mission's own
+reconciliation). Either way the PR does not *wear* the failure: a folded fix
+removes it; a mission-scope red is pinned to the tracking issue/mission it
+belongs to. See the
 [test-flakiness handling policy](testing-flakiness.md) for the
-never-retry-to-green rule behind the fourth bin.
+never-retry-to-green rule behind the fourth bin, and [Red Main and Release
+Readiness](red-main-and-release-readiness.md) for how an accepted red is
+handled honestly.
 
 ## 5. Folds: remediation commits on the contributor branch
 

--- a/tests/architectural/test_charter_references_resolve.py
+++ b/tests/architectural/test_charter_references_resolve.py
@@ -228,6 +228,11 @@ def _actual_dangling_tokens() -> set[str]:
     return cited_tokens - resolved_suffixes
 
 
+# Accepted P0 red (regression): the `red-main-release-discipline` procedure
+# landed (1eb035e20) citing itself in charter.md without wiring the reference
+# into the compiled DRG/references, so this dangler check reds. Reconciliation
+# is owned by the in-flight step-authority DRG work (#2721 / #2751); honest red.
+@pytest.mark.regression
 def test_no_new_charter_reference_danglers() -> None:
     """FR-009 / SC-004: no NEW dangling `→ `token`` citation may appear in
     charter.md, across every section.

--- a/tests/doctrine/drg/migration/test_extractor_projection.py
+++ b/tests/doctrine/drg/migration/test_extractor_projection.py
@@ -80,6 +80,12 @@ def _orphan_urns(nodes: Any, edges: Any) -> set[str]:
 class TestDRGZeroDelta:
     """The projection re-point leaves the shipped DRG graph unchanged (NFR-002)."""
 
+    # Accepted P0 red (regression): the `red-main-release-discipline` procedure
+    # landed (1eb035e20) as a doctrine source without regenerating the shipped
+    # DRG / bumping this zero-delta baseline (280), so the extractor now sees a
+    # node the frozen baseline does not. Reconciliation is owned by the in-flight
+    # step-authority DRG work (#2721 / #2751); honest red until it lands.
+    @pytest.mark.regression
     def test_regenerated_graph_matches_baseline_counts(self, tmp_path: Path) -> None:
         graph = generate_graph(DOCTRINE_ROOT, tmp_path / "graph.yaml")
 
@@ -88,6 +94,12 @@ class TestDRGZeroDelta:
         orphans = _orphan_urns(graph.nodes, graph.edges)
         assert len(orphans) == _EXPECTED_ORPHAN_COUNT  # golden-count: cardinality-is-contract
 
+    # Accepted P0 red (regression): same root cause as
+    # test_regenerated_graph_matches_baseline_counts — the red-main procedure
+    # (1eb035e20) landed without regenerating the shipped DRG, so the extractor
+    # and the shipped graph split-brain. Owned by in-flight step-authority DRG
+    # work (#2721 / #2751); honest red until it lands.
+    @pytest.mark.regression
     def test_shipped_graph_is_fresh_and_byte_identical(self) -> None:
         """A fresh regeneration matches the committed shipped graph exactly."""
         shipped = load_built_in_graph()

--- a/tests/specify_cli/cli/commands/test_doctrine_regenerate_graph.py
+++ b/tests/specify_cli/cli/commands/test_doctrine_regenerate_graph.py
@@ -93,6 +93,12 @@ def _count_orphans(graph: DRGGraph) -> int:
     return len(urns - incident)
 
 
+# Accepted P0 red (regression): the `red-main-release-discipline` procedure
+# landed (1eb035e20) without regenerating the shipped DRG / bumping the
+# migration-extractor zero-delta baseline, so `regenerate-graph` (picks up the
+# node) and the frozen baseline split-brain. Reconciliation is owned by the
+# in-flight step-authority DRG work (#2721 / #2751); honest red until it lands.
+@pytest.mark.regression
 def test_check_reports_committed_graph_fresh() -> None:
     """The shipped graph must be fresh — operator twin of the freshness gate.
 


### PR DESCRIPTION
## What

Two aligned main-hygiene changes:

### 1. Fold-first red-handling policy (runbook)
Updates the [PR-landing runbook §4 "Classify every red check"](../guides/pr-landing.md#4-classify-every-red-check). The **pre-existing main breakage** bin now says: **fold the fix in the same landing pass by default** (boyscout / campsite-clean — a stale generated artifact, a forgotten regen, a small unwired reference are all fixable inline). Falling back to an accepted-P0 `regression` mark + tracking issue is reserved for genuinely **mission-scope** fixes that need an in-flight mission's own reconciliation. Supersedes the prior "do **not** fix it inside the contributor PR, file an issue" guidance.

### 2. Mark four known DRG/doctrine P0 reds `regression`
Per the [Red-main-is-honest ADR](../adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md), accepted P0 reds carry an issue-pinned failing reproduction test. These four are pinned:
- `test_check_reports_committed_graph_fresh`
- `test_no_new_charter_reference_danglers`
- `TestDRGZeroDelta::test_regenerated_graph_matches_baseline_counts`
- `TestDRGZeroDelta::test_shipped_graph_is_fresh_and_byte_identical`

**Root cause:** the `red-main-release-discipline` procedure landed (`1eb035e20`) as a doctrine source **without** regenerating the shipped DRG graph or bumping the migration-extractor zero-delta baseline. As a result `spec-kitty doctrine regenerate-graph` picks up the new procedure node (281) while the frozen migration-extractor baseline (280) and the shipped `procedure.graph.yaml` do not — a **split-brain between two DRG generators**. Reconciling which generator is authoritative is owned by the in-flight step-authority DRG work (epic **#2721**, split-brain **#2751**), so it is *not* boy-scoutable in an unrelated pass — it is pinned and left honestly red.

## Why not just regenerate

A `regenerate-graph` boyscout was attempted: it fixes the two freshness/dangler reds but **breaks** `TestDRGZeroDelta` (the hardcoded `_EXPECTED_NODE_COUNT = 280` and the extractor byte-identity pin), because the migration extractor and `regenerate-graph` disagree. Making them agree requires the step-authority mission's baseline decision — hence mission-scope.

## Verification
- The four tests now collect under `-m regression` (4/4).
- Runbook relative-link check clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898749&installation_id=146454894&pr_number=2765&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2765&signature=aa38c50669cc1212635048afe01c6d689b9eace0f2e4419cacb781fb0432d84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->