### PR TITLE
ci: make the regression suite gate-blocking (stop faking green on red-first P0s)

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2868,21 +2868,23 @@ jobs:
           exit "$ec"
 
   # ---------------------------------------------------------------------------
-  # regression-visibility: runs `-m regression` for real so every red-first P0
-  # reproduction test (@pytest.mark.regression) has an explicit, routed CI home
-  # and its expected-red signal stays VISIBLE — the marker-completeness gate
-  # (tests/architectural/test_marker_job_completeness.py) requires that no
-  # registered marker be silently CI-invisible (#2774). Per the
-  # red-main-release-discipline procedure and docs/guides/testing-flakiness.md it
-  # is intentionally NON-BLOCKING: it MUST NOT be added to the `quality-gate`
-  # aggregation below or to branch-protection required checks, so an
-  # expected-red P0 reproduction can never turn main red or block an unrelated
-  # PR. It is EXPECTED to be red while open P0s exist; that red is the honest,
-  # tracked signal — never retried to green. Tolerates pytest exit code 5 (no
-  # regression tests currently registered) as green.
+  # regression-tests: runs `-m regression` for real so every red-first P0
+  # reproduction test (@pytest.mark.regression) has an explicit, routed CI home,
+  # and it is BLOCKING — it IS a member of the `quality-gate` aggregation below.
+  # An open P0 red-first reproduction is expected to red mainline and, because
+  # CI is the release authority, that red must gate releases: a non-blocking
+  # regression lane would FAKE GREEN on P0s and lose the very signal the marker
+  # exists to give (ADR 2026-07-17-1; issue #2772-family course-correction of
+  # the #2774 visibility-only design). The marker-completeness gate
+  # (tests/architectural/test_marker_job_completeness.py) still requires that no
+  # registered marker be silently CI-invisible; this job is that routed home.
+  # It is EXPECTED to be red while open P0s exist — that red is the honest,
+  # tracked, release-gating signal, never retried to green; maintainers clear it
+  # by fixing the product defect. Tolerates pytest exit code 5 (no regression
+  # tests currently registered) as green.
   # ---------------------------------------------------------------------------
