### PR TITLE
fix: Generated review handoff embeds stale work-package topology

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1484,6 +1484,7 @@ def review(
             review_ctx=review_ctx,
             main_repo_root=main_repo_root,
             review_feedback_path=review_feedback_path,
+            status_feature_dir=feature_dir,
         )
 
         _executor.review_finalize_and_print(

--- a/src/specify_cli/cli/commands/agent/workflow_executor.py
+++ b/src/specify_cli/cli/commands/agent/workflow_executor.py
@@ -1696,6 +1696,7 @@ def build_review_prompt_lines(
     review_ctx: dict[str, object],
     main_repo_root: Path,
     review_feedback_path: Path,
+    status_feature_dir: Path,
 ) -> list[str]:
     """Assemble the full ``REVIEW: <wp>`` prompt body."""
     lines: list[str] = []
@@ -1724,7 +1725,9 @@ def build_review_prompt_lines(
     try:
         from specify_cli.core.worktree_topology import materialize_worktree_topology, render_topology_json
 
-        topology = materialize_worktree_topology(repo_root, mission_slug)
+        topology = materialize_worktree_topology(
+            repo_root, mission_slug, status_feature_dir=status_feature_dir
+        )
         if topology.has_stacking:
             lines.extend(render_topology_json(topology, current_wp_id=normalized_wp_id))
             lines.append("")

--- a/src/specify_cli/core/worktree_topology.py
+++ b/src/specify_cli/core/worktree_topology.py
@@ -127,7 +127,9 @@ def _planning_claim_commit(repo_root: Path, wp_path: Path, wp_id: str) -> str | 
     return None
 
 
-def materialize_worktree_topology(repo_root: Path, mission_slug: str) -> FeatureTopology:
+def materialize_worktree_topology(
+    repo_root: Path, mission_slug: str, *, status_feature_dir: Path | None = None
+) -> FeatureTopology:
     """Gather the full lane worktree topology for a feature."""
     from mission_runtime import MissionArtifactKind
     from specify_cli.lanes.branch_naming import lane_branch_name
@@ -145,6 +147,7 @@ def materialize_worktree_topology(repo_root: Path, mission_slug: str) -> Feature
     feature_dir = resolve_planning_read_dir(
         main_repo_root, mission_slug, kind=MissionArtifactKind.LANE_STATE
     )
+    status_dir = status_feature_dir or feature_dir
     identity = resolve_mission_identity(feature_dir)
     lanes_manifest = read_lanes_json(feature_dir)
     graph = build_dependency_graph(feature_dir)
@@ -202,7 +205,7 @@ def materialize_worktree_topology(repo_root: Path, mission_slug: str) -> Feature
                     )
                 ),
                 dependencies=graph.get(wp_id, []),
-                lane=_read_canonical_lane_or_default(feature_dir, wp_id),
+                lane=_read_canonical_lane_or_default(status_dir, wp_id),
                 worktree_exists=worktree_exists,
                 commits_ahead_of_base=commits_ahead,
             )

--- a/src/specify_cli/core/worktree_topology.py
+++ b/src/specify_cli/core/worktree_topology.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from specify_cli.core.dependency_graph import build_dependency_graph, topological_sort
 from specify_cli.core.paths import get_main_repo_root, get_feature_target_branch
 from specify_cli.mission_metadata import mission_identity_fields, resolve_mission_identity
-from specify_cli.status import CanonicalStatusNotFoundError, Lane, get_wp_lane
+from specify_cli.status import CanonicalStatusNotFoundError, Lane, get_all_wp_lanes
 from specify_cli.workspace.context import get_normalized_wp, resolve_workspace_for_wp
 
 
@@ -71,13 +71,20 @@ class FeatureTopology:
         return self.target_branch
 
 
-def _read_canonical_lane_or_default(feature_dir: Path, wp_id: str) -> str:
+def _read_canonical_lanes_or_default(
+    feature_dir: Path, *, allow_missing: bool
+) -> dict[str, Lane]:
+    """Read one immutable lane snapshot; surface corrupt canonical state."""
     try:
-        lane = get_wp_lane(feature_dir, wp_id)
+        return get_all_wp_lanes(feature_dir)
     except CanonicalStatusNotFoundError:
-        return "planned"
-    except Exception:
-        return "planned"
+        if allow_missing:
+            return {}
+        raise
+
+
+def _lane_or_default(lanes: dict[str, Lane], wp_id: str) -> str:
+    lane = lanes.get(wp_id, Lane.UNINITIALIZED)
     if lane == Lane.UNINITIALIZED:
         return "planned"
     return str(lane)
@@ -148,6 +155,9 @@ def materialize_worktree_topology(
         main_repo_root, mission_slug, kind=MissionArtifactKind.LANE_STATE
     )
     status_dir = status_feature_dir or feature_dir
+    lanes = _read_canonical_lanes_or_default(
+        status_dir, allow_missing=status_feature_dir is None
+    )
     identity = resolve_mission_identity(feature_dir)
     lanes_manifest = read_lanes_json(feature_dir)
     graph = build_dependency_graph(feature_dir)
