### PR TITLE
test(charter): red-first P0 repro for #2772 — `generate --force` clobbers curated charter.md

### DIFF
--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -198,6 +198,56 @@ def test_generate_command_force_overwrites(tmp_path: Path) -> None:
         assert data["references_count"] >= 1
 
 
+@pytest.mark.regression
+def test_generate_force_preserves_curated_charter_prose_2772(tmp_path: Path) -> None:
+    """RED-FIRST P0 reproduction of #2772 — intentional expected-red, BLOCKING.
+
+    ``spec-kitty charter generate --force`` regenerates the human-facing
+    ``charter.md`` from the interview/default template, DESTROYING curated
+    prose: recompiling the bundle to add a single reference produced a
+    1237-line clobber of the curated v1.3.0 charter during the #2767 landing,
+    forcing a ``git checkout HEAD -- charter.md`` to recover it. ``charter.md``
+    is a curated reference and is NOT a charter-resolving input (resolving keys
+    off the structured bundle — ``config.yaml`` / ``references.yaml``), so
+    refresh / generate MUST preserve it.
+
+    This reproduces the defect through the exact ``generate --force`` entry
+    point named in the issue and asserts the curated prose survives. It fails
+    on main because of the product defect (not a test error). It is marked
+    ``@pytest.mark.regression`` for the red-first regime while KEEPING its
+    ``integration``/``git_repo`` slice (module ``pytestmark``) so a BLOCKING CI
+    job selects it — an open P0 is expected to red mainline (ADR 2026-07-17-1),
+    never shunted to the non-blocking ``regression-visibility`` lane. Un-mark
+    ``@regression`` when #2772 lands the preserve-curated-charter fix.
+    Tracking: #2772 (epic #2519).
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _git_init(repo_root)
+    charter_dir = repo_root / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True)
+    curated_sentinel = (
+        "CURATED-PROSE-SENTINEL-2772: hand-authored governance narrative "
+        "that charter refresh must never destroy."
+    )
+    (charter_dir / "charter.md").write_text(
+        f"# Curated Charter (v1.3.0)\n\n{curated_sentinel}\n", encoding="utf-8"
+    )
+
+    with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
+        mock_find_root.return_value = repo_root
+
+        result = runner.invoke(app, ["generate", "--force", "--json", "--no-from-interview"])
+
+    assert result.exit_code == 0, result.stdout
+    surviving = (charter_dir / "charter.md").read_text(encoding="utf-8")
+    assert curated_sentinel in surviving, (
+        "#2772: `charter generate --force` clobbered curated charter.md prose — "
+        "the curated sentinel was destroyed by regeneration; charter.md must be "
+        "preserved as a curated reference, not overwritten from the template."
+    )
+
+
 def test_context_bootstrap_then_compact(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()


### PR DESCRIPTION
## What

Lands an **intentional red-first P0 reproduction** for **#2772**: `spec-kitty charter generate --force` regenerates the human-facing `charter.md` from the interview/default template, **destroying curated prose**. A 1237-line clobber of the curated v1.3.0 charter hit live during the #2767 landing, forcing a `git checkout HEAD -- charter.md` to recover it.

`charter.md` is a **curated reference** and is **not** a charter-resolving input (resolving keys off the structured bundle — `config.yaml` / `references.yaml`), so refresh / generate must preserve it. The clobber site is `write_compiled_charter` (`src/charter/compiler.py`) — `charter_path.write_text(compiled.markdown)` under `force=True`.

## The test

`tests/agent/cli/commands/test_charter_cli.py::test_generate_force_preserves_curated_charter_prose_2772`

- Reproduces through the **exact `generate --force` entry point** named in the issue.
- Writes a curated sentinel into `charter.md`, runs `generate --force`, asserts the sentinel **survives**.
- Fails on main because of the **product defect** (not a test error): the command exits 0, then the curated prose is gone — replaced by the generated `# Project Charter` template.

## CI / policy

Per **[ADR 2026-07-17-1](docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md)** — an open **P0 bug is expected to red mainline**, and **red CI means no release**. This test therefore **keeps its blocking `integration`/`git_repo` slice** (module `pytestmark`) so a blocking CI job selects it; `@pytest.mark.regression` is added **on top** as the red-first regime marker (also surfaces it in the non-blocking `regression-visibility` lane). It is **not** shunted to a non-blocking-only lane — that would fake green on a P0.

## Scope

- **Refs #2772** (epic #2519). **Does not close it** — this proves the defect; the fix (preserve curated `charter.md` on refresh) lands separately and un-marks `@regression`.
- Purely additive: one test, ruff-clean. The sibling `test_generate_command_force_overwrites` is content-agnostic and stays valid.

**Expected state: this PR's `integration` gate is RED, on purpose.** The operator merges (maintainers do not self-merge to origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAFBwqsfQkmYVSvRWu8t2R

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786945346&installation_id=146454894&pr_number=2783&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2783&signature=35ef76acc6b4f4a48f0bbd8426c42c7d6e79fa2d1b04e0116e405c5e1cda48f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->