-  regression-visibility:
-    name: regression visibility (non-blocking)
+  regression-tests:
+    name: regression tests (blocking)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [changes]
     if: ${{ (always() && ( github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' )) && !contains(github.event.pull_request.labels.*.name, 'pr:deferred') && !contains(github.event.pull_request.labels.*.name, 'pr:skip-ci') }}
@@ -2897,7 +2899,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[test]
-      - name: Run regression red-first reproductions (visible, never blocks merge)
+      - name: Run regression red-first reproductions (blocking — gates releases)
         env:
           PWHEADLESS: "1"
         run: |
@@ -3893,6 +3895,7 @@ jobs:
       - timing-nfr-serial
       - e2e-cross-cutting
       - restart-daemon-nfr-timing
+      - regression-tests
       - build-wheel
       - clean-install-verification
       - consumer-compatibility

--- a/tests/architectural/test_marker_job_completeness.py
+++ b/tests/architectural/test_marker_job_completeness.py
@@ -28,11 +28,15 @@ Honest three-state split (re-derived live at implement, 2026-07-04, NFR-004;
       the spec's documented edge case: a job selects it, so it is ROUTED;
       blocking-ness is a separate axis. Its held-out population is governed by
       #2295/#2309 (17) + #2342 (`test_200_missions_under_5s`) and is never
-      hard-pinned here. `regression` is routed the same way by the NON-BLOCKING
-      `regression-visibility` gate (#2774): red-first P0 reproductions carry
-      orphan carriers by path — e.g. `tests/delivery/` reaches no path gate — so
-      an explicit `-m regression` job is their required, visible CI home rather
-      than a silent CI_INVISIBLE entry.)
+      hard-pinned here. `regression` is routed by marker to the `-m regression`
+      gate `regression-tests`, which — unlike `quarantine-visibility` — is
+      BLOCKING (a member of `quality-gate.needs`): a red-first P0 reproduction
+      is expected to red mainline and, because CI is the release authority, must
+      gate releases; a non-blocking regression lane would fake green on P0s
+      (#2772-family course-correction of the #2774 visibility-only design). Its
+      orphan carriers by path — e.g. `tests/delivery/` reaches no path gate —
+      make an explicit `-m regression` job their required CI home rather than a
+      silent CI_INVISIBLE entry.)
   ROUTED-BY-PATH (14): adversarial, agent, asyncio, distribution, doctrine,
       e2e, flaky, no_git_tmp_path, no_readiness_stub, non_sandbox,
       requires_symlinks, stress, timeout, upgrade

--- a/tests/architectural/test_suite_jobs_gate_blocking.py
+++ b/tests/architectural/test_suite_jobs_gate_blocking.py
@@ -65,14 +65,11 @@ NON_BLOCKING_ALLOWLIST: dict[str, str] = {
         "can never legitimately be promoted to gate-blocking — a quarantined "
         "flake must never be able to block a merge."
     ),
-    "regression-visibility": (
-        "Non-blocking BY DESIGN (visible-but-never-gating red-first surface, "
-        "#2774). Runs `-m regression` so every @pytest.mark.regression P0 "
-        "reproduction has a routed, VISIBLE CI home (satisfying "
-        "test_marker_job_completeness) while never gating a merge: a red-first "
-        "reproduction is expected-red until its product bug is fixed, so it must "
-        "never enter quality-gate's needs. Mirrors quarantine-visibility."
-    ),
+    # NOTE: `regression-tests` is deliberately NOT here — it is BLOCKING
+    # (a member of `quality-gate.needs`). A red-first P0 reproduction is
+    # expected to red mainline AND, because CI is the release authority, must
+    # gate releases; a non-blocking regression lane would fake green on P0s
+    # (#2772-family course-correction of the #2774 visibility-only design).
     "mutation-testing": (
         "Disabled placeholder (`if: false`, an echo-only step: "
         '`echo "Mutation testing is disabled."`) pending future '


### PR DESCRIPTION
## Why

The `regression-visibility` job (added in #2774) ran `-m regression` for real but was **non-blocking** — it was absent from `quality-gate.needs`. That **loses the signal** the marker exists to give: per **[ADR 2026-07-17-1](docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md)**, an open **P0 red-first reproduction is expected to red mainline**, and because **CI is the release authority**, that red **must gate releases**. A non-blocking regression lane **fakes green** on P0s — the exact failure mode this closes.

## What

- **Rename** `regression-visibility` → `regression-tests` ("regression tests (blocking)") and **add it to `quality-gate.needs`**. A red `-m regression` run now **fails the gate** (pytest exit-5 "nothing collected" is still tolerated as green).
- **Drop** it from `NON_BLOCKING_ALLOWLIST` (`test_suite_jobs_gate_blocking`) — the containment gate now *requires* it in needs.
- **Update the marker-completeness ledger** (`test_marker_job_completeness`): `regression` is routed-by-marker to a **BLOCKING** gate (still `ROUTED-BY-MARKER`; the 11/14/12 counts are unchanged), in contrast to the non-blocking `quarantine-visibility`.

Group-less always-on job (like `slow-tests`): `toJSON(needs)` picks it up automatically, no `JOB_GROUPS` entry needed; a `failure` result fails the gate while a filter-false skip stays OK.

## ⚠️ Intended consequence — main goes red while open P0s exist

This is the point. While issue-pinned `@pytest.mark.regression` red-first tests are open on main — currently **#2736** (poison-batch), **#2573** (sync daemon), **#2782** (skip-ingress), and **#2772** (charter.md clobber, PR #2783) — the **quality-gate is RED**, and that red **blocks releases** until the product defects are fixed. Maintainers clear it by **fixing the bug**, never by retrying to green or re-marking. That is the honest, release-gating signal ADR 2026-07-17-1 mandates.

## Verification (all green locally)

`test_suite_jobs_gate_blocking` · `test_job_count_ceiling` · `test_workflow_coherence` · `test_gate_coverage` · `test_quality_gate_decision` · `test_ci_quality_path_filters` · `test_marker_job_completeness` (incl. the slow three-state re-derivation).

Course-corrects the #2774 visibility-only design. Operator merges (maintainers do not self-merge to origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAFBwqsfQkmYVSvRWu8t2R

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786946173&installation_id=146454894&pr_number=2784&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2784&signature=dd4e10ec61d2b5258d4641f7005f463bf23a0dcf68a3b5018114141bc114f4da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->