@@ -205,7 +215,7 @@ def materialize_worktree_topology(
                     )
                 ),
                 dependencies=graph.get(wp_id, []),
-                lane=_read_canonical_lane_or_default(status_dir, wp_id),
+                lane=_lane_or_default(lanes, wp_id),
                 worktree_exists=worktree_exists,
                 commits_ahead_of_base=commits_ahead,
             )

--- a/tests/integration/test_lanes_core_coord_read.py
+++ b/tests/integration/test_lanes_core_coord_read.py
@@ -288,7 +288,10 @@ def test_materialize_worktree_topology_reads_primary(
     from specify_cli.core.worktree_topology import materialize_worktree_topology
 
     ctx = coord_topology_mission_sentinel_meta
-    topo = materialize_worktree_topology(ctx.repo, ctx.slug)
+    _seed_reducible_husk_event(ctx)
+    topo = materialize_worktree_topology(
+        ctx.repo, ctx.slug, status_feature_dir=ctx.coord_feature_dir
+    )
 
     assert {entry.wp_id for entry in topo.entries} == {"WP01"}, (
         "routed PRIMARY read must materialize WP01 from PRIMARY tasks/lanes; an "

--- a/tests/specify_cli/core/test_worktree_topology.py
+++ b/tests/specify_cli/core/test_worktree_topology.py
@@ -57,7 +57,9 @@ def _clear_workspace_cache() -> None:
     clear_workspace_resolution_caches()
 
 
-def test_mixed_mission_topology_includes_repo_root_planning_entry(tmp_path: Path) -> None:
+def test_mixed_mission_topology_includes_repo_root_planning_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo_root = tmp_path
     mission_slug = "077-feature"
     feature_dir = repo_root / "kitty-specs" / mission_slug
@@ -71,10 +73,23 @@ def test_mixed_mission_topology_includes_repo_root_planning_entry(tmp_path: Path
     _write_wp(tasks_dir / "WP01-code.md", "WP01", execution_mode="code_change")
     _write_wp(tasks_dir / "WP02-planning.md", "WP02", execution_mode="planning_artifact")
     write_lanes_json(feature_dir, _manifest(mission_slug))
+    status_feature_dir = repo_root / ".worktrees" / "coord" / "kitty-specs" / mission_slug
+    status_feature_dir.mkdir(parents=True)
+    status_reads: list[Path] = []
 
-    topology = materialize_worktree_topology(repo_root, mission_slug)
+    def _read_status(path: Path, _wp_id: str) -> str:
+        status_reads.append(path)
+        return "approved"
+
+    monkeypatch.setattr("specify_cli.core.worktree_topology._read_canonical_lane_or_default", _read_status)
+
+    topology = materialize_worktree_topology(
+        repo_root, mission_slug, status_feature_dir=status_feature_dir
+    )
 
     assert [entry.wp_id for entry in topology.entries] == ["WP01", "WP02"]
+    assert [entry.lane for entry in topology.entries] == ["approved", "approved"]
+    assert status_reads == [status_feature_dir, status_feature_dir]
     assert topology.has_stacking is True
 
     planning_entry = topology.get_entry("WP02")

--- a/tests/specify_cli/core/test_worktree_topology.py
+++ b/tests/specify_cli/core/test_worktree_topology.py
@@ -77,11 +77,15 @@ def test_mixed_mission_topology_includes_repo_root_planning_entry(
     status_feature_dir.mkdir(parents=True)
     status_reads: list[Path] = []
 
-    def _read_status(path: Path, _wp_id: str) -> str:
+    def _read_status(path: Path, *, allow_missing: bool) -> dict[str, str]:
         status_reads.append(path)
-        return "approved"
+        assert allow_missing is False
+        return {"WP01": "approved", "WP02": "approved"}
 
-    monkeypatch.setattr("specify_cli.core.worktree_topology._read_canonical_lane_or_default", _read_status)
+    monkeypatch.setattr(
+        "specify_cli.core.worktree_topology._read_canonical_lanes_or_default",
+        _read_status,
+    )
 
     topology = materialize_worktree_topology(
         repo_root, mission_slug, status_feature_dir=status_feature_dir
@@ -89,7 +93,7 @@ def test_mixed_mission_topology_includes_repo_root_planning_entry(
 
     assert [entry.wp_id for entry in topology.entries] == ["WP01", "WP02"]
     assert [entry.lane for entry in topology.entries] == ["approved", "approved"]
-    assert status_reads == [status_feature_dir, status_feature_dir]
+    assert status_reads == [status_feature_dir]
     assert topology.has_stacking is True
 
     planning_entry = topology.get_entry("WP02")


### PR DESCRIPTION
Fixes #2698.

## Summary

Generated review handoff embeds stale work-package topology

## Validation

- Mechanical gate: +27/-5, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898767&installation_id=146454894&pr_number=2766&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2766&signature=e2b357040009ac8f6e3357becdb150ac172d0b5b5367ba9fc06952c2fbd07d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->