### PR TITLE
fix(merge): coordination-done rollback transactionality (P0 #2786 + #2367-B)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -115,6 +115,23 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   Tracked follow-ups: **#2786** (write a durable reconcile marker when the rollback revert
   itself fails) and **#2794** (a `SPEC_KITTY_SYNC_MINIMAL_IMPORT` test-isolation leak that
   skips the pre-review gate under the parallel CI suite).
+- **A failed coordination-`done` revert during rollback no longer silently re-opens the
+  #2711 split-brain (#2786), and the coordination write-set rolls back transactionally
+  (#2367 Mechanism B).** When the rollback's coord-`done` `git revert` itself *failed* (#2786),
+  or when a merge aborted mid-way through `_record_merged_wps_done_for_merge` before any revert
+  ran (#2367-B), rollback restored only working-tree bytes and left a committed `done` opposed to
+  a reverted working `approved` — a silently-stranded split-brain. Rollback now **marks-not-raises**:
+  a durable `MergeState.pending_coord_reconcile` marker records the stranded WP(s) — derived from
+  the **committed** coordination ref (the reliable authority; a working-tree diff is empty at the
+  revert-failure point) over *this merge's own* pre-target `done` write-set, so a legitimately
+  pre-existing-`done` WP is never re-stranded. `spec-kitty merge --resume` heals via a strand-gated,
+  idempotent `git revert` (byte-stable on re-run), and `spec-kitty doctor coordination` detects the
+  strand (re-verifying incoherence from the committed ref, not marker-presence) with a `--fix`. A
+  behavioral class-closing guard reds if any of the seven `_restore_final_bookkeeping_snapshots`
+  rollback sites (incl. the previously-unenumerated coord-reachable site) strands without marking.
+  INV-5 (#1827) ordering preserved; happy-path merge byte-identical. Ships red-first repros for both
+  mechanisms. Deferred with follow-ups: **#2795** (#2367 Mechanism A — claim-time VCS-lock resync)
+  and **#2797** (unify the two `git revert` transport legs into one shared helper).
 - **`--json` output is now plain regardless of terminal colour; CLI tests are colour-deterministic (#2632).**
   Under a colour-forcing harness (e.g. `FORCE_COLOR=3`) Rich syntax-highlighted `--json`
   output — splicing ANSI escapes into the payload so `json.loads` and `| jq` choked — and

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/analysis-report.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/analysis-report.md
@@ -1,0 +1,90 @@
+---
+schema_version: 1
+artifact_type: spec-kitty.analysis-report
+command: /spec-kitty.analyze
+mission_slug: merge-coord-rollback-transactionality-01KXTM59
+mission_id: 01KXTM59YZZ6AGKA7YVJA0HCRS
+generated_at: '2026-07-18T17:12:10.836974+00:00'
+analyzer_agent: unknown
+input_artifacts:
+  spec.md:
+    path: /home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/spec.md
+    sha256: 545d76fd95673cccc5a3fd28f57e330711bc2c7443da801e7a57222897e752fd
+  plan.md:
+    path: /home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/plan.md
+    sha256: 537ba064a8a9264d3c3a03b4591ccc6877c75490b3b42619dd038089cfc70a21
+  tasks.md:
+    path: /home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks.md
+    sha256: cba06535380676417fdc10fab7b8a09c8912c7f1a67f14d252b76c423afba49b
+  charter:
+    path: /home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/.kittify/charter/charter.md
+    sha256: cb2dc6cd12aade3d5464997467b7ecdbd3849ea3581207b58c207c3d16fff9b8
+verdict: ready
+issue_counts:
+  critical: 0
+  low: 3
+  medium: 0
+  high: 0
+  info: 0
+findings:
+- id: I1
+  severity: low
+  category: inconsistency
+  summary: Two coord-DONE reducers coexist (coord_incoherent_done_wps + _durable_done_wps_on_coordination_ref); convergence is a documented follow-up, not in scope.
+- id: I2
+  severity: low
+  category: coverage
+  summary: NFR-001/002/003 are pinned in WP DoD checkboxes but not in requirement_refs (the mapper accepts FR refs only) — coverage is real, the ref index just doesn't show it.
+- id: I3
+  severity: low
+  category: process
+  summary: WP dependencies were set via the frontmatter preserve-path because the finalize CLI's tasks.md dependency parser did not match the section phrasing; deps are correct and validated.
+---
+
+## Specification Analysis Report
+
+**Mission**: `merge-coord-rollback-transactionality-01KXTM59` (P0 #2786 + #2367-B). Artifacts analysed:
+`spec.md`, `plan.md`, `tasks.md`, `data-model.md`, `research.md`, 5 WP prompts. This mission was hardened
+by three adversarial squads (post-spec, post-plan, post-tasks) whose findings are folded and recorded in
+the spec's audit-trail sections; this report is the non-remediating cross-artifact consistency pass.
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| I1 | Inconsistency | LOW | data-model.md (two-readers note) | `coord_incoherent_done_wps` (new strand authority) and `_durable_done_wps_on_coordination_ref` (resume-dedup) both reduce coord-`DONE` via the same contract | Already documented as a follow-up; keep `coord_incoherent_done_wps` as THE strand authority. No action this mission. |
+| I2 | Coverage | LOW | tasks/WP03,WP04 DoD | NFR-001/002/003 are pinned as WP DoD checkboxes but not in `requirement_refs` (the mapper takes FR refs only) | None required — coverage is real; the ref index simply can't hold NFRs. |
+| I3 | Process | LOW | tasks/WP0*.md frontmatter | WP `dependencies` were set via the preserve-existing frontmatter path because the finalize CLI's tasks.md parser didn't match the section phrasing | Deps are validated (`validation_passed`); consider filing a CLI parser-robustness note, out of mission scope. |
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs (WP) | Notes |
+|-----------------|-----------|---------------|-------|
+| FR-001 modify #2786 assertion | ✅ | WP01 | red-on-base SC-006 |
+| FR-002 #2786 companion (≥2-WP) | ✅ | WP01 (split-brain), WP02/WP03 (marker-names) | priti sequencing folded |
+| FR-003 #2367-B bake repro | ✅ | WP01 | bake path only |
+| FR-004 MergeState marker | ✅ | WP02 | + enumerator |
+| FR-005 mark both strands | ✅ | WP03 | candidate = write-set field |
+| FR-006 resume heal | ✅ | WP03 | strand-gated |
+| FR-007 doctor check/fix | ✅ | WP04 | canonical surface + enumerator |
+| FR-008 class-closing guard | ✅ | WP03 (primitive), WP05 (guard) | seven sites, 701 routed |
+| FR-009 single coherence owner | ✅ | WP02 | consumed by WP03/WP04 |
+| FR-010 SaaS fence | ✅ | WP03 | explicitly out-of-scope, documented |
+| NFR-001 no happy-path regression | ✅ | WP03 DoD | byte-identical |
+| NFR-002 repair idempotency | ✅ | WP03/WP04 DoD | resume-twice byte-identical |
+| NFR-003 scoped test surface | ✅ | all WPs | |
+
+**Charter Alignment Issues:** None. ATDD red-first (WP01), no-direct-push (consolidate→PR), architectural
+gates (INV-5 #1827, AC-B3/AC-F1) honored in plan Charter Check; tracker gate satisfied (#2367 reparented/
+retyped, #2795 filed). No charter MUST is violated.
+
+**Unmapped Tasks:** None — every WP maps to ≥1 FR; every FR maps to ≥1 WP.
+
+**Metrics:**
+- Total Requirements: 10 FR + 3 NFR = 13
+- Total Work Packages: 5 (16 subtasks)
+- Coverage %: 100% (13/13 requirements have ≥1 task)
+- Ambiguity Count: 0 (no vague-adjective NFRs; all measurable/behavioral)
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+**Verdict: READY** — no high/critical findings. The three LOW items are documented follow-ups /
+process notes, none blocking implementation.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/data-model.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/data-model.md
@@ -1,0 +1,168 @@
+# Data Model — Phase 1
+
+This is internal merge machinery: no HTTP/GraphQL contracts, no persisted entities beyond the one
+optional `MergeState` field below. The "state transition" of interest is the coord-branch coherence
+lifecycle, captured as an invariant.
+
+> **Post-plan revision (architect-alphonso HIGH).** The strand set is derived from the **committed
+> coordination ref**, NOT from a live committed-vs-working worktree diff. `_restore_final_bookkeeping_snapshots`
+> restores **primary `repo_root`** paths (`bookkeeping_projection.py`), never the coordination
+> worktree — so a committed-vs-working diff computed *at the #2786 mark point* (inside
+> `_revert_coord_done_commit`, which runs **before** the later restore) would see both sides `done`,
+> return an **empty delta, write no marker, and silently drop the strand** — the exact failure this
+> mission closes. The committed ref is the reliable authority at any mark point; the "approved" side
+> is known **by construction** (the rollback's intent). See D7 (revised) in research.md.
+
+## Entity: `pending_coord_reconcile` marker (field on `MergeState`)
+
+Persisted via the existing `save_state` to the **canonical per-mission runtime state**
+`.kittify/runtime/merge/<mission_id>/state.json` (NOT the legacy `.kittify/merge-state.json`, which
+`get_state_path(mission_id=None)` uses only for CLI `--abort`/`--resume` back-compat; heal + doctor
+MUST load the per-mission runtime path). Typed `dict[str, Any] | None` — a plain dict;
+`MergeState.from_dict` rehydrates JSON objects as dicts and drops unknown keys, so **no migration**
+is required for pre-existing state files.
+
+| Key | Type | Meaning | Source |
+|---|---|---|---|
+| `coord_ref` | `str` | Fully-qualified coordination branch ref carrying the stranded commit | `resolve_placement_only(...kind=STATUS_STATE).ref` |
+| `captured_sha` | `str` | Coord-branch HEAD sha captured *before* the `done` bookkeeping commit (the `git revert` base) | executor pre-bake capture |
+| `coord_worktree` | `str` | Absolute path to the coordination worktree the repair operates in (env via `_make_merge_env`). *Not* "byte-restored" — the coord worktree is **not** touched by `_restore_final_bookkeeping_snapshots`; the committed `done` is undone by a forward `git revert`. | `CoordinationWorkspace.worktree_path` |
+| `stranded_wp_ids` | `list[str]` | The **specific** WP(s) this merge marked `done` that remain `done` on the **committed coord ref** after rollback (⇒ incoherent vs the intended `approved`). NOT a static list; NOT a live worktree diff. | `_durable_done_wps_on_coordination_ref(candidate_wps=<this merge's pre-target done write-set>)` |
+| `revert_error` | `str \| None` | Diagnostic: the swallowed revert error (#2786) or the bake failure (#2367-B); `None` if unavailable | caught exception text |
+| `detected_at` | `str` | ISO-8601 UTC timestamp the strand was marked | stamped at mark time |
+
+**Derivation contract for `stranded_wp_ids` (load-bearing, anti-fakeable):**
+- Candidate set = **this merge's own pre-target done write-set** (the WPs it committed `done` during
+  this merge) — NOT all done WPs, and **NOT `run.all_wp_ids`** (the natural but WRONG value — on a
+  *resume* it includes WPs a prior attempt legitimately baked `done`, so the heal would `git revert` a
+  legitimately-done WP). This excludes a genuinely-pre-existing-`done` WP (spec edge-case: "a
+  genuinely-done WP before the abort must survive") **by construction**.
+- **Run-state provenance (WP03):** `_MergeRunState` currently carries only `all_wp_ids` — there is **no**
+  field for the pre-target done write-set. WP03 MUST add one, captured at the
+  `_record_merged_wps_done_for_merge` bake site, and pass *it* (not `all_wp_ids`) as `candidate_wps`.
+- **Non-fakeable test (WP02 owner-level + WP03):** the only fixture that distinguishes the correct
+  candidate set from `all_wp_ids` is a **pre-existing-`done` WP** (done *before* this merge) alongside a
+  this-merge strand → `stranded_wp_ids` contains only the this-merge WP; the pre-existing-done WP is
+  **excluded**. A fixture whose "coherent" WP is only-ever-`approved` does NOT catch an `all_wp_ids`
+  implementation (it's excluded either way). This fixture is a DoD checkbox, not prose.
+- Membership = still reduces to `DONE` on the **committed coordination ref**
+  (`_durable_done_wps_on_coordination_ref` reads `EventLogReadContract.coordination_branch_ref(...)`).
+  A never-committed "coherent" WP (only ever `approved`) is not done-on-ref ⇒ excluded.
+- Together these satisfy the ≥2-WP non-fakeability fixture (reviewer-renata): in a fixture with one
+  stranded WP and one coherent WP, `stranded_wp_ids == [the_stranded_one]` — a hardcoded `["WP01"]`
+  or an over-broad `all_wp_ids` both fail.
+
+**Validation rules**
+- `stranded_wp_ids` MUST be non-empty when the marker is present (an empty strand is not a strand —
+  the marker is only written when `_durable_done_wps_on_coordination_ref` over this merge's write-set
+  is non-empty).
+- `coord_ref` / `coord_worktree` MUST resolve; the marker is written from the same resolved
+  placement the rollback used (no re-resolution drift).
+- Marker presence is advisory only — repair/doctor **re-derive** the strand set from the committed
+  ref (D6); a stale marker over a now-coherent ref heals to a no-op clear.
+
+## Shared coherence owner (paula-patterns HIGH / alphonso Q1)
+
+The strand-derivation and the repair are **coordination-domain** knowledge and get exactly one home,
+consumed by all three call-sites (no three-way drift → the #2786-C seed):
+
+- `coordination`-layer **`coord_incoherent_done_wps(coord_ref, candidate_wps) -> list[str]`** — thin
+  wrapper over `_durable_done_wps_on_coordination_ref`; called by the marker-persist site, the
+  resume heal-gate, and the doctor check. (Do NOT re-implement the reduction in `merge/executor.py`
+  private helpers — that leaks coord-reduction semantics into the merge layer.)
+- The **repair primitive** (`git revert` of the stranded commit, env via `_make_merge_env`) is homed
+  as a coordination-layer function consumed by both executor-resume and `doctor --fix` — NOT an
+  executor-private that a diagnostic command reaches into (dependency inversion / DIR-044). It MUST
+  **function-locally** import `_make_merge_env` from `lanes.merge` (module-top import creates the cycle
+  `merge.executor → coordination.coherence → lanes.merge → merge.config`; executor.py:474 already uses
+  the lazy pattern). The reader half re-derives via `coordination.status_service.EventLogReadContract`
+  — zero `merge` imports, layer-clean.
+
+**Marker enumeration (paula HIGH — the doctor gap).** `load_state(repo_root, mission_id=None)` **raises**
+`MergeAmbiguousStateError` on ≥2 active states, but a stranded marker persists across missions and
+`doctor coordination` must enumerate **all** of them. There is no "list all markers" API. WP02 MUST add
+`iter_pending_coord_reconcile_markers(repo_root) -> Iterable[MergeState]` in `state.py` (scanning
+`.kittify/runtime/merge/*/state.json`, its own path authority) with a focused test; WP04 consumes it —
+NOT re-implementing the runtime-path scan inside the doctor (that would be a second path authority /
+DIR-044 breach). Without this, the enumeration falls between WP02 and WP04's `owned_files`.
+
+**Two-readers note (paula LOW→MED).** `coord_incoherent_done_wps` is **the** strand authority;
+`_durable_done_wps_on_coordination_ref` (done_bookkeeping.py) stays as the resume-dedup reader only.
+Both reduce coord-`DONE` via the same `EventLogReadContract`; converging them is a documented **follow-up**,
+not in scope — recorded so the class does not re-seed one layer away.
+
+## Repair transport (alphonso Q4 — AC-B3/AC-F1)
+
+The repair is a **forward `git revert`** of the stranded coord commit (as `_revert_coord_done_commit`
+already implements), env via `_make_merge_env`. It does **NOT** use `git/ref_advance.py::advance_branch_ref`
+— moving the coord ref back to `captured_sha` is a non-fast-forward move that `advance_branch_ref`
+**refuses by design** (`RefAdvanceNonFastForwardError`). No raw `git update-ref` (AC-B3).
+
+> **WP03 implementation deviation (documented, tracked as [#2797]).** The single strand-**derivation**
+> authority (`coord_incoherent_done_wps`) is shared by mark + heal + doctor as planned. But the raw
+> `git revert` **transport** ended up in **two** legs — `merge/executor.py::_revert_coord_done_commit`
+> (the #2711 in-merge lockstep, unconditional/clean-tree) and `coordination/coherence.py::repair_coord_strand`
+> (WP02's resume/doctor leg, strand-gated/dirty-tree). Delegating the former to the latter breaks the
+> pinned `test_executor_option_a_revert_helpers_2711.py`, and a clean shared-transport helper crosses WP
+> ownership boundaries. Both reviewers concur this is a transport-dedup residual, **not** a re-opening of
+> the #2786-C derivation drift (the derivation authority stays single). #2797 unifies the transport +
+> narrows the heal's `git reset --hard` to a scoped `git checkout HEAD -- <status paths>` (defense-in-depth).
+
+## Invariant (class-closing, FR-008 / SC-005)
+
+> **INV-COORD-ROLLBACK**: After any merge rollback, either the coordination branch is coherent (no
+> WP from this merge's write-set still reduces to `DONE` on the committed coord ref while its intended
+> lane is `approved`) **or** a `pending_coord_reconcile` marker exists naming the stranded WP(s).
+
+No rollback path may leave the coord ref with a stranded `done` *and* marker-absent. The FR-008 guard
+is **behavioral, not a source grep**: it must red under a *runtime-stubbed* mark (stub
+`_persist_coord_reconcile_marker`/`coord_incoherent_done_wps` to a no-op, drive a real bake-path
+strand, assert the checker finds a stranded-done WP AND marker-absent). A guard that stays green under
+a runtime-stubbed mark is a tautology and is rejected.
+
+**Enumeration (paula-patterns — root-cause, not two-sites; corrected post-tasks: SEVEN sites).** The
+same `_restore_final_bookkeeping_snapshots` "restore-without-revert" shape appears at **seven**
+call-sites in `executor.py`: **407, 536, 670, 691, 701, 757, 786** (verified by grep; `INV-6` in the
+module docstring names this rollback pattern). Live coord strands come from the **pre-target** path
+(≈397→407) plus the revert-failure branch (≈500-514), because `done_marked_before_target` (≈350-352)
+gates coord topology to the pre-target ordering.
+
+- Site **≈691** (post-target `_record_merged_wps_done_for_merge` failure) sits **inside**
+  `if not run.done_marked_before_target:` (≈679) → **dead-for-coord** (assert this gating).
+- Site **≈701** (`_project_status_bookkeeping_to_target` failure in `_phase_record_done_and_project`)
+  sits **OUTSIDE** that guard → runs under **coord** topology, after the target advanced, and does
+  **not** revert the committed coord `done` → a **live #2786-shape coord strand** (double-confirmed
+  by reviewer-renata + python-pedro). It MUST be routed through the marking primitive and treated as a
+  live site, not merely enumerated.
+
+FR-008 MUST enumerate the sites **programmatically** (AST/regex over the call-sites, never a hardcoded
+count — the count drifts as WP03 inserts helpers), assert ≈691's topology-gating, and assert ≈701 is
+coord-reachable-and-routed. The preferred structural close is to co-locate the coherence-mark at the
+`_restore_final_bookkeeping_snapshots` **primitive** (a thin `_restore_and_guard_coord_coherence(...)`
+**every** caller routes through, incl. 701) so a future restore site cannot strand silently — this is
+**inner** (not the phase-driver wrapper INV-5 forbids). WP03-T010 routing is the *primary* mechanism;
+the two hand-picked marks are reached *through* it (no double-mark).
+
+## Out-of-scope reconciliation fence (alphonso Q5)
+
+The transient `done` emit fired through `emit_status_transition_transactional`
+(validate→persist→materialize→views→**SaaS**). A `git revert` coherently reverts the **tracked**
+coord artifacts (`status.events.jsonl` + materialized `status.json`), so committed materialization
+self-heals — but the **outbound SaaS/dashboard emit cannot be un-sent**. This mission **fences that
+out**: the hosted projection may transiently show `done` for a rolled-back WP until the next
+authoritative emit reconciles it (SaaS is advisory / eventually-consistent). Recorded as an explicit
+scope fence in Complexity Tracking, not a silent omission. A compensating SaaS reconciliation is a
+separate follow-up if product deems the transient projection unacceptable.
+
+## Coherence lifecycle (state transition)
+
+```
+coherent ──(bake done commit lands, then rollback strands it on the committed ref)──► stranded+marked
+stranded+marked ──(merge --resume | doctor --fix, while a strand still reduces DONE-on-ref)──► coherent, marker cleared
+stranded+marked ──(resume runs but ref already coherent, e.g. crash after heal before clear)──► no-op, marker cleared
+coherent ──(happy-path merge, NFR-001)──► coherent  (byte-identical; no marker ever written)
+```
+
+Idempotency (NFR-002): the `stranded+marked → coherent` and `already-coherent → no-op clear` edges
+converge — running resume/`--fix` N times yields a byte-stable coord `status.events.jsonl` (raw
+bytes, not a reduction-equality softening) and the marker cleared exactly once.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/issue-matrix.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/issue-matrix.md
@@ -1,0 +1,17 @@
+# Issue matrix — merge-coord-rollback-transactionality-01KXTM59
+
+Per FR-037 of the spec-kitty-mission-review skill Gate-4. One row per issue referenced in spec.md.
+
+| Issue | Title | Verdict | Evidence ref |
+|-------|-------|---------|--------------|
+| #2786 | Failed coord-`done` revert during rollback swallowed → re-opens #2711 split-brain | fixed | WP01 red-first repro (50f4143b, now GREEN); WP03 mark-not-raise + strand-gated heal (ad4af8034); WP04 doctor detect/`--fix`; WP05 behavioral class-closing guard. All 5 WPs approved. |
+| #2711 | Rollback/resume incoherence (coord-done revert) | verified-already-fixed | Prior mission (PR #2785, Option A coord-done-revert); this mission's tests build on that harness |
+| #2367 | merge blocked by coord worktree: VCS-lock at claim (A) + non-transactional coord rollback (B) | deferred-with-followup | Mechanism B (non-transactional coord rollback) FIXED by WP03 (byte-restore-without-revert closed); Mechanism A (claim-time VCS-lock resync) deferred to #2795. PR partially-addresses #2367 — does NOT auto-close (A residual tracked by #2795). |
+| #2222 | Merge-owned churn classifier | verified-already-fixed | Classifier already in place; reused by the deferred #2795 (Mechanism A) |
+| #2017 | Epic: Workflow guards that block legitimate actions | deferred-with-followup | Mechanism-A (claim-time VCS-lock resync) work carried by child #2795 |
+| #1826 | Coord split-brain recurrence (chain origin) | verified-already-fixed | Recurrence-chain predecessor (#1826→#1878→#2711→#2786); historical, fixed upstream |
+| #1878 | Coord split-brain recurrence (chain) | verified-already-fixed | Recurrence-chain predecessor; historical, fixed upstream |
+| #1827 | INV-5 phase-ordering ratchet | verified-already-fixed | Constraint respected; `test_executor_phase_boundary.py` stays green (WP03 inner-only, heal not in expected_order) |
+| #2795 | merge blocked by claim-time VCS-lock resync (Mechanism A, split from #2367) | deferred-with-followup | Filed this mission under epic #2017; out of scope, own design pass (reuses #2222) |
+
+Valid `Verdict` values: `fixed`, `verified-already-fixed`, `deferred-with-followup`, `in-mission` (being fixed by a later WP in this mission; must reach a terminal verdict before mission `done`).

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/lanes.json
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/lanes.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "mission_slug": "merge-coord-rollback-transactionality-01KXTM59",
+  "mission_id": "01KXTM59YZZ6AGKA7YVJA0HCRS",
+  "mission_branch": "kitty/mission-merge-coord-rollback-transactionality-01KXTM59",
+  "target_branch": "fix/merge-coord-rollback-transactionality",
+  "lanes": [
+    {
+      "lane_id": "lane-a",
+      "wp_ids": [
+        "WP01"
+      ],
+      "write_scope": [
+        "tests/regression/test_issue_2367_bake_strand.py",
+        "tests/regression/test_issue_2786_revert_failure_split_brain.py"
+      ],
+      "predicted_surfaces": [
+        "api",
+        "legacy-cleanup",
+        "tracker-integration",
+        "workspace"
+      ],
+      "depends_on_lanes": [],
+      "parallel_group": 0
+    },
+    {
+      "lane_id": "lane-b",
+      "wp_ids": [
+        "WP02"
+      ],
+      "write_scope": [
+        "src/specify_cli/coordination/coherence.py",
+        "src/specify_cli/merge/state.py",
+        "tests/coordination/test_coherence.py"
+      ],
+      "predicted_surfaces": [
+        "api",
+        "legacy-cleanup"
+      ],
+      "depends_on_lanes": [
+        "lane-a"
+      ],
+      "parallel_group": 1
+    },
+    {
+      "lane_id": "lane-c",
+      "wp_ids": [
+        "WP03"
+      ],
+      "write_scope": [
+        "src/specify_cli/merge/executor.py",
+        "tests/merge/test_executor_coord_reconcile.py"
+      ],
+      "predicted_surfaces": [
+        "api",
+        "tests",
+        "tracker-integration"
+      ],
+      "depends_on_lanes": [
+        "lane-b"
+      ],
+      "parallel_group": 2
+    },
+    {
+      "lane_id": "lane-d",
+      "wp_ids": [
+        "WP04"
+      ],
+      "write_scope": [
+        "src/specify_cli/cli/commands/_coordination_doctor.py",
+        "tests/specify_cli/cli/commands/test_coordination_doctor.py"
+      ],
+      "predicted_surfaces": [
+        "api"
+      ],
+      "depends_on_lanes": [
+        "lane-b"
+      ],
+      "parallel_group": 2
+    },
+    {
+      "lane_id": "lane-e",
+      "wp_ids": [
+        "WP05"
+      ],
+      "write_scope": [
+        "tests/architectural/test_coord_rollback_coherence_guard.py"
+      ],
+      "predicted_surfaces": [
+        "api"
+      ],
+      "depends_on_lanes": [
+        "lane-c"
+      ],
+      "parallel_group": 3
+    }
+  ],
+  "computed_at": "2026-07-18T14:54:11.212601+00:00",
+  "computed_from": "dependency_graph+ownership",
+  "planning_artifact_wps": []
+}

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/meta.json
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/meta.json
@@ -1,0 +1,17 @@
+{
+  "coordination_branch": "kitty/mission-merge-coord-rollback-transactionality-01KXTM59",
+  "created_at": "2026-07-18T12:45:30.464479+00:00",
+  "flattened": false,
+  "friendly_name": "merge coord rollback transactionality",
+  "mission_id": "01KXTM59YZZ6AGKA7YVJA0HCRS",
+  "mission_number": null,
+  "mission_slug": "merge-coord-rollback-transactionality-01KXTM59",
+  "mission_type": "software-dev",
+  "purpose_context": "This mission advances merge coord rollback transactionality on fix/merge-coord-rollback-transactionality so stakeholders can track the work from mission creation onward.",
+  "purpose_tldr": "merge coord rollback transactionality",
+  "slug": "merge-coord-rollback-transactionality-01KXTM59",
+  "target_branch": "fix/merge-coord-rollback-transactionality",
+  "topology": "coord",
+  "vcs": "git",
+  "vcs_locked_at": "2026-07-18T15:20:57.408281+00:00"
+}

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/plan.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/plan.md
@@ -1,0 +1,157 @@
+# Implementation Plan: Merge coord-write rollback transactionality (#2786 + #2367-B)
+
+**Branch**: `fix/merge-coord-rollback-transactionality` | **Date**: 2026-07-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `kitty-specs/merge-coord-rollback-transactionality-01KXTM59/spec.md`
+
+## Summary
+
+A merge that rolls back after committing coord-`done` bookkeeping can leave the coordination
+branch **incoherent** — the committed reduction says a WP is `done` while the working-tree
+reduction (and reality) says `approved` — re-opening the #2711 split-brain. Two strands share
+**one mechanism** (byte-restore-of-working-tree *without* reverting the committed coord commit):
+
+- **#2786** — `_revert_coord_done_commit` is *called but fails*; the failure is swallowed
+  (`executor.py:500-514`) and rollback continues, stranding the committed `done`.
+- **#2367-B** — a failure *inside* `_record_merged_wps_done_for_merge` hits the byte-restore-only
+  branch (`executor.py:406-408`) that *never calls* `_revert_coord_done_commit` at all.
+
+**Approach (chosen):** make any rollback that strands committed coord state either **revert** or
+**mark-and-repair**. Persist a durable `MergeState.pending_coord_reconcile` marker at both strand
+sites (mark-not-raise, so leg-b byte-restore still runs), heal it on `merge --resume` via a
+dedicated coherence-gated repair entry, and surface + `--fix` it from `doctor coordination`. The
+executor's existing coord-write rollback seam is *extended*, not wrapped — no new transaction
+abstraction (rejected: grain mismatch vs per-WP `BookkeepingTransaction`; see research.md).
+
+**Rejected alternatives:** (a) *raise on revert failure* — skips leg-b byte-restore and masks the
+underlying target-advance fault; (b) *wrap the phase driver in a BookkeepingTransaction* — wrong
+grain + trips the INV-5 #1827 phase-ordering ratchet (C-002); (c) *sidecar marker file* — needless
+new artifact + migration when `MergeState` already persists and `from_dict` drops unknown keys.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: stdlib + existing `specify_cli.merge` / `specify_cli.coordination` / `specify_cli.status` / `specify_cli.doctor` packages; no new third-party dependency
+**Storage**: canonical per-mission runtime state `.kittify/runtime/merge/<mission_id>/state.json` (existing `MergeState`, extended with one optional field; NOT the legacy `.kittify/merge-state.json`); coord branch `status.events.jsonl` (append-only event log, unchanged format)
+**Testing**: pytest ATDD/red-first — `tests/regression/test_issue_2786_*`, `tests/regression/test_issue_2367_*`, `tests/merge/`, `tests/architectural/` (INV-5 #1827 via `tests/merge/test_executor_phase_boundary.py` + AC-B3/AC-F1 ratchets), doctor tests. Reuse the #2711 coord harness (`_init_git_repo`, `_bootstrap_coord_mission`, `CoordinationWorkspace.worktree_path`); committed-ref reduction via `_durable_done_wps_on_coordination_ref`
+**Target Platform**: Linux/macOS dev + CI (git worktree merge machinery)
+**Project Type**: single (CLI/library — `src/specify_cli`)
+**Performance Goals**: none new — the marker/repair path runs only on the rollback/resume/doctor cold paths; the happy-path merge stays byte-identical (NFR-001)
+**Constraints**: repair is a forward coord-worktree `git revert` (env via `_make_merge_env`, AC-F1) — **NOT** `git/ref_advance.py::advance_branch_ref` (it refuses the non-FF move to `captured_sha`); no raw `git update-ref` (AC-B3); no wrapper around the phase driver (INV-5 #1827 — wrong on *grain*, see research D2); touched functions stay ≤ CC-15 via helper extraction; ATDD red-first before fix; no direct push to origin/main
+**Scale/Scope**: 4 WPs; ~1 new `MergeState` field, 2 mark call-sites, 1 resume repair entry, 1 doctor check + fix, 3 helper extractions, ~3 regression test files (2 new + 1 modified)
+
+## Charter Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Loaded via `spec-kitty charter context --action plan` (compact; DIR-001…DIR-013).
+
+| Gate / Standing Order | Applies? | How this plan satisfies it |
+|---|---|---|
+| **ATDD-first / red-first (test-remediation discipline)** | ✅ | WP01 lands red-first repros before any fix; existing #2786 assertion is *modified* (FR-001) so it can go green post-repair rather than stay permanently red. |
+| **Red-main-is-honest (ADR 2026-07-17-1)** | ✅ | Repros carry `@pytest.mark.regression` + issue-referencing docstrings; they fail for the product reason, not setup. |
+| **Architectural gate discipline** | ✅ | INV-5 #1827 (no wrapper around phase driver), AC-B3 (no raw `update-ref`), AC-F1 (`_make_merge_env`) held green; FR-008 adds a *non-vacuous* class-closing guard. |
+| **Single canonical authority (DIR-044)** | ✅ | Marker lives on the canonical `MergeState`; repair reuses the resume path; doctor reuses `DoctorFinding.error_code`. No parallel state. |
+| **Campsite cleaning / CC-15** | ✅ | 3 helper extractions keep `_record_merged_wps_done_for_merge`, the resume entry, and the doctor check ≤ CC-15; each extraction gets focused tests. |
+| **Canonical sources, no improvisation** | ✅ | Extends the existing executor rollback seam + `resolve_placement_only`/`wp_lane_actor_from_events`; no hand-rolled coord-ref reads. |
+| **Git/workflow discipline (no direct push)** | ✅ | Lands via consolidation → local `main` → `pr/<slug>` PR (same as #2785); never `git push origin main`. |
+| **Tracker Ticket Assignment Rule** | ✅ | #2786 = Bug/P0/parent **#1795**. #2367 **reparented** #2392(closed)→**#1795** + **retyped Task→Bug**; Mechanism A **split out to #2795** (Bug, parent **#2017**, reuses #2222). The mission PR **partially addresses #2367** (Mechanism B) — must NOT auto-close it (A tracked by #2795). Done + verified 2026-07-18. |
+| **Pre-existing Failure Reporting Rule** | ✅ | Baseline reds (known-P0 / CI-env / stale-install) classified per the folded gotcha doc; only branch-red-∧-base-green folded. |
+
+**One gate PENDING (tracker hygiene), no unjustified code violations.** The Complexity Tracking rows below record the deliberate scope fences (#2367-A + SaaS-emit reconciliation fenced out).
+
+## Project Structure
+
+### Documentation (this mission)
+
+```
+kitty-specs/merge-coord-rollback-transactionality-01KXTM59/
+├── plan.md              # This file
+├── spec.md              # Committed, substantive (post-spec squad folded)
+├── research.md          # Phase 0 — consolidated decisions (this command)
+├── data-model.md        # Phase 1 — the pending_coord_reconcile marker shape (this command)
+├── research/            # 6-lens pre-spec research (lens-a..f) — already committed
+└── tasks/               # Phase 2 (/spec-kitty.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```
+src/specify_cli/
+├── merge/
+│   ├── executor.py        # strand sites: _record_merged_wps_done_for_merge failure (≈406-408),
+│   │                      #   _revert_coord_done_commit failure branch (≈500-514);
+│   │                      #   third same-shape site ≈690-692 (dead-for-coord via done_marked_before_target ≈350-352);
+│   │                      #   + _persist_coord_reconcile_marker helper (marks at both live sites);
+│   │                      #   + _heal_pending_coord_reconcile at resume startup (strand-gated);
+│   │                      #   FR-008: co-locate mark at _restore_and_guard_coord_coherence primitive (inner-only)
+│   ├── done_bookkeeping.py # _durable_done_wps_on_coordination_ref (committed-ref strand reader — reuse)
+│   └── state.py           # MergeState.pending_coord_reconcile: dict[str, Any] | None (+ from_dict); runtime state path
+├── coordination/          # coord_incoherent_done_wps(coord_ref, candidate_wps) — SINGLE coherence owner
+│   │                      #   (over _durable_done_wps_on_coordination_ref) consumed by mark + heal + doctor;
+│   │                      #   + git-revert repair primitive (coordination-homed, not executor-private)
+│   └── status_service.py  # wp_lane_actor_from_events / EventLogReadContract.coordination_branch_ref
+└── cli/commands/
+    └── _coordination_doctor.py  # CANONICAL doctor coordination surface: register _check_stranded_coord_revert
+                            #   into _collect_coordination_findings + _fix into the existing --fix dispatch
+                            #   (reuse DoctorFinding.error_code) — NOT a new src/specify_cli/doctor/ home
+
+tests/
+├── regression/
+│   ├── test_issue_2786_revert_failure_split_brain.py   # MODIFY: assert coherence AFTER heal (SC-006)
+│   └── test_issue_2367_*.py                            # NEW — bake-mid-write-set strand repro (≥2-WP fixture)
+├── merge/
+│   ├── test_executor_phase_boundary.py                 # INV-5 #1827 frozen phase-order ratchet (do not add heal to expected_order)
+│   └── ...                                             # helper-level unit coverage
+└── architectural/                                      # AC-B3/AC-F1 + FR-008 behavioral guard
+```
+
+**Structure Decision**: Single-project CLI/library. No new package. The fix extends the existing
+`merge` executor rollback seam, adds one optional `MergeState` field, one `coordination`-layer
+coherence owner + repair primitive (consumed by resume AND doctor), and registers a check/fix into
+the **canonical** coordination-doctor surface. The strand set is derived from the committed coord ref
+(not a worktree diff — data-model D7). No data model beyond the marker; no API contracts (internal
+merge machinery).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| #2367-A (VCS-lock resync) fenced out of this mission | Deliberate stop-gap: the shared root closes #2786 + #2367-B with one seam; #2367-A is a distinct lock-resync concern with its own churn classifier (#2222) | Bundling #2367-A would widen scope past one coherent seam and delay the P0 split-brain fix; tracked separately under #2017 |
+| **SaaS/dashboard outbound-emit reconciliation fenced OUT** (alphonso Q5) | `git revert` heals tracked coord artifacts + committed materialization, but the transient `done` SaaS emit cannot be un-sent; SaaS is advisory / eventually-consistent | A compensating emit widens scope past the split-brain fix; the hosted projection self-heals on the next authoritative emit. Separate follow-up if product deems the transient projection unacceptable (FR-010) |
+| Helper extractions (`_persist_coord_reconcile_marker`, `_heal_pending_coord_reconcile`, `coord_incoherent_done_wps`, coordination-homed `git-revert` repair, doctor `_check_stranded_coord_revert`) | Keep touched functions ≤ CC-15; one shared coherence owner prevents the three-way strand-derivation drift (#2786-C seed); coordination-homed repair avoids doctor→executor dependency inversion | Inlining would push the touched functions past CC-15 and leave new branches only integration-covered; three private re-derivations of the strand set is the ownership-confusion smell paula flagged |
+
+## Implementation Concern Map
+
+> Concerns are NOT work packages. `/spec-kitty.tasks` translates these into executable WPs.
+
+### IC-01 — Red-first reproduction (git-reducible reds only)
+
+- **Purpose**: Prove both #2786 (revert-failed) and #2367-B (revert-never-called) strand committed coord state, and un-break the permanently-red existing assertion — using only assertions whose surfaces exist today.
+- **Relevant requirements**: FR-001, FR-003, split-brain half of FR-002; US1 scenarios 1,3 + the split-brain half of scenario 2.
+- **Affected surfaces**: `tests/regression/test_issue_2786_revert_failure_split_brain.py` (MODIFY the ~line-204 assertion → assert coherence *after* the heal step, SC-006; never bare-delete), `tests/regression/test_issue_2367_*.py` (NEW — inject failure inside `_record_merged_wps_done_for_merge` after ≥1 committed `done`), **≥2-WP fixture** (one stranded / one coherent), reuse #2711 coord harness; committed-ref reduction via `_durable_done_wps_on_coordination_ref`.
+- **Sequencing/depends-on**: none (first). **Expected-red until IC-03 lands — single-PR landing unit.**
+- **Risks (priti sequencing):** marker-exists / doctor-exit-1 assertions do NOT belong here — those surfaces don't exist yet, so asserting them would red with `AttributeError` (setup-red, forbidden by ADR 2026-07-17-1). They move to IC-02/IC-03. #2367-B must inject on the **bake** path (target-advance/squash-conflict are revert-covered/vacuous, alphonso).
+
+### IC-02 — Durable marker + single coherence owner + mark-not-raise at both strand sites
+
+- **Purpose**: Persist a non-fakeable marker naming the *specific* stranded WP (committed-ref authority) so no strand is silently swallowed; establish the ONE coherence owner.
+- **Relevant requirements**: FR-004, FR-005, FR-009; US2 scenario 1 + FR-002's marker-names-specific-WP assertion.
+- **Affected surfaces**: `src/specify_cli/merge/state.py` (`pending_coord_reconcile: dict[str, Any] | None`, `from_dict`; canonical runtime state path), `src/specify_cli/coordination/` (`coord_incoherent_done_wps(coord_ref, candidate_wps)` over `_durable_done_wps_on_coordination_ref` — the SINGLE owner), `src/specify_cli/merge/executor.py` (extract `_persist_coord_reconcile_marker(run, error)` calling the owner; call from the ≈500-514 revert-failure branch AND the ≈406-408 bake branch; `save_state`; mark-not-raise so leg-b byte-restore still runs).
+- **Sequencing/depends-on**: IC-01 (red first).
+- **Risks (alphonso HIGH):** `stranded_wp_ids` MUST derive from the **committed coord ref** over *this merge's* write-set — a live committed-vs-working diff is **empty at the #2786 mark point** (restore touches primary paths, not the coord worktree) → silent strand-drop. `from_dict` rehydrates a plain dict (type `dict[str,Any]|None`). Must not perturb the happy path (NFR-001).
+
+### IC-03 — Strand-gated repair (resume) + canonical doctor detection/fix
+
+- **Purpose**: Heal the strand deterministically and idempotently; make it operator-detectable via the canonical doctor surface.
+- **Relevant requirements**: FR-006, FR-007; US2 scenarios 2–5, NFR-002.
+- **Affected surfaces**: `src/specify_cli/merge/executor.py` (dedicated `_heal_pending_coord_reconcile` at resume startup — strand-gated on committed-ref DONE, atomic clear; NOT an overload of `_reconcile_completed_wps_for_resume`), `src/specify_cli/coordination/` (git-revert repair primitive, consumed by resume AND doctor), **`src/specify_cli/cli/commands/_coordination_doctor.py`** (register `_check_stranded_coord_revert` into `_collect_coordination_findings` + `_fix_stranded_reverts` into the existing `--fix` dispatch; reuse `DoctorFinding.error_code` + `coord_incoherent_done_wps`).
+- **Sequencing/depends-on**: IC-02 (marker + owner must exist).
+- **Risks (alphonso/paula):** doctor home is the CANONICAL `_coordination_doctor.py`, NOT `src/specify_cli/doctor/` (orphan-ops — a second authority = DIR-044 breach). Repair = forward `git revert` (env via `_make_merge_env`), NOT `advance_branch_ref` (refuses non-FF). Re-heal gates on *live* strand-on-ref (a blind revert re-applies `done`); doctor needs the **negative** AC (marker+coherent→exit 0). Resume-twice byte-identical incl. a crash between heal and clear (NFR-002).
+
+### IC-04 — Class-closing invariant guard (behavioral)
+
+- **Purpose**: Prevent regression of the whole defect class — any rollback leaving a stranded `done` on the committed coord ref MUST leave a durable marker.
+- **Relevant requirements**: FR-008; SC-005.
+- **Affected surfaces**: `tests/architectural/` (behavioral property/guard test), and preferably the executor `_restore_and_guard_coord_coherence` primitive.
+- **Sequencing/depends-on**: IC-02, IC-03.
+- **Risks (renata/paula):** MUST be **behavioral** — red under a *runtime-stubbed* mark (no-op `_persist_coord_reconcile_marker`/`coord_incoherent_done_wps`) driving a real bake strand; a source-grep-for-the-call guard is a tautology and is rejected. MUST enumerate all six `_restore_final_bookkeeping_snapshots` sites (≈406/536/670/691/757/786) and assert site ≈691 is dead-for-coord only via `done_marked_before_target` (≈350-352). Preferred structural close: co-locate the mark at the restore primitive so a future restore site cannot strand silently (inner-only, INV-5-safe).

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research.md
@@ -1,0 +1,166 @@
+# Phase 0 Research — Merge coord-write rollback transactionality
+
+Consolidates the 6-lens pre-spec research (`research/lens-a..f-*.md`) and the post-spec squad
+(reviewer-renata + python-pedro). Every decision below is code-verified against `main`.
+
+## D1 — Marker home: extend `MergeState`, not a sidecar file
+
+- **Decision**: Add `pending_coord_reconcile: dict[str, Any] | None` to `MergeState`
+  (`src/specify_cli/merge/state.py`), persisted through the existing `save_state`.
+- **Rationale**: `MergeState` already persists to `.kittify/merge-state.json` and survives across
+  `merge --resume`; `from_dict` drops unknown keys, so an old state file simply rehydrates the
+  field as `None` — **no migration**. A sidecar file would add a new artifact + its own lifecycle.
+- **Alternatives considered**: dedicated sidecar JSON (rejected — needless artifact + migration);
+  a new dataclass field (rejected by pedro — `from_dict` rehydrates a plain `dict`, so a nested
+  dataclass would silently arrive as a dict; type it `dict[str, Any] | None`).
+
+## D2 — Fix seam: extend the executor rollback, don't wrap it in a transaction
+
+- **Decision**: Extend the executor's existing coord-write rollback seam
+  (`_MergeRunState` + `_restore_pre_target_if_at_baseline` / `_revert_coord_done_commit` /
+  `_restore_final_bookkeeping_snapshots`). Mark at the two strand sites; heal on resume.
+- **Rationale (B-vs-E divergence resolved)**: the per-WP `coordination.transaction.BookkeepingTransaction`
+  is a **single-commit, single-lock** chokepoint; the merge's pre-target done write-set is a
+  **multi-WP loop** (`_record_merged_wps_done_for_merge`, each WP opening its own transactional emit).
+  Wrapping the linear phase driver in one `BookkeepingTransaction` is a genuine **grain mismatch** —
+  that, not a ratchet, is the load-bearing reason it is wrong (alphonso: a `with` wrapper would
+  *indent* but not *reorder* the phase substrings, so it likely would **not** trip the ordering
+  ratchet). Extending the existing seam is minimal and ratchet-safe (inner-only changes).
+- **Citation correction (alphonso LOW)**: the enforced INV-5 #1827 ratchet is
+  `tests/merge/test_executor_phase_boundary.py::test_locked_driver_calls_phases_in_frozen_order`
+  (asserts frozen `_phase_*` call order). "C-002" was mis-borrowed — in this corpus it maps to
+  *doctrine governance union*, not a merge-phase constraint. **Task guardrail:** if the resume heal is
+  inserted *within* the driver, it must NOT be added to the asserted `expected_order` list, or the
+  ratchet flips red on a correct change (a tests-as-scaffold trap).
+- **Alternatives considered**: wrap in `BookkeepingTransaction` (rejected — grain mismatch +
+  #1827 tripwire); raise on failure (rejected — see D4).
+
+## D3 — #2367-B is the SAME mechanism as #2786 (post-spec correction)
+
+- **Decision**: Treat #2367-B and #2786 as one defect class. The live #2367-B strand is a failure
+  **inside `_record_merged_wps_done_for_merge`** whose byte-restore-only branch
+  (`executor.py:406-408`) restores working bytes **without** calling `_revert_coord_done_commit` —
+  the identical "byte-restore-without-revert" mechanism as #2786 (where the revert is *called but
+  fails*). One marker-at-both-sites fix closes both.
+- **Rationale**: renata + pedro traced the paths against `main`. The *target-advance* and
+  *squash-conflict* rollback paths already run `_restore_final_bookkeeping_snapshots` +
+  `_revert_coord_done_commit` (`executor.py:535-536`), so a #2367-B repro there is **vacuously
+  green**. The strand only exists on the bake path.
+- **Alternatives considered**: reproduce #2367-B on the squash-conflict path (rejected — vacuous;
+  lens-D's original guess, now superseded); descope #2367-B as a phantom (rejected — it is real on
+  the bake path).
+
+## D4 — Mark-not-raise on strand
+
+- **Decision**: On revert failure (or the bake byte-restore branch), *persist the marker and
+  continue*; do **not** raise.
+- **Rationale**: raising out of the rollback would skip leg-b byte-restore, leaving the working
+  tree dirty AND masking the real target-advance fault that triggered the rollback. Marking keeps
+  the working tree consistent and defers the (committed-side) coherence repair to resume/doctor.
+- **Alternatives considered**: raise + abort (rejected — masks the primary fault, worse operator
+  state).
+
+## D5 — Repair is coherence-gated, git-re-derived, and idempotent
+
+- **Decision**: Heal on `merge --resume` via a dedicated `_heal_pending_coord_reconcile` entry
+  (NOT an overload of `_reconcile_completed_wps_for_resume`). The re-heal acts **only while
+  committed-vs-working is still incoherent** (re-derived from the coord ref via
+  `wp_lane_actor_from_events`), then clears the marker atomically.
+- **Rationale (renata double-heal finding)**: a blind `git revert captured_sha..HEAD` on resume
+  would revert the *successful* revert and re-apply `done`. Gating on live incoherence — not on
+  `head != captured_sha` — makes a second resume a no-op (NFR-002), including a crash between heal
+  and clear (the next run re-derives coherent → no-op → clears).
+- **Alternatives considered**: unconditional re-revert (rejected — double-heal re-applies `done`);
+  clear-then-heal (rejected — a clear-without-heal would drop the strand silently).
+
+## D6 — Doctor re-verifies, never trusts the marker
+
+- **Decision**: `doctor coordination` loads `MergeState` markers, **re-verifies** committed-vs-working
+  incoherence from git, and only then reports (stable `error_code`, exit 1); `--fix` runs the same
+  repair as resume.
+- **Rationale**: marker-presence alone is fakeable and can go stale (e.g. a prior resume healed but
+  crashed before clearing). Re-verification makes the check truthful and the fix idempotent.
+- **Alternatives considered**: report on marker-presence only (rejected — false positives on stale
+  markers; not the contract US2-S4 demands).
+
+## D7 — Non-fakeable marker contents *(REVISED post-plan — architect-alphonso HIGH)*
+
+- **Decision**: `stranded_wp_ids` = the WP(s) **this merge marked `done`** (its pre-target done
+  write-set) that still reduce to `DONE` on the **committed coordination ref** after rollback —
+  derived via `_durable_done_wps_on_coordination_ref(candidate_wps=<this merge's write-set>)`. NOT a
+  static list; NOT a live committed-vs-working worktree diff.
+- **Rationale**: a committed-vs-working diff computed *at the #2786 mark point* (inside
+  `_revert_coord_done_commit`, **before** the later `_restore_final_bookkeeping_snapshots`) returns an
+  **empty delta** — that restore touches **primary `repo_root`** paths, never the coord worktree, so
+  both sides read `done` → no marker → silent strand-drop (the mission's own failure mode). The
+  committed ref is the reliable authority at any mark point; the "approved" side is known **by
+  construction** (the rollback's intent). Scoping candidates to *this merge's* write-set excludes a
+  genuinely-pre-existing-`done` WP; the committed-ref membership excludes a never-committed coherent
+  WP — together satisfying renata's ≥2-WP non-fakeability fixture (a hardcoded `["WP01"]` or an
+  over-broad `all_wp_ids` both fail).
+- **Alternatives considered**: committed-vs-working delta via `wp_lane_actor_from_events` (rejected —
+  empty at the #2786 mark point; the original pre-plan framing, now superseded); static/all-WP list
+  (rejected — fakeable).
+- **Note**: the *existing* on-main #2786 test asserts final-state committed-vs-working (post-restore),
+  a **different** observation point where the diff IS non-empty — that assertion stays valid; only the
+  *marker's* internal derivation changes to the committed-ref authority. Confirm the empty-at-mark-point
+  timing with the IC-01 repro before locking the derivation (alphonso's static trace, conceded).
+
+## D8 — Scope fence: #2367-A deferred
+
+- **Decision**: #2367-A (VCS-lock resync) is **out of scope**, tracked under #2017; the #2222 churn
+  classifier already exists for it.
+- **Rationale (B-vs-C divergence resolved)**: paula + planner agree the shared root closes
+  #2786 + #2367-B with one seam; #2367-A is a distinct lock-resync concern. Bundling it would widen
+  past one coherent seam and delay the P0 split-brain fix.
+
+## D9 — Canonical surfaces: one coherence owner, correct doctor home, right repair transport *(post-plan)*
+
+- **Decision**: (a) one `coordination`-layer `coord_incoherent_done_wps(coord_ref, candidate_wps)`
+  (thin wrapper over `_durable_done_wps_on_coordination_ref`) consumed by mark + heal-gate + doctor —
+  no per-call-site re-implementation; (b) the repair primitive (`git revert` of the stranded commit)
+  homed as a coordination-layer function consumed by both executor-resume and `doctor --fix`, NOT
+  executor-private; (c) the doctor check/fix registers into the **canonical** coordination-doctor
+  surface `src/specify_cli/cli/commands/_coordination_doctor.py` (`_collect_coordination_findings`,
+  `DoctorFinding.error_code`, the existing `--fix` dispatch), NOT `src/specify_cli/doctor/` (orphan-ops).
+- **Rationale (paula HIGH + alphonso Q1/Q4)**: three independent re-derivations of the strand set is
+  the ownership-confusion smell that produces #2786-C drift; a diagnostic command depending on
+  merge-executor internals inverts the dependency; a second coordination-doctor home is a DIR-044
+  canonical-source split. The repair is a forward `git revert` (not `advance_branch_ref`, which refuses
+  the non-FF move) — AC-B3/AC-F1 clean.
+- **Alternatives considered**: private executor helpers for the delta (rejected — layer leak);
+  `advance_branch_ref` for repair (rejected — structurally refuses non-FF); a new `doctor/` coordination
+  check (rejected — canonical split).
+
+## D10 — SaaS/dashboard outbound-emit reconciliation fenced OUT *(post-plan — alphonso Q5)*
+
+- **Decision**: out of scope. `git revert` heals the tracked coord artifacts + committed materialization,
+  but the outbound SaaS emit for the transient `done` cannot be un-sent; the hosted projection may
+  transiently show `done` for a rolled-back WP until the next authoritative emit reconciles it.
+- **Rationale**: SaaS is advisory / eventually-consistent; a compensating emit is a distinct concern.
+  Recorded as an explicit scope fence (Complexity Tracking + doctor remediation notes), not a silent
+  omission (DIR-031).
+- **Alternatives considered**: emit a compensating `approved` transition during heal (deferred — widens
+  scope past the split-brain fix; separate follow-up if product deems the transient projection unacceptable).
+
+## D11 — Root-cause enumeration, not two-sites *(post-plan — paula HIGH)*
+
+- **Decision**: FR-008 enumerates all six `_restore_final_bookkeeping_snapshots` sites (≈406, 536, 670,
+  691, 757, 786), documents that site ≈691 (post-target `_record_merged_wps_done_for_merge` failure) is
+  the same restore-without-revert shape and is dead-for-coord **only** via the `done_marked_before_target`
+  invariant (≈350-352), and prefers co-locating the coherence-mark at the restore **primitive**
+  (`_restore_and_guard_coord_coherence`) so a future restore site cannot strand silently.
+- **Rationale**: marking two hand-picked callers proves the marker path for one injected rollback but
+  does not close the enumeration — a flipped `done_marked_before_target` or a new coord-routed restore
+  reintroduces the strand. Co-locating at the primitive is **inner** (not the phase-driver wrapper INV-5
+  forbids) → converts "mark at two callers" into "mark by construction at the restore seam".
+- **Alternatives considered**: mark only at 406-408 + 500-514 (rejected — leaves 691 as a #2786-C seed);
+  full transaction rewrite (rejected — grain, D2).
+
+## Feasibility confirmation (python-pedro)
+
+`MergeState` / `save_state` / `DoctorFinding.error_code` / `resolve_placement_only` /
+`wp_lane_actor_from_events` all exist on `main` and behave as the plan assumes. Three helper
+extractions keep the touched functions ≤ CC-15. INV-5 #1827 / AC-B3 / AC-F1 ratchets stay green as
+long as changes remain inner-only (no wrapper around the phase driver, no raw `git update-ref`,
+coord env via `_make_merge_env`). **Verdict: buildable as specified.**

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-a-2786-reconcile-marker.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-a-2786-reconcile-marker.md
@@ -1,0 +1,253 @@
+# Lens A — #2786: the swallowed coord-`done` revert during rollback
+
+**Investigator:** Debugger Debbie (profile `debugger-debbie`)
+**Applied directives:** D-001 (Architectural Integrity — reuse the single canonical
+merge-transaction authority, refuse a sidecar), D-003 (Decision Documentation —
+persist the falsified marker-home alternatives), D-030 (Test/Typecheck Gate — the
+red-first repro already exists and the fix must flip it), D-032 (Conceptual
+Alignment — committed↔working coord divergence is the alignment failure the
+divergence matrix surfaces). Tactics: review-intent-and-risk-first, five-paradigm
+convergence.
+**Mode:** READ-ONLY pre-spec research. No product code edited.
+
+---
+
+## 1. Exact swallowed-failure site
+
+**File:** `src/specify_cli/merge/executor.py`
+
+### 1a. The swallow — `_revert_coord_done_commit`, failure branch (lines 500–514)
+
+```python
+    revert = subprocess.run(
+        ["git", "-C", str(coord_worktree), "revert", "--no-edit", f"{captured_sha}..HEAD"],
+        capture_output=True, text=True, check=False, env=env,
+    )
+    if revert.returncode != 0:
+        subprocess.run(
+            ["git", "-C", str(coord_worktree), "revert", "--abort"],
+            capture_output=True, text=True, check=False, env=env,
+        )
+        logger.warning(
+            "#2711: could not revert coordination 'done' commit(s) on %s (%s..HEAD); "
+            "committed/working coherence may be degraded: %s",
+            coord_ref, captured_sha[:12],
+            (revert.stderr or revert.stdout or "").strip(),
+        )
+        # <-- implicit `return None`: no raise, no durable write, nothing recorded
+```
+
+On a `git revert` conflict/failure the helper runs `revert --abort`, logs a
+`warning`, and falls off the end (implicit `return None`). **Nothing durable is
+written.** No `save_state`, no marker field, no event, no sentinel file. The only
+trace is a log line that vanishes with the process.
+
+### 1b. The enclosing flow — `_restore_pre_target_if_at_baseline` (lines 517–536)
+
+```python
+def _restore_pre_target_if_at_baseline(run: _MergeRunState) -> None:
+    if run.done_marked_before_target and _target_branch_still_at_baseline(
+        run.main_repo, run.lanes_manifest.target_branch, run.target_baseline_sha,
+    ):
+        _revert_coord_done_commit(run)                       # (a) revert committed done -> approved
+        _restore_final_bookkeeping_snapshots(                # (b) restore working bytes -> approved
+            run.pre_target_bookkeeping_snapshots
+        )
+```
+
+The two rollback legs run **sequentially and unconditionally**: leg (a) reverts the
+*committed* coord `done`; leg (b) restores the *working* bytes to `approved`. When
+leg (a) silently no-ops on a revert failure, leg (b) still runs — so the committed
+ref is stranded at `done` while the working tree reduces to `approved`. This helper
+is the shared rollback exit reached from `_reject_zero_diff_noop_squash` (551),
+`_handle_mission_merge_result` (579), and `_phase_mission_to_target`'s `except`
+(614). The #2786 test drives the (614) path via an injected
+`integrate_mission_into_target` `RuntimeError`.
+
+### 1c. Confirmation that nothing durable survives the failure
+
+- `_revert_coord_done_commit` has no `save_state` / marker / event write on any path.
+- `clear_state` fires **only** at `_phase_finalize_and_summary` (line 973), never on
+  rollback — so `.kittify/runtime/merge/<mission_id>/state.json` **survives** the
+  failed merge with `completed_wps` still listing the WP whose committed `done` is
+  now stranded. That surviving `MergeState` is the durable object the marker rides
+  on: it already outlives the rollback and is already the resume authority.
+- Grep confirms `executor.py` writes no state during rollback (only the finalize
+  `clear_state`). The divergence is therefore **undetectable** by any later
+  resume/doctor pass — exactly the silent re-open the red pins.
+
+---
+
+## 2. The durable reconcile marker — surface + shape (single canonical authority)
+
+**Verdict: put the marker on `MergeState` (`src/specify_cli/merge/state.py`),
+persisted to the existing `.kittify/runtime/merge/<mission_id>/state.json`. Do NOT
+add a sidecar file, and do NOT invent a new status event.**
+
+Why `MergeState` is the canonical owner (D-001, single-canonical-authority):
+
+1. **It is already the durable authority for merge-transaction progress/resume.**
+   The incoherence is a *merge-transaction* fact ("a rollback could not restore
+   committed↔working coherence"), not a lane-lifecycle fact. Its natural home is the
+   merge-transaction record, not the event log.
+2. **It already survives the rollback** (`clear_state` runs only at finalize) and is
+   already re-loaded by both `merge --resume` (`_dispatch_resume` →
+   `_load_merge_state_for_mission`) and available to `doctor`. Zero new lifecycle.
+3. **It already carries the reconcile seam.** `done_bookkeeping._reconcile_completed_wps_for_resume`
+   already reconciles `completed_wps` against durable `done` evidence — the marker's
+   repair is the *inverse* of logic that already lives one function away.
+4. The event log is the authority for *lane state*; `MergeState` is the authority for
+   *merge transactions*. Recording "reconcile needed" on `MergeState` while *reading*
+   the event log to heal keeps each authority single — no second authority is minted.
+
+### Marker shape (new optional field on `MergeState`)
+
+```python
+@dataclass
+class MergeState:
+    ...
+    # #2786: set by the rollback when the coherent coord-``done`` revert FAILS,
+    # stranding the committed ``done`` against the rolled-back working ``approved``.
+    # None on a healthy transaction; populated => a repair is owed before the
+    # transaction can be considered coherent. Read by merge --resume and
+    # `doctor coordination`. Cleared when the revert is re-attempted successfully
+    # (or the whole state file is cleared at merge finalize).
+    pending_coord_reconcile: dict[str, Any] | None = None
+```
+
+Payload written by the rollback:
+
+```json
+{
+  "coord_ref":       "kitty/mission-<slug>-<mid8>-coord",   // run.pre_target_coord_ref
+  "captured_sha":    "<pre-emit coord tip>",                 // run.pre_target_coord_sha
+  "coord_worktree":  "<abs path to coord worktree>",         // _coord_worktree_root(run)
+  "stranded_wp_ids": ["WP01", ...],                          // run.all_wp_ids marked done pre-target
+  "revert_error":    "<git revert stderr/stdout, trimmed>",
+  "detected_at":     "2026-07-18T…Z"
+}
+```
+
+`from_dict` already filters unknown keys, so the field is backward/forward
+compatible with pre-#2786 state files (loads as `None`) — no migration.
+
+- **Writer (rollback):** `_revert_coord_done_commit`'s failure branch sets
+  `run.state.pending_coord_reconcile = {…}` and calls
+  `save_state(run.state, run.main_repo)` **before** returning. This is the entire
+  behavioral change on the write side: turn the silent `return` into a durable
+  record, then keep returning (see §4 on why it still returns rather than raises).
+- **Readers/repairers:** `merge --resume` and `doctor coordination` (see §3).
+
+---
+
+## 3. Repair semantics — who reads and heals
+
+"Repair" = make the **committed** coord ref agree again with the **working**
+reduction. Two symmetric heals, both grounded in code that already exists:
+
+### 3a. Roll-back heal (re-attempt the coherent revert)
+
+The revert failed because the coord worktree was transiently non-revertable (dirty
+index, conflict, broken worktree). Once the operator clears that, re-running the
+**same** `git revert <captured_sha>..HEAD` in the coord worktree rolls the committed
+`done` back to `approved` — coherent with the already-rolled-back working tree.
+This is a straight re-invocation of `_revert_coord_done_commit` seeded from the
+marker's `coord_ref`/`captured_sha`/`coord_worktree`. On success, clear
+`pending_coord_reconcile` and `save_state`.
+
+### 3b. Roll-forward heal (resume the merge)
+
+If the operator instead `merge --resume`s, the merge re-advances the target; the
+committed `done` becomes *correct* once the mission actually lands, and finalize's
+`clear_state` drops the whole state file (marker included). So a successful resume
+is self-healing — the marker only needs to *survive an abandoned* transaction.
+
+### Surfacing + healing wiring
+
+- **`merge --resume`:** extend the existing reconcile seam. Before
+  `_record_merged_wps_done_for_merge`, if `state.pending_coord_reconcile` is set,
+  attempt 3a (re-revert); if it still fails, keep the marker and fail loud with a
+  remediation hint (`doctor coordination --fix` / `merge --abort`). This sits
+  naturally beside `_reconcile_completed_wps_for_resume`, which already drops stale
+  `completed_wps` — the two together make resume idempotent in both divergence
+  directions.
+- **`doctor coordination`** (`src/specify_cli/cli/commands/_coordination_doctor.py`):
+  add a check `_check_coord_done_reconcile_pending(repo_root, mission_meta)` alongside
+  the existing `_coord_worktree_head/dirty/stale_finding` probes. It loads the
+  mission's `MergeState` and, when `pending_coord_reconcile` is set, emits:
+
+  ```python
+  DoctorFinding(
+      severity="error",                       # a stranded committed done is a real defect, not advisory
+      message="Coordination 'done' revert failed during a rolled-back merge; the "
+              "committed coord ref is stranded at 'done' while the working tree is "
+              "'approved' (mission <slug>, WPs <ids>).",
+      next_step="Run `spec-kitty doctor coordination --fix` to re-attempt the "
+                "coherent revert, or `spec-kitty merge --resume` to roll forward.",
+      error_code="COORDINATION_DONE_REVERT_STRANDED",
+      extra={"mission_slug": ..., "captured_sha": ..., "coord_worktree": ...,
+             "stranded_wp_ids": [...]},
+  )
+  ```
+
+  `doctor coordination --fix` already has a `--fix` loop (`_fix_never_created_branches`);
+  add a sibling `_fix_stranded_coord_done(findings)` that re-runs the coherent revert
+  from the marker and clears it on success — the exact `--fix` pattern this module
+  already uses.
+
+  *Defense-in-depth option:* the doctor check can additionally **recompute** the
+  divergence directly (reduce committed coord-ref events vs working-file events, the
+  `wp_lane_actor_from_events` comparison the #2786 test already uses) so the finding
+  fires even for a state file that was cleared out-of-band. The marker stays the
+  primary, cheap signal; the recomputation is the belt-and-suspenders authority.
+
+---
+
+## 4. Raise-vs-mark verdict
+
+**Recommendation: MARK durably; do NOT raise from `_revert_coord_done_commit`.**
+
+The reviewer is correct that raising "wouldn't mask a success" — the enclosing merge
+is already failing. But raising from the helper is still the wrong lever, for two
+code-grounded reasons the reviewer's framing doesn't cover:
+
+1. **Raising skips the second rollback leg.** In
+   `_restore_pre_target_if_at_baseline`, `_revert_coord_done_commit` and
+   `_restore_final_bookkeeping_snapshots` run **sequentially** (lines 535–536). An
+   exception out of the revert helper would bypass the working-byte restore, leaving
+   the working tree mid-rollback — trading the *committed-done/working-approved*
+   split-brain for a *committed-done/working-done-but-target-not-advanced* one. That
+   is a **different** incoherence, not a cure.
+2. **Raising obscures the real rollback trigger.** The rollback exists *because* the
+   target advance failed (the injected `RuntimeError`). A revert-conflict exception
+   would surface at the CLI *instead of* that root fault, sending the operator to
+   debug the revert rather than the merge failure that caused it.
+
+Meanwhile the actual requirement the red encodes is **detectability + repairability**,
+not additional loudness: the enclosing merge already exits non-zero and prints the
+target-advance error, so the CLI failure is *not* silent — only the residual
+divergence is. The durable marker (§2) closes exactly that gap and lets the byte
+restore complete, keeping the rollback single-purpose.
+
+**Concrete minimal fix:** in the failure branch, replace the bare `return` with
+`set pending_coord_reconcile + save_state` (keep the existing `warning`), then
+return. Add the resume + doctor readers of §3. This flips
+`test_swallowed_revert_failure_re_opens_2711_split_brain` green **by repair**, not by
+suppression.
+
+**Falsified / deferred alternatives (D-003):**
+- *Sidecar reconcile file* (`.kittify/…/coord-incoherence.json`) — rejected: mints a
+  second authority beside `MergeState`, violates single-canonical-authority (D-001).
+- *New status event on the coord log* — rejected: writing another coord event during
+  a failed coord revert is the surface that is already broken; the event log is the
+  *lane* authority, not the *merge-transaction* authority.
+- *Skip the byte-restore on revert failure so both legs stay `done`* (coherent-but-
+  not-rolled-back, and arguably resume-friendlier) — **not** the minimal fix: it
+  reorders INV-6 and leaves a `done` that is wrong if the transaction is abandoned
+  (still needs the marker for that case). Flagged for architect consideration, out of
+  scope for the #2786 close.
+
+---
+
+## Terminology note
+Uses canonical **Mission** throughout; no `feature*` aliases introduced.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-b-2367-coord-worktree-resync.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-b-2367-coord-worktree-resync.md
@@ -1,0 +1,60 @@
+# Lens B — #2367: `spec-kitty merge` blocked by the coordination worktree
+
+**Author:** Architect Alphonso (architect-alphonso profile)
+**Mode:** READ-ONLY pre-spec research. No product code edited.
+**Directives applied:** 001 (Architectural Integrity — component boundaries/ownership), 003 (Decision Documentation), 031 (Context-Aware Design — the coord worktree is a bounded context with its own write authority), 043 (Close Defect Classes by Construction — the fix must make partial coord state *unrepresentable*, not remind an operator to hand-fix), 044 (Canonical Sources and Unification — one classifier for "spec-kitty-owned churn", one transactional boundary).
+
+Issue: `Priivacy-ai/spec-kitty#2367` (P0, child of #2392, sibling of CLOSED #1826). Two distinct mechanisms, both real-witnessed on mission `ci-suite-map-bind-01KWNPMP`.
+
+---
+
+## 1. The coord-worktree resync guard (#1826 / NFR-002)
+
+**Canonical site:** `src/specify_cli/git/ref_advance.py` — `advance_branch_ref()` is *the single sanctioned way* the merge pipeline advances a branch ref (an architectural ratchet, `tests/architectural/test_merge_pipeline_ratchets.py` AC-B3, forbids raw `update-ref` anywhere else in `src/specify_cli`).
+
+**How it decides "dirty" and refuses:** `_dirty_entries()` (lines 167–211) runs `git status --porcelain --ignored` in every worktree that has the advanced branch checked out, BEFORE the ref moves (atomic refusal, lines 284–301). Any staged/unstaged entry against a *tracked* path is unconditionally treated as local state and appended to `dirty`; untracked/ignored entries are dirty only if they obstruct a target-tree path. If `dirty` is non-empty it raises `RefAdvanceDirtyWorktreeError` (lines 66–100) — the exact "uncommitted local changes that a resync (`git reset --hard`) would destroy (#1826 / NFR-002)" message from the issue. Nothing is mutated on refusal.
+
+**The one escape hatch that already exists:** `advance_branch_ref(..., coord_owned_filenames=frozenset)` → passed to `_dirty_entries(excluded_filenames=...)` (lines 203–204). Merge callers in `src/specify_cli/lanes/merge.py:675` and `:710` pass `COORD_OWNED_STATUS_FILES`. **Critically, that set is only `{status.events.jsonl, status.json}`** (`src/specify_cli/status/__init__.py:210`) — and the exclusion (line 203) applies **only to untracked/ignored `??`/`!!` lines**, not to *tracked-file* modifications. This is the seam both mechanisms fall through.
+
+---
+
+## 2. Mechanism A — uncommitted VCS-lock at claim (tool-churn, not user work)
+
+**Write site:** `src/specify_cli/cli/commands/implement.py:1009` — on first claim, if `"vcs" not in meta`, `set_vcs_lock(feature_dir, vcs_type="git", locked_at=now_iso)` (`src/specify_cli/mission_metadata.py:512`) writes `vcs` + `vcs_locked_at` into `meta.json` via `write_meta`. This is a one-time **VCS-TYPE** lock (which VCS backend), NOT the concurrency mutex — pure tool-generated metadata. It is **not auto-committed** at claim; under `auto_commit=False` it lingers as an uncommitted tracked-file diff.
+
+**Why it trips the resync guard:** `meta.json` is a tracked file. At merge time `advance_branch_ref` → `_dirty_entries` sees the modified `meta.json` and, because the exclusion set contains only the two status filenames (and only excludes untracked lines anyway), lists it as dirty → refusal → merge blocked. The operator had to hand-commit `meta.json` in the coord worktree to unblock.
+
+**The canonical classifier already exists — but only on the claim side.** `src/specify_cli/cli/commands/implement_cores.py` already solved the *symmetric* problem for the next claim's dirty-tree guard: `_is_vcs_lock_only_meta_diff()` (line 216) is a pure predicate — "is every changed key a member of `_VCS_LOCK_META_FIELDS = {vcs, vcs_locked_at}`?" — and `_drop_vcs_lock_only_meta()` (line 315, #2222 / C-003) drops a lock-only diff from the claim guard while keeping any genuine meta edit blocking. **The merge-side resync guard does not know about this classifier.** That is the directive-044 gap: two guards (claim vs merge) over the *same* tool-churn class, only one of which recognizes it.
+
+**Architectural options (for the spec, not decided here):** (a) auto-commit the VCS-TYPE lock at claim onto the coord/planning surface (it is tool metadata — commit it the moment it is written, closing the class by construction, directive 043); OR (b) teach `advance_branch_ref` to recognize spec-kitty-owned churn by threading a *classifier*, not a *filename set* — reuse `_is_vcs_lock_only_meta_diff` as the single canonical "is this a lock-only meta diff" authority so a genuine user meta edit still blocks. (a) is structurally stronger (no uncommitted tool state ever exists); (b) generalizes the escape hatch from "filenames" to "owned-churn predicate".
+
+---
+
+## 3. Mechanism B — non-transactional rollback of the coord status write-set
+
+**Write path (per-WP, N independent commits):** `src/specify_cli/merge/done_bookkeeping.py::_record_merged_wps_done_for_merge` (line 611) loops every WP and calls `_mark_wp_merged_done` (line 229), which calls `emit_status_transition_transactional` (up to twice per WP: an `approved` replay + the `done`). Each such call opens its **own** `BookkeepingTransaction.acquire(...)` and **commits to the coordination branch** (`coordination/status_transition.py:859,948`; `coordination/transaction.py::commit`). So the merge's "coord write set" is a **sequence of N separate committed transactions**, not one atomic unit.
+
+**Rollback path (parallel, hand-rolled — NOT the canonical transaction):** the executor rolls back via a *separate* mechanism in `src/specify_cli/merge/bookkeeping_projection.py` — `_capture_bookkeeping_snapshots` / `_restore_final_bookkeeping_snapshots` (byte snapshot+restore of the working-tree status files) — invoked at ~6 exception exits in `src/specify_cli/merge/executor.py` (`_restore_pre_target_if_at_baseline`, lines 517–536, and the `_phase_*` handlers). **This is a second, parallel rollback engine that duplicates `BookkeepingTransaction._rollback`'s job** (directive 044 violation): the transaction already owns surgical truncate + byte-snapshot restore, but the merge cannot use it because the writes were committed by N *already-closed* transactions.
+
+**Relation to the just-merged #2711 (Option A):** #2711 added `_revert_coord_done_commit` (`executor.py:458`) + `_capture_pre_target_coord_ref_sha` (line 411): it captures the coord-branch tip BEFORE the pre-target `done` emit and, on a target-advance rollback, `git revert`s `{captured}..HEAD` on the coord worktree so the *committed* `done` is coherently reversed in lockstep with the working-byte restore (avoiding the "committed `done` vs rolled-back `approved`" split-brain). **#2367 is the same non-transactional root, one level up.** #2711 makes the *committed done commit(s)* revertible; it does **not** make the *whole coord write-set* one atomic boundary. The residue the issue witnessed — stale `status.events.jsonl`/`status.json` emissions left in the coord worktree after an aborted run, forcing a manual `git checkout --` before `--resume` — is exactly what a per-write-set transaction (open once, commit once, roll back once) would prevent. #2711 patched the symptom for the `done` commit; the class stays open for the rest of the set (`approved` replays, partial mid-loop failures, the working-tree emissions before the coord commit).
+
+---
+
+## 4. Ownership / seam verdict
+
+- **Coord status-write transactionality is ALREADY OWNED** by `src/specify_cli/coordination/transaction.py::BookkeepingTransaction` — self-described as "the single owner of writes that target the coordination branch … acquire → policy gate → append → materialize → commit → outbound → release" with surgical-truncate + byte-snapshot rollback (C-009: never `git checkout --`). **The merge does not route its multi-WP coord write-set through a single instance of it.** It opens N short-lived transactions (one per emit) and then bolts a *parallel* snapshot/revert engine (`bookkeeping_projection.py` + `_revert_coord_done_commit`) on top to undo them. That parallel engine is the architectural smell (044).
+
+- **Coord-worktree cleanliness is owned by** `src/specify_cli/git/ref_advance.py::advance_branch_ref`, whose dirty-vs-clean decision is a **filename-exclusion set** (`COORD_OWNED_STATUS_FILES`), not a **tool-churn classifier**. It has no knowledge of `_is_vcs_lock_only_meta_diff` (the claim-side authority for the same question). Two guards, one class of churn — the 044 gap for Mechanism A.
+
+- **Is there ONE transactional boundary that makes coord writes + resync atomic and tool-churn-aware? Today: no.** The pieces exist but are not composed: (1) `BookkeepingTransaction` (real transaction, but per-emit and not spanning the merge loop); (2) `bookkeeping_projection` snapshots (parallel rollback); (3) `_revert_coord_done_commit` (#2711 point-fix for the committed `done`); (4) `advance_branch_ref` filename exclusion (cleanliness gate). The architecturally coherent target is a **single merge-scoped coordination transaction** that (a) spans the entire done/approved write-set for the mission (open once, commit once, roll back once — folding #2711's revert and the projection snapshots into `BookkeepingTransaction`'s own rollback so the parallel engine is retired, 044), and (b) shares ONE "spec-kitty-owned churn" classifier with `advance_branch_ref`'s dirty gate (retiring the filename-set escape hatch in favor of the `_is_vcs_lock_only_meta_diff`-style predicate, so tool-churn is auto-resolved while genuine user edits still refuse — 043 + 044). That single boundary is the seam #2367 is really asking for; #2711 is a down-payment on it, not the whole thing.
+
+### Key code sites (absolute paths)
+- Resync guard: `/home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/src/specify_cli/git/ref_advance.py` (`_dirty_entries` 167–211; `advance_branch_ref` 214–320; `RefAdvanceDirtyWorktreeError` 66–100)
+- Exclusion set: `/home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/src/specify_cli/status/__init__.py:210` (`COORD_OWNED_STATUS_FILES`)
+- Merge callers of the guard: `/home/stijn/Documents/_code/SDD/fork/spec-kitty-gate-doctrine/src/specify_cli/lanes/merge.py:675,710`
+- VCS-lock write: `/home/stijn/.../src/specify_cli/cli/commands/implement.py:1009`; `/home/stijn/.../src/specify_cli/mission_metadata.py:512`
+- Claim-side tool-churn classifier: `/home/stijn/.../src/specify_cli/cli/commands/implement_cores.py:216` (`_is_vcs_lock_only_meta_diff`), `:315` (`_drop_vcs_lock_only_meta`), `:51` (`_VCS_LOCK_META_FIELDS`)
+- Canonical coord transaction: `/home/stijn/.../src/specify_cli/coordination/transaction.py` (`BookkeepingTransaction`; `_rollback` 1145–1212)
+- Merge done write-set: `/home/stijn/.../src/specify_cli/merge/done_bookkeeping.py:611` (`_record_merged_wps_done_for_merge`), `:229` (`_mark_wp_merged_done`)
+- Parallel rollback engine: `/home/stijn/.../src/specify_cli/merge/bookkeeping_projection.py` (`_capture_bookkeeping_snapshots` 202, `_restore_final_bookkeeping_snapshots` 217)
+- #2711 Option-A point-fix: `/home/stijn/.../src/specify_cli/merge/executor.py:411` (`_capture_pre_target_coord_ref_sha`), `:458` (`_revert_coord_done_commit`), `:517` (`_restore_pre_target_if_at_baseline`)

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-c-shared-transactional-seam.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-c-shared-transactional-seam.md
@@ -1,0 +1,94 @@
+# Lens C — Is there ONE transactional seam that closes both #2786 and #2367?
+
+**Scout:** Paula Patterns (architecture-scout). **Mode:** framing → synthesis.
+**Directives applied:** 001 (owning-boundary-first), 003 (record the ownership call),
+030 (release action carries the minimum regression), 032 (conceptual/ownership alignment).
+**Tactics:** domain-event-capture (durable failure marker), anti-corruption-layer
+(VCS-lock leaking into coord logic), review-intent-and-risk-first (does the fix close the
+class + blast radius). **Charter:** single canonical authority — reconcile, do not duplicate.
+
+READ-ONLY pre-spec research. No product code edited.
+
+---
+
+## 1. Ownership map (who owns each concern + boundary leaks)
+
+| Concern | Owning module / symbol | Verdict |
+|---|---|---|
+| Coord-branch **commit** of `done` | `coordination/transaction.py::BookkeepingTransaction` (append→materialize→**safe_commit**→outbound→release; surgical-truncate + byte-snapshot rollback on exception, NEVER `git checkout --`), invoked per-WP via `coordination/status_transition.py::emit_status_transition_transactional` | **Canonical single owner** of coord-branch writes. Correct. |
+| Coord-branch **revert** on merge rollback | `merge/executor.py::_capture_pre_target_coord_ref_sha` + `_revert_coord_done_commit` + `_restore_pre_target_if_at_baseline` | **BOUNDARY LEAK.** A second, home-grown compensation that `git revert`s what the canonical txn already committed. |
+| Coord **status writes** (per-WP `done`) | `merge/done_bookkeeping.py::_mark_wp_merged_done` / `_record_merged_wps_done_for_merge` → routes through the transactional emit (good) | Write leg is canonical; the **rollback leg is not**. |
+| Byte snapshot/restore + target projection | `merge/bookkeeping_projection.py::_capture_bookkeeping_snapshots` / `_restore_final_bookkeeping_snapshots` / `_project_status_bookkeeping_to_target` | A **third** rollback mechanism (raw byte restore) layered outside the txn. |
+| Coord-worktree cleanliness / resync | `git/ref_advance.py::advance_branch_ref` (`_dirty_entries`, `RefAdvanceDirtyWorktreeError`, `coord_owned_filenames` #1878 exclusion) — the #1826 guard | Correctly refuses `reset --hard` over uncommitted churn (NFR-002). It is the *victim*, not the defect. |
+| Merge state (resumable) | `merge/state.py::MergeState` | Resume/dedup depends on committed==working coherence, which the leak breaks. |
+| Doctor / repair | `status/doctor.py` | **GAP.** Checks uninitialized/stale-claims/orphan/drift/self-approval/issue-matrix/sparse-checkout — **no coord split-brain / reconcile-marker repair path.** |
+
+**Core leak:** two competing transaction owners for one concern. `BookkeepingTransaction`
+commits each `done` atomically; the merge executor then tries to *un-commit* via an OUTER
+`git revert` (`_revert_coord_done_commit`) + raw byte restore that are **not** inside any
+transaction. No single merge-scoped transaction wraps `{all done emits + target advance +
+worktree resync}` with one rollback — compensation is scattered across every failure exit
+via `_restore_pre_target_if_at_baseline`.
+
+## 2. Shared-root verdict
+
+**One seam closes #2786 AND #2367-B — but NOT #2367-A.** Strongest evidence:
+
+- **#2786** (`executor.py:500-514`): on a failed `git revert`, the code runs `revert --abort`
+  then `logger.warning("…coherence may be degraded…")` — **no raise, no durable marker.** The
+  merge proceeds; committed reduction (`done`) diverges from the rolled-back working tree
+  (`approved`) → the #2711 split-brain re-opens; resume dedup/idempotency break.
+- **#2367-B** (roadmap `docs/plans/3-2-x-milestone-roadmap.md:125,151`, changelog:609): "rollback
+  stale status … lives in the merge-snapshot path." The non-transactional rollback leaves the
+  coord worktree dirty; `advance_branch_ref`'s #1826 dirty guard then **refuses to resync**,
+  blocking the merge. Same root: the merge's coord-write **rollback** is not owned by the
+  canonical transaction, so it strands uncommitted churn.
+- The single missing boundary: a **merge-scoped coordination transaction** (delegate the merge's
+  `done` write+rollback to `BookkeepingTransaction`'s ownership) whose rollback (a) reverses
+  committed-`done` + working-bytes + worktree resync **coherently and atomically**, (b) writes a
+  **durable reconcile marker** when rollback cannot complete (closes the #2786 swallow), (c) is
+  consumed by a **doctor-repair path**. Route the rollback through the txn → it never leaves
+  uncommitted churn → the #1826 guard has nothing to refuse (#2367-B dissolves).
+
+**#2367-A (vcs-lock at claim) is FENCED OUT.** The roadmap is explicit: #2367 is
+"one-invariant-**three**-seams, not one code fix"; #2367-A is a *deliberate* stop-gap for the
+#2222 / C-003 race, and "committing it would reverse that call." Folding it into the transaction
+seam reverses a standing decision — the exact Paula over-reach boundary. So: **partially** shared —
+one seam for #2786 + #2367-B; #2367-A stays a distinct concern.
+
+**This is the completion of the #2711 Option-A arc.** Option-A added the coherent-revert leg
+(`_revert_coord_done_commit`) but left it *best-effort*; #2786 is precisely that incompleteness.
+
+## 3. Recurrence signature
+
+"Merge leaves coord state partial/incoherent on failure" has been patched per-site and regressed:
+`#1826` (dirty-guard + worktree resync, CLOSED) → `#1878` (coord-residue exclusion so the guard
+does not over-refuse) → `#2711` Option-A (PARTIAL transactional revert) → **`#2786`** (that revert
+swallows failure). Each landed as a new guard at one call site rather than one boundary.
+**Class-closing construction (vs whack-a-site):** (1) a transactional context manager owning the
+merge's coord write+rollback — **reuse `BookkeepingTransaction`, do not duplicate** (charter
+single-canonical-authority); (2) a **durable reconcile marker** persisted on any incomplete
+rollback; (3) a **doctor-repair path** that detects + repairs the marker. Regression already fired
+once (#2711 → #2786); a fourth per-site patch will recur.
+
+## 4. Scope boundary + WP slicing hint
+
+**IN:** the shared seam. WP-A — fail-loud + durable reconcile marker in `_revert_coord_done_commit`
+(closes #2786; flips the already-red `tests/regression/test_issue_2786_revert_failure_split_brain.py`
+green — the minimum required regression, directive 030). WP-B — `status/doctor.py` check + repair
+that consumes the marker. WP-C — #2367-B: make the merge coord-status **rollback** leave zero
+uncommitted churn (commit/rollback within the canonical txn) so the #1826 guard never trips at
+merge-rollback time.
+**Deferred (architecture issue, needs compatibility justification — resume/idempotency blast
+radius):** collapse the executor's home-grown `_capture/_restore_final_bookkeeping_snapshots` +
+`_revert_coord_done_commit` into `BookkeepingTransaction` ownership (retire the parallel owner).
+**OUT (do not touch):** #2367-A vcs-lock stop-gap (#2222 / C-003 race — reversing it is a
+regression); the broader #2392 upgrade-worktree-coherence epic; any non-merge coord write path.
+
+**Overlap risk:** `merge-squash-provenance-and-rollback-coherence-01KXRRB7` is the just-landed
+#2709/#2711 mission that *authored* `_revert_coord_done_commit`; its kitty branch worktree is still
+checked out (`+` in `git branch`). **Confirm it is closed before editing the same executor rollback
+code — shared-file collision.** #2367 is held by the HiC/operator, not a dedicated agent session; no
+`2367` code branch exists (only roadmap doc refs), so no agent-session collision — but confirm with
+the operator since they own it. Adjacent low-collision surfaces: `merge-base-diff-ssot-01KX44SD`,
+`coord-shadows-followups-01KXBCZ1`.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-d-red-first-repro-design.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-d-red-first-repro-design.md
@@ -1,0 +1,228 @@
+# Lens D — Red-first ATDD repro design (merge/coord rollback transactionality)
+
+Scope: #2786 (durable reconcile marker on failed coord `done` revert) and #2367
+(coord-worktree tool-churn blocks merge + non-transactional coord-status rollback).
+Read-only pre-spec research. No tests written/committed.
+
+**Profile applied:** `researcher-robbie` — mode `investigation` + `validation`;
+directive **003 Decision Documentation Requirement** (findings carry sources +
+rationale). Avoidance boundary honoured: no production code, no test authoring,
+no final decision — this is a repro *design* for the mission to land red-first.
+
+---
+
+## Ground truth established (sources)
+
+- **#2786 existing red** lives at
+  `tests/regression/test_issue_2786_revert_failure_split_brain.py`
+  (`test_swallowed_revert_failure_re_opens_2711_split_brain`). It forces the
+  coord-worktree `git revert` inside
+  `specify_cli.merge.executor._revert_coord_done_commit` to return non-zero via
+  `_revert_forced_to_fail()`, drives `_run_lane_based_merge`, and asserts
+  `committed_lane == working_lane`. It imports its whole harness from the #2711
+  sibling module.
+- **The swallowed-failure branch** is `executor.py` `_revert_coord_done_commit`
+  (`if revert.returncode != 0:` → `git revert --abort` + `warning` + `return`,
+  no raise, **no durable marker**). Confirmed at `executor.py:458-536`.
+- **#2367 Mechanism A defect** is in `src/specify_cli/git/ref_advance.py`
+  `_dirty_entries` (lines 167-211). The `excluded_filenames` /
+  `coord_owned_filenames` exclusion **only applies to untracked/ignored lines**
+  (`if line.startswith(("??", "!!"))` → line 202-209). A **tracked-modified**
+  `meta.json` (the uncommitted VCS-lock) falls through to the unconditional
+  `dirty.append(line)` at line 210 → `RefAdvanceDirtyWorktreeError` → merge
+  blocked. `coord_owned_filenames=COORD_OWNED_STATUS_FILES` (= `{status.events.jsonl,
+  status.json}`, `status/__init__.py:210`) does **not** cover meta churn and does
+  not cover tracked modifications at all.
+- **VCS-lock is written but never committed at claim:** `implement.py:1007-1009`
+  → `set_vcs_lock(feature_dir, vcs_type="git", locked_at=now_iso)` →
+  `mission_metadata.set_vcs_lock` (line 512) `write_meta(...)` — **no commit**.
+  The lock fields are exactly `_VCS_LOCK_META_FIELDS = frozenset({"vcs",
+  "vcs_locked_at"})` (`implement_cores.py:51`).
+- **Canonical predicate the fix should reuse:**
+  `implement_cores._is_vcs_lock_only_meta_diff(committed, working)` (line 216) —
+  returns True iff every changed meta key ∈ `_VCS_LOCK_META_FIELDS`. This is the
+  existing, tested "is this only spec-kitty's own lock churn?" decision (#2222 /
+  C-003). The #2367-A fix wires this (or an auto-commit at claim) into the merge
+  dirty gate; the repro must go RED **because that wiring does not yet exist**.
+- **The merge ref-advance seam that trips:** `merge/ordering.py:467`
+  `advance_branch_ref(main_repo, mission_branch, new_sha,
+  coord_owned_filenames=COORD_OWNED_STATUS_FILES)` during lane→mission
+  consolidation. The coord worktree has the mission branch checked out
+  (coord-topology), so its dirty tracked `meta.json` trips this call before any
+  target advance.
+
+---
+
+## Issue #2786 — does the existing red suffice? (answer: only for the in-band-revert fix shape)
+
+**Verdict:** the existing `committed_lane == working_lane` assertion suffices
+**iff** the chosen fix reverts (or fails loud) *in lockstep during the same
+merge invocation*. It is **insufficient** for the durable-reconcile-marker fix
+shape that the charter/#2786 body explicitly allows ("record a durable reconcile
+marker so the divergence is never silent"). A marker-only fix leaves committed
+`done` stranded against working `approved` on purpose and repairs later — so the
+existing assertion would **stay RED after a correct marker fix**. Worse, the
+existing test's non-vacuity precondition (`assert isinstance(exc, RuntimeError)
+and _INJECTED_TARGET_FAILURE in str(exc)`) means a fix that raises a *new*
+reconcile error would flip that precondition to failing, not the contract.
+
+**Therefore add an ADDITIONAL test** targeting the marker route. Design below.
+
+### #2786 additional test
+
+1. **Path + markers.** New test in the existing module
+   `tests/regression/test_issue_2786_revert_failure_split_brain.py`
+   (append; do not edit the harness import block), function
+   `test_failed_coord_revert_leaves_durable_reconcile_marker_and_doctor_repairs`.
+   Markers inherited from module `pytestmark = [regression, git_repo, non_sandbox]`.
+2. **Arrange.** Reuse the *already-imported* helpers (no new harness):
+   `_init_git_repo`, `_bootstrap_coord_mission`, `_assert_pre_target_done_path`
+   (from #2711 sibling), and the module-local `_run_merge_with_target_and_revert_failing`
+   / `_revert_forced_to_fail`. Same forced target-advance failure + forced
+   revert-failure as the existing red — the setup is identical; only the assertion
+   surface differs.
+3. **Act.** `exc, revert_cmds = _run_merge_with_target_and_revert_failing(repo)`
+   (the pre-existing `_run_lane_based_merge` entry point). Keep the two non-vacuity
+   witnesses (injected-target `RuntimeError`; `revert_cmds` non-empty).
+4. **Assert (RED now / GREEN after marker fix):**
+   - **(a) Durable marker exists.** A durable reconcile record is present after the
+     failed revert — asserted through a canonical read surface, **not** a hand-rolled
+     path guess. Candidate surfaces the implementer must choose/create (harness gap):
+     a field on `.kittify/merge-state.json` (e.g. `coord_reconcile_required` naming
+     the stranded `WP01` + the two divergent lanes `done`/`approved`), or a sidecar
+     marker under `kitty-specs/<slug>/`. Assert it exists AND names WP01 + both lanes.
+     RED today: `_revert_coord_done_commit` writes nothing.
+   - **(b) doctor detects the incoherence.** Invoke `spec-kitty doctor coordination
+     --json` (CliRunner, patching `_coordination_doctor.locate_project_root` → repo,
+     mirroring `test_merge_coord_topology_1772.test_doctor_flags_tracked_worktrees_content`).
+     Assert exit 1 and a finding with a stable `error_code`
+     (e.g. `COORD_REVERT_SPLIT_BRAIN`) carrying a `next_step` remediation hint.
+     RED today: nothing durable for doctor to read, so no finding.
+   - **(c) repair restores coherence.** Drive the repair (`spec-kitty merge --resume`
+     through `_run_lane_based_merge`, or `doctor --repair` once it exists), then
+     re-read via `_committed_coord_events` / `_working_coord_events` +
+     `wp_lane_actor_from_events` and assert `committed_lane == working_lane`
+     (both `approved`). RED today: no marker → resume cannot detect or repair the
+     divergence (the existing red's whole point).
+5. **Red-proof command.**
+   `PWHEADLESS=1 uv run pytest tests/regression/test_issue_2786_revert_failure_split_brain.py -n0 -q`
+   Both the existing coherence test and the new marker test are RED on the mission base.
+6. **Harness gap the implementer must fill.** There is **no** durable-reconcile-marker
+   read surface today. The implementer must (i) define the marker's canonical home
+   (merge-state field vs sidecar) and a read accessor, and (ii) add a `doctor
+   coordination` finding + `error_code`. The test's assertions (a)/(b)/(c) should
+   consume those canonical surfaces, never a raw path.
+
+> Recommendation: **keep the existing coherence red** (it pins the fail-loud/in-band
+> route) **and add the marker test** (it pins the durable-marker route). Together they
+> make either acceptable fix shape green while forbidding the silent-swallow status quo.
+
+---
+
+## Issue #2367 — NEW red-first repro (Mechanism A primary; Mechanism B companion)
+
+### Mechanism A — coord-worktree VCS-lock tool-churn blocks the merge (primary, deterministic)
+
+1. **Path + markers.** New module
+   `tests/regression/test_issue_2367_coord_worktree_toolchurn_blocks_merge.py`,
+   function `test_merge_not_blocked_by_uncommitted_coord_vcs_lock`.
+   `pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]`.
+2. **Arrange — reuse the canonical coord harness (do NOT improvise).** Import the
+   #2711 regression-sibling fusion helpers (same precedent by which #2786 imports
+   from #2711 — a `tests.regression.*` sibling, keeps `advance_branch_ref` + lane
+   consolidation REAL):
+   ```python
+   from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
+       MID8, MISSION_SLUG, LANE_CODE,
+       _init_git_repo, _bootstrap_coord_mission, _merge_external_mocks, _git,
+   )
+   from specify_cli.coordination.workspace import CoordinationWorkspace
+   ```
+   `_bootstrap_coord_mission` materializes the coord worktree with the mission
+   branch checked out (`CoordinationWorkspace.resolve`) and a real lane diff.
+   `_merge_external_mocks` mocks only out-of-git side effects and **leaves
+   `advance_branch_ref` + `consolidate_lane_into_mission` real** — the guard under
+   test runs. (Structural template for the assertion inversion:
+   `test_merge_coord_worktree_resync_1826.test_dirty_coord_worktree_refuses_loudly_and_preserves_data`,
+   AC-B4 — which asserts refusal; this test asserts the OPPOSITE for tool-churn.)
+   - **Seed the tool-churn (HARNESS GAP — new local helper).** No helper seeds a
+     coord-worktree VCS-lock. Add `_seed_uncommitted_vcs_lock(coord_wt)`: read the
+     coord worktree's tracked `kitty-specs/<slug>/meta.json`, call the *real*
+     `mission_metadata.set_vcs_lock(coord_feature_dir, vcs_type="git",
+     locked_at=<iso>)` (realistic data — the exact call `implement.py:1009` makes),
+     and **do not commit**. Locate the worktree via
+     `CoordinationWorkspace.worktree_path(repo, MISSION_SLUG, MID8)`.
+   - Non-vacuity witness: assert `git -C <coord_wt> status --porcelain -- meta.json`
+     shows ` M ...meta.json` before the act (the churn is genuinely dirty + tracked).
+3. **Act.** Plain (non-injected) merge through the pre-existing entry point:
+   ```python
+   with _merge_external_mocks():
+       _run_lane_based_merge(repo_root=repo, mission_slug=MISSION_SLUG, push=False,
+           delete_branch=False, remove_worktree=False,
+           strategy=MergeStrategy.SQUASH, allow_sparse_checkout=True)
+   ```
+   No injected failure — the *only* obstacle is spec-kitty's own meta churn.
+4. **Assert (RED now / GREEN after fix).**
+   - The merge does **not** raise (neither `RefAdvanceDirtyWorktreeError` nor the
+     `typer.Exit` it surfaces as). Wrap in a "did it raise?" capture and assert clean.
+   - The lane code reaches the target: `_file_on_branch(repo, "main", LANE_CODE)` True.
+   - RED today: the first `advance_branch_ref` (lane→mission consolidation,
+     `ordering.py:467`) dirty-checks the coord worktree, sees tracked-modified
+     `meta.json`, raises `RefAdvanceDirtyWorktreeError` → merge blocked. GREEN after
+     the fix teaches the merge dirty gate to treat a `_is_vcs_lock_only_meta_diff`
+     meta change as auto-committable/excludable (or `implement` auto-commits the lock
+     at claim).
+5. **Red-proof command.**
+   `PWHEADLESS=1 uv run pytest tests/regression/test_issue_2367_coord_worktree_toolchurn_blocks_merge.py -n0 -q`
+6. **Harness gaps.** (i) `_seed_uncommitted_vcs_lock` (above) — new local helper.
+   (ii) Code gap the fix closes: `ref_advance._dirty_entries` never runs a
+   lock-only/coord-owned predicate over **tracked-modified** paths (exclusion is
+   `??`/`!!`-only). The fix likely threads `_is_vcs_lock_only_meta_diff` (or a
+   generalized "coord-owned tracked churn" predicate) into `_dirty_entries`, or
+   auto-commits the lock. The test must stay agnostic to which — it asserts the
+   *merge outcome*, not the internal mechanism.
+
+### Mechanism B — non-transactional rollback leaves partial coord status writes (companion; overlaps #2786/#2711)
+
+1. **Path + markers.** Second function in the same #2367 module,
+   `test_rolled_back_merge_leaves_coord_worktree_resumable`
+   (or fold into #2786 — see caveat). Same markers.
+2. **Arrange.** Same #2711 harness; use `_run_failing_merge` (injected
+   target-advance failure) to trigger the rollback.
+3. **Act.** `_run_failing_merge(repo)`; then locate the coord worktree and inspect
+   its tracked status files.
+4. **Assert (RED if residue stranded).** After rollback, the coord worktree's
+   tracked `status.events.jsonl` + `status.json` are **clean** (`git -C <coord_wt>
+   status --porcelain -- kitty-specs/<slug>/status.events.jsonl
+   kitty-specs/<slug>/status.json` is empty), so a subsequent `--resume` is not
+   blocked by a dirty coord tree. RED if the aborted run's emissions sit uncommitted.
+5. **Red-proof command.** Same module `-n0 -q` invocation.
+6. **CAVEAT / overlap (validation finding).** #2711's
+   `_restore_final_bookkeeping_snapshots` **already reverts the working-tree bytes**
+   of the coord event log on the *target-advance-failure* path (the #2711 red asserts
+   `working_lane == Lane.APPROVED`). So on that exact path Mechanism B may be
+   **GREEN-on-base / vacuous**. The live #2367-B was observed on the **squash-conflict
+   rollback path** (`consolidate_lane_into_mission` failing), which may capture a
+   different snapshot set. **Implementer must confirm which rollback path leaves the
+   residue** (inject a consolidation/squash conflict, not a target-advance failure)
+   before pinning Mechanism B; if #2711/#2786's snapshot restore already covers it,
+   Mechanism B folds into the #2786 durable-marker fix and should not be a separate
+   red. Recommendation: **land Mechanism A as the mission's #2367 red; treat
+   Mechanism B as a confirmation spike, promoting it to a red only if a
+   squash-conflict rollback demonstrably strands coord status writes.**
+
+---
+
+## Charter-constraint checklist
+
+- **Canonical sources:** reuses the real coord harness (#2711 fusion helpers,
+  #1772/#1826 lineage) and the real entry point `_run_lane_based_merge`; the fix
+  predicate is the canonical `_is_vcs_lock_only_meta_diff`. No improvised paths.
+- **Red-first through the pre-existing entry point:** every assertion is driven
+  through `_run_lane_based_merge` (+ `spec-kitty doctor coordination` for the
+  marker route), never an isolated seam.
+- **Realistic data:** the VCS-lock churn is seeded via the real `set_vcs_lock`
+  call `implement` makes at claim; the coord mission is the production coord
+  topology (mission branch checked out in the coord worktree, real lane diff).
+- **Terminology canon:** Mission/coordination/lane throughout; no `feature*`
+  aliases introduced.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-e-seam-alignment.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-e-seam-alignment.md
@@ -1,0 +1,234 @@
+# Lens E — Canonical Seam Alignment (Architect Alphonso)
+
+**Scope:** READ-ONLY pre-spec seam-alignment research for the contemplated fix in
+mission `merge-coord-rollback-transactionality-01KXTM59` (#2786 + #2367): a
+**transactional boundary for the merge's coord writes** (coord-branch ref moves +
+status writes + worktree resync roll back atomically on failure, leaving a durable,
+`doctor`/`merge --resume`-detectable reconcile marker).
+
+**Lens:** DIRECTIVE_044 (Canonical Sources & Unification) + DIRECTIVE_001
+(Architectural Integrity) + DIRECTIVE_043 (Close Defect Classes by Construction).
+Central question per seam: does the contemplated boundary **route-through / extend /
+avoid** each canonical authority, and what is the split-brain / duplication risk if it
+bypasses.
+
+**Directives applied:** 001, 003, 031, 043, 044 (044 load-bearing).
+
+**Framing correction that drives every verdict below:** the merge pipeline
+**already has** a coord-write transaction. It is not a single named object — it is the
+`merge/executor.py` phase decomposition + `_MergeRunState`-threaded rollback
+(`_restore_pre_target_if_at_baseline`, `_restore_final_bookkeeping_snapshots`) + the
+#2711 committed-`done` coherent revert (`_revert_coord_done_commit`) + the INV-5/INV-6
+ordering ratchets. The contemplated "transactional boundary" is therefore an
+**extension of an existing transaction**, not a greenfield one. Every duplication risk
+below flows from treating it as greenfield.
+
+---
+
+## Seam 1 — Coord/primary surface resolution
+
+**Canonical symbol/module:** `coordination/surface_resolver.py` —
+`resolve_status_surface` / `resolve_status_surface_with_anchor`
+(`ResolvedStatusSurface{surface_path, primary_anchor}`), plus the placement facade
+`mission_runtime.resolve_placement_only(repo_root, slug, kind=STATUS_STATE).ref`.
+Read-path primitives it composes live in `missions/_read_path_resolver.py`
+(`candidate_feature_dir_for_mission`, `coord_feature_dir`, `probe_coord_state`,
+`stored_topology_from_meta`).
+
+**Verdict: ROUTE-THROUGH (do not add a second resolver).**
+
+The module docstring declares itself the **sole** canonical authority for coord-vs-primary
+surface selection (FR-001/FR-007, NFR-003): "no secondary fallback or parallel resolution
+mechanism survives outside this seam." The merge pipeline already obeys this:
+
+- `_phase_baseline_and_surface` reads `resolve_status_surface(main_repo, slug)` and derives
+  `canonical_events_path` / `canonical_status_path` from it — never a hand-composed
+  `.worktrees/<slug>-coord/...` path.
+- The #2711 additions `_capture_pre_target_coord_ref_sha` and
+  `_durable_done_wps_on_coordination_ref` both source the coord ref from
+  `resolve_placement_only(..., kind=STATUS_STATE).ref`, explicitly *not* an inline
+  `meta.get("coordination_branch")` (the retired D-2 CWD-divergence class).
+- `_coord_worktree_root(run)` re-derives the coord worktree by walking *up* from the
+  already-resolved `canonical_events_path` — it does not re-resolve.
+
+**Split-brain risk if bypassed:** a boundary that hand-rolls its own coord-ref/surface
+derivation (e.g. `meta["coordination_branch"]` or a fresh `.worktrees` path compose)
+reintroduces the #1589 / #1821 / #2069 class: CWD-dependent branch selection, a
+wrong-but-plausible `kitty-specs/<mid8>/` surface, or topology re-inferred from
+`coordination_branch is None` instead of the stored topology SSOT. The rollback would then
+capture/revert a *different* ref than the one the write committed to — the exact coherence
+break the mission exists to close.
+
+---
+
+## Seam 2 — Status write-target contract (the crux)
+
+**Canonical symbols/modules:**
+- `coordination/transaction.py::BookkeepingTransaction` — "the single owner of writes that
+  target the coordination branch" / "single chokepoint for coordination-branch writes":
+  `acquire → policy gate → append → materialize → commit → outbound → release`, with
+  **surgical-truncate** event-log rollback (FR-010) + byte-snapshot artifact restore on
+  exception, C-009 (never `git checkout --`).
+- `coordination/status_transition.py` — `_read_contract_from_transaction_target`,
+  `_resolve_write_target` (routes through `resolve_placement_only(...STATUS_STATE).ref`),
+  `_TransactionIdentity`, the worktree-vs-committed-ref `EventLogReadContract` selection.
+- `status/event_log_merge.py` — pure, deterministic three-way union of append-only event
+  logs (dedupe by `event_id`, sort by `at`); a stateless helper, not a transaction.
+
+**Verdict: EXTEND the executor's merge-time transaction; do NOT wrap
+`BookkeepingTransaction` from outside, and do NOT build a third transaction object.**
+
+This is where the duplication trap lives, so name the two granularities precisely:
+
+1. **`BookkeepingTransaction` is the seam for a SINGLE coord status transition** (one
+   `emit_status_transition_transactional` → one `safe_commit` on the coord branch, with
+   in-process surgical rollback). It is already the atomic authority at that grain and must
+   stay it.
+2. **The merge's atomicity is a DIFFERENT grain** — a multi-phase span across *many* status
+   writes (per-WP `done`), a mission→target branch integration, a `mission_number` bake, a
+   baseline record, and a bookkeeping projection commit. The executor already runs its own
+   rollback orchestration for this span (`_capture_bookkeeping_snapshots` /
+   `_restore_final_bookkeeping_snapshots` / `_restore_pre_target_if_at_baseline` + #2711
+   `_revert_coord_done_commit`). Notably the merge path does **not** funnel its status
+   writes through `BookkeepingTransaction` — it uses `commit_merge_bookkeeping` /
+   `_mark_wp_merged_done` + its own snapshot machinery.
+
+An "outer coord merge transaction" that *wraps* `BookkeepingTransaction` (or wraps the phase
+driver) would become a **second transaction authority** governing the same coord branch —
+two rollback mechanisms with two commit orderings racing over one ref. That is the
+DIRECTIVE_044 violation. The seam-aligned move is to **consolidate and name the executor's
+existing per-phase rollback** into the mission's "coord merge transaction" — extending the
+`_MergeRunState` + `_restore_*` + `_revert_coord_done_commit` machinery — while each
+*individual* coord status write it performs continues to compose the same
+`status_transition` / `safe_commit` primitives. `event_log_merge` is consumed as-is for any
+log reconciliation; it is not a transaction and needs no change.
+
+**Split-brain risk if bypassed:** two authorities that both "own coordination-branch writes"
+is the definitional single-canonical-authority breach — divergent rollback semantics
+(surgical-truncate vs snapshot-restore vs ref-revert) applied to the same ref produce
+exactly the committed-vs-working `done`/`approved` divergence #2711 just closed.
+
+---
+
+## Seam 3 — Ref-move seam
+
+**Canonical symbol/module:** `git/ref_advance.py::advance_branch_ref` — the single
+sanctioned forward branch-ref advance, with the #1826 invariant (no worktree left checked
+out behind an advanced ref), the AC-B3 ratchet (no raw `git update-ref` in `src/specify_cli`
+outside this module — `tests/architectural/test_merge_pipeline_ratchets.py`), and AC-F1
+(`_make_merge_env`). It **refuses non-fast-forward moves by design**
+(`RefAdvanceNonFastForwardError`).
+
+**Verdict: ROUTE-THROUGH for forward advances; for ROLLBACK use the established
+forward-revert pattern (`_revert_coord_done_commit`), NOT a backward `update-ref`.**
+
+The #2711 code already models the correct asymmetry: forward coord/lane/mission advances go
+through `advance_branch_ref`; the rollback of a committed coord `done` cannot use
+`advance_branch_ref` (moving the ref *back* to the captured tip is the non-FF move it
+refuses), so `_revert_coord_done_commit` performs a **forward reversing `git revert`** inside
+the coord worktree (HEAD+index+working-tree resync), wrapped in `_make_merge_env` (AC-F1),
+never a raw `update-ref` (AC-B3-symmetric). The contemplated boundary must adopt this exact
+pattern for any coord-write rollback.
+
+**Split-brain / duplication risk if bypassed:** a transactional rollback reaching for
+`git update-ref <ref> <old_sha>` (a) trips the AC-B3 ratchet, and (b) recreates the #1826
+defect class — a coord/lane worktree left behind its own HEAD, so the next safe-commit
+through it sees phantom staged deletions. The "worktree resync" leg named in the mission
+must therefore *be* `advance_branch_ref`'s resync (forward) + `git revert`'s resync
+(rollback), not a new reset routine.
+
+---
+
+## Seam 4 — Durable marker authority
+
+**Canonical symbol/module:** `merge/state.py::MergeState` at
+`.kittify/runtime/merge/<mission_id>/state.json` (per-mission), with
+`save_state`/`load_state`/`clear_state`/`has_active_merge`, the merge lock, and the resume
+reconcile `done_bookkeeping._reconcile_completed_wps_for_resume` →
+`_durable_done_wps_on_coordination_ref`. Contrast: `status/doctor.py` (a set of stateless
+`check_*` advisories — no merge-state ownership) and `status/doctor_husks.py`.
+
+**Verdict: EXTEND `MergeState` — a new FIELD, not a new sidecar, not a `doctor.py` marker.**
+
+`MergeState` is already the canonical durable, resumable, `doctor`/`merge --resume`-visible
+merge marker: it carries `current_wp`, `has_pending_conflicts`, `mission_number_baked`,
+`push_requested` — precisely the "durable pointer the operator can repair from" role the
+contemplated reconcile marker wants. The #2711 design is the precedent: `completed_wps` is
+explicitly demoted to an **advisory hint** (docstring on the field), and the *authority* for
+resume progress is the **durable committed event log** on the coord ref
+(`_durable_done_wps_on_coordination_ref`), against which the hint is reconciled and stale
+entries dropped + re-saved. So the marker split is already doctrine:
+
+- **Authority of truth** = the committed coordination-branch event log (via
+  `resolve_placement_only` + `read_event_log`).
+- **Repairable index/pointer** = `MergeState` fields.
+
+A reconcile marker should be a new `MergeState` field (e.g. a rollback/repair-needed flag +
+the captured pre-emit coord tip already modelled transiently as
+`_MergeRunState.pre_target_coord_sha`), persisted via `save_state`.
+
+**Split-brain / duplication risk if bypassed:** a new sidecar file (e.g.
+`.kittify/coord-reconcile.json`) or a marker owned by `status/doctor.py` forks the
+resume-state authority `MergeState` already owns — two files answering "is a merge
+mid-flight / needs repair" that `--resume`, the lock, and `clear_state` would then have to
+keep in sync. That is a second authority by construction.
+
+---
+
+## Seam 5 — INV-5 / #1827 phase-ordering ratchet
+
+**Canonical guards:** `merge/executor.py::_run_lane_based_merge_locked` frozen phase list;
+`tests/merge/test_executor_phase_boundary.py`
+(`test_locked_driver_calls_phases_in_frozen_order`,
+`test_record_then_commit_then_assert_ordering`, INV-6 restore-then-reraise tests);
+`tests/specify_cli/merge/test_1827_baseline_regression.py`. Frozen order: baseline **RECORD**
+(`_phase_capture_and_baseline`, post-target-merge / pre-bookkeeping-commit) → bookkeeping
+**safe_commit** → baseline **ASSERT** (`_phase_commit_and_assert`, post-commit); INV-6 =
+`_restore_final_bookkeeping_snapshots`-then-reraise at each failure exit, per-exception-class
+scoped.
+
+**Verdict: REAL RISK — an *outer* boundary would violate it; the safe form is *inner*
+extension (the #2711 pattern).**
+
+An outer contextmanager wrapping the whole coord-write span with its own
+commit/rollback sequencing is the dangerous shape: it can reorder RECORD → commit → ASSERT,
+or move the commit relative to the baseline record, or add a rollback exit that the INV-6
+per-class scoping and the frozen-order test do not cover. #2711 demonstrates the sanctioned
+way to add coord-rollback coherence **without touching INV-5**: it added `pre_target_coord_ref`
+/ `pre_target_coord_sha` *fields* to `_MergeRunState`, a capture call inside the existing
+`_phase_bake_and_pre_target_done`, and a revert call *inside* the existing
+`_restore_pre_target_if_at_baseline` — the phase list and the RECORD/commit/ASSERT order were
+untouched, and the phase-boundary + 1827 regression tests stayed green. The contemplated
+boundary must extend the same way: new `_MergeRunState` fields, new helpers called from
+*within* existing phases and the existing `_restore_*` sites — never a wrapper around the
+phase driver.
+
+**Risk flag:** any design that introduces a `with CoordMergeTransaction(...)` around
+`_run_lane_based_merge_locked` (or around `_phase_commit_and_assert`) should be treated as an
+INV-5 regression until proven otherwise against both test files.
+
+---
+
+## VERDICT
+
+A "coord merge transaction + durable reconcile marker" **is seam-aligned — but only as an
+EXTENSION of the merge executor's already-existing coord-write transaction**, not as a new
+authority. It **routes-through** `surface_resolver` / `resolve_placement_only` for every
+coord ref/surface read (Seam 1), **routes-through** `advance_branch_ref` for forward moves
+and the `_revert_coord_done_commit` forward-revert for rollback (Seam 3), and **consumes**
+`event_log_merge` as-is. It **extends** `MergeState` with the durable marker as a field
+(Seam 4) and **extends** `BookkeepingTransaction`'s per-write atomicity only at the
+single-transition grain (Seam 2). It **must not** become an outer wrapper (Seam 5 / INV-5).
+
+**It risks a second authority** — and should be rejected in that form — if implemented as:
+(a) an outer transaction object wrapping the phase driver or `BookkeepingTransaction`;
+(b) a new sidecar reconcile file outside `MergeState`;
+(c) any hand-rolled coord-ref / surface / ref-move / topology resolver;
+(d) a backward `git update-ref` rollback (AC-B3 breach + #1826 revival).
+
+**Single recommended seam to extend:** the **`merge/executor.py` `_MergeRunState`-threaded
+phase-rollback orchestration** — specifically `_restore_pre_target_if_at_baseline` +
+`_revert_coord_done_commit` + the `_restore_final_bookkeeping_snapshots` exit sites — with
+the durable marker persisted as a **`MergeState` field** via `save_state`. This is the merge
+pipeline's coord-write transaction; the #2711 change is the exact, tested precedent for
+growing it coherently without disturbing INV-5.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-f-related-surface-discovery.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/research/lens-f-related-surface-discovery.md
@@ -1,0 +1,84 @@
+# Lens F — Related-Surface / Work-Graph Discovery
+
+**Mission:** merge-coord-rollback-transactionality-01KXTM59
+**Targets:** #2786 (swallowed coord-`done`-revert → silent split-brain) + #2367 (merge blocked by coord-worktree tool-churn + non-transactional rollback of coord status writes)
+**Lens owner:** Planner Priti (read-only, pre-spec). **Date:** 2026-07-18
+**Directives applied:** work-decomposition, dependency-mapping, task-sequencing, risk-identification, prioritisation (Eisenhower), Directive 003 (Decision Documentation — each call grounded in evidence below).
+
+---
+
+## 0. Anchor facts (target issues)
+
+| # | State | Priority | Assignee | Core ask |
+|---|-------|----------|----------|----------|
+| **2786** | OPEN | **P0** (labelled) | stijn-dejongh (HiC) | On `_revert_coord_done_commit` failure, write a **durable reconcile marker** (merge-state field / `doctor`-detectable flag) instead of only `logger.warning`. Optionally raise to abort rollback. Issue type = **Bug**. |
+| **2367** | OPEN | **P0** | stijn-dejongh (HiC) | (A) auto-commit VCS-lock at claim; (B) make merge rollback **transactional over the coord worktree's `status.events.jsonl` / `status.json`**. Base-divergence symlink note (adjacent). |
+
+- **#2711 is CLOSED** — fixed by **PR #2785** (`fix(merge): #2709 squash provenance reconciliation + #2711 rollback/resume coherence`), **merged 2026-07-18 (today)**. #2786 is the *residual revert-failure edge* the #2711 fix left best-effort. This mission's branch sits **on top of** the merged #2711 work (main-worktree log shows the #2709/#2711 commits as ancestors).
+- Code surface confirmed live: `src/specify_cli/merge/executor.py:458 def _revert_coord_done_commit`, called at `executor.py:535`. Coord-touching merge modules: `executor.py`, `done_bookkeeping.py`, `bookkeeping_projection.py`, `resolve.py`, `state.py`, `git_probes.py`.
+- **Neither #2786 nor #2367 has a native sub-issue parent wired** (`trackedInIssues` empty on both). Tracker-hygiene gap the spec should close (native sub-issue parenting per `docs/guides/manage-issue-tracker.md`).
+
+---
+
+## 1. Sibling / related open issues (relation to this mission)
+
+| # | Title (short) | Type/Prio | State | Relation |
+|---|---------------|-----------|-------|----------|
+| **2367** | merge blocked by coord worktree: VCS-lock at claim + non-transactional coord-status rollback | workflow/reliability/git, **P0** | OPEN | **FOLD-IN (Mechanism B) / same-class (Mechanism A).** B ("make merge rollback transactional over coord status writes") is *the same seam* as 2786. A (auto-commit VCS-lock at claim) is a different, claim-time seam. |
+| **2711** | rollback/resume leave committed `done` opposed to reverted working status | reliability/git, P0/P1 | **CLOSED** | **Direct parent defect** (closed by PR #2785 today). 2786 is its residual edge. Not fold — already fixed; cite as lineage + rebase baseline. |
+| **1826** | coord worktree falls behind its own branch mid-merge (safe_commit backstop) | reliability/git | **CLOSED** | Same neighborhood, **distinct mechanism** (behind-HEAD after update-ref). Cite as prior-art; not in scope. |
+| **1795** | **Epic:** Parallel-lane git mechanics & event-log merge semantics | epic/reliability/git | OPEN | **Parent-epic candidate (best fit)** — merge git-mechanics + event-log coherence is exactly this class. |
+| **2017** | **Epic:** Workflow guards that block legitimate actions / lack depth | epic/workflow/reliability | OPEN | **Parent-epic candidate for 2367** — 2367 self-declares "New scoped child of #2017". Guard-depth framing. |
+| **2160** | **Epic:** Coord topology: unify artifact authority for task/status surfaces | epic/reliability, **P0** | OPEN | Dependency/neighbor — owns *authority* of the `status.*` files this mission must roll back. Coordinate, don't collide. |
+| **1619 / 1666** | Epics: unify execution context / execution-state domain redesign | epic, **P0** | OPEN | Broad domain redesign; out-of-scope umbrellas. This mission is a tactical slice under them, not a fold. |
+| **1878** | Umbrella: coordination placement/identity strangler (post-3.2.0) | epic, P2 | OPEN | Umbrella neighbor; out-of-scope. |
+| **2745** | terminus gaps / orphaned coordination_branch (no `--skip-lanes`) | workflow/reliability/git, P1 | OPEN | Same-class, **defer** — different command (accept/close/terminus), not merge-rollback. |
+| **2626** | lane-transition auto-commit crashes when lane worktree missing | workflow/reliability, P1 | OPEN | Same-class (auto-commit resilience), **defer** — implement/lane path, not merge rollback. |
+| **2549** | move-task --force commits placement status.* to lane branch | workflow/reliability/git, P1 | OPEN | Same-class (coord/lane status-write partition), **defer** — move-task, not merge. |
+| **2570** | multi-lane implement loop: allocator serialized behind uncommitted frontmatter | workflow/reliability | OPEN | Same-class (uncommitted tool-churn blocks action), **defer** — implement loop, not merge. |
+| **2300** | unify coord+protected skip-vs-refuse across move-task/mark-status | workflow/reliability, P1 | OPEN | Neighbor (guard behavior unify); out-of-scope. |
+| **2739** | spec-commit / commit-router refusals + under-committed scaffold | workflow/reliability/git, P1 | OPEN | Neighbor (commit-router on coord/protected); out-of-scope. |
+| **2618** | unify flatten_mission() single seam (doctor --fix vs close) | reliability/tech-debt, P1 | OPEN | Neighbor (doctor-repair seam this mission's marker may feed); out-of-scope, note only. |
+| **2334** | cross-worktree planning-artifact duplication (hand-synced N copies) | workflow/tech-debt, P2 | OPEN | Neighbor (coord-worktree copy drift); 2367 cites it. Out-of-scope. |
+| **2144** | guarantee every Teamspace-bound event has SQLite/git durability | design-spike/reliability, P2 | OPEN | Neighbor (durability arch); the reconcile-marker's durability aligns philosophically. Out-of-scope. |
+| **2533 / 2683** | PR-bound redundant coord topology / research-plan split authority | workflow/git, P1 / — | OPEN | Coord-topology cousins; out-of-scope. |
+
+---
+
+## 2. Parent epic(s) + graph recommendation
+
+- **No sub-issue edges are wired today** on #2786 or #2367 — the spec should add them.
+- **Recommended parenting:**
+  - **#2786 → #1795** ("Parallel-lane git mechanics & event-log merge semantics"): the durable-reconcile-marker + transactional-merge-rollback is squarely merge git-mechanics / event-log coherence.
+  - **#2367 → #1795** for Mechanism B (merge-rollback transactionality) and **#2017** for Mechanism A (guard/auto-commit depth). If a single parent is required for tracker cleanliness, **#1795** covers the fold seam both issues share.
+  - Keep #1619/#1666/#1878/#2160 as **context epics**, not parents (they are domain-redesign umbrellas; over-parenting there dilutes signal — charter's single-canonical-authority principle favors the tightest true owner, #1795).
+- This mission's own tickets/WPs sit **under this mission's `meta.json`** and roll up to **#1795**; #2786 is the primary tracker issue, #2367-Mechanism-B the fold-in.
+
+---
+
+## 3. In-flight collision check — **VERDICT: NO active collision**
+
+- **PR #2785 (sibling mission `merge-squash-provenance-and-rollback-coherence-01KXRRB7`) is MERGED (today).** That mission owned `_revert_coord_done_commit` and the merge executor; it is **done**, not in-flight. This mission builds directly on it.
+- **Lingering (not colliding):** the sibling's coord worktree `.worktrees/merge-squash-provenance-and-rollback-coherence-01KXRRB7-coord` still exists and its branch `kitty/mission-merge-squash-...-01KXRRB7` is checked out there. Housekeeping only — no divergent edits to the shared file.
+- **#2367 is assigned to the HiC (stijn-dejongh)** but **no open PR and no agent branch references #2367** (the three PRs matching "2367" are unrelated merged upgrade/guard PRs). **No active agent session is on it.** Safe to fold Mechanism B here with operator confirmation.
+- **No open PR touches `merge/executor.py`** in this class. Open PRs (#2766, #2612, #2492, #2606…) are review-handoff / lane-recovery / dashboard work on other surfaces.
+- **Freshness caution (risk):** the fix lands on code merged **today** (PR #2785). Rebase this mission's branch onto the post-#2785 baseline before implementation, or the reconcile-marker will collide with the just-landed Option-A revert helper.
+- Adjacent local spec `merge-base-diff-ssot-01KX44SD` exists and maps to #2367's base-divergence symlink Note — route that Note there, not into this mission.
+
+---
+
+## 4. Fold-in vs defer vs out-of-scope (recommendation)
+
+**FOLD-IN (this mission can CLOSE / partially close as the shared-seam fix):**
+- **#2786** — primary target (durable reconcile marker on revert failure).
+- **#2367 Mechanism B** — "make merge rollback transactional over coord `status.events.jsonl`/`status.json`" is the *same transactional-merge-rollback seam*. Fold; on close, split #2367 or check off B. **Requires operator sign-off** (#2367 is HiC-assigned, P0).
+
+**SAME-CLASS BUT DEFER (tracked follow-up, different command/seam):**
+- **#2367 Mechanism A** (auto-commit VCS-lock at claim) — claim-time, not merge-rollback. Adjacent WP or separate ticket.
+- **#2626** (lane auto-commit / missing worktree), **#2549** (move-task lane-branch pollution), **#2570** (allocator uncommitted frontmatter), **#2745** (terminus/orphaned coord_branch). All coord/lane transactional-write cousins on *non-merge* commands.
+
+**OUT-OF-SCOPE (dependency / context, do not fold):**
+- Epics #1795, #2017, #2160, #1619, #1666, #1878 (parent/context).
+- #2334, #2144, #2618, #2300, #2739, #2683, #2533 (neighbor seams: copy drift, durability, flatten unify, skip-vs-refuse, commit-router, topology derivation).
+- #2367 base-divergence symlink Note → route to `merge-base-diff-ssot-01KX44SD`.
+- Closed lineage #2711 / #1826 → cite as prior-art, not scope.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/spec.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/spec.md
@@ -1,0 +1,372 @@
+# Mission Specification: Merge coord-write rollback transactionality (P0 #2786 + #2367-B)
+
+**Mission Branch**: `kitty/mission-merge-coord-rollback-transactionality-01KXTM59`
+**Created**: 2026-07-18
+**Status**: Draft (pre-spec 6-lens research folded)
+**Input**: Complete the #2711 Option-A arc — make the merge's coord-write rollback
+transactional and failure-detectable. Remediate **#2786** (a failed coord-`done` revert
+during rollback is swallowed, silently re-opening the #2711 split-brain — its red-first repro
+is already on `main`) and **#2367 Mechanism B** (the merge's multi-WP coord write-set is not
+one atomic unit, so an aborted run strands partial/uncommitted coord state).
+
+<!--
+  Grounded by a pre-spec research squad (findings in ./research/lens-{a,b,c,d,e,f}-*.md):
+  A debugger — #2786 reconcile-marker design; B architect — #2367 coord-worktree resync;
+  C paula — shared transactional seam + scope; D researcher — red-first repro design;
+  E architect — canonical-seam alignment; F planner — related-surface / work-graph discovery.
+-->
+
+## ⚠️ Scope decision requiring operator sign-off
+
+**#2367 is a P0 you (HiC) own, and this mission addresses only its Mechanism B.** Per lenses C
+and F, #2367 is a "one-invariant-three-seams" issue:
+
+- **Mechanism B** (non-transactional rollback of coord `status.*` writes) is the **same seam**
+  as #2786 → **IN SCOPE** (fold-in).
+- **Mechanism A** (an uncommitted VCS-lock in tracked `meta.json` at claim blocks `spec-kitty
+  merge` because the `advance_branch_ref` dirty gate excludes only *untracked* status files) is
+  a **different, claim-time seam** and a **deliberate #2222 / C-003 race stop-gap** — lens C:
+  "committing it would reverse that call." → **DEFERRED** to a tracked follow-up (candidate
+  parent #2017). Its clean deterministic repro (lens D) is captured for that follow-up.
+
+Confirm this partial-#2367 scope before implementation, or redirect.
+
+## Problem & Root Cause *(context)*
+
+This is the recurring class **"merge leaves coordination state partial/incoherent on
+failure"** — #1826 (closed) → #1878 → #2711 Option-A → **#2786**. Each prior fix patched a
+site; the class is not closed by construction.
+
+**The coord-write transaction already exists** (lens E): it is `merge/executor.py`'s
+`_MergeRunState`-threaded phase pipeline + the #2711 committed-`done` revert
+(`_revert_coord_done_commit`) + the INV-5/INV-6 ratchets. `coordination/transaction.py::BookkeepingTransaction`
+is the atomic authority at the **single-transition** grain; the merge's **multi-phase**
+atomicity is a *different grain the executor already owns*. The defects are gaps *inside* that
+executor transaction, not a missing outer one.
+
+- **#2786 — the rollback is not failure-detectable.** `merge/executor.py::_revert_coord_done_commit`
+  (the `if revert.returncode != 0:` branch, ~lines 500–514) runs `git revert --abort`, logs
+  `warning("…coherence may be degraded")`, and falls off the end — **no raise, no durable
+  record**. Its caller `_restore_pre_target_if_at_baseline` (~517–536) then runs
+  `_restore_final_bookkeeping_snapshots` **unconditionally**, restoring the working tree to
+  `approved` while the committed `done` is stranded. `clear_state` fires only at finalize, so
+  `MergeState` survives the rollback with no signal. The committed-`done`-vs-reverted-`approved`
+  split-brain re-opens silently and breaks resume dedup. Red-first repro already on `main`:
+  `tests/regression/test_issue_2786_revert_failure_split_brain.py`.
+- **#2367-B — the coord write-set is not atomic; the SAME mechanism as #2786.** (Post-spec
+  correction, lens renata+pedro.) `merge/done_bookkeeping.py` marks each WP done via its **own**
+  `BookkeepingTransaction` (N independent committed transactions). The genuine non-atomic strand
+  is a **failure mid `_record_merged_wps_done_for_merge`**: its failure branch (`executor.py:406-408`)
+  restores **working bytes only — it does NOT call `_revert_coord_done_commit`**, so per-WP
+  committed `done` commits already on the coord ref remain while working bytes revert to
+  `approved` → tracked-dirty coord worktree + committed/working split-brain. This is the
+  **identical byte-restore-without-revert mechanism** as #2786 (#2786 = the revert itself
+  *failed*; #2367-B = the revert was *never called* because failure preceded it). The #1826
+  safe-resync guard (`git/ref_advance.py::advance_branch_ref`, the *victim* not the defect) then
+  correctly refuses to `reset --hard` over the strand, blocking the next merge/resume. **Note
+  (lens pedro/renata):** the *target-advance* and *squash-conflict* rollback paths already run
+  `_restore_final_bookkeeping_snapshots` + `_revert_coord_done_commit` (executor.py:535-536), so
+  a repro on those paths is **vacuously green** — the repro MUST inject failure inside
+  `_record_merged_wps_done_for_merge`. So one unified fix — *any rollback that strands committed
+  coord state either reverts or marks-and-repairs* — closes both #2786 and #2367-B.
+
+## The fix posture (seam-aligned — lens E verdict)
+
+Extend the executor's existing coord-write transaction; do **not** add an outer wrapper, a
+sidecar marker, a hand-rolled resolver, or a backward `update-ref`:
+
+- **Durable marker → a `MergeState` field** (`merge/state.py`, persisted `state.json`) — the
+  authority that already survives rollback and is read by `--resume`/`doctor`. New
+  `pending_coord_reconcile` field; `from_dict` already drops unknown keys → **no migration, no
+  sidecar** (single canonical authority).
+- **Repair reads that marker** — `--resume` extends `_reconcile_completed_wps_for_resume`;
+  `spec-kitty doctor coordination` gains a stranded-revert check + `--fix`.
+- **Surface/ref seams route through canon** — coord ref via `resolve_placement_only(..., kind=MissionArtifactKind.STATUS_STATE).ref`;
+  ref move / revert via `git/ref_advance.py` and a **forward** `git revert` (AC-B3: never raw
+  `update-ref`; AC-F1: env via `_make_merge_env`).
+- **INV-5 #1827 safety** — all new logic is an **inner** extension (fields/helpers called inside
+  existing phases and `_restore_*` sites, per the #2711 precedent) — **never** a wrapper around
+  the phase driver (that would trip `test_executor_phase_boundary.py` / `test_1827_baseline_regression.py`).
+
+## User Scenarios & Testing *(mandatory)*
+
+> **RED-integrity note (binding):** every reproduction is RED-for-the-right-reason — the first
+> failing assertion is the contract, not setup (SC-001).
+
+### User Story 1 — Red-first reproductions land first (Priority: P1)
+
+As a maintainer, I want committed failing reproductions that witness both defects before any
+fix, so they are witnessed against live code and can never silently regress.
+
+**Acceptance Scenarios**:
+
+1. **(#2786 — the existing on-main repro MUST be modified, not left permanently red — BLOCKER
+   fix.)** `tests/regression/test_issue_2786_revert_failure_split_brain.py::test_swallowed_revert_failure_re_opens_2711_split_brain`
+   asserts `committed_lane == working_lane` with **no resume step (line ~204)** — under
+   mark-not-raise (FR-005) the committed `done` is *deliberately* stranded until repair, so that
+   assertion **can never go green** and the mission would ship a permanent red (violates
+   SC-001/SC-004). The WP MUST (delete-the-assertion-not-the-test) **replace** that synchronous
+   coherence assertion with the post-repair contract, OR add the `--resume`/heal step before it.
+2. **(#2786 companion — non-fakeable marker + doctor + repair.)** **Given** a merge whose
+   coord-`done` revert fails during rollback, **Then**: (a) a durable marker exists whose
+   `stranded_wp_ids` equals the **specific** WP(s) whose *committed* reduction is `done` while
+   *working* reduces to `approved` — derived from the committed-vs-working event delta
+   (`wp_lane_actor_from_events` over the coord ref, as the existing test does), NOT a static/over-broad
+   list; (b) `spec-kitty doctor coordination --json` exits 1 with a stable `error_code`, and the
+   check **re-verifies committed-vs-working incoherence** (not merely marker-presence); (c) after
+   `--resume`/`--fix`, `committed_lane`/`working_lane` **re-reduced from the actual coord ref**
+   (not read from the marker) are equal — so a resume that clears-without-healing FAILS. RED today.
+3. **(#2367-B — the REAL path is bake-mid-write-set failure, not target-advance/squash-conflict.)**
+   **Given** a coord multi-WP merge that fails **inside `_record_merged_wps_done_for_merge`**
+   (after some per-WP `done` commits land, before `_revert_coord_done_commit` runs), **When** it
+   rolls back via the `executor.py:406-408` byte-restore-only branch, **Then** the coord worktree's
+   tracked `status.*` are clean AND committed==working — asserted RED today (the strand exists
+   there). The repro MUST inject failure on THIS path; the target-advance and squash-conflict
+   paths are revert-covered (vacuously green) — do not reproduce there. Since this is the same
+   mechanism as #2786, if the fix's marker/repair already covers it, the WP folds #2367-B into
+   the unified fix with a documented note rather than inventing a second mechanism.
+
+### User Story 2 — A failed rollback revert is detectable and repairable (Priority: P1)
+
+As an operator whose merge fails and whose coord-`done` revert then also fails, I want the
+incoherence recorded durably and healed by `doctor`/`--resume`, not silently degraded.
+
+**Acceptance Scenarios**:
+
+1. **Given** `_revert_coord_done_commit` fails, **When** rollback completes, **Then** a
+   `MergeState.pending_coord_reconcile` marker is persisted (coord_ref, captured_sha,
+   coord_worktree, stranded_wp_ids, revert_error, detected_at) — and the rollback **marks, does
+   not raise** (raising would skip leg-b byte-restore and mask the real target-advance fault).
+2. **Given** a persisted marker, **When** `spec-kitty merge --resume` runs, **Then** it re-heals
+   coherence and clears the marker — but the re-heal is **coherence-gated**: it acts only while
+   committed-vs-working is *still incoherent* (re-derived from git), and the marker clear is
+   atomic with the heal. (A blind second `git revert captured_sha..HEAD` after a successful heal
+   would revert the revert and re-apply `done` — so re-attempt MUST gate on live incoherence, not
+   on `head != captured_sha`.)
+3. **Given** a healed merge, **When** `--resume` (or `doctor --fix`) runs a **second** time,
+   **Then** the coord event log is byte-identical to after the first heal and the marker stays
+   cleared (NFR-002 — no destructive double-heal, incl. a crash between heal and clear).
+4. **Given** a persisted marker AND a strand still `DONE` on the committed coord ref, **When**
+   `spec-kitty doctor coordination` runs, **Then** it loads the `MergeState` markers, **re-verifies**
+   the strand from the committed ref, reports it with a stable `error_code` (exit 1), and `--fix`
+   repairs it — registered in the canonical `cli/commands/_coordination_doctor.py` surface.
+5. **(negative — separates re-verification from marker-presence)** **Given** a marker present but the
+   committed coord ref re-derives **coherent** (e.g. a prior heal cleared the strand but crashed before
+   clearing the marker), **When** `doctor coordination` runs, **Then** it exits 0 with no finding — a
+   doctor that reports on marker-presence alone FAILS this.
+
+### User Story 3 — The merge coord write-set rolls back atomically (Priority: P1)
+
+As an operator, I want an aborted merge to leave zero uncommitted/partial coord `status.*` in
+the coordination worktree, so the safe-resync guard does not block the next merge/resume.
+
+**Acceptance Scenarios**:
+
+1. **Given** a merge that aborts mid multi-WP write-set, **When** it rolls back, **Then** the
+   coordination worktree is clean of merge-owned partial state (the resync guard finds nothing
+   tracked-dirty to refuse).
+2. **Given** the fix, **When** a normal (non-aborting) merge runs, **Then** behavior is
+   byte-identical to today (no regression; INV-5 ratchets green).
+
+### Edge Cases
+
+- A genuinely-`done` WP before the abort must survive rollback+resume without re-emission.
+- Non-coord topologies (`single_branch`/`lanes`) have no coord worktree — the marker/repair path
+  is a proven no-op.
+- Marker repair must be idempotent under repeated `--resume` and under the post-merge finalize.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+| ID | Title | Priority | Status |
+|----|-------|----------|--------|
+| FR-001 | **Modify** the existing on-main `test_issue_2786_*` synchronous `committed==working` assertion (permanently red under mark-not-raise) → replace with the post-repair contract (assert coherence *after* the heal step), never bare-delete the assertion. Pinned by SC-006 (red-on-base + post-heal coherence). | High | Open |
+| FR-002 | Red-first #2786 companion repro on a **≥2-WP fixture** (one WP stranded done/approved, one coherent): assert `stranded_wp_ids == [the_stranded_one]` (the coherent WP **excluded** — falsifies both a hardcoded `["WP01"]` and an over-broad `all_wp_ids`); marker derived from the **committed coord ref** (`_durable_done_wps_on_coordination_ref` over this merge's write-set), NOT a live worktree diff (empty at the #2786 mark point — see data-model D7). The doctor-exit-1 sub-assertion lands with FR-007's surface (WP03), not WP01 (priti sequencing). | High | Open |
+| FR-003 | Red-first #2367-B repro injecting failure inside `_record_merged_wps_done_for_merge` **after ≥1 committed `done`** (the bake byte-restore-without-revert branch, executor ≈406-408) — NOT target-advance/squash-conflict (vacuous) | High | Open |
+| FR-004 | Durable reconcile marker as a `MergeState.pending_coord_reconcile` field, typed `dict[str, Any] \| None`, persisted via `save_state` to the **canonical per-mission runtime state** (`.kittify/runtime/merge/<mission_id>/state.json`, NOT legacy `.kittify/merge-state.json`); rehydrates as plain dict via `from_dict`; no sidecar, no migration | High | Open |
+| FR-005 | Rollback MARKS on any strand (revert failure #2786 ≈500-514 AND bake failure #2367-B ≈406-408) via one `_persist_coord_reconcile_marker`, persists via `save_state`, does NOT raise; leg-b byte-restore still runs. Candidate set = **this merge's pre-target done write-set** (a NEW `_MergeRunState` field), NOT `run.all_wp_ids` (which re-strands a pre-existing-done WP on resume). | High | Open |
+| FR-006 | Repair via a dedicated `_heal_pending_coord_reconcile` entry at resume startup (NOT overloading `_reconcile_completed_wps_for_resume`); **strand-gated** re-heal (act only while a WP still reduces DONE-on-committed-ref), atomic clear, idempotent; repair = forward `git revert` (NOT `advance_branch_ref` — refuses the non-FF move; AC-B3 clean) | High | Open |
+| FR-007 | `doctor coordination` registers into the **canonical** `cli/commands/_coordination_doctor.py` surface (`_collect_coordination_findings` + `--fix` dispatch, NOT `src/specify_cli/doctor/`); enumerates ALL markers via a NEW `iter_pending_coord_reconcile_markers(repo_root)` in `state.py` (NOT `load_state(mission_id=None)` — it *raises* on ≥2 markers); RE-VERIFIES strand from the committed ref (positive: marker+strand → exit 1 stable `error_code`; **negative: marker present but ref re-derives coherent → exit 0 / no finding** — the AC that separates re-verification from marker-presence); `--fix` repairs | High | Open |
+| FR-008 | Class-closing guard — **behavioral, not a source grep**: runtime-stub the mark to a no-op, drive a real bake-path strand, require the checker to red on `strand-on-ref ∧ marker-absent`. MUST enumerate the `_restore_final_bookkeeping_snapshots` sites **programmatically** (SEVEN today: ≈407/536/670/691/701/757/786 — never a hardcoded count), assert ≈691 is dead-for-coord via `done_marked_before_target` (≈350-352), AND assert ≈701 is coord-reachable-and-routed-through-the-marking-primitive. | Medium | Open |
+| FR-009 | Single coherence owner: `coordination`-layer `coord_incoherent_done_wps(coord_ref, candidate_wps)` (over `_durable_done_wps_on_coordination_ref`) consumed by mark + heal-gate + doctor — no re-implementation in `merge/executor.py` private helpers; the repair primitive homed in `coordination/`, consumed by executor-resume AND `doctor --fix` (no dependency inversion). | High | Open |
+| FR-010 | SaaS/dashboard outbound-emit reconciliation is **explicitly OUT of scope** (fenced): `git revert` heals tracked coord artifacts but cannot un-send the transient `done` emit; documented in Complexity Tracking + doctor remediation notes, not silently omitted. | Low | Open |
+
+### Non-Functional Requirements
+
+| ID | Title | Requirement | Category | Priority | Status |
+|----|-------|-------------|----------|----------|--------|
+| NFR-001 | No happy-path regression | A non-aborting merge is byte-identical to pre-fix; INV-5 #1827 + AC-B3/AC-F1 ratchets stay green. | Reliability | High | Open |
+| NFR-002 | Repair idempotency | `--resume`/`doctor --fix` run N times → byte-stable coord log, marker cleared exactly once. | Reliability | High | Open |
+| NFR-003 | Scoped test surface | `tests/regression/test_issue_2786_*`, `tests/regression/test_issue_2367_*`, `tests/merge/`, `tests/merge/test_executor_phase_boundary.py`, `tests/specify_cli/merge/test_1827_baseline_regression.py`, the doctor tests. | Performance | Medium | Open |
+
+### Constraints
+
+| ID | Title | Constraint | Priority | Status |
+|----|-------|------------|----------|--------|
+| C-001 | Single canonical authority | Extend the executor's existing coord-write transaction + `MergeState`; do NOT add an outer wrapper, a sidecar marker, a hand-rolled coord-ref resolver, or wrap `BookkeepingTransaction` (wrong grain — lens E). | High | Open |
+| C-002 | INV-5 inner-only | New logic lives inside existing phases / `_restore_*` sites (the #2711 precedent); never a wrapper around the phase driver. | High | Open |
+| C-003 | AC-B3 / AC-F1 | Repair is a forward coord-worktree `git revert` (env via `_make_merge_env`); **NOT** `advance_branch_ref` (it refuses the non-FF move back to `captured_sha` by design); never raw `update-ref`. | High | Open |
+| C-004 | Scope fence | #2367-A (vcs-lock resync), the parallel-engine retirement (fold executor rollback into `BookkeepingTransaction`), and non-merge coord paths are DEFERRED / OUT. | High | Open |
+| C-005 | Rebase-first + housekeeping | Rebase onto the post-#2785 baseline; the fix edits code merged today (`_revert_coord_done_commit`, executor.py). Clean up the stale `…01KXRRB7` coord/lane worktrees before implementing. | High | Open |
+| C-006 | Terminology canon | `Mission` not `feature`; `--mission`. | Medium | Open |
+
+### Key Entities
+
+- **`MergeState.pending_coord_reconcile`** — the durable reconcile marker (canonical authority for "a rollback left coord incoherent"): coord_ref, captured_sha, coord_worktree, `stranded_wp_ids` (derived via `_durable_done_wps_on_coordination_ref` over this merge's write-set — committed-ref authority, not a worktree diff), revert_error, detected_at. Persisted at `.kittify/runtime/merge/<mission_id>/state.json`.
+- **`coord_incoherent_done_wps(coord_ref, candidate_wps)`** — the single `coordination`-layer coherence owner + `git revert` repair primitive, consumed by mark + heal-gate + doctor (FR-009).
+- **Executor coord-write transaction** — `_MergeRunState` + phase pipeline + `_restore_pre_target_if_at_baseline`/`_revert_coord_done_commit`/`_restore_final_bookkeeping_snapshots` (the seam to extend; six restore sites enumerated in FR-008).
+- **Doctor coordination check** — the stranded-revert detector + `--fix` repair, in canonical `cli/commands/_coordination_doctor.py`.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Both new repros are RED on the mission base with the first failing assertion being the contract (not setup), GREEN on the final commit.
+- **SC-002**: After a failed rollback revert, a durable marker exists; `doctor coordination` exits 1 with a stable `error_code`; `--resume`/`--fix` restores `committed == working` — repair, not suppression.
+- **SC-003**: An aborted merge (bake-mid-write-set failure, #2367-B) leaves zero tracked-dirty coord `status.*` after repair — or, if the repro proves genuinely vacuous, #2367-B is descoped with a documented finding per FR-003.
+- **SC-004**: NFR-001 — non-aborting merge byte-identical; INV-5 #1827 + AC-B3/AC-F1 + full merge suite green.
+- **SC-005**: The FR-008 guard reds under a **runtime-stubbed** mark (stub `_persist_coord_reconcile_marker`/`coord_incoherent_done_wps` to a no-op, drive a real bake-path strand) — a guard that stays green under a runtime-stubbed mark, or that only source-greps for the mark call, is a tautology and is rejected. The guard enumerates the six restore sites and asserts ≈691's topology-gating.
+- **SC-006**: The *modified* `test_issue_2786_*` is RED on the mission base (pre-fix) and asserts `committed == working` (re-reduced from the coord ref) **after** the heal step — a bare deletion of the old assertion without a post-repair contract fails this SC.
+- **SC-007**: `stranded_wp_ids` is derived from the committed coord ref over *this merge's* write-set; in the ≥2-WP fixture it equals exactly the stranded WP (coherent WP excluded), and the SaaS-emit reconciliation is documented as fenced-out (FR-010), not silently dropped.
+
+## Implementation Notes for Planning *(non-binding — from the research squad)*
+
+Suggested WP slicing (red-first first; #2786 and #2367-B are one mechanism → one marker fix).
+**Post-plan sequencing correction (priti):** each red assertion co-locates with the surface it
+needs — a marker/doctor assertion in WP01 would red with `AttributeError` (setup-red, forbidden by
+ADR 2026-07-17-1). WP01 keeps only the **git-reducible** reds. The whole set lands in **one PR**
+(do NOT split repros from fix — a lone WP01 would open a red-main window).
+
+- **WP01** — red-first, git-reducible reds only (FR-001/003 + split-brain half of FR-002):
+   **modify** the existing `test_issue_2786_*` synchronous assertion so it asserts coherence *after*
+   the heal step (SC-006 — never bare-delete); add the #2367-B repro (≥1 committed `done` then
+   failure inside `_record_merged_wps_done_for_merge`, executor ≈406-408). Use a **≥2-WP fixture**
+   (one stranded, one coherent). Reuse the #2711 coord harness (`_init_git_repo`,
+   `_bootstrap_coord_mission`, `CoordinationWorkspace.worktree_path`; committed-ref reduction via
+   `_durable_done_wps_on_coordination_ref`). *Expected-red until WP03 lands (single landing unit).*
+- **WP02** — durable marker + shared owner (FR-004/005/009): add `pending_coord_reconcile`
+   (`dict[str,Any]|None`) to `MergeState`, persisted at `.kittify/runtime/merge/<mission_id>/state.json`;
+   add the `coordination`-layer `coord_incoherent_done_wps(coord_ref, candidate_wps)` (over
+   `_durable_done_wps_on_coordination_ref`); extract `_persist_coord_reconcile_marker(run, error)`
+   (CC≤15) calling it from BOTH strand sites (≈500-514 AND ≈406-408); mark-not-raise. Move FR-002's
+   *marker-names-specific-WP* assertion here (surface now exists).
+- **WP03** — repair + doctor (FR-006/007): dedicated `_heal_pending_coord_reconcile` at resume startup
+   (strand-gated on committed-ref DONE, atomic clear; repair = forward `git revert`, NOT
+   `advance_branch_ref`); register the check/fix into canonical
+   `cli/commands/_coordination_doctor.py` (`_collect_coordination_findings` + `--fix` dispatch),
+   reusing `DoctorFinding.error_code` and `coord_incoherent_done_wps`. Move FR-002's *doctor-exit-1*
+   + FR-007's *negative* AC (marker+coherent→exit 0) here.
+- **WP04** — class-closing guard (FR-008): **behavioral** guard reds under a runtime-stubbed mark;
+   enumerate the six `_restore_final_bookkeeping_snapshots` sites, assert ≈691 topology-gating;
+   prefer co-locating the mark at the `_restore_and_guard_coord_coherence` primitive (inner-only).
+
+## Post-Spec Squad Findings (folded) *(audit trail)*
+
+Two fresh lenses (reviewer-renata, python-pedro), read-only, code-verified. Verdict: **safe to
+plan with-changes** — all folded above.
+
+- **[BLOCKER, renata]** the existing on-main #2786 test asserts `committed==working` with no
+  resume → permanently red under mark-not-raise → **FR-001 replaces that assertion**.
+- **[HIGH, renata] #2367-B path corrected** — the real strand is a failure inside
+  `_record_merged_wps_done_for_merge` (`executor.py:406-408` byte-restore-**without**-revert),
+  NOT target-advance/squash-conflict (revert-covered, vacuous). It is the **same mechanism** as
+  #2786 → one unified marker fix (FR-005 marks at both strand sites). #2367-B is real, not a
+  phantom — folded, not descoped.
+- **[HIGH, renata] non-fakeability** — marker names the *specific* stranded WP (committed-vs-working
+  delta, not a static list); repair re-derives coherence from git (no clear-without-heal); doctor
+  re-verifies incoherence (not marker-presence). Folded into FR-002/006/007.
+- **[HIGH, renata] double-heal** — re-attempted revert must be **coherence-gated** (heal only
+  while incoherent; a blind `git revert captured_sha..HEAD` re-applies `done`); + a resume-twice
+  byte-identical AC. Folded into FR-006 / US2-S2,S3 / NFR-002.
+- **[LOW, pedro] marker typing** — `from_dict` rehydrates a nested marker as a plain dict → type
+  it `dict[str,Any]|None`. Folded into FR-004.
+- **[MED, pedro] resume-repair** — needs a dedicated `_heal_pending_coord_reconcile` entry, not an
+  overload of `_reconcile_completed_wps_for_resume`. Folded into FR-006.
+- **[INFO, pedro] feasibility CONFIRMED** — `MergeState`/`save_state`/`DoctorFinding.error_code`/
+  `resolve_placement_only` all exist and behave as claimed; three helper extractions keep the
+  touched functions under CC-15; INV-5 tripwires safe as long as it stays inner-only (no wrapper
+  around the phase driver, C-002).
+
+**Tracker (actioned + verified post-plan, 2026-07-18):** #2786 = Bug/P0/parent **#1795**. #2367
+**reparented** #2392(closed)→**#1795** and **retyped Task→Bug**. Mechanism A **split out to #2795**
+(Bug, parent **#2017**, reuses the #2222 churn classifier); #2367 stays open tracking the A-residual
+until #2795 lands. The mission PR **partially addresses #2367** (Mechanism B) — must NOT auto-close it.
+Deferred (tracked): **#2795** (Mechanism A), the parallel-engine→`BookkeepingTransaction` retirement.
+
+## Post-Plan Squad Findings (folded) *(audit trail)*
+
+Four lenses (architect-alphonso, paula-patterns, planner-priti, reviewer-renata), read-only,
+code-verified. All four verdicts **SAFE-WITH-CHANGES**; all folded above. One divergence adjudicated.
+
+- **[HIGH, alphonso — design-changing] `stranded_wp_ids` derivation was wrong.**
+  `_restore_final_bookkeeping_snapshots` restores **primary** paths, not the coord worktree → a
+  committed-vs-working diff at the #2786 mark point returns **empty → no marker → silent strand-drop**.
+  Corrected to derive from the **committed coord ref** via `_durable_done_wps_on_coordination_ref` over
+  this merge's write-set. Folded into FR-002/004, data-model D7, research D7. **Divergence resolved:**
+  supersedes the renata/paula/data-model "committed-vs-working delta" framing; renata's ≥2-WP fixture is
+  *compatible* and verifies it (coherent WP excluded by construction).
+- **[HIGH, paula] third same-shape strand site** at executor ≈690-692, dead-for-coord only via the
+  unstated `done_marked_before_target` invariant → FR-008 enumerates six restore sites + asserts the
+  gating; prefer marking at the restore primitive. Folded into FR-008, data-model, research D11.
+- **[HIGH, paula + alphonso] one coherence owner + correct surfaces** — `coord_incoherent_done_wps` in
+  `coordination/` consumed by mark+heal+doctor; doctor home corrected `doctor/` → canonical
+  `cli/commands/_coordination_doctor.py`; repair primitive coordination-homed. Folded into FR-007/009,
+  research D9.
+- **[MED, alphonso] repair transport** — forward `git revert`, NOT `advance_branch_ref` (refuses non-FF).
+  Folded into FR-006, C-003, data-model.
+- **[MED, alphonso] SaaS emit** cannot be un-sent → explicit scope fence (FR-010, data-model D10).
+- **[LOW, alphonso] storage path** — canonical `.kittify/runtime/merge/<mission_id>/state.json`, not
+  legacy. Folded into FR-004, data-model.
+- **[LOW, alphonso] INV-5 citation** — real ratchet is `test_executor_phase_boundary.py`; wrapping is
+  wrong on *grain*, not that ratchet; "C-002" mis-borrowed. Folded into research D2 + note.
+- **[HIGH, renata] anti-fakeability** — FR-002 ≥2-WP fixture; FR-008 behavioral falsifier
+  (runtime-stubbed mark); FR-007 negative AC (marker+coherent→exit 0); FR-001 red-on-base SC. Folded
+  into FR-001/002/007/008 + SC-005/006/007.
+- **[HIGH, priti] sequencing** — FR-002's marker/doctor sub-asserts move to WP02/WP03 (else WP01 reds
+  with `AttributeError`, forbidden setup-red); one-PR landing. **[HIGH/MED, priti] tracker** — see the
+  Tracker line above (reparent/retype #2367, file #2367-A, partial-close).
+
+## Post-Tasks Squad Findings (folded) *(audit trail)*
+
+Three lenses (reviewer-renata, python-pedro, paula-patterns) on the 5 WPs, read-only, code-verified.
+All three **SAFE-WITH-CHANGES**; all folded into the WP prompts + FR-005/007/008 + data-model.
+
+- **[HIGH — renata + pedro DOUBLE-confirmed] SEVEN restore sites, not six.** `executor.py:701`
+  (`_project_status_bookkeeping_to_target` failure) runs **outside** the `done_marked_before_target`
+  guard → coord-reachable, un-marked, same #2786 shape. My six-site list would let WP05's DoD pass while
+  the class stays open at 701. → FR-008 + WP03-T010 + WP05-T016 enumerate **programmatically** (SEVEN:
+  407/536/670/691/701/757/786), route 701 through the marking primitive, assert its coord-reachability;
+  691 stays dead-for-coord.
+- **[HIGH — paula + renata converged] candidate set is unowned + untested.** `_MergeRunState` carries
+  only `all_wp_ids`; passing it re-strands a pre-existing-`done` WP on resume. Every fixture uses
+  "coherent = only-ever-approved" (excluded regardless), so `all_wp_ids` passes them all. → WP03 adds a
+  `_MergeRunState` pre-target-write-set field; WP02/WP03 add a **pre-existing-done fixture** asserting
+  that WP is excluded (DoD checkbox). Folded into FR-005 + data-model.
+- **[HIGH — paula] doctor marker enumeration falls between WP02 and WP04.** `load_state(mission_id=None)`
+  *raises* on ≥2 markers; no list-all API. → WP02 adds `iter_pending_coord_reconcile_markers(repo_root)`
+  in `state.py` + test; WP04 consumes it. Folded into FR-007 + data-model.
+- **[MED — paula + renata] WP03 DoD gaps** — pin the specific-WP `stranded_wp_ids` at the
+  marker-construction site (not only WP02's reducer) + gate single-owner consumption (an inline
+  `_durable_done_wps_on_coordination_ref` would pass the loose DoD → drift reopens). WP03-T010 primary
+  over T008 (mark *through* the primitive; WP05's "routes-through-primitive" is the acceptance contract).
+- **[MED — pedro] WP01 harness** — the #2711 `_bootstrap_coord_mission` is single-WP and has no
+  bake-loop injection hook; it is in **no** WP's `owned_files`. WP01 authors its own multi-WP bootstrap
+  in its owned file (reusing only `_init_git_repo`/`_git`), must NOT edit the unowned harness.
+- **[LOW — pedro] cycle guard** — `coherence.py` repair fn must **function-locally** import
+  `_make_merge_env` (module-top creates `merge.executor→coordination.coherence→lanes.merge→merge.config`).
+  Reader half is clean. **[LOW — pedro] WP04** extract `_apply_coordination_fixes` for CC.
+  **[LOW — renata] WP01** DoD: verify `merge --resume` no-ops (not raises) on base.
+- **Concessions (all three):** WP05 behavioral falsifier, WP04 negative AC, WP01 no-bare-delete, NFR-002
+  byte-identical, disjoint `owned_files`, real WP03∥WP04 parallelism, single-PR framing — all well-pinned.
+  WP03 CC-15 not at risk (T010 delegation *reduces* CC); WP02 layer-clean (no coordination→merge import).
+
+## Pre-Spec Squad Findings (folded) *(audit trail)*
+
+Six lenses; convergent on the seam (extend the executor transaction, `MergeState` marker), one
+divergence resolved:
+
+- **A (debugger):** swallowed site `executor.py:500–514`; marker on `MergeState`; **mark-not-raise**; repair via resume+doctor.
+- **B (architect):** #2367-B is #2711's root one level up (per-WP `BookkeepingTransaction`s + parallel rollback engine, not one atomic set); #2222 churn classifier already exists (for the deferred #2367-A).
+- **C (paula):** shared-root **PARTIAL** — one seam closes #2786 + #2367-B; **#2367-A fenced out** (deliberate stop-gap). Recurrence #1826→#1878→#2711→#2786.
+- **D (researcher):** existing #2786 red insufficient for the marker fix → **companion test needed**; #2367-B may be vacuous on the target-advance path. *(Superseded by post-spec: the live #2367-B strand is the bake-mid-write-set path at `executor.py:406-408`, NOT squash-conflict — see Post-Spec Squad Findings.)*
+- **E (architect, seam-alignment):** **EXTEND** the executor's coord-write transaction; do **not** wrap `BookkeepingTransaction` (single-transition grain ≠ multi-phase grain — a second authority / 044 breach). Marker as a `MergeState` field. INV-5 safe **inner-only**. *(Resolves B's "one `BookkeepingTransaction`" toward an executor-transaction extension.)*
+- **F (planner):** FOLD #2786 + #2367-B; DEFER #2367-A + cousins; parent under **#1795**; **no active collision** (sibling `…01KXRRB7` merged; worktree lingers = housekeeping); rebase onto post-#2785.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks.md
@@ -1,0 +1,100 @@
+# Tasks: Merge coord-write rollback transactionality (#2786 + #2367-B)
+
+**Mission**: `merge-coord-rollback-transactionality-01KXTM59`
+**Planning base / merge target**: `fix/merge-coord-rollback-transactionality` → consolidate → local `main` → `pr/<slug>` PR
+**Inputs**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md)
+
+Five work packages. **Single-PR landing unit** — WP01's red repros stay red until WP03 lands; do NOT
+split the repros from the fix (a lone WP01 would open a red-`main` window). Ownership is file-disjoint:
+executor.py's mark + heal + restore-primitive all land in one WP (WP03) because a file cannot be
+co-owned.
+
+## Subtask Index
+
+| ID | Description | WP | Parallel |
+|----|-------------|----|----------|
+| T001 | Modify existing `test_issue_2786_*` assertion → assert coherence AFTER heal (SC-006) | WP01 | | [D] |
+| T002 | New `test_issue_2367_bake_strand.py` — inject failure inside `_record_merged_wps_done_for_merge` after ≥1 committed `done` (≥2-WP fixture) | WP01 | [D] |
+| T003 | Assert committed-ref split-brain via `_durable_done_wps_on_coordination_ref` (git-reducible reds only; NO marker/doctor asserts here) | WP01 | | [D] |
+| T004 | Add `MergeState.pending_coord_reconcile: dict[str,Any]\|None` + `from_dict` passthrough; canonical runtime state path | WP02 | | [D] |
+| T005 | New `coordination/coherence.py` — `coord_incoherent_done_wps(coord_ref, candidate_wps)` (committed-ref authority) | WP02 | | [D] |
+| T006 | Coordination-homed `git revert` repair primitive (env via `_make_merge_env`; NOT `advance_branch_ref`) | WP02 | | [D] |
+| T007 | `tests/coordination/test_coherence.py` — ≥2-WP fixture: `stranded_wp_ids == [the_stranded_one]`, coherent WP excluded | WP02 | [D] |
+| T008 | Extract `_persist_coord_reconcile_marker(run, error)` (CC≤15); mark at BOTH strand sites (≈500-514 revert-fail AND ≈406-408 bake); mark-not-raise | WP03 | | [D] |
+| T009 | `_heal_pending_coord_reconcile` at resume startup — strand-gated (committed-ref DONE), atomic clear, idempotent; delegate revert to WP02 primitive | WP03 | | [D] |
+| T010 | Co-locate the mark at a `_restore_and_guard_coord_coherence` restore primitive (inner-only, INV-5-safe); refactor `_revert_coord_done_commit` to delegate | WP03 | | [D] |
+| T011 | `tests/merge/test_executor_coord_reconcile.py` — mark/heal integration + marker-names-specific-WP; make WP01 repros green | WP03 | | [D] |
+| T012 | Register `_check_stranded_coord_revert` into `_collect_coordination_findings` (loads MergeState, re-verifies via `coord_incoherent_done_wps`, stable `error_code`, exit 1) | WP04 | | [D] |
+| T013 | `_fix_stranded_reverts` into the existing `--fix` dispatch (delegates to WP02 repair primitive) | WP04 | | [D] |
+| T014 | Doctor tests: positive (marker+strand→exit 1) AND negative (marker present + ref-coherent→exit 0) | WP04 | [D] |
+| T015 | Behavioral class-closing guard — reds under a runtime-stubbed mark driving a real bake strand | WP05 | | [D] |
+| T016 | Enumerate (AST) the seven `_restore_final_bookkeeping_snapshots` sites; assert ≈691 dead-for-coord AND ≈701 coord-reachable-and-routed | WP05 | [D] |
+
+---
+
+## Phase 1 — Red-first reproduction
+
+### WP01 — Red-first repros (git-reducible reds only)
+
+- **Goal**: Prove both strands (#2786 revert-failed, #2367-B revert-never-called) with assertions whose surfaces exist today; un-break the permanently-red existing #2786 assertion.
+- **Priority**: P0 · **Profile**: debugger-debbie
+- Dependencies: none (first)
+- **Independent test**: `PWHEADLESS=1 pytest tests/regression/test_issue_2786_revert_failure_split_brain.py tests/regression/test_issue_2367_bake_strand.py` — RED on the mission base for the *product* reason (not `AttributeError`).
+- **Subtasks**: T001, T002, T003
+- **Risk**: marker/doctor asserts do NOT belong here (surfaces absent → setup-red, forbidden by ADR 2026-07-17-1). Expected-red until WP03. #2367-B must inject on the **bake** path only.
+
+## Phase 2 — Foundations (marker + coherence owner + repair primitive)
+
+### WP02 — MergeState marker + single coherence owner + repair primitive
+
+- **Goal**: Add the durable marker field, the ONE coordination-layer coherence owner, and the coordination-homed `git revert` repair primitive — consumed by WP03 (executor) and WP04 (doctor).
+- **Priority**: P0 · **Profile**: python-pedro
+- Depends on WP01
+- **Independent test**: `pytest tests/coordination/test_coherence.py` — ≥2-WP fixture; `coord_incoherent_done_wps` returns exactly the stranded WP (coherent excluded), falsifying a hardcoded `["WP01"]` and an over-broad `all_wp_ids`.
+- **Subtasks**: T004, T005, T006, T007
+- **Risk**: `stranded_wp_ids` derives from the **committed coord ref** over *this merge's* write-set — never a live worktree diff (empty at the #2786 mark point). Repair is `git revert`, NOT `advance_branch_ref`.
+
+## Phase 3 — Integration (parallel: executor + doctor)
+
+### WP03 — Executor: mark both sites + resume heal + restore primitive
+
+- **Goal**: Mark-not-raise at both strand sites, strand-gated resume heal, and co-locate the mark at the restore primitive so a future restore site cannot strand silently. Makes WP01's repros green.
+- **Priority**: P0 · **Profile**: python-pedro
+- Depends on WP02
+- **Independent test**: `pytest tests/merge/test_executor_coord_reconcile.py` + WP01 repros now GREEN; `tests/merge/test_executor_phase_boundary.py` (INV-5) stays green.
+- **Subtasks**: T008, T009, T010, T011
+- **Risk**: INV-5 #1827 inner-only — do NOT add the heal to the frozen `expected_order` list; repair delegates to WP02's primitive (no raw `update-ref`, AC-B3); NFR-001 happy-path byte-identical.
+
+### WP04 — Doctor: canonical coordination check + `--fix`
+
+- **Goal**: Register the stranded-revert detector + fix into the canonical `_coordination_doctor.py` surface (NOT a new `doctor/` home), re-verifying incoherence from the committed ref.
+- **Priority**: P1 · **Profile**: implementer-ivan · parallel with WP03
+- Depends on WP02
+- **Independent test**: `pytest tests/specify_cli/cli/commands/test_coordination_doctor.py` — positive (marker+strand→exit 1 stable `error_code`) AND negative (marker present + ref-coherent→exit 0).
+- **Subtasks**: T012, T013, T014
+- **Risk**: canonical surface only (DIR-044 — no second authority); `--fix` delegates to WP02's repair primitive; the negative AC is the one that separates re-verification from marker-presence.
+
+## Phase 4 — Class-closing guard
+
+### WP05 — Behavioral class-closing invariant guard
+
+- **Goal**: Prove the whole class is closed — any rollback leaving a stranded `done` on the committed ref MUST leave a durable marker — behaviorally, not by source-grep.
+- **Priority**: P1 · **Profile**: reviewer-renata
+- Depends on WP03
+- **Independent test**: `pytest tests/architectural/test_coord_rollback_coherence_guard.py` — reds under a runtime-stubbed mark driving a real bake strand; green with the real mark.
+- **Subtasks**: T015, T016
+- **Risk**: must be a runtime behavioral falsifier (a source-grep-for-the-call guard is a tautology and is rejected); enumerate the six restore sites + assert ≈691's topology-gating.
+
+---
+
+## Dependencies
+
+```
+WP01 ─→ WP02 ─→ WP03 ─→ WP05
+                └→ WP04            (WP04 ∥ WP03; both depend only on WP02)
+```
+
+## MVP scope
+
+WP01→WP02→WP03 is the split-brain fix (closes #2786 + #2367-B). WP04 (operator detectability) and
+WP05 (class-closing proof) complete the durable safety net. All five land in **one PR**.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/README.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/README.md
@@ -1,0 +1,64 @@
+# Tasks Directory
+
+This directory contains work package (WP) prompt files.
+
+## Directory Structure (v0.9.0+)
+
+```
+tasks/
+├── WP01-setup-infrastructure.md
+├── WP02-user-authentication.md
+├── WP03-api-endpoints.md
+└── README.md
+```
+
+All WP files are stored flat in `tasks/`. Status is tracked in `status.events.jsonl`, not in WP frontmatter.
+
+## Work Package File Format
+
+Each WP file **MUST** use YAML frontmatter:
+
+```yaml
+---
+work_package_id: "WP01"
+title: "Work Package Title"
+dependencies: []
+planning_base_branch: "fix/merge-coord-rollback-transactionality"
+merge_target_branch: "fix/merge-coord-rollback-transactionality"
+branch_strategy: "Planning artifacts were generated on fix/merge-coord-rollback-transactionality; completed changes must merge back into fix/merge-coord-rollback-transactionality."
+subtasks:
+  - "T001"
+  - "T002"
+phase: "Phase 1 - Setup"
+assignee: ""
+agent: ""
+shell_pid: ""
+history:
+  - timestamp: "2025-01-01T00:00:00Z"
+    agent: "system"
+    action: "Prompt generated via /spec-kitty.tasks"
+---
+
+# Work Package Prompt: WP01 – Work Package Title
+
+[Content follows...]
+```
+
+## Status Tracking
+
+Status is tracked via the canonical event log (`status.events.jsonl`), not in WP frontmatter.
+Use `spec-kitty agent tasks move-task` to change WP status:
+
+```bash
+spec-kitty agent tasks move-task <WPID> --to <lane>
+```
+
+Example:
+```bash
+spec-kitty agent tasks move-task WP01 --to doing
+```
+
+## File Naming
+
+- Format: `WP01-kebab-case-slug.md`
+- Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP01-red-first-repros.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP01-red-first-repros.md
@@ -1,0 +1,136 @@
+---
+work_package_id: WP01
+title: Red-first repros (git-reducible reds only)
+dependencies: []
+requirement_refs:
+- FR-001
+- FR-002
+- FR-003
+tracker_refs: []
+planning_base_branch: fix/merge-coord-rollback-transactionality
+merge_target_branch: fix/merge-coord-rollback-transactionality
+branch_strategy: Planning artifacts for this mission were generated on fix/merge-coord-rollback-transactionality. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/merge-coord-rollback-transactionality unless the human explicitly redirects the landing branch.
+subtasks:
+- T001
+- T002
+- T003
+phase: Phase 1 - Red-first reproduction
+assignee: ''
+agent: "claude"
+shell_pid: "615737"
+shell_pid_created_at: "1784389369.26"
+history:
+- at: '2026-07-18T14:30:00Z'
+  actor: system
+  action: Prompt generated via /spec-kitty.tasks
+agent_profile: debugger-debbie
+authoritative_surface: tests/regression/
+create_intent:
+- tests/regression/test_issue_2367_bake_strand.py
+execution_mode: code_change
+model: ''
+owned_files:
+- tests/regression/test_issue_2786_revert_failure_split_brain.py
+- tests/regression/test_issue_2367_bake_strand.py
+role: implementer
+tags: []
+task_type: implement
+---
+
+# Work Package Prompt: WP01 – Red-first repros (git-reducible reds only)
+
+## ⚡ Do This First: Load Agent Profile
+
+Use the `/ad-hoc-profile-load` skill to load the agent profile specified in the frontmatter (or any user-defined profile), and behave according to its guidance before parsing the rest of this prompt.
+
+- **Profile**: `debugger-debbie`
+- **Role**: `implementer`
+- **Agent/tool**: `claude`
+
+---
+
+## Objectives & Success Criteria
+
+Author two **red-first** regression reproductions that fail for the *product* reason on the mission
+base, and repair the permanently-red existing #2786 assertion so it can go green after the fix.
+
+- **SC-001**: both repros RED on the mission base with the first failing assertion being the contract (not setup), GREEN on the final commit.
+- **SC-006**: the *modified* `test_issue_2786_*` is RED on base and asserts `committed == working` (re-reduced from the coord ref) **after** the heal step — a bare deletion of the old assertion fails this SC.
+- Both tests carry `@pytest.mark.regression` and a docstring referencing the issue (#2786 / #2367).
+
+**CRITICAL — do NOT assert marker/doctor surfaces here.** `MergeState.pending_coord_reconcile` and
+the `doctor coordination` stranded-revert finding do NOT exist yet (they land in WP02/WP03/WP04). An
+assertion against them here reds with `AttributeError` — **setup-red, forbidden** by
+[ADR 2026-07-17-1](../../../docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md).
+Assert only **git-reducible** state (committed coord ref vs intended lane).
+
+## Context & Constraints
+
+- Spec: [spec.md](../spec.md) FR-001, FR-003, split-brain half of FR-002; US1 scenarios 1,3.
+- Research: [research.md](../research.md) D3 (bake-path mechanism), D7 (committed-ref derivation).
+- Data model: [data-model.md](../data-model.md) — the strand set = WPs this merge marked `done` that remain `DONE` on the committed coord ref.
+- Charter: ATDD red-first; [testing-flakiness.md#test-run-baseline-red-gotcha](../../../docs/guides/testing-flakiness.md#test-run-baseline-red-gotcha) — classify baseline reds, don't green-wash.
+- **Expected-red until WP03 lands** (single-PR landing unit). This is not a violation — it's the red-first contract.
+
+### Code anchors (verified on base)
+- `src/specify_cli/merge/executor.py` — bake strand `_record_merged_wps_done_for_merge` failure branch ≈406-408 (byte-restore-**without**-revert); revert-failure branch ≈500-514 (swallowed).
+- `src/specify_cli/merge/done_bookkeeping.py:510` — `_durable_done_wps_on_coordination_ref(...)` reads `EventLogReadContract.coordination_branch_ref` → the committed-ref reduction the tests use.
+- Existing harness in `tests/regression/test_issue_2786_revert_failure_split_brain.py` — reuse `_init_git_repo`, `_bootstrap_coord_mission`, `CoordinationWorkspace.worktree_path`, and its committed/working coord-event readers.
+
+## Branch Strategy
+
+- **Planning base branch**: `fix/merge-coord-rollback-transactionality`
+- **Merge target branch**: `fix/merge-coord-rollback-transactionality` (→ consolidate → local main → PR)
+- Execution worktrees are allocated per computed lane from `lanes.json`.
+
+## Subtasks & Detailed Guidance
+
+### Subtask T001 – Modify the existing #2786 assertion → assert-after-heal
+
+- **Purpose**: The on-base assertion `assert committed_lane == working_lane` (≈line 204) has **no resume step**. Under the mark-not-raise fix the committed `done` is *deliberately* stranded until repair, so that synchronous assertion can never go green → permanent red. Fix it to assert coherence **after** invoking the heal.
+- **Steps**:
+  1. Read the existing test end-to-end. Keep the strand-inducing setup (revert-failure injection) and the witnesses.
+  2. Replace the synchronous coherence assertion with: drive the strand → assert the strand exists (committed `done`, intended `approved`) → invoke `spec-kitty merge --resume` (or the heal entry once it exists) → assert `committed_lane == working_lane` re-reduced from the coord ref.
+  3. Until WP03 lands the heal, this test is RED at the post-heal assertion (the heal is a no-op) — that is the expected red.
+  4. **Never** bare-delete the assertion (SC-006 / delete-the-assertion-not-the-test anti-pattern).
+- **Files**: `tests/regression/test_issue_2786_revert_failure_split_brain.py`
+
+### Subtask T002 – New #2367-B bake-strand repro (≥2-WP fixture)
+
+- **Purpose**: Prove the bake-mid-write-set strand — a failure **inside** `_record_merged_wps_done_for_merge` after ≥1 committed `done`, hitting the ≈406-408 byte-restore-without-revert branch.
+- **Steps**:
+  1. Bootstrap a coord mission with a **≥2-WP** write-set (one WP that commits `done` before the injected failure = *stranded*; one that is only ever `approved` = *coherent*). **Author your OWN multi-WP bootstrap in this owned file** — the shared `_bootstrap_coord_mission` (in the #2711 harness) is hardcoded single-WP and has NO bake-loop injection hook; it is in NO WP's `owned_files`, so do NOT edit it (locality violation). Reuse only the primitive helpers `_init_git_repo` / `_git`. Inject the failure via a `_mark_wp_merged_done` `side_effect` that raises on the 2nd WP.
+  2. Inject the failure inside the bake loop after the first WP's `done` commit lands (monkeypatch the per-WP emit to raise on the 2nd, or similar). Confirm it exercises the ≈406-408 branch, NOT target-advance/squash-conflict (those are revert-covered — vacuous).
+  3. Assert (git-reducible): the stranded WP reduces to `DONE` on the committed coord ref while its intended lane is `approved`; the coherent WP is not stranded. RED today.
+- **Files**: `tests/regression/test_issue_2367_bake_strand.py` (NEW)
+
+### Subtask T003 – Committed-ref split-brain assertions (no marker/doctor)
+
+- **Purpose**: Ground both tests on the committed-ref authority the fix will use, so the reds are product-reds and the ≥2-WP fixture pins the specific stranded WP.
+- **Steps**:
+  1. Use `_durable_done_wps_on_coordination_ref` (or the test's existing committed-event reader) to reduce the committed coord ref.
+  2. Assert the stranded set equals exactly the stranded WP — establishing the contract WP02's `coord_incoherent_done_wps` must satisfy.
+  3. Keep all assertions git-reducible; no import of `pending_coord_reconcile` or doctor findings.
+- **Files**: both test files above.
+
+## Definition of Done
+
+- [ ] Both tests RED on the mission base for the product reason (verified: run on base via `PYTHONPATH="$(pwd)/src"`), not `AttributeError`/setup.
+- [ ] The modified #2786 test's `merge --resume`/heal step is verified to **run and no-op (not raise)** on base — so the first failing assertion is provably the post-heal coherence contract, not infra.
+- [ ] `@pytest.mark.regression` + issue-referencing docstrings on both.
+- [ ] Existing #2786 test modified to assert-after-heal (not deleted); ≥2-WP fixture in the #2367 test, authored in the owned file (the unowned #2711 `_bootstrap_coord_mission` is NOT edited).
+- [ ] `pytest tests/architectural/test_pytest_marker_convention.py tests/architectural/test_no_legacy_terminology.py` green.
+- [ ] No production code touched (tests only).
+
+## Reviewer Guidance
+
+Verify the reds fail for the product reason on base (not setup); confirm no marker/doctor surface is
+referenced; confirm the #2786 assertion was *modified* not deleted (SC-006); confirm the #2367
+fixture is ≥2-WP with one stranded + one coherent WP and injects on the bake path.
+
+## Activity Log
+
+- 2026-07-18T15:21:07Z – claude – shell_pid=579351 – Assigned agent via action command
+- 2026-07-18T15:42:33Z – claude – shell_pid=579351 – Red-first repros: intentionally RED until WP03 (single-PR landing unit, ADR 2026-07-17-1)
+- 2026-07-18T15:42:57Z – claude – shell_pid=615737 – Started review via action command
+- 2026-07-18T15:49:55Z – user – shell_pid=615737 – Review passed (renata): SC-006/007 + product-red + bake-path verified

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP02-marker-and-coherence-owner.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP02-marker-and-coherence-owner.md
@@ -1,0 +1,144 @@
+---
+work_package_id: WP02
+title: MergeState marker + single coherence owner + repair primitive
+dependencies: 
+- WP01
+requirement_refs:
+- FR-004
+- FR-009
+tracker_refs: []
+planning_base_branch: fix/merge-coord-rollback-transactionality
+merge_target_branch: fix/merge-coord-rollback-transactionality
+branch_strategy: Planning artifacts for this mission were generated on fix/merge-coord-rollback-transactionality. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/merge-coord-rollback-transactionality unless the human explicitly redirects the landing branch.
+subtasks:
+- T004
+- T005
+- T006
+- T007
+phase: Phase 2 - Foundations
+assignee: ''
+agent: "claude"
+shell_pid: "674338"
+shell_pid_created_at: "1784390676.55"
+history:
+- at: '2026-07-18T14:30:00Z'
+  actor: system
+  action: Prompt generated via /spec-kitty.tasks
+agent_profile: python-pedro
+authoritative_surface: src/specify_cli/coordination/
+create_intent:
+- src/specify_cli/coordination/coherence.py
+- tests/coordination/test_coherence.py
+execution_mode: code_change
+model: ''
+owned_files:
+- src/specify_cli/merge/state.py
+- src/specify_cli/coordination/coherence.py
+- tests/coordination/test_coherence.py
+role: implementer
+tags: []
+task_type: implement
+---
+
+# Work Package Prompt: WP02 – MergeState marker + single coherence owner + repair primitive
+
+## ⚡ Do This First: Load Agent Profile
+
+Use the `/ad-hoc-profile-load` skill to load the agent profile specified in the frontmatter (or any user-defined profile), and behave according to its guidance before parsing the rest of this prompt.
+
+- **Profile**: `python-pedro`
+- **Role**: `implementer`
+- **Agent/tool**: `claude`
+
+---
+
+## Objectives & Success Criteria
+
+Build the three foundations the executor (WP03) and doctor (WP04) consume: the durable marker field,
+the ONE coordination-layer coherence owner, and the coordination-homed `git revert` repair primitive.
+
+- **FR-004**: `MergeState.pending_coord_reconcile: dict[str, Any] | None`, persisted via `save_state` to the canonical per-mission runtime state; `from_dict` rehydrates it as a plain dict (no migration).
+- **FR-009**: one `coord_incoherent_done_wps(coord_ref, candidate_wps)` (committed-ref authority) + one repair primitive, both in `coordination/` — consumed by mark + heal + doctor, never re-implemented per call-site.
+- **SC-007 / anti-fakeability**: in a ≥2-WP fixture, `coord_incoherent_done_wps` returns exactly the stranded WP; a hardcoded `["WP01"]` and an over-broad `all_wp_ids` both fail.
+
+## Context & Constraints
+
+- Spec: [spec.md](../spec.md) FR-004, FR-005 (marker shape), FR-009; data-model [derivation contract](../data-model.md).
+- Research: [research.md](../research.md) D1 (marker home), D7 (committed-ref derivation), D9 (surfaces/repair transport).
+- **The derivation is committed-ref, NOT a worktree diff** — a committed-vs-working diff is empty at the #2786 mark point (restore touches primary paths, not the coord worktree) → silent strand-drop.
+
+### Code anchors (verified on base)
+- `src/specify_cli/merge/state.py` — `MergeState`, `from_dict` (≈102-104, drops unknown keys), `save_state` (≈153-165, writes canonical `.kittify/runtime/merge/<mission_id>/state.json`; legacy `.kittify/merge-state.json` is `mission_id=None` back-compat only).
+- `src/specify_cli/merge/done_bookkeeping.py:510` — `_durable_done_wps_on_coordination_ref(candidate_wps, ...)` reads `EventLogReadContract.coordination_branch_ref`. This is the reduction `coord_incoherent_done_wps` wraps. (It is merge-private; the coordination owner may either call it or re-derive via the same `EventLogReadContract` primitive to avoid a coordination→merge import — prefer re-deriving via `EventLogReadContract` to keep the layer clean.)
+- `src/specify_cli/merge/executor.py:469-483` — the existing `_revert_coord_done_commit` `git revert` (env via `_make_merge_env`); its docstring already notes `advance_branch_ref` refuses the non-FF move. The repair primitive extracts this logic to `coordination/`.
+
+## Branch Strategy
+
+- **Planning base branch**: `fix/merge-coord-rollback-transactionality`
+- **Merge target branch**: `fix/merge-coord-rollback-transactionality`
+- Execution worktrees are allocated per computed lane from `lanes.json`.
+
+## Subtasks & Detailed Guidance
+
+### Subtask T004 – MergeState.pending_coord_reconcile field
+
+- **Purpose**: The durable marker surface, persisted with the merge state, that survives `--resume`.
+- **Steps**:
+  1. Add `pending_coord_reconcile: dict[str, Any] | None = None` to `MergeState` (plain dict — `from_dict` rehydrates JSON objects as dicts; a nested dataclass would silently arrive as a dict).
+  2. Ensure `to_dict`/`from_dict` round-trip it (unknown-key drop already handles old files → `None`).
+  3. Confirm `save_state` writes the canonical runtime path; heal/doctor will load from there.
+  4. **Add `iter_pending_coord_reconcile_markers(repo_root) -> Iterable[MergeState]`** in `state.py` — scan `.kittify/runtime/merge/*/state.json` and yield states carrying a `pending_coord_reconcile` (state.py owns the runtime path shape). `load_state(mission_id=None)` **raises** `MergeAmbiguousStateError` on ≥2 states, so the doctor (WP04) CANNOT use it to enumerate — it consumes this iterator instead. Give it a focused test.
+- **Files**: `src/specify_cli/merge/state.py`
+- **Marker keys** (see data-model): `coord_ref`, `captured_sha`, `coord_worktree`, `stranded_wp_ids`, `revert_error`, `detected_at`.
+
+### Subtask T005 – coord_incoherent_done_wps (the single owner)
+
+- **Purpose**: The one committed-ref coherence reducer consumed by mark (WP03), heal (WP03), and doctor (WP04).
+- **Steps**:
+  1. New `src/specify_cli/coordination/coherence.py`: `coord_incoherent_done_wps(coord_ref: str, candidate_wps: list[str]) -> list[str]` — returns the subset of `candidate_wps` still reducing to `DONE` on the committed coord ref.
+  2. Read via `EventLogReadContract.coordination_branch_ref(...)` + the status reducer (mirror `_durable_done_wps_on_coordination_ref`). Do NOT read the working tree.
+  3. `candidate_wps` is always *this merge's* pre-target done write-set — callers pass it; the function never enumerates all WPs.
+- **Files**: `src/specify_cli/coordination/coherence.py` (NEW)
+
+### Subtask T006 – Coordination-homed git-revert repair primitive
+
+- **Purpose**: The single repair operation both executor-resume (WP03) and `doctor --fix` (WP04) call — avoids doctor→executor dependency inversion.
+- **Steps**:
+  1. In `coherence.py`, add a repair fn: forward `git revert` of the stranded coord commit in the coord worktree, env via `_make_merge_env`. **Import `_make_merge_env` function-locally** (module-top `from specify_cli.lanes.merge import _make_merge_env` creates the cycle `merge.executor → coordination.coherence → lanes.merge → merge.config`; executor.py:474 already uses the lazy pattern). NOT `advance_branch_ref` (refuses non-FF); no raw `git update-ref` (AC-B3).
+  2. Make it **strand-gated**: re-derive via `coord_incoherent_done_wps`; if the ref is already coherent, no-op (so a double-heal cannot revert the revert / re-apply `done`).
+  3. Keep it idempotent and safe under repeated invocation (NFR-002).
+- **Files**: `src/specify_cli/coordination/coherence.py`
+
+### Subtask T007 – ≥2-WP non-fakeability tests
+
+- **Purpose**: Pin the anti-fakeable contract (renata) at the owner level.
+- **Steps**:
+  1. New `tests/coordination/test_coherence.py`: a fixture with a committed coord ref where WP-A is `done`, WP-B is `approved`.
+  2. Assert `coord_incoherent_done_wps(ref, ["WP-A","WP-B"]) == ["WP-A"]` — WP-B excluded. A hardcoded `["WP01"]` and `== candidate_wps` both fail.
+  3. **Pre-existing-done exclusion (the only test that distinguishes the write-set from `all_wp_ids`):** a fixture where WP-C is `done` on the ref *from before this merge* (NOT in the candidate write-set) → `coord_incoherent_done_wps(ref, candidate_wps_without_WPC)` excludes WP-C. This is what proves passing `run.all_wp_ids` would be wrong.
+  4. Test the repair primitive's strand-gating: applied twice → byte-stable coord log; applied to an already-coherent ref → no-op.
+  5. Test `iter_pending_coord_reconcile_markers` returns all markers across ≥2 runtime state dirs (where `load_state(None)` would raise) — keep this test in the owned `tests/coordination/test_coherence.py` (do not edit the unowned `tests/` state suite).
+- **Files**: `tests/coordination/test_coherence.py` (NEW)
+
+## Definition of Done
+
+- [ ] `MergeState.pending_coord_reconcile` round-trips; old state files rehydrate to `None` (no migration).
+- [ ] `iter_pending_coord_reconcile_markers(repo_root)` enumerates markers across ≥2 runtime state dirs (tested); doctor (WP04) consumes it — `load_state(None)` is NOT used to enumerate.
+- [ ] `coord_incoherent_done_wps` derives from the committed ref only; `tests/coordination/test_coherence.py` green (≥2-WP specific-WP, **pre-existing-done exclusion**, gating, idempotency).
+- [ ] Repair primitive uses `git revert` + a **function-local** `_make_merge_env` import; no `advance_branch_ref`, no raw `update-ref`, no `coordination→merge` module-top import.
+- [ ] `ruff check .` + `mypy` clean on touched files; every new branch/helper has a focused test.
+- [ ] No executor.py or doctor edits (those are WP03/WP04).
+
+## Reviewer Guidance
+
+Confirm the derivation reads the committed ref (not the worktree); confirm the ≥2-WP test would fail
+a hardcoded or over-broad list; confirm the repair is `git revert` (not `advance_branch_ref`) and
+strand-gated; confirm the owner is a single function both future callers can share (no duplication
+seeded).
+
+## Activity Log
+
+- 2026-07-18T15:52:15Z – claude – shell_pid=643623 – Assigned agent via action command
+- 2026-07-18T16:04:24Z – claude – shell_pid=643623 – Foundations green
+- 2026-07-18T16:04:44Z – claude – shell_pid=674338 – Started review via action command
+- 2026-07-18T16:10:09Z – user – shell_pid=674338 – Review passed (renata): committed-ref derivation + pre-existing-done falsifier + layer-clean + git-revert transport all verified

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP03-executor-mark-heal-primitive.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP03-executor-mark-heal-primitive.md
@@ -1,0 +1,151 @@
+---
+work_package_id: WP03
+title: 'Executor: mark both sites + resume heal + restore primitive'
+dependencies: 
+- WP02
+requirement_refs:
+- FR-002
+- FR-005
+- FR-006
+- FR-008
+- FR-010
+tracker_refs: []
+planning_base_branch: fix/merge-coord-rollback-transactionality
+merge_target_branch: fix/merge-coord-rollback-transactionality
+branch_strategy: Planning artifacts for this mission were generated on fix/merge-coord-rollback-transactionality. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/merge-coord-rollback-transactionality unless the human explicitly redirects the landing branch.
+subtasks:
+- T008
+- T009
+- T010
+- T011
+phase: Phase 3 - Integration
+assignee: ''
+agent: "claude"
+shell_pid: "805610"
+shell_pid_created_at: "1784394010.93"
+history:
+- at: '2026-07-18T14:30:00Z'
+  actor: system
+  action: Prompt generated via /spec-kitty.tasks
+agent_profile: python-pedro
+authoritative_surface: src/specify_cli/merge/executor.py
+create_intent:
+- tests/merge/test_executor_coord_reconcile.py
+execution_mode: code_change
+model: ''
+owned_files:
+- src/specify_cli/merge/executor.py
+- tests/merge/test_executor_coord_reconcile.py
+role: implementer
+tags: []
+task_type: implement
+---
+
+# Work Package Prompt: WP03 – Executor: mark both sites + resume heal + restore primitive
+
+## ⚡ Do This First: Load Agent Profile
+
+Use the `/ad-hoc-profile-load` skill to load the agent profile specified in the frontmatter (or any user-defined profile), and behave according to its guidance before parsing the rest of this prompt.
+
+- **Profile**: `python-pedro`
+- **Role**: `implementer`
+- **Agent/tool**: `claude`
+
+---
+
+## Objectives & Success Criteria
+
+Wire the marker into the executor: mark-not-raise at **both** strand sites, a strand-gated resume
+heal, and co-locate the mark at the restore **primitive** so a future restore site cannot strand
+silently. This WP makes WP01's repros GREEN.
+
+- **FR-005**: rollback marks on any strand (revert-failure ≈500-514 AND bake ≈406-408) via one `_persist_coord_reconcile_marker`; does NOT raise; leg-b byte-restore still runs.
+- **FR-006**: dedicated `_heal_pending_coord_reconcile` at resume startup — strand-gated, atomic clear, idempotent; repair delegates to WP02's coordination primitive.
+- **FR-008 (structural half)**: co-locate the mark at a `_restore_and_guard_coord_coherence` restore primitive (inner-only; the FR-008 *guard test* is WP05).
+- **SC-006**: WP01's modified #2786 test now GREEN after the heal.
+- **NFR-001**: non-aborting merge byte-identical; **INV-5 #1827** (`test_executor_phase_boundary.py`) green.
+
+## Context & Constraints
+
+- Spec: [spec.md](../spec.md) FR-005, FR-006, FR-008 (structural), FR-010 (SaaS fence — do NOT add a compensating emit); research [D2 (grain/INV-5), D4 (mark-not-raise), D5 (coherence-gated), D11 (enumeration)](../research.md).
+- **Depends on WP02** — imports `MergeState.pending_coord_reconcile`, `coord_incoherent_done_wps`, and the repair primitive from `coordination/coherence.py`.
+- **INV-5 #1827 inner-only**: all new logic lives inside existing phases / `_restore_*` sites, or at resume startup BEFORE the phase list. Do NOT wrap the phase driver. If the heal is inserted *within* the driver, do NOT add it to the frozen `expected_order` list in `tests/merge/test_executor_phase_boundary.py` (it would flip the ratchet red on a correct change).
+- **AC-B3 / AC-F1**: repair is `git revert` via `_make_merge_env`; never raw `update-ref`; never `advance_branch_ref`.
+
+### Code anchors (verified on base)
+- `_record_merged_wps_done_for_merge` failure branch ≈406-408 (bake — byte-restore-without-revert).
+- `_revert_coord_done_commit` failure branch ≈500-514 (revert swallowed) — refactor to delegate revert to WP02's primitive.
+- `_restore_final_bookkeeping_snapshots` restores **primary** paths (`bookkeeping_projection.py`), not the coord worktree — so the marker derives the strand from the committed ref (via `coord_incoherent_done_wps`), NOT a worktree diff.
+- `done_marked_before_target` ≈350-352 gates coord topology to the pre-target ordering (why the third restore site ≈691 is dead-for-coord).
+- Resume path: `_reconcile_completed_wps_for_resume` — do NOT overload it; add a dedicated `_heal_pending_coord_reconcile`.
+
+## Branch Strategy
+
+- **Planning base branch**: `fix/merge-coord-rollback-transactionality`
+- **Merge target branch**: `fix/merge-coord-rollback-transactionality`
+- Execution worktrees are allocated per computed lane from `lanes.json`.
+
+## Subtasks & Detailed Guidance
+
+### Subtask T008 – Extract `_persist_coord_reconcile_marker`; mark at both strand sites
+
+- **Purpose**: One helper writes the marker at both strands so neither is silently swallowed.
+- **Steps**:
+  0. **FIRST add a `_MergeRunState` field capturing this merge's pre-target done write-set** (the WPs it committed `done` during THIS merge), populated at the `_record_merged_wps_done_for_merge` bake site. This is the `candidate_wps` — do NOT pass `run.all_wp_ids` (on a resume it includes WPs a prior attempt legitimately baked `done` → the heal would revert a legitimately-done WP; see data-model derivation contract).
+  1. `_persist_coord_reconcile_marker(run, error)` (CC≤15): compute `stranded_wp_ids = coord_incoherent_done_wps(coord_ref, run.pre_target_done_write_set)`; if non-empty, build the marker dict (coord_ref, captured_sha, coord_worktree, stranded_wp_ids, revert_error=str(error), detected_at) and `save_state`. Call `coordination.coherence.coord_incoherent_done_wps` — do NOT re-derive the coord reduction locally (that reopens the three-way drift → #2786-C).
+  2. Reached via the T010 restore primitive at the ≈500-514 revert-failure branch AND the ≈406-408 bake branch (T010 is the primary mechanism — see there; no double-mark).
+  3. **Mark-not-raise**: on the revert-failure branch, log+mark+continue (leg-b restore still runs). On the bake branch, mark BEFORE the re-raise so the strand is recorded.
+- **Files**: `src/specify_cli/merge/executor.py`
+
+### Subtask T009 – `_heal_pending_coord_reconcile` at resume startup
+
+- **Purpose**: Heal the strand deterministically and idempotently on `--resume`.
+- **Steps**:
+  1. At resume startup, load `MergeState`; if `pending_coord_reconcile` present, call the WP02 repair primitive (strand-gated: it re-derives via `coord_incoherent_done_wps` and no-ops if already coherent).
+  2. Clear the marker **atomically** with the heal (persist cleared state only after the revert commits). A crash between heal and clear → next resume re-derives coherent → no-op → clears (NFR-002).
+  3. Dedicated entry — NOT an overload of `_reconcile_completed_wps_for_resume`.
+- **Files**: `src/specify_cli/merge/executor.py`
+
+### Subtask T010 – Restore-primitive co-location (FR-008 structural)
+
+- **Purpose**: Convert "mark at two hand-picked callers" into "mark by construction at the restore seam" so a future restore site cannot strand silently. **This is the PRIMARY marking mechanism — T008's two marks are reached THROUGH this primitive, not added independently.**
+- **Steps**:
+  1. Introduce a thin `_restore_and_guard_coord_coherence(run, ...)` that wraps `_restore_final_bookkeeping_snapshots` and, when coord topology, invokes `_persist_coord_reconcile_marker` on any residual strand.
+  2. Route **every** `_restore_final_bookkeeping_snapshots` call-site through it. There are **SEVEN** (≈407/536/670/691/701/757/786) — enumerate by grep, don't trust a remembered count. Site ≈691 is dead-for-coord (inside `if not run.done_marked_before_target:` ≈679); **site ≈701 (`_project_status_bookkeeping_to_target` failure) is OUTSIDE that guard → coord-reachable and MUST be routed + markable** (double-confirmed live strand). This is **inner** (not the phase-driver wrapper INV-5 forbids).
+  3. Refactor `_revert_coord_done_commit` to delegate the actual `git revert` to WP02's coordination primitive (single repair authority).
+- **Files**: `src/specify_cli/merge/executor.py`
+
+### Subtask T011 – Executor integration tests
+
+- **Purpose**: Cover the mark/heal branches directly + confirm the marker names the specific WP.
+- **Steps**:
+  1. New `tests/merge/test_executor_coord_reconcile.py`: drive a revert-failure strand and a bake strand; assert the marker is written with the correct `stranded_wp_ids` (specific WP, ≥2-WP fixture); include the **pre-existing-done exclusion** case (a WP `done` before this merge is NOT in `stranded_wp_ids`); assert mark-not-raise (leg-b restore ran).
+  2. Assert `_heal_pending_coord_reconcile` heals to `committed == working` and clears the marker; run resume twice → byte-stable coord `status.events.jsonl`.
+  3. Confirm WP01's repros now pass; confirm `test_executor_phase_boundary.py` still green.
+- **Files**: `tests/merge/test_executor_coord_reconcile.py` (NEW)
+
+## Definition of Done
+
+- [ ] `_MergeRunState` carries this merge's pre-target done write-set; the marker's `candidate_wps` is that field, NOT `run.all_wp_ids`.
+- [ ] Marker `stranded_wp_ids == [the_stranded_one]` on a ≥2-WP fixture (coherent WP excluded) AND a pre-existing-done WP is excluded — falsifies a hardcoded list and `all_wp_ids`.
+- [ ] mark + heal call `coordination.coherence.coord_incoherent_done_wps`; executor.py does NOT re-derive the coord reduction locally (no inline `_durable_done_wps_on_coordination_ref`).
+- [ ] Marker written via the `_restore_and_guard_coord_coherence` primitive; ALL seven `_restore_final_bookkeeping_snapshots` sites routed through it (incl. ≈701); mark-not-raise; leg-b byte-restore preserved.
+- [ ] `_heal_pending_coord_reconcile` heals + clears atomically; resume-twice byte-identical (NFR-002).
+- [~] `_revert_coord_done_commit` delegates to the WP02 primitive — **DEFERRED to [#2797]** (documented deviation, both reviewers concur). Full delegation breaks the pre-existing pinned `test_executor_option_a_revert_helpers_2711.py`, and a clean shared-transport helper crosses WP ownership boundaries (coherence.py is WP02-owned). The anti-drift invariant is still met: the single strand-**derivation** authority (`coord_incoherent_done_wps`) is shared by mark+heal+doctor; only the raw `git revert` *transport* is duplicated across two differently-gated legs. #2797 tracks unifying the transport.
+- [ ] WP01 repros GREEN; `tests/merge/test_executor_phase_boundary.py` + `tests/specify_cli/merge/test_1827_baseline_regression.py` GREEN; heal NOT added to `expected_order`.
+- [ ] Happy-path merge byte-identical (NFR-001); `ruff`/`mypy` clean; touched functions ≤ CC-15.
+- [ ] No compensating SaaS emit added (FR-010 fence honored).
+
+## Reviewer Guidance
+
+Confirm the strand set is derived from the committed ref (not a worktree diff); mark-not-raise on the
+revert branch (leg-b runs); heal is strand-gated and atomic-clear (a blind `git revert
+captured_sha..HEAD` would re-apply `done` — reject that); INV-5 ratchet green and the heal is not in
+`expected_order`; happy path byte-identical.
+
+## Activity Log
+
+- 2026-07-18T16:10:56Z – claude – shell_pid=696516 – Assigned agent via action command
+- 2026-07-18T16:59:58Z – claude – shell_pid=696516 – Executor mark/heal/primitive: WP01 repros GREEN, 661 sweep pass, 7 sites routed (incl 701). Two deviations flagged (see review).
+- 2026-07-18T17:00:19Z – claude – shell_pid=805610 – Started review via action command
+- 2026-07-18T17:11:54Z – user – shell_pid=805610 – Dual-lens APPROVED (renata contracts + alphonso git-safety): DONE-coherence faithful, reset--hard bounded-safe, 7-site routing incl 701, WP01 repros green. DIR-044 transport-dedup documented+deferred to #2797.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP03-executor-mark-heal-primitive/review-cycle-1.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP03-executor-mark-heal-primitive/review-cycle-1.md
@@ -1,0 +1,30 @@
+---
+work_package_id: WP03
+review_cycle: 1
+verdict: approved
+reviewer: reviewer-renata+architect-alphonso
+reviewed_commit: a26245a857f8d6c8caf3cead4925f67caa14948c
+mission: merge-coord-rollback-transactionality-01KXTM59
+requirement_refs:
+- FR-005
+- FR-006
+- FR-008
+- FR-010
+---
+
+# WP03 Review — Cycle 1 — APPROVED (dual-lens)
+
+Two independent reviewers on the mission's highest-stakes WP (executor mark/heal/restore-primitive).
+
+## reviewer-renata (contract/test/semantics) — APPROVE
+- **DONE-coherence is a FAITHFUL #2786 contract, not a weakening (load-bearing judgment).** Proven load-bearing by running lane-b (WP03 absent) → both repros RED for the right reason (`committed=DONE vs working=APPROVED` split-brain); lane-c → GREEN. SC-006's literal contract is "committed==working re-reduced from the coord ref after heal" (does NOT mandate `approved`). The production heal-to-`approved`+clear is pinned separately (`test_bake_strand_resume_heals_and_clears`, real revert); clear-without-heal is pinned to FAIL. Non-blocking observation: the #2786 test in isolation is a weaker pin, but the companion suite closes the hole.
+- SC-007 candidate-set (write-set not `all_wp_ids`, pre-existing-done exclusion), seven-site routing (incl. 701), NFR-001/002, INV-5 (heal not in `expected_order`), FR-010 — all PASS. ruff/mypy/C901 clean; only 2 owned files.
+
+## architect-alphonso (git-safety/architecture) — SAFE-WITH-CHANGES
+- **`git reset --hard HEAD` is SAFE.** Guard chain (`_persist_coord_reconcile_marker` → `_coord_worktree_root` → `is_under_worktrees_segment`) bounds the reset to a `.worktrees/` coordination checkout — never the operator's main checkout or a code lane. Merge-lock serializes writers + status-emit auto-commits ⇒ only the byte-restore delta is destroyed. Revert-fail leaves coherent-at-done + marker (cosmetic on a non-authoritative worktree; committed ref is the coherence authority). LOW defense-in-depth: narrower `git checkout HEAD -- <paths>` (folded into #2797).
+- INV-5, seven-site routing, committed-ref derivation, FR-010 — all PASS.
+
+## Consolidated disposition
+Both lenses agree the code is **correct and safe**. The single gating item — the DIR-044 DoD "`_revert_coord_done_commit` delegates to the WP02 primitive" — ships **unmet but documented**: full delegation breaks the pinned `test_executor_option_a_revert_helpers_2711.py` and a clean shared-transport helper crosses WP ownership boundaries. Both reviewers concur this is a transport-dedup residual, **not** a re-opening of #2786-C (the single strand-**derivation** authority `coord_incoherent_done_wps` is preserved across mark+heal+doctor). Reconciled honestly: DoD marked deferred, data-model annotated, tracked as **#2797** (parent #1795). NOT green-washed.
+
+Verdict: **APPROVED** (commit `a26245a857f8d6c8caf3cead4925f67caa14948c`).

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check.md
@@ -1,0 +1,126 @@
+---
+work_package_id: WP04
+title: 'Doctor: canonical coordination check + --fix'
+dependencies: 
+- WP02
+requirement_refs:
+- FR-007
+tracker_refs: []
+planning_base_branch: fix/merge-coord-rollback-transactionality
+merge_target_branch: fix/merge-coord-rollback-transactionality
+branch_strategy: Planning artifacts for this mission were generated on fix/merge-coord-rollback-transactionality. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/merge-coord-rollback-transactionality unless the human explicitly redirects the landing branch.
+subtasks:
+- T012
+- T013
+- T014
+phase: Phase 3 - Integration
+assignee: ''
+shell_pid_created_at: "1784392503.55"
+agent: "claude"
+shell_pid: "749761"
+history:
+- at: '2026-07-18T14:30:00Z'
+  actor: system
+  action: Prompt generated via /spec-kitty.tasks
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/cli/commands/_coordination_doctor.py
+create_intent: []
+execution_mode: code_change
+model: ''
+owned_files:
+- src/specify_cli/cli/commands/_coordination_doctor.py
+- tests/specify_cli/cli/commands/test_coordination_doctor.py
+role: implementer
+tags: []
+task_type: implement
+---
+
+# Work Package Prompt: WP04 – Doctor: canonical coordination check + --fix
+
+## ⚡ Do This First: Load Agent Profile
+
+Use the `/ad-hoc-profile-load` skill to load the agent profile specified in the frontmatter (or any user-defined profile), and behave according to its guidance before parsing the rest of this prompt.
+
+- **Profile**: `implementer-ivan`
+- **Role**: `implementer`
+- **Agent/tool**: `claude`
+
+---
+
+## Objectives & Success Criteria
+
+Make the strand operator-detectable and repairable via the **canonical** coordination-doctor surface,
+re-verifying incoherence from the committed ref (never trusting marker-presence).
+
+- **FR-007**: register `_check_stranded_coord_revert` into `_collect_coordination_findings` (loads `MergeState`, re-verifies via `coord_incoherent_done_wps`, stable `error_code`, exit 1); `_fix_stranded_reverts` into the existing `--fix` dispatch.
+- **US2-S5 (negative AC)**: marker present but the committed ref re-derives coherent → exit 0 / no finding. This is the AC that separates re-verification from marker-presence — a doctor reporting on marker-presence alone FAILS it.
+- **DIR-044**: canonical surface only — no second coordination-doctor home under `src/specify_cli/doctor/`.
+
+## Context & Constraints
+
+- Spec: [spec.md](../spec.md) FR-007, US2 scenarios 4–5; research [D6 (re-verify), D9 (canonical surface)](../research.md).
+- **Depends on WP02** — imports `coord_incoherent_done_wps` + the repair primitive from `coordination/coherence.py`. Does NOT depend on WP03 (doctor is an independent detection/fix surface); can run in parallel with WP03.
+- The doctor tests may construct a `pending_coord_reconcile` marker directly in a fixture (no full merge needed).
+
+### Code anchors (verified on base)
+- `src/specify_cli/cli/commands/_coordination_doctor.py` — `run_coordination_health` (≈611), `_collect_coordination_findings` (≈525), `_emit_coordination_findings` + `DoctorFinding.error_code` (≈56/595), `--fix` dispatch `_fix_never_created_branches` (≈550) — mirror this for `_fix_stranded_reverts`.
+- Existing tests: `tests/specify_cli/cli/commands/test_coordination_doctor.py` — extend, don't fork.
+
+## Branch Strategy
+
+- **Planning base branch**: `fix/merge-coord-rollback-transactionality`
+- **Merge target branch**: `fix/merge-coord-rollback-transactionality`
+- Execution worktrees are allocated per computed lane from `lanes.json`.
+
+## Subtasks & Detailed Guidance
+
+### Subtask T012 – `_check_stranded_coord_revert` detection
+
+- **Purpose**: A coordination finding that re-verifies the strand from git, not from the marker.
+- **Steps**:
+  1. Enumerate markers via WP02's `iter_pending_coord_reconcile_markers(repo_root)` — do NOT call `load_state(mission_id=None)` (it *raises* `MergeAmbiguousStateError` on ≥2 markers) and do NOT re-implement the runtime-path scan (that is a second path authority / DIR-044 breach). For each `pending_coord_reconcile`, re-derive `coord_incoherent_done_wps(coord_ref, marker.stranded_wp_ids)`.
+  2. If a strand remains → emit a `DoctorFinding` with a stable `error_code` (e.g. `COORDINATION_STRANDED_COORD_REVERT`) and exit 1. If the ref is coherent → NO finding (stale marker).
+  3. Register into `_collect_coordination_findings` (do NOT create a new module).
+- **Files**: `src/specify_cli/cli/commands/_coordination_doctor.py`
+
+### Subtask T013 – `_fix_stranded_reverts` repair
+
+- **Purpose**: `doctor coordination --fix` heals the strand via the shared primitive.
+- **Steps**:
+  1. Add `_fix_stranded_reverts` to the existing `--fix` dispatch, delegating to WP02's coordination repair primitive (strand-gated; atomic marker clear).
+  2. `run_coordination_health` already carries an inline fix/re-collect block — extract `_apply_coordination_fixes(findings, repo_root)` so adding this second fixer keeps the dispatch ≤ CC-15.
+- **Files**: `src/specify_cli/cli/commands/_coordination_doctor.py`
+
+### Subtask T014 – Doctor tests (positive + negative)
+
+- **Purpose**: Pin the re-verification contract.
+- **Steps**:
+  1. Positive: marker + a still-`DONE`-on-ref strand → `doctor coordination --json` exits 1 with the stable `error_code`; `--fix` restores `committed == working`.
+  2. **Negative (the separator)**: marker present but ref re-derives coherent → exit 0, no finding. A marker-presence-only implementation fails this.
+  3. Idempotency: `--fix` twice → byte-stable coord log, marker cleared once.
+- **Files**: `tests/specify_cli/cli/commands/test_coordination_doctor.py`
+
+## Definition of Done
+
+- [ ] Check + fix registered in the canonical `_coordination_doctor.py` (no new `doctor/` home).
+- [ ] Markers enumerated via WP02's `iter_pending_coord_reconcile_markers` (NOT `load_state(None)`, NOT a re-implemented runtime-path scan); a ≥2-marker case is tested.
+- [ ] Positive AND negative doctor tests green; `--fix` idempotent.
+- [ ] Re-verification reads the committed ref (via `coord_incoherent_done_wps`), never marker-presence.
+- [ ] `_apply_coordination_fixes` extracted; `ruff`/`mypy` clean; fix-dispatch ≤ CC-15.
+- [ ] No executor.py / state.py / coherence.py edits (owned by WP02/WP03).
+
+## Reviewer Guidance
+
+The load-bearing check is the **negative** AC — confirm a marker-present-but-coherent case exits 0.
+Confirm the finding uses a stable `error_code`, the fix delegates to the shared primitive (no
+re-implemented revert), and everything lands in the canonical surface (no second authority).
+
+## Activity Log
+
+- 2026-07-18T16:11:45Z – claude – shell_pid=699757 – Assigned agent via action command
+- 2026-07-18T16:27:14Z – claude – shell_pid=699757 – Doctor check+fix: positive/negative/idempotency green (52 passed)
+- 2026-07-18T16:27:39Z – claude – shell_pid=735356 – Started review via action command
+- 2026-07-18T16:34:42Z – user – Moved to planned
+- 2026-07-18T16:35:18Z – claude – shell_pid=749761 – Started implementation via action command
+- 2026-07-18T16:37:34Z – claude – shell_pid=749761 – review-cycle-1 fix applied
+- 2026-07-18T16:40:32Z – user – shell_pid=749761 – review-cycle-2 APPROVED: noqa MUST-FIX resolved (0 noqa, ruff/mypy clean, 52 passed)

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check/review-cycle-1.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check/review-cycle-1.md
@@ -1,0 +1,38 @@
+---
+work_package_id: WP04
+review_cycle: 1
+verdict: rejected
+reviewer: reviewer-renata
+mission: merge-coord-rollback-transactionality-01KXTM59
+requirement_refs:
+- FR-007
+---
+
+# WP04 Review Cycle 1 — REJECT (reviewer-renata)
+
+**Verdict:** REJECT — single blocker. The entire FR-007 contract is implemented correctly
+(negative-AC re-verification, committed-ref derivation via `coord_incoherent_done_wps`,
+canonical-surface registration, `iter_pending_coord_reconcile_markers` enumeration, delegated
+idempotent `repair_coord_strand` fix). 52 tests green. Only a hygiene-suppression violation blocks.
+
+## [MUST-FIX] Remove 3 new `# noqa: E402` suppressions
+**File:** `tests/specify_cli/cli/commands/test_coordination_doctor.py:494,496,499`
+
+Three new `# noqa: E402` were added on the WP04-block imports:
+- `import json as _json`
+- `from specify_cli.coordination.coherence import ...`
+- `from specify_cli.merge.state import ...`
+
+This violates DIR-030 / the charter's suppression standing order ("Do NOT disable, suppress, or
+relax checks … no blanket `# noqa` … fix the code instead"). The stated rationale ("grouped with the
+WP04 block, not module-top") is a locality preference, NOT a "the check is genuinely wrong about
+correct code" justification — E402 is correct, and the suppression is avoidable.
+
+**Required change:** hoist those three imports to the module top (alongside the existing
+`import subprocess` / `from specify_cli.cli.commands import _coordination_doctor as cd`) and DELETE
+the three `# noqa: E402` comments. Trivial, no logic change. Re-run `ruff check` to confirm clean
+without the suppressions, and re-run the doctor test file to confirm still 52 passed.
+
+## Everything else: PASS (no changes needed)
+- Negative AC separator (`test_stranded_check_no_finding_for_stale_marker_over_coherent_ref`) — verified reds a marker-presence-only impl.
+- Re-verification reads committed ref; enumeration via `iter_pending_coord_reconcile_markers` (not `load_state(None)`); canonical surface only; fix delegates to `repair_coord_strand`; idempotent; positive AC exit-1 + stable `error_code`; `_apply_coordination_fixes` extracted; only 2 owned files touched.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check/review-cycle-2.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP04-doctor-coordination-check/review-cycle-2.md
@@ -1,0 +1,28 @@
+---
+work_package_id: WP04
+review_cycle: 2
+verdict: approved
+reviewer: reviewer-renata
+reviewed_commit: 4633b2a4164a319d7a12f10cb422de99b2c55f0d
+mission: merge-coord-rollback-transactionality-01KXTM59
+requirement_refs:
+- FR-007
+---
+
+# WP04 Review — Cycle 2 — APPROVED
+
+Cycle-1 (reviewer-renata) verified every load-bearing FR-007 contract PASS — negative-AC
+separator, committed-ref re-verification, `iter_pending_coord_reconcile_markers` enumeration,
+canonical-surface registration, delegated idempotent `repair_coord_strand` fix, positive-AC exit-1
++ stable error_code. The **sole** blocker was a mechanical hygiene item: 3 new `# noqa: E402`
+suppressions on WP04-block test imports (charter suppression standing order).
+
+## Resolution (objectively verified)
+The 3 imports were hoisted to the module top and the `# noqa: E402` comments deleted
+(commit `4633b2a4164a319d7a12f10cb422de99b2c55f0d`). Machine-checkable pass criteria confirmed:
+- `grep -c noqa` → **0** in the file
+- `ruff check` → **All checks passed!** (no suppressions)
+- `mypy` → **Success: no issues found**
+- `pytest tests/specify_cli/cli/commands/test_coordination_doctor.py` → **52 passed**
+
+No logic changed; the cycle-1 substantive review stands. Verdict: **APPROVED**.

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP05-class-closing-guard.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP05-class-closing-guard.md
@@ -1,0 +1,114 @@
+---
+work_package_id: WP05
+title: Behavioral class-closing invariant guard
+dependencies: 
+- WP03
+requirement_refs:
+- FR-008
+tracker_refs: []
+planning_base_branch: fix/merge-coord-rollback-transactionality
+merge_target_branch: fix/merge-coord-rollback-transactionality
+branch_strategy: Planning artifacts for this mission were generated on fix/merge-coord-rollback-transactionality. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/merge-coord-rollback-transactionality unless the human explicitly redirects the landing branch.
+subtasks:
+- T015
+- T016
+phase: Phase 4 - Class-closing guard
+assignee: ''
+agent: "claude"
+shell_pid: "858430"
+shell_pid_created_at: "1784395465.77"
+history:
+- at: '2026-07-18T14:30:00Z'
+  actor: system
+  action: Prompt generated via /spec-kitty.tasks
+agent_profile: reviewer-renata
+authoritative_surface: tests/architectural/
+create_intent:
+- tests/architectural/test_coord_rollback_coherence_guard.py
+execution_mode: code_change
+model: ''
+owned_files:
+- tests/architectural/test_coord_rollback_coherence_guard.py
+role: implementer
+tags: []
+task_type: implement
+---
+
+# Work Package Prompt: WP05 – Behavioral class-closing invariant guard
+
+## ⚡ Do This First: Load Agent Profile
+
+Use the `/ad-hoc-profile-load` skill to load the agent profile specified in the frontmatter (or any user-defined profile), and behave according to its guidance before parsing the rest of this prompt.
+
+- **Profile**: `reviewer-renata`
+- **Role**: `implementer`
+- **Agent/tool**: `claude`
+
+---
+
+## Objectives & Success Criteria
+
+Prove the whole defect class is closed — **behaviorally**. The guard must red when the mark is
+stubbed out, not merely check that a mark call exists in source.
+
+- **FR-008 / SC-005**: the guard reds under a **runtime-stubbed** mark (stub `_persist_coord_reconcile_marker`/`coord_incoherent_done_wps` to a no-op, drive a real bake-path strand, assert `strand-on-ref ∧ marker-absent`). A source-grep-for-the-call guard is a tautology and is **rejected**.
+- Enumerate all six `_restore_final_bookkeeping_snapshots` sites (≈406/536/670/691/757/786) and assert site ≈691 is dead-for-coord only via `done_marked_before_target` (≈350-352) — so a future refactor that flips that invariant is caught.
+
+## Context & Constraints
+
+- Spec: [spec.md](../spec.md) FR-008, SC-005; data-model [INV-COORD-ROLLBACK + enumeration](../data-model.md); research [D11](../research.md).
+- **Depends on WP03** — the mark behavior + restore primitive it exercises must exist.
+- INV-COORD-ROLLBACK is **behavioral**, so the guard must be behavioral. Do not assert on source text of the mark call.
+
+### Code anchors
+- The six restore sites in `src/specify_cli/merge/executor.py`; `done_marked_before_target` ≈350-352.
+- Reuse the bake-strand harness pattern from WP01 / `tests/merge/test_executor_coord_reconcile.py`.
+
+## Branch Strategy
+
+- **Planning base branch**: `fix/merge-coord-rollback-transactionality`
+- **Merge target branch**: `fix/merge-coord-rollback-transactionality`
+- Execution worktrees are allocated per computed lane from `lanes.json`.
+
+## Subtasks & Detailed Guidance
+
+### Subtask T015 – Behavioral falsifier
+
+- **Purpose**: The guard proves the marker path actually fires — by breaking it and observing the class reopen.
+- **Steps**:
+  1. New `tests/architectural/test_coord_rollback_coherence_guard.py`.
+  2. Drive a real bake-path strand (reuse the WP03 harness). Assert the invariant checker finds coherence (marker written → strand healed/recorded) with the real mark.
+  3. `monkeypatch` `_persist_coord_reconcile_marker` (and/or `coord_incoherent_done_wps`) to a no-op, re-drive the strand, and assert the checker now finds `strand-on-ref ∧ marker-absent` → the guard REDs. This is the non-vacuity proof.
+- **Files**: `tests/architectural/test_coord_rollback_coherence_guard.py` (NEW)
+
+### Subtask T016 – Restore-site enumeration + topology-gating assertion
+
+- **Purpose**: Make the guard class-closing over the enumeration, not just the two hand-picked sites.
+- **Steps**:
+  1. Enumerate the `_restore_final_bookkeeping_snapshots` call-sites **programmatically** — AST/regex over `executor.py`, NEVER a hardcoded count or line numbers (they drift as WP03 inserts helpers). There are **SEVEN** today (≈407/536/670/691/701/757/786).
+  2. Assert every site that can run under coord topology routes through `_restore_and_guard_coord_coherence` (the marking primitive).
+  3. Assert site ≈691 is reachable for coord only when `done_marked_before_target` is False (dead-for-coord); **assert site ≈701 (`_project_status_bookkeeping_to_target` failure) IS coord-reachable and IS routed through the primitive** — it is the live same-shape site my six-site list missed (double-confirmed). A new same-shape site added later that is NOT routed must red this test.
+- **Files**: `tests/architectural/test_coord_rollback_coherence_guard.py`
+
+## Definition of Done
+
+- [ ] Guard REDs under a runtime-stubbed mark and GREENs with the real mark (behavioral non-vacuity).
+- [ ] Restore sites enumerated **programmatically** (AST/regex, no hardcoded count/line-numbers); ≈691 asserted dead-for-coord AND ≈701 asserted coord-reachable-and-routed.
+- [ ] `@pytest.mark.regression` (+ appropriate arch marker); references FR-008.
+- [ ] `pytest tests/architectural/test_pytest_marker_convention.py` green; `ruff`/`mypy` clean.
+- [ ] Tests only — no production edits.
+
+## Reviewer Guidance
+
+The single most important check: does the guard actually RED when the mark is stubbed to a no-op? If
+it stays green under a stubbed mark, it is a tautology — reject. Confirm the enumeration is programmatic
+(seven sites today), ≈701 is asserted coord-reachable-and-routed (not omitted like the original
+six-site list), and ≈691's dead-for-coord gating is asserted — so the guard closes the class, not just
+the two known sites.
+
+## Activity Log
+
+- 2026-07-18T17:12:33Z – claude – shell_pid=831250 – Assigned agent via action command
+- 2026-07-18T17:24:35Z – claude – shell_pid=831250 – Behavioral class-closing guard: reds under stubbed mark, AST enumeration (7 sites, 701 routed, 691 dead-for-coord); 10 passed
+- 2026-07-18T17:24:43Z – claude – shell_pid=858430 – Started review via action command
+- 2026-07-18T17:31:02Z – user – shell_pid=858430 – Review passed (pedro): non-vacuity independently verified (reds under stubbed/deleted mark), AST enumeration drift-proof (7 sites, 701 routed, 691 dead-for-coord)

--- a/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP05-class-closing-guard/review-cycle-1.md
+++ b/kitty-specs/merge-coord-rollback-transactionality-01KXTM59/tasks/WP05-class-closing-guard/review-cycle-1.md
@@ -1,0 +1,21 @@
+---
+work_package_id: WP05
+review_cycle: 1
+verdict: approved
+reviewer: python-pedro
+reviewed_commit: b7cc971f4f98cb2fa3ef39ef94910820dcd34316
+mission: merge-coord-rollback-transactionality-01KXTM59
+requirement_refs:
+- FR-008
+---
+
+# WP05 Review — Cycle 1 — APPROVED (python-pedro)
+
+Independent review of the behavioral class-closing guard (implementer: reviewer-renata).
+
+- **Non-vacuity VERIFIED INDEPENDENTLY (SC-005, load-bearing).** Reviewer wrote his own probe bypassing the test's assertions: `[REAL mark] violation=[] → GREEN`; `[STUBBED/deleted mark] violation=['WP01'] → RED`. Stubbing `_persist_coord_reconcile_marker` to no-op is behaviorally identical to deleting the mark call at executor.py:703 — the invariant genuinely reopens. The `pytest.raises(match="INV-COORD-ROLLBACK")` blocks are non-tautological (checker reads the committed ref via the *unpatched* `coord_incoherent_done_wps`, each followed by a pinned `== {STRANDED_WP}`).
+- **Not a source-grep tautology.** Drives a real coord bake strand (WP01/WP03 harness); asserts committed-ref state + marker presence.
+- **AST enumeration correct + drift-proof.** Programmatic (ast.parse + parent-map, no line numbers); exactly ONE raw `_restore_final_bookkeeping_snapshots` call, inside `_restore_and_guard_coord_coherence`; seven routed sites; 691 dead-for-coord (inside `done_marked_before_target`), 701 coord-reachable-and-routed. Tripwires: un-routed new restore → red; un-routing 701 → red; flipping 691 gating → red.
+- **Hygiene PASS.** regression+architectural+git_repo+non_sandbox markers; FR-008 docstring; marker-convention green; ruff+mypy clean; only 1 owned file. The lone `# noqa: F401` is a narrowly-scoped, inline-justified import-order guard (legitimate).
+
+Verdict: **APPROVED** (commit `b7cc971f4f98cb2fa3ef39ef94910820dcd34316`).

--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -87,6 +87,38 @@ _STRANDED_COORD_REVERT_HINT = (
     "`done` commit(s) and clear the reconcile marker."
 )
 
+#: STUCK variant (FR-007): a live strand whose recorded coordination worktree no
+#: longer exists. ``--fix`` cannot revert it (there is nothing to run the revert
+#: in), so this surfaces as a distinct ``warning`` with a manual-recovery hint
+#: rather than an ``error`` whose ``next_step`` loops the user back to ``--fix``.
+_STRANDED_COORD_REVERT_STUCK_CODE = "COORDINATION_STRANDED_COORD_REVERT_STUCK"
+_STRANDED_COORD_REVERT_STUCK_HINT = (
+    "The coordination worktree recorded for this strand no longer exists, so "
+    "`--fix` cannot revert it. Recreate the coordination worktree (see the "
+    "worktree hints from `spec-kitty doctor coordination`) then re-run `--fix`, or "
+    "clear the stale `pending_coord_reconcile` marker after manually reconciling "
+    "the coordination ref."
+)
+
+#: An enumerated ``pending_coord_reconcile`` marker that cannot be parsed into
+#: repair inputs (missing ref/sha/worktree or an empty strand). A safety-net
+#: checker must NOT silently drop it — surface a ``warning`` (reviewer-renata LOW).
+_MARKER_UNPARSEABLE_CODE = "COORDINATION_RECONCILE_MARKER_UNPARSEABLE"
+_MARKER_UNPARSEABLE_HINT = (
+    "A `pending_coord_reconcile` marker could not be parsed into repair inputs "
+    "(missing coord_ref/captured_sha/coord_worktree or an empty strand). Inspect "
+    "`.kittify/runtime/merge/<mission_id>/state.json` and clear or repair the marker."
+)
+
+#: A marker whose mission slug cannot be resolved to a planning directory
+#: (unsafe/ambiguous handle). Surface a ``warning`` rather than a silent skip.
+_MARKER_UNRESOLVABLE_MISSION_CODE = "COORDINATION_RECONCILE_MISSION_UNRESOLVABLE"
+_MARKER_UNRESOLVABLE_MISSION_HINT = (
+    "A `pending_coord_reconcile` marker names a mission that could not be resolved "
+    "to a planning directory (unsafe or ambiguous handle). Run "
+    "`spec-kitty doctor identity --json` and disambiguate before re-running `--fix`."
+)
+
 
 def _detect_git_version() -> tuple[int, int] | None:
     """Return ``(major, minor)`` of the local git binary, or ``None`` on failure."""
@@ -627,6 +659,118 @@ def _parse_reconcile_marker(
     return coord_ref, captured_sha, coord_worktree, [str(w) for w in stranded]
 
 
+def _marker_extra(state: object, coord_ref: str, captured_sha: str,
+                  coord_worktree: str, candidate_wps: list[str],
+                  remaining: list[str]) -> dict[str, object]:
+    """Assemble the stable ``extra`` payload shared by the strand findings."""
+    return {
+        "mission_id": getattr(state, "mission_id", None),
+        "mission_slug": getattr(state, "mission_slug", None),
+        "coord_ref": coord_ref,
+        "captured_sha": captured_sha,
+        "coord_worktree": coord_worktree,
+        "candidate_wps": candidate_wps,
+        "stranded_wp_ids": remaining,
+    }
+
+
+def _finding_for_reconcile_marker(
+    state: object, repo_root: Path
+) -> DoctorFinding | None:
+    """Re-verify one ``pending_coord_reconcile`` marker → a single finding (or None).
+
+    Returns ``None`` only for a genuinely-stale marker (the committed ref
+    re-derives coherent, US2-S5). Every other terminal path yields a finding — a
+    safety-net checker must never silently drop a marker (reviewer-renata LOW):
+
+    * un-parseable marker → ``warning`` (:data:`_MARKER_UNPARSEABLE_CODE`);
+    * unresolvable/ambiguous mission slug → ``warning``
+      (:data:`_MARKER_UNRESOLVABLE_MISSION_CODE`);
+    * live strand whose coord worktree is pruned → ``warning`` STUCK
+      (:data:`_STRANDED_COORD_REVERT_STUCK_CODE`) — ``--fix`` cannot revert it;
+    * live strand with an intact worktree → ``error``
+      (:data:`_STRANDED_COORD_REVERT_CODE`), healable by ``--fix``.
+    """
+    from mission_runtime import MissionArtifactKind
+
+    from specify_cli.coordination.coherence import coord_incoherent_done_wps
+    from specify_cli.missions._read_path_resolver import (
+        MissionSelectorAmbiguous,
+        resolve_planning_read_dir,
+    )
+
+    mission_slug = getattr(state, "mission_slug", None)
+    mission_id = getattr(state, "mission_id", None)
+    base_extra: dict[str, object] = {"mission_id": mission_id, "mission_slug": mission_slug}
+
+    parsed = _parse_reconcile_marker(getattr(state, "pending_coord_reconcile", None))
+    if parsed is None:
+        return DoctorFinding(
+            severity="warning",
+            message=(
+                f"Mission {mission_slug!r} carries a `pending_coord_reconcile` marker "
+                "that could not be parsed into repair inputs."
+            ),
+            next_step=_MARKER_UNPARSEABLE_HINT,
+            error_code=_MARKER_UNPARSEABLE_CODE,
+            extra=base_extra,
+        )
+    coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
+    try:
+        # Same canonicalizing WORK_PACKAGE_TASK read seam the executor's mark/heal
+        # use (folds a bare handle → `<slug>-<mid8>`), so all three strand sites
+        # resolve the identical feature_dir — a raw resolver here would read a
+        # divergent path on a non-canonical slug and silently miss the strand.
+        feature_dir = resolve_planning_read_dir(
+            repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
+        )
+    except (ValueError, MissionSelectorAmbiguous):
+        # Unsafe/ambiguous mission_slug — surface a warning rather than silently drop.
+        return DoctorFinding(
+            severity="warning",
+            message=(
+                f"Mission {mission_slug!r} on a `pending_coord_reconcile` marker "
+                "could not be resolved to a planning directory."
+            ),
+            next_step=_MARKER_UNRESOLVABLE_MISSION_HINT,
+            error_code=_MARKER_UNRESOLVABLE_MISSION_CODE,
+            extra=base_extra,
+        )
+    remaining = coord_incoherent_done_wps(
+        coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir,
+    )
+    if not remaining:
+        # Stale marker: the committed ref re-derives coherent (US2-S5). No finding.
+        return None
+    extra = _marker_extra(state, coord_ref, captured_sha, coord_worktree, candidate_wps, remaining)
+    if not Path(coord_worktree).exists():
+        # Live strand, but the coord worktree is pruned — `--fix` cannot revert it.
+        # Surface a distinct STUCK warning instead of an error whose hint loops the
+        # user back to a `--fix` that can never succeed (FR-007).
+        return DoctorFinding(
+            severity="warning",
+            message=(
+                f"Coordination ref {coord_ref!r} for mission {mission_slug!r} still "
+                f"strands WP(s) {remaining} at `done`, but its coordination worktree "
+                f"{coord_worktree!r} no longer exists — `--fix` cannot revert it."
+            ),
+            next_step=_STRANDED_COORD_REVERT_STUCK_HINT,
+            error_code=_STRANDED_COORD_REVERT_STUCK_CODE,
+            extra=extra,
+        )
+    return DoctorFinding(
+        severity="error",
+        message=(
+            f"Coordination ref {coord_ref!r} for mission "
+            f"{mission_slug!r} still reduces WP(s) {remaining} to "
+            "`done` after a merge rollback (expected `approved`)."
+        ),
+        next_step=_STRANDED_COORD_REVERT_HINT,
+        error_code=_STRANDED_COORD_REVERT_CODE,
+        extra=extra,
+    )
+
+
 def _check_stranded_coord_revert(repo_root: Path) -> list[DoctorFinding]:
     """FR-007: re-verify each reconcile marker against the **committed** coord ref.
 
@@ -634,64 +778,20 @@ def _check_stranded_coord_revert(repo_root: Path) -> list[DoctorFinding]:
     :func:`~specify_cli.merge.state.iter_pending_coord_reconcile_markers` — NOT
     ``load_state(mission_id=None)`` (it *raises* ``MergeAmbiguousStateError`` on
     >=2 markers) and NOT a re-implemented runtime-path scan (a second path
-    authority / DIR-044 breach). For each marker the strand is **re-derived from
-    the committed ref** via
-    :func:`~specify_cli.coordination.coherence.coord_incoherent_done_wps` — never
-    from marker-presence. Only a strand that still reduces to ``DONE`` on the ref
-    yields an ``error`` finding; a marker whose ref re-derives coherent is stale
-    and yields NO finding (US2-S5, the load-bearing negative AC).
+    authority / DIR-044 breach). Each marker is re-verified by
+    :func:`_finding_for_reconcile_marker`, which re-derives the strand **from the
+    committed ref** (never from marker-presence) and returns exactly one finding —
+    ``error`` for a healable live strand, ``warning`` for a pruned-worktree STUCK
+    strand or an un-parseable/unresolvable marker, and ``None`` only for a
+    genuinely-stale marker (US2-S5, the load-bearing negative AC).
     """
-    from mission_runtime import MissionArtifactKind
-
-    from specify_cli.coordination.coherence import coord_incoherent_done_wps
     from specify_cli.merge.state import iter_pending_coord_reconcile_markers
-    from specify_cli.missions._read_path_resolver import (
-        MissionSelectorAmbiguous,
-        resolve_planning_read_dir,
-    )
 
     findings: list[DoctorFinding] = []
     for state in iter_pending_coord_reconcile_markers(repo_root):
-        parsed = _parse_reconcile_marker(state.pending_coord_reconcile)
-        if parsed is None:
-            continue
-        coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
-        try:
-            # Same canonicalizing WORK_PACKAGE_TASK read seam the executor's mark/heal
-            # use (folds a bare handle → `<slug>-<mid8>`), so all three strand sites
-            # resolve the identical feature_dir — a raw resolver here would read a
-            # divergent path on a non-canonical slug and silently miss the strand.
-            feature_dir = resolve_planning_read_dir(
-                repo_root, state.mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
-            )
-        except (ValueError, MissionSelectorAmbiguous):
-            # Unsafe/ambiguous mission_slug — skip rather than crash the doctor.
-            continue
-        remaining = coord_incoherent_done_wps(
-            coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir,
-        )
-        if not remaining:
-            # Stale marker: the committed ref re-derives coherent (US2-S5). No finding.
-            continue
-        findings.append(DoctorFinding(
-            severity="error",
-            message=(
-                f"Coordination ref {coord_ref!r} for mission "
-                f"{state.mission_slug!r} still reduces WP(s) {remaining} to "
-                "`done` after a merge rollback (expected `approved`)."
-            ),
-            next_step=_STRANDED_COORD_REVERT_HINT,
-            error_code=_STRANDED_COORD_REVERT_CODE,
-            extra={
-                "mission_id": state.mission_id,
-                "mission_slug": state.mission_slug,
-                "coord_ref": coord_ref,
-                "captured_sha": captured_sha,
-                "coord_worktree": coord_worktree,
-                "candidate_wps": candidate_wps,
-                "stranded_wp_ids": remaining,
-            },
-        ))
+        finding = _finding_for_reconcile_marker(state, repo_root)
+        if finding is not None:
+            findings.append(finding)
     return findings
 
 
@@ -706,15 +806,18 @@ def _clear_pending_marker(repo_root: Path, mission_id: str) -> None:
     save_state(state, repo_root)
 
 
-def _fix_stranded_reverts(findings: list[DoctorFinding], repo_root: Path) -> list[str]:
-    """Heal every live-strand finding via WP02's shared repair primitive.
+def _heal_one_strand(
+    f: DoctorFinding, repo_root: Path
+) -> tuple[str | None, DoctorFinding | None]:
+    """Attempt to heal one live-strand finding.
 
-    Delegates to
-    :func:`~specify_cli.coordination.coherence.repair_coord_strand` (strand-gated:
-    it re-derives the strand from the committed ref, so a double-heal cannot
-    revert the revert) and clears the marker only on a genuine heal — so
-    ``--fix`` run twice is byte-stable and the marker is cleared exactly once.
-    Never re-implements the revert. Returns the mission slugs healed on this call.
+    Returns ``(healed_slug, warning)``: at most one is non-``None``. A genuine heal
+    yields ``(slug, None)`` (and clears the marker); an un-parseable marker, an
+    unresolvable mission, or a repair that reports a pruned worktree yields
+    ``(None, warning)`` — a safety-net fixer must never silently drop a marker.
+    ``head_advanced`` / revert-error outcomes yield ``(None, None)``: the strand is
+    intentionally left for the next pass and the check's persistent ``error``
+    finding still surfaces it.
     """
     from mission_runtime import MissionArtifactKind
 
@@ -724,37 +827,89 @@ def _fix_stranded_reverts(findings: list[DoctorFinding], repo_root: Path) -> lis
         resolve_planning_read_dir,
     )
 
+    parsed = _parse_reconcile_marker(f.extra)
+    mission_id = f.extra.get("mission_id")
+    mission_slug = f.extra.get("mission_slug")
+    if parsed is None or not isinstance(mission_id, str) or not isinstance(mission_slug, str):
+        return None, DoctorFinding(
+            severity="warning",
+            message="A live-strand finding carried an unparseable reconcile marker.",
+            next_step=_MARKER_UNPARSEABLE_HINT,
+            error_code=_MARKER_UNPARSEABLE_CODE,
+            extra={"mission_id": mission_id, "mission_slug": mission_slug},
+        )
+    coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
+    try:
+        # Mirror the check + the executor: the canonicalizing WORK_PACKAGE_TASK
+        # read seam (one feature_dir authority across all three strand sites).
+        feature_dir = resolve_planning_read_dir(
+            repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
+        )
+    except (ValueError, MissionSelectorAmbiguous):
+        return None, DoctorFinding(
+            severity="warning",
+            message=(
+                f"Mission {mission_slug!r} on a live-strand finding could not be "
+                "resolved to a planning directory; skipping its heal."
+            ),
+            next_step=_MARKER_UNRESOLVABLE_MISSION_HINT,
+            error_code=_MARKER_UNRESOLVABLE_MISSION_CODE,
+            extra={"mission_id": mission_id, "mission_slug": mission_slug},
+        )
+    outcome = repair_coord_strand(
+        coord_ref=coord_ref,
+        captured_sha=captured_sha,
+        coord_worktree=Path(coord_worktree),
+        candidate_wps=candidate_wps,
+        repo_root=repo_root,
+        feature_dir=feature_dir,
+    )
+    if outcome.healed:
+        _clear_pending_marker(repo_root, mission_id)
+        return mission_slug, None
+    if outcome.worktree_missing:
+        return None, DoctorFinding(
+            severity="warning",
+            message=(
+                f"Coordination worktree {coord_worktree!r} for mission "
+                f"{mission_slug!r} no longer exists — `--fix` cannot revert its strand."
+            ),
+            next_step=_STRANDED_COORD_REVERT_STUCK_HINT,
+            error_code=_STRANDED_COORD_REVERT_STUCK_CODE,
+            extra={"mission_id": mission_id, "mission_slug": mission_slug},
+        )
+    return None, None
+
+
+def _fix_stranded_reverts(
+    findings: list[DoctorFinding], repo_root: Path
+) -> tuple[list[str], list[DoctorFinding]]:
+    """Heal every live-strand finding via WP02's shared repair primitive.
+
+    Delegates to
+    :func:`~specify_cli.coordination.coherence.repair_coord_strand` (strand-gated +
+    self-sufficient: it re-derives the strand from the committed ref, HEAD-freshness
+    guards the concurrency TOCTOU, and it performs the scoped clean-to-HEAD so the
+    forward revert applies over the byte-restored dirty tree) and clears the marker
+    only on a genuine heal — so ``--fix`` run twice is byte-stable and the marker is
+    cleared exactly once. Never re-implements the revert.
+
+    Returns ``(healed_slugs, warnings)``: the mission slugs healed on this call, and
+    ``warning``-severity findings for markers that could not be healed and would
+    otherwise be silently dropped (unparseable marker, unresolvable mission, pruned
+    coord worktree).
+    """
     healed: list[str] = []
+    warnings: list[DoctorFinding] = []
     for f in findings:
         if f.error_code != _STRANDED_COORD_REVERT_CODE:
             continue
-        parsed = _parse_reconcile_marker(f.extra)
-        mission_id = f.extra.get("mission_id")
-        mission_slug = f.extra.get("mission_slug")
-        if parsed is None or not isinstance(mission_id, str) or not isinstance(mission_slug, str):
-            continue
-        coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
-        try:
-            # Mirror the check + the executor: the canonicalizing WORK_PACKAGE_TASK
-            # read seam (one feature_dir authority across all three strand sites).
-            feature_dir = resolve_planning_read_dir(
-                repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
-            )
-        except (ValueError, MissionSelectorAmbiguous):
-            # Unsafe/ambiguous mission_slug — skip rather than crash the fix pass.
-            continue
-        outcome = repair_coord_strand(
-            coord_ref=coord_ref,
-            captured_sha=captured_sha,
-            coord_worktree=Path(coord_worktree),
-            candidate_wps=candidate_wps,
-            repo_root=repo_root,
-            feature_dir=feature_dir,
-        )
-        if outcome.healed:
-            _clear_pending_marker(repo_root, mission_id)
-            healed.append(mission_slug)
-    return healed
+        slug, warning = _heal_one_strand(f, repo_root)
+        if slug is not None:
+            healed.append(slug)
+        if warning is not None:
+            warnings.append(warning)
+    return healed, warnings
 
 
 def _apply_never_created_fix(findings: list[DoctorFinding], repo_root: Path) -> None:
@@ -776,24 +931,37 @@ def _apply_never_created_fix(findings: list[DoctorFinding], repo_root: Path) -> 
         )
 
 
-def _apply_stranded_revert_fix(findings: list[DoctorFinding], repo_root: Path) -> None:
-    """Heal live coord strands (FR-007) via the shared repair primitive."""
-    for slug in _fix_stranded_reverts(findings, repo_root):
+def _apply_stranded_revert_fix(
+    findings: list[DoctorFinding], repo_root: Path
+) -> list[DoctorFinding]:
+    """Heal live coord strands (FR-007) via the shared repair primitive.
+
+    Returns the ``warning`` findings for strands that could not be healed (pruned
+    worktree / unparseable / unresolvable) so the caller can fold them into the
+    post-fix findings — a safety-net fixer never silently drops a marker.
+    """
+    healed, warnings = _fix_stranded_reverts(findings, repo_root)
+    for slug in healed:
         console.print(
             f"[green]Healed:[/green] reverted the stranded coordination `done` and "
             f"cleared the reconcile marker for {slug}."
         )
+    return warnings
 
 
-def _apply_coordination_fixes(findings: list[DoctorFinding], repo_root: Path) -> None:
+def _apply_coordination_fixes(
+    findings: list[DoctorFinding], repo_root: Path
+) -> list[DoctorFinding]:
     """Run every registered ``--fix`` handler over the collected findings.
 
     Extracted so adding a fixer keeps the caller (:func:`run_coordination_health`)
     and this dispatch each well under the CC-15 ceiling. Each handler is
-    error-code-scoped and idempotent, so the order is irrelevant.
+    error-code-scoped and idempotent, so the order is irrelevant. Returns any
+    ``warning`` findings the fixers raised (e.g. a strand whose coord worktree is
+    pruned) so the entrypoint surfaces them in the post-fix output.
     """
     _apply_never_created_fix(findings, repo_root)
-    _apply_stranded_revert_fix(findings, repo_root)
+    return _apply_stranded_revert_fix(findings, repo_root)
 
 
 def _emit_coordination_findings(findings: list[DoctorFinding], json_output: bool) -> None:
@@ -840,9 +1008,13 @@ def run_coordination_health(json_output: bool, fix: bool = False) -> None:
     findings = _collect_coordination_findings(repo_root)
 
     if fix:
-        _apply_coordination_fixes(findings, repo_root)
-        # Re-collect findings after fix so the exit code reflects the new state.
+        fix_warnings = _apply_coordination_fixes(findings, repo_root)
+        # Re-collect findings after fix so the exit code reflects the new state,
+        # then fold in any warnings the fixers raised for markers they could not
+        # heal (pruned worktree / unparseable / unresolvable) — these must not be
+        # silently dropped by the re-collect.
         findings = _collect_coordination_findings(repo_root)
+        findings.extend(fix_warnings)
 
     _emit_coordination_findings(findings, json_output)
     raise typer.Exit(1 if any(f.severity == "error" for f in findings) else 0)

--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -74,6 +74,19 @@ _COORD_BRANCH_ABSENT_HINT = (
     "`spec-kitty migrate backfill-topology` to re-derive and persist the topology."
 )
 
+#: Stable error code for a coord strand that survives a rollback (#2786 / #2367-B,
+#: FR-007). Emitted only when the committed coordination ref *still* reduces a
+#: this-merge ``done`` WP to ``DONE`` — a marker whose ref re-derives coherent is
+#: stale and yields NO finding (US2-S5 negative AC). Downstream tooling keys off
+#: this constant, so it must stay stable.
+_STRANDED_COORD_REVERT_CODE = "COORDINATION_STRANDED_COORD_REVERT"
+
+#: Recovery hint for a live strand — points at the ``--fix`` repair path.
+_STRANDED_COORD_REVERT_HINT = (
+    "Run `spec-kitty doctor coordination --fix` to revert the stranded coordination "
+    "`done` commit(s) and clear the reconcile marker."
+)
+
 
 def _detect_git_version() -> tuple[int, int] | None:
     """Return ``(major, minor)`` of the local git binary, or ``None`` on failure."""
@@ -528,6 +541,8 @@ def _collect_coordination_findings(repo_root: Path) -> list[DoctorFinding]:
     findings.extend(_check_git_version())
     # FR-035 (#1772 Bug 0): repo-level tracked-.worktrees/ hygiene check.
     findings.extend(_check_tracked_worktrees_content(repo_root))
+    # FR-007 (#2786 / #2367-B): repo-level stranded-coord-revert re-verification.
+    findings.extend(_check_stranded_coord_revert(repo_root))
 
     specs_dir = repo_root / KITTY_SPECS_DIR
     if not specs_dir.exists():
@@ -584,6 +599,179 @@ def _fix_never_created_branches(findings: list[DoctorFinding]) -> list[str]:
     return fixed
 
 
+def _parse_reconcile_marker(
+    marker: dict[str, object] | None,
+) -> tuple[str, str, str, list[str]] | None:
+    """Validate a ``pending_coord_reconcile`` marker into repair inputs.
+
+    Returns ``(coord_ref, captured_sha, coord_worktree, stranded_wp_ids)`` or
+    ``None`` when the marker is malformed (missing ref/sha/worktree or an empty
+    strand — an empty strand is not a strand, per the data-model derivation
+    contract). ``coord_worktree`` stays a ``str`` so the finding's ``extra`` dict
+    remains JSON-serializable; the fixer rehydrates it to a ``Path``.
+    """
+    if not marker:
+        return None
+    coord_ref = marker.get("coord_ref")
+    captured_sha = marker.get("captured_sha")
+    coord_worktree = marker.get("coord_worktree")
+    stranded = marker.get("stranded_wp_ids")
+    if not (isinstance(coord_ref, str) and coord_ref):
+        return None
+    if not (isinstance(captured_sha, str) and captured_sha):
+        return None
+    if not (isinstance(coord_worktree, str) and coord_worktree):
+        return None
+    if not (isinstance(stranded, list) and stranded):
+        return None
+    return coord_ref, captured_sha, coord_worktree, [str(w) for w in stranded]
+
+
+def _check_stranded_coord_revert(repo_root: Path) -> list[DoctorFinding]:
+    """FR-007: re-verify each reconcile marker against the **committed** coord ref.
+
+    Enumerate ``pending_coord_reconcile`` markers via WP02's
+    :func:`~specify_cli.merge.state.iter_pending_coord_reconcile_markers` — NOT
+    ``load_state(mission_id=None)`` (it *raises* ``MergeAmbiguousStateError`` on
+    >=2 markers) and NOT a re-implemented runtime-path scan (a second path
+    authority / DIR-044 breach). For each marker the strand is **re-derived from
+    the committed ref** via
+    :func:`~specify_cli.coordination.coherence.coord_incoherent_done_wps` — never
+    from marker-presence. Only a strand that still reduces to ``DONE`` on the ref
+    yields an ``error`` finding; a marker whose ref re-derives coherent is stale
+    and yields NO finding (US2-S5, the load-bearing negative AC).
+    """
+    from specify_cli.coordination.coherence import coord_incoherent_done_wps
+    from specify_cli.merge.state import iter_pending_coord_reconcile_markers
+    from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+
+    findings: list[DoctorFinding] = []
+    for state in iter_pending_coord_reconcile_markers(repo_root):
+        parsed = _parse_reconcile_marker(state.pending_coord_reconcile)
+        if parsed is None:
+            continue
+        coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
+        try:
+            feature_dir = primary_feature_dir_for_mission(repo_root, state.mission_slug)
+        except ValueError:
+            # Unsafe mission_slug path segment — skip rather than crash the doctor.
+            continue
+        remaining = coord_incoherent_done_wps(
+            coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir,
+        )
+        if not remaining:
+            # Stale marker: the committed ref re-derives coherent (US2-S5). No finding.
+            continue
+        findings.append(DoctorFinding(
+            severity="error",
+            message=(
+                f"Coordination ref {coord_ref!r} for mission "
+                f"{state.mission_slug!r} still reduces WP(s) {remaining} to "
+                "`done` after a merge rollback (expected `approved`)."
+            ),
+            next_step=_STRANDED_COORD_REVERT_HINT,
+            error_code=_STRANDED_COORD_REVERT_CODE,
+            extra={
+                "mission_id": state.mission_id,
+                "mission_slug": state.mission_slug,
+                "coord_ref": coord_ref,
+                "captured_sha": captured_sha,
+                "coord_worktree": coord_worktree,
+                "candidate_wps": candidate_wps,
+                "stranded_wp_ids": remaining,
+            },
+        ))
+    return findings
+
+
+def _clear_pending_marker(repo_root: Path, mission_id: str) -> None:
+    """Atomically clear a mission's ``pending_coord_reconcile`` marker after a heal."""
+    from specify_cli.merge.state import load_state, save_state
+
+    state = load_state(repo_root, mission_id=mission_id)
+    if state is None:
+        return
+    state.pending_coord_reconcile = None
+    save_state(state, repo_root)
+
+
+def _fix_stranded_reverts(findings: list[DoctorFinding], repo_root: Path) -> list[str]:
+    """Heal every live-strand finding via WP02's shared repair primitive.
+
+    Delegates to
+    :func:`~specify_cli.coordination.coherence.repair_coord_strand` (strand-gated:
+    it re-derives the strand from the committed ref, so a double-heal cannot
+    revert the revert) and clears the marker only on a genuine heal — so
+    ``--fix`` run twice is byte-stable and the marker is cleared exactly once.
+    Never re-implements the revert. Returns the mission slugs healed on this call.
+    """
+    from specify_cli.coordination.coherence import repair_coord_strand
+    from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+
+    healed: list[str] = []
+    for f in findings:
+        if f.error_code != _STRANDED_COORD_REVERT_CODE:
+            continue
+        parsed = _parse_reconcile_marker(f.extra)
+        mission_id = f.extra.get("mission_id")
+        mission_slug = f.extra.get("mission_slug")
+        if parsed is None or not isinstance(mission_id, str) or not isinstance(mission_slug, str):
+            continue
+        coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
+        feature_dir = primary_feature_dir_for_mission(repo_root, mission_slug)
+        outcome = repair_coord_strand(
+            coord_ref=coord_ref,
+            captured_sha=captured_sha,
+            coord_worktree=Path(coord_worktree),
+            candidate_wps=candidate_wps,
+            repo_root=repo_root,
+            feature_dir=feature_dir,
+        )
+        if outcome.healed:
+            _clear_pending_marker(repo_root, mission_id)
+            healed.append(mission_slug)
+    return healed
+
+
+def _apply_never_created_fix(findings: list[DoctorFinding], repo_root: Path) -> None:
+    """Flatten missions with a stale ``coordination_branch`` key, then re-backfill topology."""
+    fixable = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
+    if not fixable:
+        return
+    fixed_slugs = _fix_never_created_branches(fixable)
+    for slug in fixed_slugs:
+        console.print(
+            f"[green]Flattened:[/green] removed coordination_branch from {slug}/meta.json"
+        )
+    if fixed_slugs:
+        from specify_cli.migration.backfill_topology import backfill_topology_repo
+        backfill_topology_repo(repo_root)
+        console.print(
+            "[green]Topology backfilled.[/green] "
+            "Run `spec-kitty doctor coordination` to verify."
+        )
+
+
+def _apply_stranded_revert_fix(findings: list[DoctorFinding], repo_root: Path) -> None:
+    """Heal live coord strands (FR-007) via the shared repair primitive."""
+    for slug in _fix_stranded_reverts(findings, repo_root):
+        console.print(
+            f"[green]Healed:[/green] reverted the stranded coordination `done` and "
+            f"cleared the reconcile marker for {slug}."
+        )
+
+
+def _apply_coordination_fixes(findings: list[DoctorFinding], repo_root: Path) -> None:
+    """Run every registered ``--fix`` handler over the collected findings.
+
+    Extracted so adding a fixer keeps the caller (:func:`run_coordination_health`)
+    and this dispatch each well under the CC-15 ceiling. Each handler is
+    error-code-scoped and idempotent, so the order is irrelevant.
+    """
+    _apply_never_created_fix(findings, repo_root)
+    _apply_stranded_revert_fix(findings, repo_root)
+
+
 def _emit_coordination_findings(findings: list[DoctorFinding], json_output: bool) -> None:
     """Render coordination findings as JSON or coloured human output."""
     if json_output:
@@ -628,22 +816,9 @@ def run_coordination_health(json_output: bool, fix: bool = False) -> None:
     findings = _collect_coordination_findings(repo_root)
 
     if fix:
-        fixable = [f for f in findings if f.error_code == "COORDINATION_WORKTREE_NEVER_CREATED"]
-        if fixable:
-            fixed_slugs = _fix_never_created_branches(fixable)
-            for slug in fixed_slugs:
-                console.print(
-                    f"[green]Flattened:[/green] removed coordination_branch from {slug}/meta.json"
-                )
-            if fixed_slugs:
-                from specify_cli.migration.backfill_topology import backfill_topology_repo
-                backfill_topology_repo(repo_root)
-                console.print(
-                    "[green]Topology backfilled.[/green] "
-                    "Run `spec-kitty doctor coordination` to verify."
-                )
-            # Re-collect findings after fix so the exit code reflects the new state.
-            findings = _collect_coordination_findings(repo_root)
+        _apply_coordination_fixes(findings, repo_root)
+        # Re-collect findings after fix so the exit code reflects the new state.
+        findings = _collect_coordination_findings(repo_root)
 
     _emit_coordination_findings(findings, json_output)
     raise typer.Exit(1 if any(f.severity == "error" for f in findings) else 0)

--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -88,9 +88,12 @@ _STRANDED_COORD_REVERT_HINT = (
 )
 
 #: STUCK variant (FR-007): a live strand whose recorded coordination worktree no
-#: longer exists. ``--fix`` cannot revert it (there is nothing to run the revert
-#: in), so this surfaces as a distinct ``warning`` with a manual-recovery hint
-#: rather than an ``error`` whose ``next_step`` loops the user back to ``--fix``.
+#: longer exists. It is STILL a committed-ref split-brain, so it stays an
+#: ``error`` (exit 1 — the coord branch carries a wrong ``done``; the doctor must
+#: NOT report the mission healthy). ``--fix`` cannot revert it (nothing to run the
+#: revert in), so it carries a distinct code + a *manual-recovery* ``next_step``
+#: instead of looping the user back to ``--fix`` (debugger-debbie HIGH: a
+#: ``warning`` here would exit 0 and hide the split-brain).
 _STRANDED_COORD_REVERT_STUCK_CODE = "COORDINATION_STRANDED_COORD_REVERT_STUCK"
 _STRANDED_COORD_REVERT_STUCK_HINT = (
     "The coordination worktree recorded for this strand no longer exists, so "
@@ -745,10 +748,13 @@ def _finding_for_reconcile_marker(
     extra = _marker_extra(state, coord_ref, captured_sha, coord_worktree, candidate_wps, remaining)
     if not Path(coord_worktree).exists():
         # Live strand, but the coord worktree is pruned — `--fix` cannot revert it.
-        # Surface a distinct STUCK warning instead of an error whose hint loops the
-        # user back to a `--fix` that can never succeed (FR-007).
+        # It is STILL a committed-ref split-brain, so it stays an `error` (exit 1):
+        # the coord branch carries a wrong `done` and the mission is NOT healthy.
+        # Only the `next_step` changes — a manual-recovery hint instead of looping
+        # the user back to `--fix` (debugger-debbie HIGH: a `warning` here exits 0
+        # and hides the split-brain).
         return DoctorFinding(
-            severity="warning",
+            severity="error",
             message=(
                 f"Coordination ref {coord_ref!r} for mission {mission_slug!r} still "
                 f"strands WP(s) {remaining} at `done`, but its coordination worktree "
@@ -868,8 +874,10 @@ def _heal_one_strand(
         _clear_pending_marker(repo_root, mission_id)
         return mission_slug, None
     if outcome.worktree_missing:
+        # Still a committed-ref split-brain `--fix` couldn't heal — stays `error`
+        # (exit 1) with a manual-recovery hint; a `warning` would exit 0 and hide it.
         return None, DoctorFinding(
-            severity="warning",
+            severity="error",
             message=(
                 f"Coordination worktree {coord_worktree!r} for mission "
                 f"{mission_slug!r} no longer exists — `--fix` cannot revert its strand."

--- a/src/specify_cli/cli/commands/_coordination_doctor.py
+++ b/src/specify_cli/cli/commands/_coordination_doctor.py
@@ -641,9 +641,14 @@ def _check_stranded_coord_revert(repo_root: Path) -> list[DoctorFinding]:
     yields an ``error`` finding; a marker whose ref re-derives coherent is stale
     and yields NO finding (US2-S5, the load-bearing negative AC).
     """
+    from mission_runtime import MissionArtifactKind
+
     from specify_cli.coordination.coherence import coord_incoherent_done_wps
     from specify_cli.merge.state import iter_pending_coord_reconcile_markers
-    from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+    from specify_cli.missions._read_path_resolver import (
+        MissionSelectorAmbiguous,
+        resolve_planning_read_dir,
+    )
 
     findings: list[DoctorFinding] = []
     for state in iter_pending_coord_reconcile_markers(repo_root):
@@ -652,9 +657,15 @@ def _check_stranded_coord_revert(repo_root: Path) -> list[DoctorFinding]:
             continue
         coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
         try:
-            feature_dir = primary_feature_dir_for_mission(repo_root, state.mission_slug)
-        except ValueError:
-            # Unsafe mission_slug path segment — skip rather than crash the doctor.
+            # Same canonicalizing WORK_PACKAGE_TASK read seam the executor's mark/heal
+            # use (folds a bare handle → `<slug>-<mid8>`), so all three strand sites
+            # resolve the identical feature_dir — a raw resolver here would read a
+            # divergent path on a non-canonical slug and silently miss the strand.
+            feature_dir = resolve_planning_read_dir(
+                repo_root, state.mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
+            )
+        except (ValueError, MissionSelectorAmbiguous):
+            # Unsafe/ambiguous mission_slug — skip rather than crash the doctor.
             continue
         remaining = coord_incoherent_done_wps(
             coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir,
@@ -705,8 +716,13 @@ def _fix_stranded_reverts(findings: list[DoctorFinding], repo_root: Path) -> lis
     ``--fix`` run twice is byte-stable and the marker is cleared exactly once.
     Never re-implements the revert. Returns the mission slugs healed on this call.
     """
+    from mission_runtime import MissionArtifactKind
+
     from specify_cli.coordination.coherence import repair_coord_strand
-    from specify_cli.missions._read_path_resolver import primary_feature_dir_for_mission
+    from specify_cli.missions._read_path_resolver import (
+        MissionSelectorAmbiguous,
+        resolve_planning_read_dir,
+    )
 
     healed: list[str] = []
     for f in findings:
@@ -718,7 +734,15 @@ def _fix_stranded_reverts(findings: list[DoctorFinding], repo_root: Path) -> lis
         if parsed is None or not isinstance(mission_id, str) or not isinstance(mission_slug, str):
             continue
         coord_ref, captured_sha, coord_worktree, candidate_wps = parsed
-        feature_dir = primary_feature_dir_for_mission(repo_root, mission_slug)
+        try:
+            # Mirror the check + the executor: the canonicalizing WORK_PACKAGE_TASK
+            # read seam (one feature_dir authority across all three strand sites).
+            feature_dir = resolve_planning_read_dir(
+                repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK,
+            )
+        except (ValueError, MissionSelectorAmbiguous):
+            # Unsafe/ambiguous mission_slug — skip rather than crash the fix pass.
+            continue
         outcome = repair_coord_strand(
             coord_ref=coord_ref,
             captured_sha=captured_sha,

--- a/src/specify_cli/coordination/coherence.py
+++ b/src/specify_cli/coordination/coherence.py
@@ -108,11 +108,103 @@ class CoordRepairOutcome:
     this call. ``stranded_wp_ids`` is the strand set the gate derived (empty when
     the ref was already coherent). ``error`` carries the swallowed revert
     diagnostic when the revert could not be applied.
+
+    ``worktree_missing`` distinguishes the unresolvable/pruned coordination
+    worktree (the ``coord_worktree`` path does not exist) so callers can surface a
+    STUCK-marker diagnostic instead of looping the same live-strand error forever.
+    ``head_advanced`` flags the concurrency TOCTOU refusal: HEAD moved past the
+    expected ``captured_sha + this-merge's-done`` shape (e.g. a concurrent healer
+    already reverted), so a blind ``git revert captured_sha..HEAD`` would re-apply
+    ``done`` — the repair refuses rather than re-strand.
     """
 
     healed: bool
     stranded_wp_ids: list[str] = field(default_factory=list)
     error: str | None = None
+    worktree_missing: bool = False
+    head_advanced: bool = False
+
+
+def _rev_parse_head(coord_worktree: Path, env: dict[str, str]) -> str | None:
+    """Return the coord worktree HEAD SHA, or ``None`` when it cannot be resolved."""
+    head = subprocess.run(
+        ["git", "-C", str(coord_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if head.returncode != 0:
+        return None
+    return head.stdout.strip() or None
+
+
+def _head_shape_is_expected(
+    coord_worktree: Path,
+    captured_sha: str,
+    head_sha: str,
+    candidate_wps: list[str],
+    *,
+    repo_root: Path,
+    feature_dir: Path,
+    env: dict[str, str],
+) -> bool:
+    """HEAD-freshness guard closing the concurrent-double-heal TOCTOU (FR-006).
+
+    The forward revert range is ``captured_sha..HEAD``. Before running it, verify
+    HEAD is still the shape the marker was captured against:
+
+    * ``captured_sha`` must be an ancestor of HEAD (reachable) — otherwise the
+      worktree diverged and ``captured_sha..HEAD`` is not this merge's done range.
+    * the strand must still be LIVE at the worktree HEAD *itself* (re-derived from
+      ``head_sha``, not the possibly-lagging ``coord_ref`` the gate read). A
+      concurrent healer that already reverted advances HEAD to a coherent tip, so
+      the reduction at HEAD is empty here — reverting ``captured_sha..HEAD`` would
+      then revert that concurrent revert too and re-apply ``done``. Refuse instead.
+    """
+    ancestor = subprocess.run(
+        ["git", "-C", str(coord_worktree), "merge-base", "--is-ancestor", captured_sha, head_sha],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if ancestor.returncode != 0:
+        return False
+    live_at_head = coord_incoherent_done_wps(
+        head_sha, candidate_wps, repo_root=repo_root, feature_dir=feature_dir
+    )
+    return bool(live_at_head)
+
+
+def _clean_coord_status_paths_to_head(
+    coord_worktree: Path, feature_dir: Path, env: dict[str, str]
+) -> None:
+    """Scoped clean-to-HEAD of the mission's coordination status paths.
+
+    The rollback byte-restore leaves the coord worktree DIRTY — the WORKING
+    ``status.events.jsonl`` rolled back to ``approved`` while HEAD is still the
+    committed ``done``; ``git revert`` refuses over that divergence. Restore ONLY
+    the mission's coord-owned status paths (the event log + its materialized
+    ``status.json`` snapshot) to HEAD via a scoped ``git checkout HEAD -- <paths>``
+    — bounding the blast radius by construction, rather than a whole-worktree
+    ``git reset --hard``. Idempotent and a no-op when already clean; the forward
+    revert then supersedes it (re-landing the working tree on ``approved`` in
+    lockstep with the committed ref). Each path is restored independently with
+    ``check=False`` so an untracked-at-HEAD snapshot never aborts the clean.
+    """
+    from specify_cli.status import COORD_OWNED_STATUS_FILES
+
+    slug = feature_dir.name
+    for filename in sorted(COORD_OWNED_STATUS_FILES):
+        rel = f"kitty-specs/{slug}/{filename}"
+        subprocess.run(
+            ["git", "-C", str(coord_worktree), "checkout", "HEAD", "--", rel],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
 
 
 def repair_coord_strand(
@@ -124,17 +216,33 @@ def repair_coord_strand(
     repo_root: Path,
     feature_dir: Path,
 ) -> CoordRepairOutcome:
-    """Strand-gated forward ``git revert`` of a stranded coord ``done`` commit.
+    """Strand-gated, self-sufficient forward ``git revert`` of a stranded coord ``done``.
 
     The single repair operation both executor-resume (WP03) and ``doctor --fix``
     (WP04) call — homed in ``coordination`` so a diagnostic command never reaches
-    into an executor-private helper (dependency inversion / DIR-044).
+    into an executor-private helper (dependency inversion / DIR-044). Both callers
+    are thin + equivalent: the primitive owns the worktree-existence check, the
+    strand gate, the HEAD-freshness guard, the scoped clean-to-HEAD, and the revert.
 
-    **Strand-gated (NFR-002 idempotency):** the strand set is re-derived from the
-    committed ref via :func:`coord_incoherent_done_wps` first. If the ref is
-    already coherent the repair is a no-op — so a double-heal cannot revert the
-    revert and re-apply ``done``. Running it N times yields a byte-stable coord
-    ``status.events.jsonl``.
+    Ordered contract:
+
+    0. **Unresolvable/pruned worktree (FR-007):** if ``coord_worktree`` does not
+       exist, return ``worktree_missing=True`` (a distinguishable outcome) so the
+       caller surfaces a STUCK diagnostic instead of looping the live-strand error.
+    1. **Strand gate (NFR-002 idempotency):** the strand set is re-derived from the
+       committed ref via :func:`coord_incoherent_done_wps` first. If the ref is
+       already coherent the repair is a no-op — a double-heal cannot revert the
+       revert. Running it N times yields a byte-stable coord ``status.events.jsonl``.
+    2. **HEAD-freshness guard (concurrency TOCTOU):** :func:`_head_shape_is_expected`
+       verifies HEAD has not advanced past the expected ``captured_sha + this
+       merge's done`` shape before the ``captured_sha..HEAD`` revert; if it has
+       (e.g. a concurrent healer already reverted), the repair refuses
+       (``head_advanced=True``) rather than revert a wider range that re-applies
+       ``done``.
+    3. **Scoped clean-to-HEAD** (:func:`_clean_coord_status_paths_to_head`): AFTER
+       the gate, BEFORE the revert, the mission's coord status paths are restored
+       to HEAD so the forward revert can apply over the rollback's byte-restored
+       (dirty) tree. Idempotent + no-op when clean; scoped to bound the blast radius.
 
     **Transport (AC-B3/AC-F1):** a forward ``git revert`` of ``captured_sha..HEAD``
     in the coordination worktree, subprocess env via ``_make_merge_env`` (imported
@@ -154,6 +262,11 @@ def repair_coord_strand(
     Returns:
         A :class:`CoordRepairOutcome` describing whether a revert ran.
     """
+    if not coord_worktree.exists():
+        # Pruned / unresolvable coord worktree — a distinguishable outcome so the
+        # caller emits a STUCK diagnostic rather than looping the live-strand error.
+        return CoordRepairOutcome(healed=False, worktree_missing=True)
+
     stranded = coord_incoherent_done_wps(
         coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir
     )
@@ -167,17 +280,29 @@ def repair_coord_strand(
     from specify_cli.lanes.merge import _make_merge_env
 
     env = _make_merge_env()
-    head = subprocess.run(
-        ["git", "-C", str(coord_worktree), "rev-parse", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
-    if head.returncode != 0 or head.stdout.strip() == captured_sha:
+    head_sha = _rev_parse_head(coord_worktree, env)
+    if head_sha is None or head_sha == captured_sha:
         # No commits since capture — the strand is not reachable as
         # ``captured_sha..HEAD``; do not attempt an empty revert.
         return CoordRepairOutcome(healed=False, stranded_wp_ids=stranded)
+
+    if not _head_shape_is_expected(
+        coord_worktree,
+        captured_sha,
+        head_sha,
+        candidate_wps,
+        repo_root=repo_root,
+        feature_dir=feature_dir,
+        env=env,
+    ):
+        # HEAD advanced unexpectedly (concurrency TOCTOU) — refuse the wider revert.
+        return CoordRepairOutcome(
+            healed=False, stranded_wp_ids=stranded, head_advanced=True
+        )
+
+    # Scoped clean-to-HEAD (after the gate, before the revert) so the forward
+    # revert applies over the byte-restored (dirty) coord worktree.
+    _clean_coord_status_paths_to_head(coord_worktree, feature_dir, env)
 
     revert = subprocess.run(
         ["git", "-C", str(coord_worktree), "revert", "--no-edit", f"{captured_sha}..HEAD"],

--- a/src/specify_cli/coordination/coherence.py
+++ b/src/specify_cli/coordination/coherence.py
@@ -1,0 +1,202 @@
+"""Coordination-branch coherence: the single strand-derivation + repair owner.
+
+Mission ``merge-coord-rollback-transactionality`` (#2786 + #2367-B), FR-009.
+
+The strand-derivation and the git-revert repair are **coordination-domain**
+knowledge and get exactly one home here, consumed by all three call-sites — the
+marker-persist site, the resume heal-gate, and the ``doctor coordination`` check
+— so the three never drift (the #2786-C seed).
+
+Two load-bearing layering rules keep this module clean:
+
+* The reader (:func:`coord_incoherent_done_wps`) derives from the **committed
+  coordination ref** via ``coordination.status_service.EventLogReadContract`` —
+  never the working tree. A committed-vs-working diff at a #2786 mark point is
+  empty (the rollback restores primary paths, not the coord worktree) and would
+  silently drop the strand.
+* The repair (:func:`repair_coord_strand`) imports ``_make_merge_env``
+  **function-locally**. A module-top ``from specify_cli.lanes.merge import
+  _make_merge_env`` creates the cycle ``merge.executor -> coordination.coherence
+  -> lanes.merge -> merge.config``. There is intentionally **no** module-top
+  ``coordination -> merge`` / ``coordination -> lanes`` import in this file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "CoordRepairOutcome",
+    "coord_incoherent_done_wps",
+    "repair_coord_strand",
+]
+
+
+def coord_incoherent_done_wps(
+    coord_ref: str,
+    candidate_wps: list[str],
+    *,
+    repo_root: Path,
+    feature_dir: Path,
+) -> list[str]:
+    """Subset of *candidate_wps* still reducing to ``DONE`` on the committed coord ref.
+
+    This is **the** strand authority (FR-009). ``candidate_wps`` is always *this
+    merge's* pre-target ``done`` write-set — the caller passes it; this function
+    NEVER enumerates all WPs. Passing ``run.all_wp_ids`` instead would be wrong:
+    on a resume it includes WPs a prior attempt legitimately baked ``done``, so
+    the heal would revert a genuinely-done WP. A genuinely-pre-existing-``done``
+    WP is excluded here **by construction** — it is simply not in the write-set.
+
+    The reduction reads the committed coordination-branch ref (mirroring
+    ``merge.done_bookkeeping._durable_done_wps_on_coordination_ref``) and NEVER the
+    roll-backable working tree. When the coordination events cannot be read (a
+    non-coord topology, a legacy mission, or an unresolvable ref) an empty list is
+    returned — there is no strand to repair.
+
+    Args:
+        coord_ref: Fully-qualified coordination branch ref carrying the events log.
+            Passed in (not re-resolved) so the derivation matches the placement the
+            rollback used — no re-resolution drift.
+        candidate_wps: This merge's pre-target ``done`` write-set.
+        repo_root: Repository root the ``git show`` runs against.
+        feature_dir: Mission directory whose ``.name`` anchors the ref path
+            (``kitty-specs/<name>/status.events.jsonl``) and whose path drives the
+            legacy slug-to-mission-id parse.
+
+    Returns:
+        The subset of ``candidate_wps`` still ``DONE`` on the committed ref, in
+        the order they appear in ``candidate_wps``.
+    """
+    if not candidate_wps:
+        return []
+
+    # Imported function-locally to mirror the proven, cycle-free pattern in
+    # ``_durable_done_wps_on_coordination_ref`` (both reduce coord-``DONE`` via the
+    # same ``EventLogReadContract``). No module-top coupling to status internals.
+    from specify_cli.coordination.status_service import (
+        EventLogReadContract,
+        read_event_log,
+        wp_lane_actor_from_events,
+    )
+    from specify_cli.status import Lane
+
+    events = read_event_log(
+        EventLogReadContract.coordination_branch_ref(
+            repo_root=repo_root,
+            destination_ref=coord_ref,
+            feature_dir=feature_dir,
+            parser_feature_dir=feature_dir,
+        )
+    )
+    if not events:
+        return []
+    return [
+        wp_id
+        for wp_id in candidate_wps
+        if wp_lane_actor_from_events(events, wp_id)[0] == Lane.DONE
+    ]
+
+
+@dataclass(frozen=True)
+class CoordRepairOutcome:
+    """Result of a strand-gated coordination repair.
+
+    ``healed`` is ``True`` only when a ``git revert`` was actually performed on
+    this call. ``stranded_wp_ids`` is the strand set the gate derived (empty when
+    the ref was already coherent). ``error`` carries the swallowed revert
+    diagnostic when the revert could not be applied.
+    """
+
+    healed: bool
+    stranded_wp_ids: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def repair_coord_strand(
+    *,
+    coord_ref: str,
+    captured_sha: str,
+    coord_worktree: Path,
+    candidate_wps: list[str],
+    repo_root: Path,
+    feature_dir: Path,
+) -> CoordRepairOutcome:
+    """Strand-gated forward ``git revert`` of a stranded coord ``done`` commit.
+
+    The single repair operation both executor-resume (WP03) and ``doctor --fix``
+    (WP04) call — homed in ``coordination`` so a diagnostic command never reaches
+    into an executor-private helper (dependency inversion / DIR-044).
+
+    **Strand-gated (NFR-002 idempotency):** the strand set is re-derived from the
+    committed ref via :func:`coord_incoherent_done_wps` first. If the ref is
+    already coherent the repair is a no-op — so a double-heal cannot revert the
+    revert and re-apply ``done``. Running it N times yields a byte-stable coord
+    ``status.events.jsonl``.
+
+    **Transport (AC-B3/AC-F1):** a forward ``git revert`` of ``captured_sha..HEAD``
+    in the coordination worktree, subprocess env via ``_make_merge_env`` (imported
+    function-locally to avoid the import cycle). NOT ``advance_branch_ref`` (it
+    refuses the non-fast-forward move back to ``captured_sha`` by design); no raw
+    ``git update-ref``.
+
+    Args:
+        coord_ref: Coordination branch ref used to re-derive coherence.
+        captured_sha: Coord tip captured *before* the ``done`` bookkeeping commit;
+            the ``git revert`` base.
+        coord_worktree: Coordination worktree the revert operates in.
+        candidate_wps: This merge's pre-target ``done`` write-set (the strand gate).
+        repo_root: Repository root for the committed-ref coherence read.
+        feature_dir: Mission directory anchoring the coordination events read.
+
+    Returns:
+        A :class:`CoordRepairOutcome` describing whether a revert ran.
+    """
+    stranded = coord_incoherent_done_wps(
+        coord_ref, candidate_wps, repo_root=repo_root, feature_dir=feature_dir
+    )
+    if not stranded:
+        # Already coherent (or nothing to heal): no-op — never revert the revert.
+        return CoordRepairOutcome(healed=False, stranded_wp_ids=[])
+
+    # Function-local import: a module-top ``from specify_cli.lanes.merge import
+    # _make_merge_env`` would create the cycle merge.executor ->
+    # coordination.coherence -> lanes.merge -> merge.config.
+    from specify_cli.lanes.merge import _make_merge_env
+
+    env = _make_merge_env()
+    head = subprocess.run(
+        ["git", "-C", str(coord_worktree), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if head.returncode != 0 or head.stdout.strip() == captured_sha:
+        # No commits since capture — the strand is not reachable as
+        # ``captured_sha..HEAD``; do not attempt an empty revert.
+        return CoordRepairOutcome(healed=False, stranded_wp_ids=stranded)
+
+    revert = subprocess.run(
+        ["git", "-C", str(coord_worktree), "revert", "--no-edit", f"{captured_sha}..HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    if revert.returncode != 0:
+        subprocess.run(
+            ["git", "-C", str(coord_worktree), "revert", "--abort"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        return CoordRepairOutcome(
+            healed=False,
+            stranded_wp_ids=stranded,
+            error=(revert.stderr or revert.stdout or "").strip() or "git revert failed",
+        )
+    return CoordRepairOutcome(healed=True, stranded_wp_ids=stranded)

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -35,11 +35,16 @@ if TYPE_CHECKING:
 
 from specify_cli.cli.console import console
 from specify_cli.core.constants import KITTIFY_DIR
+from specify_cli.coordination.coherence import (
+    coord_incoherent_done_wps,
+    repair_coord_strand,
+)
 from specify_cli.coordination.surface_resolver import (
     is_under_worktrees_segment,
     resolve_status_surface,
 )
 from specify_cli.core.git_ops import has_remote, run_command
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.core.paths import get_main_repo_root
 from specify_cli.git.bookkeeping_commit import commit_merge_bookkeeping
 from specify_cli.git.commit_helpers import SafeCommitRecoveryFailed
@@ -95,6 +100,7 @@ from specify_cli.merge.state import (
     clear_state,
     get_state_path,
     release_merge_lock,
+    save_state,
 )
 from specify_cli.merge.workspace import _worktree_removal_delay, cleanup_merge_workspace
 from specify_cli.mission_metadata import resolve_mission_identity
@@ -217,6 +223,16 @@ class _MergeRunState:
     # while the working tree rolls back to ``approved`` (the split-brain).
     pre_target_coord_ref: str | None = None
     pre_target_coord_sha: str | None = None
+
+    # #2786 / #2367-B FR-005: the WPs THIS merge newly bakes ``done`` for during
+    # its pre-target bake — every lane WP MINUS those already durably ``done`` on
+    # the committed coordination ref at bake time. This (never ``all_wp_ids``) is
+    # the candidate set handed to ``coord_incoherent_done_wps``: on a resume
+    # ``all_wp_ids`` would include a WP a prior attempt legitimately baked
+    # ``done``, so the heal would revert a genuinely-done WP (data-model
+    # derivation contract). A genuinely-pre-existing-``done`` WP is excluded by
+    # construction. Unused off the coord path.
+    pre_target_done_write_set: list[str] = field(default_factory=list)
 
 
 def _phase_gates_and_state(run: _MergeRunState) -> None:
@@ -391,6 +407,10 @@ def _phase_bake_and_pre_target_done(run: _MergeRunState) -> None:
         # #2711 FR-006: capture the coordination-branch tip BEFORE the ``done``
         # emit so a rollback can revert the committed ``done`` coherently.
         _capture_pre_target_coord_ref_sha(run)
+        # #2786 / #2367-B FR-005: record THIS merge's ``done`` write-set (the
+        # marker's candidate set) BEFORE the bake, so the strand derivation
+        # excludes any legitimately-pre-existing-``done`` WP.
+        _capture_pre_target_done_write_set(run)
         # Modern coordination-backed missions must carry done events in the
         # mission branch before it is merged to target.
         try:
@@ -403,8 +423,10 @@ def _phase_bake_and_pre_target_done(run: _MergeRunState) -> None:
                 merge_state=run.state,
                 all_wp_ids=run.all_wp_ids,
             )
-        except Exception:
-            _restore_final_bookkeeping_snapshots(run.pre_target_bookkeeping_snapshots)
+        except Exception as exc:
+            _restore_and_guard_coord_coherence(
+                run, run.pre_target_bookkeeping_snapshots, error=exc
+            )
             raise
 
 
@@ -435,6 +457,50 @@ def _capture_pre_target_coord_ref_sha(run: _MergeRunState) -> None:
     if ret == 0 and sha.strip():
         run.pre_target_coord_ref = coord_ref
         run.pre_target_coord_sha = sha.strip()
+
+
+def _coord_reconcile_read_feature_dir(run: _MergeRunState) -> Path:
+    """Primary feature dir (name == slug) anchoring the committed-coord read.
+
+    Mirrors ``done_bookkeeping._durable_done_wps_on_coordination_ref``: a
+    ``WORK_PACKAGE_TASK`` read folds onto the topology-blind
+    ``primary_feature_dir_for_mission`` (name == slug), so the coord-ref path
+    (``kitty-specs/<slug>/status.events.jsonl``) and the legacy-parse dir match
+    the placement the rollback used — no ``-coord`` husk, no re-resolution drift.
+    """
+    feature_dir: Path = resolve_planning_read_dir(
+        run.main_repo, run.mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK
+    )
+    return feature_dir
+
+
+def _capture_pre_target_done_write_set(run: _MergeRunState) -> None:
+    """Record the WPs THIS merge will newly bake ``done`` (#2786 / #2367-B FR-005).
+
+    The write-set is every lane WP that is NOT already durably ``done`` on the
+    committed coordination ref at bake time. Handing this (never
+    ``run.all_wp_ids``) to :func:`coord_incoherent_done_wps` excludes a
+    genuinely-pre-existing-``done`` WP by construction, so a resume never
+    re-strands a legitimately-done WP. The reduction is the single coordination
+    authority (``coord_incoherent_done_wps``) — never re-derived locally. When
+    the coordination ref is unresolved (non-coord topology / legacy mission) the
+    write-set degrades to all WPs; it is unused off the coord path.
+    """
+    coord_ref = run.pre_target_coord_ref
+    if not coord_ref:
+        run.pre_target_done_write_set = list(run.all_wp_ids)
+        return
+    pre_existing_done = set(
+        coord_incoherent_done_wps(
+            coord_ref,
+            run.all_wp_ids,
+            repo_root=run.main_repo,
+            feature_dir=_coord_reconcile_read_feature_dir(run),
+        )
+    )
+    run.pre_target_done_write_set = [
+        wp for wp in run.all_wp_ids if wp not in pre_existing_done
+    ]
 
 
 def _coord_worktree_root(run: _MergeRunState) -> Path | None:
@@ -470,6 +536,13 @@ def _revert_coord_done_commit(run: _MergeRunState) -> None:
     (AC-B3); ``advance_branch_ref`` cannot serve here because moving the ref back
     to the captured tip is the non-fast-forward move it refuses by design.
     Subprocess env routes through ``_make_merge_env`` (AC-F1).
+
+    This is the #2711 in-merge lockstep revert on the (still-clean) pre-restore
+    worktree — kept in its canonical raw form (its no-op / success / abort branches
+    are pinned by ``test_executor_option_a_revert_helpers_2711.py``). The NEW #2786
+    / #2367-B reconciliation authority is the resume/doctor heal, which routes
+    through the shared coordination primitive ``repair_coord_strand`` (see
+    :func:`_heal_pending_coord_reconcile`); this leg stays orthogonal.
     """
     from specify_cli.lanes.merge import _make_merge_env
 
@@ -514,6 +587,124 @@ def _revert_coord_done_commit(run: _MergeRunState) -> None:
         )
 
 
+def _persist_coord_reconcile_marker(
+    run: _MergeRunState, error: BaseException | None
+) -> None:
+    """Durably record a stranded committed-coord ``done`` (#2786 / #2367-B FR-005).
+
+    Derives the strand set from the COMMITTED coordination ref (never a
+    committed-vs-working diff, which is empty at the mark point per data-model D7)
+    via the single coordination authority :func:`coord_incoherent_done_wps` over
+    THIS merge's ``done`` write-set — so the marker names the SPECIFIC WP(s) this
+    merge stranded, excluding both a coherent (only-``approved``) WP and a
+    genuinely-pre-existing-``done`` WP. Writes the marker (via ``save_state``) only
+    when the strand is non-empty (an empty strand is not a strand). Mark-not-raise:
+    the caller keeps propagating its original failure; this merely records.
+    """
+    coord_ref = run.pre_target_coord_ref
+    captured_sha = run.pre_target_coord_sha
+    if not coord_ref or not captured_sha:
+        return
+    coord_worktree = _coord_worktree_root(run)
+    if coord_worktree is None:
+        return
+    stranded = coord_incoherent_done_wps(
+        coord_ref,
+        run.pre_target_done_write_set,
+        repo_root=run.main_repo,
+        feature_dir=_coord_reconcile_read_feature_dir(run),
+    )
+    if not stranded:
+        return
+    run.state.pending_coord_reconcile = {
+        "coord_ref": coord_ref,
+        "captured_sha": captured_sha,
+        "coord_worktree": str(coord_worktree),
+        "stranded_wp_ids": list(stranded),
+        "revert_error": str(error) if error is not None else None,
+        "detected_at": now_utc_iso(),
+    }
+    save_state(run.state, run.main_repo)
+
+
+def _clean_coord_worktree_to_head(coord_worktree: Path) -> None:
+    """Reset the coordination worktree's tracked bytes to HEAD before a heal revert.
+
+    The rollback byte-restore (:func:`_restore_final_bookkeeping_snapshots`) leaves
+    the coord worktree DIRTY (working ``status.events.jsonl`` rolled to ``approved``
+    while HEAD is still the committed ``done``). ``git revert`` refuses to run over
+    that divergence, so the heal must first discard the byte-restore delta — the
+    coherent forward revert supersedes it (it lands the working tree back on
+    ``approved`` anyway, now in lockstep with the committed ref). Env routes through
+    ``_make_merge_env`` (AC-F1), mirroring :func:`_revert_coord_done_commit`.
+    """
+    from specify_cli.lanes.merge import _make_merge_env
+
+    subprocess.run(
+        ["git", "-C", str(coord_worktree), "reset", "--hard", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_make_merge_env(),
+    )
+
+
+def _heal_pending_coord_reconcile(run: _MergeRunState) -> None:
+    """Strand-gated ``git revert`` heal of a pending coord-reconcile marker (FR-006).
+
+    Delegates the repair to the single coordination authority
+    :func:`repair_coord_strand` (which re-derives the strand from the committed
+    ref and no-ops if already coherent — a blind ``git revert captured_sha..HEAD``
+    would re-apply ``done`` and is rejected). The coord worktree is first cleaned to
+    HEAD so the forward revert can apply over the byte-restored (dirty) tree.
+    Idempotent (NFR-002): the marker is cleared atomically with the heal only once
+    the revert commits (or the ref is already coherent — a stale marker heals to a
+    no-op clear). A revert that could not be applied leaves the marker for the next
+    resume/doctor pass.
+    """
+    marker = run.state.pending_coord_reconcile
+    if not marker:
+        return
+    coord_worktree = Path(str(marker["coord_worktree"]))
+    _clean_coord_worktree_to_head(coord_worktree)
+    outcome = repair_coord_strand(
+        coord_ref=str(marker["coord_ref"]),
+        captured_sha=str(marker["captured_sha"]),
+        coord_worktree=coord_worktree,
+        candidate_wps=[str(wp) for wp in marker.get("stranded_wp_ids", [])],
+        repo_root=run.main_repo,
+        feature_dir=_coord_reconcile_read_feature_dir(run),
+    )
+    if outcome.healed or not outcome.stranded_wp_ids:
+        run.state.pending_coord_reconcile = None
+        save_state(run.state, run.main_repo)
+
+
+def _restore_and_guard_coord_coherence(
+    run: _MergeRunState,
+    snapshots: dict[Path, bytes | None],
+    *,
+    error: BaseException | None = None,
+) -> None:
+    """Restore primitive (FR-008 structural): byte-restore + coord-coherence guard.
+
+    Co-locates the coherence mark/heal AT the ``_restore_final_bookkeeping_snapshots``
+    seam so a future restore site cannot strand silently — EVERY restore call-site
+    routes through here (the primary marking mechanism; the hand-picked marks are
+    reached THROUGH it, no double-mark). Inner-only (not the INV-5 phase-driver
+    wrapper): leg-b byte-restore always runs first and is preserved verbatim. On a
+    coord-topology rollback it records any residual strand (mark-not-raise) and, on
+    a resume, heals it via the strand-gated coordination primitive. Off the coord
+    path (``done_marked_before_target`` False) it is a pure byte-restore.
+    """
+    _restore_final_bookkeeping_snapshots(snapshots)
+    if not run.done_marked_before_target:
+        return
+    _persist_coord_reconcile_marker(run, error)
+    if run.is_resume:
+        _heal_pending_coord_reconcile(run)
+
+
 def _restore_pre_target_if_at_baseline(run: _MergeRunState) -> None:
     """Roll back the pre-target state iff the target never advanced (INV-6).
 
@@ -533,7 +724,7 @@ def _restore_pre_target_if_at_baseline(run: _MergeRunState) -> None:
         run.target_baseline_sha,
     ):
         _revert_coord_done_commit(run)
-        _restore_final_bookkeeping_snapshots(run.pre_target_bookkeeping_snapshots)
+        _restore_and_guard_coord_coherence(run, run.pre_target_bookkeeping_snapshots)
 
 
 def _reject_zero_diff_noop_squash(run: _MergeRunState) -> None:
@@ -667,7 +858,7 @@ def _phase_capture_and_baseline(run: _MergeRunState) -> None:
             mission_id=run.baseline_mission_id,
         )
     except BaselineMergeCommitError as exc:
-        _restore_final_bookkeeping_snapshots(run.final_bookkeeping_snapshots)
+        _restore_and_guard_coord_coherence(run, run.final_bookkeeping_snapshots, error=exc)
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
 
@@ -687,8 +878,11 @@ def _phase_record_done_and_project(run: _MergeRunState) -> None:
                 merge_state=run.state,
                 all_wp_ids=run.all_wp_ids,
             )
-        except Exception:
-            _restore_final_bookkeeping_snapshots(run.final_bookkeeping_snapshots)
+        except Exception as exc:
+            # Site is inside ``if not run.done_marked_before_target:`` →
+            # dead-for-coord (the guard inside the primitive no-ops the mark/heal);
+            # routed for structural uniformity so no restore site can strand.
+            _restore_and_guard_coord_coherence(run, run.final_bookkeeping_snapshots, error=exc)
             raise
 
     try:
@@ -697,8 +891,10 @@ def _phase_record_done_and_project(run: _MergeRunState) -> None:
             mission_slug=run.mission_slug,
             status_feature_dir=run.feature_dir,
         )
-    except Exception:
-        _restore_final_bookkeeping_snapshots(run.final_bookkeeping_snapshots)
+    except Exception as exc:
+        # Coord-reachable live strand: OUTSIDE the done_marked_before_target guard,
+        # after the target advanced — MUST be markable (#2786-shape site 701).
+        _restore_and_guard_coord_coherence(run, run.final_bookkeeping_snapshots, error=exc)
         raise
     run.target_events_path = target_events_path
     run.target_status_path = target_status_path
@@ -754,7 +950,7 @@ def _phase_porcelain_invariant(run: _MergeRunState) -> None:
             "\nUnexpected working-tree state after merge. "
             "Run `git status` to investigate before retrying."
         )
-    _restore_final_bookkeeping_snapshots(run.final_bookkeeping_snapshots)
+    _restore_and_guard_coord_coherence(run, run.final_bookkeeping_snapshots)
     raise typer.Exit(1)
 
 
@@ -783,7 +979,7 @@ def _phase_commit_and_assert(run: _MergeRunState) -> None:
             )
         except Exception as exc:
             if not (isinstance(exc, SafeCommitRecoveryFailed) and exc.commit_sha is not None):
-                _restore_final_bookkeeping_snapshots(run.final_bookkeeping_snapshots)
+                _restore_and_guard_coord_coherence(run, run.final_bookkeeping_snapshots, error=exc)
             raise
     else:
         console.print("  [dim]No post-merge bookkeeping changes to commit; continuing cleanup.[/dim]")
@@ -1085,6 +1281,13 @@ def _run_lane_based_merge_locked(
         state=state,
         is_resume=is_resume,
     )
+
+    # FR-006: at resume startup, heal any coord strand a prior attempt left
+    # durably marked (strand-gated + atomic-clear via the coordination primitive).
+    # Placed BEFORE the frozen phase list (not a phase-driver wrapper — INV-5),
+    # so it is never part of ``expected_order``.
+    if run.is_resume:
+        _heal_pending_coord_reconcile(run)
 
     _phase_gates_and_state(run)
     _phase_merge_lanes(run)

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -655,7 +655,13 @@ def _heal_pending_coord_reconcile(run: _MergeRunState) -> None:
         repo_root=run.main_repo,
         feature_dir=_coord_reconcile_read_feature_dir(run),
     )
-    if outcome.healed or not outcome.stranded_wp_ids:
+    # Clear the marker only on a genuine heal OR a re-derived-coherent no-op.
+    # A ``worktree_missing`` short-circuit returns an EMPTY ``stranded_wp_ids``
+    # because the strand was never checked (the worktree is gone) — NOT because
+    # it is coherent. Clearing on that would erase the marker for an unresolved
+    # committed split-brain, making it invisible to a later doctor/resume once the
+    # worktree is re-materialized (debugger-debbie HIGH). Preserve it.
+    if outcome.healed or (not outcome.stranded_wp_ids and not outcome.worktree_missing):
         run.state.pending_coord_reconcile = None
         save_state(run.state, run.main_repo)
 

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 from specify_cli.cli.console import console
 from specify_cli.core.constants import KITTIFY_DIR
 from specify_cli.coordination.coherence import (
+    CoordRepairOutcome,
     coord_incoherent_done_wps,
     repair_coord_strand,
 )
@@ -627,36 +628,16 @@ def _persist_coord_reconcile_marker(
     save_state(run.state, run.main_repo)
 
 
-def _clean_coord_worktree_to_head(coord_worktree: Path) -> None:
-    """Reset the coordination worktree's tracked bytes to HEAD before a heal revert.
-
-    The rollback byte-restore (:func:`_restore_final_bookkeeping_snapshots`) leaves
-    the coord worktree DIRTY (working ``status.events.jsonl`` rolled to ``approved``
-    while HEAD is still the committed ``done``). ``git revert`` refuses to run over
-    that divergence, so the heal must first discard the byte-restore delta — the
-    coherent forward revert supersedes it (it lands the working tree back on
-    ``approved`` anyway, now in lockstep with the committed ref). Env routes through
-    ``_make_merge_env`` (AC-F1), mirroring :func:`_revert_coord_done_commit`.
-    """
-    from specify_cli.lanes.merge import _make_merge_env
-
-    subprocess.run(
-        ["git", "-C", str(coord_worktree), "reset", "--hard", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=_make_merge_env(),
-    )
-
-
 def _heal_pending_coord_reconcile(run: _MergeRunState) -> None:
     """Strand-gated ``git revert`` heal of a pending coord-reconcile marker (FR-006).
 
-    Delegates the repair to the single coordination authority
+    Delegates the repair to the single self-sufficient coordination authority
     :func:`repair_coord_strand` (which re-derives the strand from the committed
     ref and no-ops if already coherent — a blind ``git revert captured_sha..HEAD``
-    would re-apply ``done`` and is rejected). The coord worktree is first cleaned to
-    HEAD so the forward revert can apply over the byte-restored (dirty) tree.
+    would re-apply ``done`` and is rejected). The primitive itself performs the
+    scoped clean-to-HEAD (after its strand gate, before the revert) so the forward
+    revert can apply over the byte-restored (dirty) tree — this caller no longer
+    pre-cleans, keeping the clean happening exactly once, inside the primitive.
     Idempotent (NFR-002): the marker is cleared atomically with the heal only once
     the revert commits (or the ref is already coherent — a stale marker heals to a
     no-op clear). A revert that could not be applied leaves the marker for the next
@@ -666,8 +647,7 @@ def _heal_pending_coord_reconcile(run: _MergeRunState) -> None:
     if not marker:
         return
     coord_worktree = Path(str(marker["coord_worktree"]))
-    _clean_coord_worktree_to_head(coord_worktree)
-    outcome = repair_coord_strand(
+    outcome: CoordRepairOutcome = repair_coord_strand(
         coord_ref=str(marker["coord_ref"]),
         captured_sha=str(marker["captured_sha"]),
         coord_worktree=coord_worktree,

--- a/src/specify_cli/merge/state.py
+++ b/src/specify_cli/merge/state.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,7 @@ __all__ = [
     "load_state",
     "clear_state",
     "has_active_merge",
+    "iter_pending_coord_reconcile_markers",
     "get_state_path",
     "acquire_merge_lock",
     "release_merge_lock",
@@ -85,6 +87,13 @@ class MergeState:
     updated_at: str = field(default_factory=now_utc_iso)
     mission_number_baked: bool = False  # WP04 — set True once mission_number is committed
     push_requested: bool = False  # WP02 — True when --push was passed at merge start
+    # #2786 / #2367-B FR-004: durable coord-strand reconcile marker. A plain dict
+    # (NOT a nested dataclass) because ``from_dict`` rehydrates JSON objects as
+    # dicts and drops unknown keys — so pre-existing state files that predate this
+    # field simply rehydrate to ``None`` with no migration. Keys (see data-model):
+    # ``coord_ref``, ``captured_sha``, ``coord_worktree``, ``stranded_wp_ids``,
+    # ``revert_error``, ``detected_at``.
+    pending_coord_reconcile: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dict."""
@@ -260,6 +269,37 @@ def has_active_merge(repo_root: Path, mission_id: str | None = None) -> bool:
     if state is None:
         return False
     return len(state.remaining_wps) > 0
+
+
+def iter_pending_coord_reconcile_markers(repo_root: Path) -> Iterable[MergeState]:
+    """Yield every persisted merge state that carries a ``pending_coord_reconcile`` marker.
+
+    The coordination doctor (#2786 / #2367-B WP04) must enumerate stranded-coord
+    markers across ALL active missions, but :func:`load_state` with
+    ``mission_id=None`` **raises** :class:`MergeAmbiguousStateError` as soon as two
+    or more active states exist — so it cannot be used to enumerate. This iterator
+    is the enumeration seam: ``state.py`` owns the runtime-path shape
+    (``.kittify/runtime/merge/*/state.json``), so the doctor consumes this rather
+    than re-implementing the scan (which would be a second path authority /
+    DIR-044 breach).
+
+    States whose ``pending_coord_reconcile`` is ``None`` (the common, coherent
+    case) and unparseable state files are skipped. Yields in deterministic
+    ``mission_id``-directory sort order.
+
+    Args:
+        repo_root: Repository root path.
+
+    Yields:
+        Each :class:`MergeState` carrying a non-``None`` ``pending_coord_reconcile``.
+    """
+    runtime_merge_dir = repo_root / ".kittify" / "runtime" / "merge"
+    if not runtime_merge_dir.exists():
+        return
+    for candidate in sorted(runtime_merge_dir.iterdir()):
+        state = _load_state_file(candidate / _STATE_FILE)
+        if state is not None and state.pending_coord_reconcile is not None:
+            yield state
 
 
 # ---------------------------------------------------------------------------

--- a/tests/architectural/test_coord_rollback_coherence_guard.py
+++ b/tests/architectural/test_coord_rollback_coherence_guard.py
@@ -1,0 +1,426 @@
+"""WP05 / FR-008 — behavioral class-closing guard for INV-COORD-ROLLBACK (#2786 + #2367-B).
+
+INV-COORD-ROLLBACK (data-model): *after any merge rollback, either the
+coordination branch is coherent (no WP from this merge's write-set still reduces
+to ``DONE`` on the committed coord ref while its lane rolled back to
+``approved``) OR a ``pending_coord_reconcile`` marker names the stranded WP(s).*
+No rollback path may leave a stranded committed ``done`` **and** marker-absent.
+
+The invariant is **behavioral**, so this guard is behavioral — NOT a source grep
+for the mark call. Two complementary halves close the whole defect class:
+
+* **T015 — behavioral falsifier (non-vacuity).** The SAME invariant assertion
+  (:func:`_assert_coord_rollback_invariant`) is driven against a REAL bake-path
+  strand. With the real mark in place it is GREEN (the strand is marked, so the
+  committed/working split-brain is recoverable). When
+  ``_persist_coord_reconcile_marker`` / ``coord_incoherent_done_wps`` is
+  monkeypatched to a runtime no-op and the same real strand is re-driven, the
+  guard REDS (``strand-on-committed-ref ∧ marker-absent``). A guard that stayed
+  green under a runtime-stubbed mark would be a tautology and is rejected — these
+  ``pytest.raises(AssertionError)`` tests prove it does not.
+
+* **T016 — programmatic restore-site enumeration + topology-gating.** The seven
+  ``_restore_final_bookkeeping_snapshots`` restore-shape sites are enumerated
+  from the executor AST (never a hardcoded line-number list — they drift as
+  helpers move). The class-closing structural invariant is that the ONLY raw
+  ``_restore_final_bookkeeping_snapshots(`` call lives inside the marking
+  primitive ``_restore_and_guard_coord_coherence`` — every other restore site
+  routes through it, so a future un-routed restore site cannot strand silently.
+  Site ≈691 is asserted dead-for-coord (inside ``if not
+  run.done_marked_before_target:``) and site ≈701
+  (``_project_status_bookkeeping_to_target`` failure) is asserted
+  coord-reachable-and-routed — the live same-shape site the original six-site
+  enumeration missed.
+
+Behavioral harnesses (fixture bootstrap + bake-mid-write-set failure injection +
+git-reducible committed/working readers) are REUSED verbatim from the WP01
+red-first repro and the WP03 executor integration tests; this module never
+re-authors them.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Import the status package before any coordination submodule (production import
+# order; see the #2711 / #2367-B harness docstrings for rationale).
+import specify_cli.status  # noqa: F401  # import-order guard
+
+from specify_cli.coordination.coherence import coord_incoherent_done_wps
+from specify_cli.merge import executor as ex
+from specify_cli.merge.state import load_state
+
+# --- Reused bake-strand (#2367-B / WP01) harness ----------------------------
+from tests.regression.test_issue_2367_bake_strand import (
+    COHERENT_WP,
+    COORD_BRANCH,
+    MISSION_ID,
+    MISSION_SLUG,
+    STRANDED_WP,
+    _bootstrap_two_wp_coord_mission,
+    _run_bake_failing_merge,
+)
+
+# ``_init_git_repo`` is DEFINED in the #2711 harness and only re-exported by the
+# #2367-B module; import it from its definition site so mypy's strict
+# no-implicit-reexport check is satisfied.
+from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
+    _init_git_repo,
+)
+
+pytestmark = [
+    pytest.mark.regression,
+    pytest.mark.architectural,
+    pytest.mark.git_repo,
+    pytest.mark.non_sandbox,
+]
+
+# This merge's pre-target ``done`` write-set for the 2-WP fixture. ``STRANDED_WP``
+# commits ``done`` before the injected bake failure (→ stranded on the committed
+# coord ref); ``COHERENT_WP`` is only ever ``approved`` (the coherent control).
+_WRITE_SET: list[str] = [STRANDED_WP, COHERENT_WP]
+
+
+# ===========================================================================
+# The behavioral invariant checker + guard (the thing T015 falsifies)
+# ===========================================================================
+
+
+def _feature_dir(repo: Path) -> Path:
+    """Primary feature dir (``name == slug``) anchoring the committed-coord read.
+
+    Mirrors ``executor._coord_reconcile_read_feature_dir`` — the same placement the
+    rollback marker derivation uses, so the checker reads the identical committed
+    coordination ref.
+    """
+    return repo / "kitty-specs" / MISSION_SLUG
+
+
+def _marker_stranded_wps(repo: Path) -> set[str]:
+    """WP ids named by the persisted ``pending_coord_reconcile`` marker (∅ if none)."""
+    state = load_state(repo, MISSION_ID)
+    marker = state.pending_coord_reconcile if state is not None else None
+    if not marker:
+        return set()
+    return {str(wp) for wp in marker["stranded_wp_ids"]}
+
+
+def _coord_rollback_violation(repo: Path) -> set[str]:
+    """Return the INV-COORD-ROLLBACK violation set (∅ ⇒ invariant holds).
+
+    The strand is derived from the COMMITTED coordination ref via the single
+    coordination authority :func:`coord_incoherent_done_wps` over this merge's
+    write-set — never a committed-vs-working diff (empty at the mark point per
+    data-model D7). The invariant holds when there is no strand OR every stranded
+    WP is named by a ``pending_coord_reconcile`` marker (recoverable). A stranded
+    WP with NO marker is the violation this guard exists to catch.
+    """
+    stranded = set(
+        coord_incoherent_done_wps(
+            COORD_BRANCH,
+            _WRITE_SET,
+            repo_root=repo,
+            feature_dir=_feature_dir(repo),
+        )
+    )
+    if not stranded:
+        return set()
+    return stranded - _marker_stranded_wps(repo)
+
+
+def _assert_coord_rollback_invariant(repo: Path) -> None:
+    """FR-008 behavioral guard: no rollback may strand a committed ``done`` unmarked.
+
+    This is the SINGLE assertion T015 drives both ways: GREEN with the real mark,
+    RED (``AssertionError`` carrying ``INV-COORD-ROLLBACK``) when the mark is
+    stubbed to a runtime no-op.
+    """
+    unreconciled = _coord_rollback_violation(repo)
+    assert not unreconciled, (
+        "INV-COORD-ROLLBACK violated (FR-008): the committed coordination ref "
+        f"strands {sorted(unreconciled)} at ``done`` while the working tree rolled "
+        "back to ``approved`` and NO pending_coord_reconcile marker names it — a "
+        "silent committed/working split-brain. The rollback must mark (or revert) "
+        "the stranded coord ``done`` so it stays recoverable."
+    )
+
+
+# ===========================================================================
+# T015 — behavioral falsifier: GREEN with the real mark, RED under a stubbed mark
+# ===========================================================================
+
+
+def test_guard_is_green_with_the_real_mark(tmp_path: Path) -> None:
+    """With the real mark, a bake-path strand is recorded → the invariant holds.
+
+    Drives a REAL #2367-B bake-mid-write-set failure. The leg-b byte-restore rolls
+    the working tree back to ``approved`` while ``STRANDED_WP``'s committed coord
+    ``done`` survives — a strand — but ``_persist_coord_reconcile_marker`` records
+    it, so ``strand ∧ marked`` ⇒ recoverable ⇒ INV-COORD-ROLLBACK holds.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    exc, _calls = _run_bake_failing_merge(repo)
+    assert isinstance(exc, RuntimeError), f"expected the injected bake fault; got {exc!r}"
+
+    # Precondition: the strand genuinely exists (else the guard would be vacuously
+    # green — nothing to reconcile). The real mark then names it.
+    assert coord_incoherent_done_wps(
+        COORD_BRANCH, _WRITE_SET, repo_root=repo, feature_dir=_feature_dir(repo)
+    ) == [STRANDED_WP], "precondition: the bake path must strand exactly STRANDED_WP"
+    assert _marker_stranded_wps(repo) == {STRANDED_WP}, (
+        "the real mark must record the stranded WP in pending_coord_reconcile"
+    )
+
+    # The behavioral guard is GREEN: strand present, but marked → recoverable.
+    _assert_coord_rollback_invariant(repo)
+
+
+def test_guard_reds_when_persist_marker_is_stubbed_to_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-vacuity (FR-008 / SC-005): stub the marker-persist → the guard REDS.
+
+    ``_persist_coord_reconcile_marker`` is monkeypatched to a runtime no-op and the
+    SAME real bake strand is re-driven. The leg-b byte-restore still runs (working
+    → ``approved``) and ``STRANDED_WP``'s committed ``done`` still survives, but now
+    NO marker names it → ``strand-on-committed-ref ∧ marker-absent``. The behavioral
+    guard must raise ``AssertionError`` — proving it is not a tautology that stays
+    green regardless of whether the mark actually fires.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    monkeypatch.setattr(
+        ex, "_persist_coord_reconcile_marker", lambda run, error: None
+    )
+    exc, _calls = _run_bake_failing_merge(repo)
+    assert isinstance(exc, RuntimeError), f"expected the injected bake fault; got {exc!r}"
+
+    # The strand is real (leg-b restore ran; committed ``done`` survives) …
+    assert coord_incoherent_done_wps(
+        COORD_BRANCH, _WRITE_SET, repo_root=repo, feature_dir=_feature_dir(repo)
+    ) == [STRANDED_WP], "precondition: the strand must exist even with the mark stubbed"
+    # … and, with the mark stubbed, unrecorded.
+    assert _marker_stranded_wps(repo) == set(), (
+        "precondition: the stubbed mark must leave pending_coord_reconcile absent"
+    )
+
+    # The falsifier: the SAME guard that was green above now REDS.
+    with pytest.raises(AssertionError, match="INV-COORD-ROLLBACK"):
+        _assert_coord_rollback_invariant(repo)
+    assert _coord_rollback_violation(repo) == {STRANDED_WP}
+
+
+def test_guard_reds_when_strand_authority_is_stubbed_to_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-vacuity (second seam): stub the strand-derivation authority → guard REDS.
+
+    ``executor.coord_incoherent_done_wps`` is monkeypatched to always return ``[]``.
+    ``_persist_coord_reconcile_marker`` then derives an empty strand and writes no
+    marker, while the leg-b byte-restore still strands ``STRANDED_WP``'s committed
+    ``done``. The checker's OWN (unpatched) strand read still sees the strand, so
+    the behavioral guard REDS — falsifying the mark at the derivation seam as well
+    as the persist seam.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    monkeypatch.setattr(
+        ex, "coord_incoherent_done_wps", lambda *args, **kwargs: []
+    )
+    exc, _calls = _run_bake_failing_merge(repo)
+    assert isinstance(exc, RuntimeError), f"expected the injected bake fault; got {exc!r}"
+
+    assert _marker_stranded_wps(repo) == set(), (
+        "precondition: a no-op strand authority must leave the marker absent"
+    )
+    with pytest.raises(AssertionError, match="INV-COORD-ROLLBACK"):
+        _assert_coord_rollback_invariant(repo)
+    assert _coord_rollback_violation(repo) == {STRANDED_WP}
+
+
+# ===========================================================================
+# T016 — programmatic restore-site enumeration + topology-gating
+# ===========================================================================
+
+_EXECUTOR_PATH = Path(ex.__file__)
+_PRIMITIVE = "_restore_and_guard_coord_coherence"
+_RAW_RESTORE = "_restore_final_bookkeeping_snapshots"
+_RECORD_DONE_PHASE = "_phase_record_done_and_project"
+_DONE_GATE_TOKEN = "done_marked_before_target"
+_RECORD_DONE_CALLEE = "_record_merged_wps_done_for_merge"
+_PROJECT_CALLEE = "_project_status_bookkeeping_to_target"
+
+# Restore-shape sites that route through the marking primitive today (≈407, 536,
+# 670, 691, 701, 757, 786). Derived by enumerating the primitive's call-sites from
+# the AST below — NOT hardcoded line numbers. This is a drift tripwire: if you add
+# a legitimately-routed restore site, bump this AND confirm it routes; if you add a
+# RAW restore, ``test_only_raw_restore_call_routes_through_the_primitive`` reds.
+_EXPECTED_ROUTED_SITES = 7
+
+
+def _load_executor_ast() -> tuple[ast.Module, dict[ast.AST, ast.AST]]:
+    tree = ast.parse(_EXECUTOR_PATH.read_text(encoding="utf-8"), filename=str(_EXECUTOR_PATH))
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return tree, parents
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _calls_named(tree: ast.Module, name: str) -> list[ast.Call]:
+    return [n for n in ast.walk(tree) if isinstance(n, ast.Call) and _call_name(n) == name]
+
+
+def _path_to_root(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> list[ast.AST]:
+    path: list[ast.AST] = [node]
+    cur: ast.AST = node
+    while cur in parents:
+        cur = parents[cur]
+        path.append(cur)
+    return path
+
+
+def _enclosing_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+    for anc in _path_to_root(node, parents)[1:]:
+        if isinstance(anc, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return anc.name
+    return ""
+
+
+def _enclosing_if_tests(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> list[str]:
+    """Unparsed test source of every ``If`` whose *body* (not ``orelse``) holds node."""
+    path = _path_to_root(node, parents)
+    tests: list[str] = []
+    for lower, upper in zip(path, path[1:], strict=False):
+        if isinstance(upper, ast.If) and lower in upper.body:
+            tests.append(ast.unparse(upper.test))
+    return tests
+
+
+def _enclosing_except_try_body_callees(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> set[str]:
+    """Callee names in the *try body* of the nearest ``Try`` whose handler holds node."""
+    path = _path_to_root(node, parents)
+    for lower, upper in zip(path, path[1:], strict=False):
+        if isinstance(upper, ast.Try) and lower in upper.handlers:
+            return {
+                _call_name(n)
+                for stmt in upper.body
+                for n in ast.walk(stmt)
+                if isinstance(n, ast.Call)
+            }
+    return set()
+
+
+def test_only_raw_restore_call_routes_through_the_primitive() -> None:
+    """FR-008 class-closer: the ONLY raw ``_restore_final_bookkeeping_snapshots(``
+    call lives inside the marking primitive — every restore site routes through it.
+
+    This is the structural invariant that closes the whole defect class rather than
+    two hand-picked sites: a NEW restore-shape site added later that calls
+    ``_restore_final_bookkeeping_snapshots`` directly (bypassing the coherence
+    mark/heal) makes ``len(raw) > 1`` → RED, because it can strand a committed coord
+    ``done`` silently.
+    """
+    tree, parents = _load_executor_ast()
+    raw_calls = _calls_named(tree, _RAW_RESTORE)
+    assert len(raw_calls) == 1, (
+        f"expected EXACTLY ONE raw {_RAW_RESTORE}( call (inside the {_PRIMITIVE} "
+        f"primitive); found {len(raw_calls)} at lines {[c.lineno for c in raw_calls]}. "
+        "A restore call OUTSIDE the primitive can strand a committed coord ``done`` "
+        "without a marker (FR-008 class breach) — route it through "
+        f"{_PRIMITIVE} instead."
+    )
+    host = _enclosing_function(raw_calls[0], parents)
+    assert host == _PRIMITIVE, (
+        f"the sole raw {_RAW_RESTORE}( call must live inside {_PRIMITIVE}; "
+        f"found it in {host!r}"
+    )
+
+
+def test_all_restore_sites_route_through_the_marking_primitive() -> None:
+    """FR-008: the restore-shape sites are enumerated from the AST (not hardcoded
+    line numbers) and every one routes through the marking primitive.
+
+    Seven sites route today (≈407/536/670/691/701/757/786). ``_EXPECTED_ROUTED_SITES``
+    is a self-documenting drift tripwire; the load-bearing class-closer is the
+    raw-call-inside-the-primitive assertion above.
+    """
+    tree, _parents = _load_executor_ast()
+    routed = _calls_named(tree, _PRIMITIVE)
+    lines = sorted(c.lineno for c in routed)
+    assert len(routed) == _EXPECTED_ROUTED_SITES, (
+        f"expected {_EXPECTED_ROUTED_SITES} routed {_PRIMITIVE}( sites; found "
+        f"{len(routed)} at {lines}. If you added a legitimately-routed restore site, "
+        "bump _EXPECTED_ROUTED_SITES AND confirm it routes; if you added a RAW "
+        "restore, test_only_raw_restore_call_routes_through_the_primitive reds."
+    )
+
+
+def test_site_691_dead_for_coord_and_site_701_coord_reachable_and_routed() -> None:
+    """FR-008: the two ``_phase_record_done_and_project`` restore sites carry the
+    correct topology gating.
+
+    * Site ≈691 (``_record_merged_wps_done_for_merge`` failure) sits INSIDE
+      ``if not run.done_marked_before_target:`` → dead-for-coord (the primitive's
+      internal guard no-ops the mark/heal there); a refactor that flips that gating
+      REDs this test.
+    * Site ≈701 (``_project_status_bookkeeping_to_target`` failure) sits OUTSIDE
+      that guard → coord-reachable, after the target advanced, routed through the
+      primitive so it CAN mark. This is the live same-shape site the original
+      six-site enumeration missed; un-routing or gating it out REDs this test.
+    """
+    tree, parents = _load_executor_ast()
+    calls = [
+        c
+        for c in _calls_named(tree, _PRIMITIVE)
+        if _enclosing_function(c, parents) == _RECORD_DONE_PHASE
+    ]
+    assert len(calls) == 2, (
+        f"expected exactly two routed restore sites in {_RECORD_DONE_PHASE} "
+        f"(dead-for-coord ≈691 + coord-reachable ≈701); found {len(calls)} at "
+        f"{sorted(c.lineno for c in calls)}"
+    )
+
+    dead_for_coord: list[ast.Call] = []
+    coord_reachable: list[ast.Call] = []
+    for c in calls:
+        gated = any(_DONE_GATE_TOKEN in test for test in _enclosing_if_tests(c, parents))
+        try_callees = _enclosing_except_try_body_callees(c, parents)
+        if gated and _RECORD_DONE_CALLEE in try_callees:
+            dead_for_coord.append(c)
+        elif not gated and _PROJECT_CALLEE in try_callees:
+            coord_reachable.append(c)
+
+    assert len(dead_for_coord) == 1, (
+        "site ≈691 must be dead-for-coord: the restore in the "
+        f"{_RECORD_DONE_CALLEE} except handler must sit INSIDE "
+        f"``if not run.{_DONE_GATE_TOKEN}:`` — got "
+        f"{[c.lineno for c in dead_for_coord]} matching"
+    )
+    assert len(coord_reachable) == 1, (
+        "site ≈701 must be coord-reachable-and-routed: the restore in the "
+        f"{_PROJECT_CALLEE} except handler must route through {_PRIMITIVE} and NOT "
+        f"be gated by ``run.{_DONE_GATE_TOKEN}`` — got "
+        f"{[c.lineno for c in coord_reachable]} matching"
+    )

--- a/tests/coordination/test_coherence.py
+++ b/tests/coordination/test_coherence.py
@@ -283,6 +283,100 @@ def test_repair_reverts_strand_then_is_a_byte_stable_noop_on_reapply(tmp_path: P
         assert _committed_events_bytes(repo, "coord") == bytes_after_first
 
 
+def test_repair_missing_worktree_returns_distinct_outcome(tmp_path: Path) -> None:
+    """A marker whose ``coord_worktree`` does not exist → a distinguishable outcome.
+
+    FR-007: the primitive returns ``worktree_missing=True`` (and never touches git)
+    so callers can surface a STUCK diagnostic instead of crashing or looping the
+    same live-strand error forever. The worktree check short-circuits BEFORE the
+    strand gate, so ``stranded_wp_ids`` stays empty.
+    """
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [_event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved")],
+    )
+
+    outcome = repair_coord_strand(
+        coord_ref="coord",
+        captured_sha="deadbeef",
+        coord_worktree=tmp_path / "pruned-coord-wt",  # does not exist
+        candidate_wps=["WP-A"],
+        repo_root=repo,
+        feature_dir=feature_dir,
+    )
+
+    assert isinstance(outcome, CoordRepairOutcome)
+    assert outcome.healed is False
+    assert outcome.worktree_missing is True
+    assert outcome.stranded_wp_ids == []
+    assert outcome.head_advanced is False
+
+
+def test_repair_refuses_when_head_already_reverted(tmp_path: Path) -> None:
+    """HEAD-freshness guard: a concurrent heal already advanced HEAD → refuse.
+
+    Simulates the concurrency TOCTOU: the passed ``coord_ref`` still reduces WP-A
+    to ``done`` (a stale view — so the strand gate passes), but the coordination
+    worktree HEAD has ALREADY been reverted to a coherent ``approved`` tip. A blind
+    ``git revert captured_sha..HEAD`` would then revert that concurrent revert too
+    and churn the ref; the guard instead REFUSES (``head_advanced=True``, no revert)
+    so a double-heal cannot re-apply ``done``. Without the guard the worktree HEAD
+    would advance with fresh revert commits — here it must stay put.
+    """
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [_event("WP-A", "approved", at="2026-07-18T10:00:00+00:00", event_id="01A00", from_lane="in_review")],
+    )
+    captured_sha = _git(repo, "rev-parse", "coord").stdout.strip()  # C0 (pre-done)
+
+    worktree = tmp_path / "coord-wt"
+    _git(repo, "worktree", "add", str(worktree), "coord")
+    wt_events = worktree / "kitty-specs" / MISSION_SLUG / "status.events.jsonl"
+    with wt_events.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                _event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved"),
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    _git(worktree, "add", ".")
+    _git(worktree, "commit", "-m", "bake WP-A done")
+    # Pin a STALE ref at the ``done`` tip (C1) — this is what the gate reads.
+    _git(repo, "branch", "coord_done", "coord")
+
+    # A concurrent healer already reverted the ``done`` → worktree HEAD advances to
+    # a coherent ``approved`` tip (C2); the ``coord`` branch moves with it.
+    _git(worktree, "revert", "--no-edit", "HEAD")
+    head_before = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Sanity: the stale ref STILL reduces WP-A to done (gate would pass) …
+    assert coord_incoherent_done_wps(
+        "coord_done", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == ["WP-A"]
+    # … while the worktree HEAD is already coherent (approved).
+    assert coord_incoherent_done_wps(
+        head_before, ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == []
+
+    outcome = repair_coord_strand(
+        coord_ref="coord_done",  # stale: still reduces to done → gate passes
+        captured_sha=captured_sha,
+        coord_worktree=worktree,
+        candidate_wps=["WP-A"],
+        repo_root=repo,
+        feature_dir=feature_dir,
+    )
+
+    assert outcome.healed is False
+    assert outcome.head_advanced is True
+    assert outcome.stranded_wp_ids == ["WP-A"]
+    # The guard must NOT run a revert — HEAD is unchanged (no re-applied ``done``).
+    assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == head_before
+
+
 def test_repair_on_already_coherent_ref_is_a_noop(tmp_path: Path) -> None:
     """A ref whose candidate WP is only ever ``approved`` heals to a no-op — the
     repair never reverts the (non-existent) strand."""

--- a/tests/coordination/test_coherence.py
+++ b/tests/coordination/test_coherence.py
@@ -1,0 +1,379 @@
+"""Owner-level coherence tests for ``coordination.coherence`` (WP02, #2786/#2367-B).
+
+Pins the anti-fakeable strand-derivation contract (FR-009 / SC-007) and the
+strand-gated repair primitive at the single coordination-domain owner, plus the
+``iter_pending_coord_reconcile_markers`` enumeration seam that the doctor (WP04)
+consumes because ``load_state(mission_id=None)`` raises on >=2 states.
+
+Import ``specify_cli.status`` before any coordination submodule to mirror the
+production import order (``specify_cli/__init__`` imports ``status`` first) and
+avoid the known ``coordination -> transaction -> status`` init-order cycle when a
+test module imports coordination first.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import specify_cli.status  # noqa: F401  # import-order guard (see module docstring)
+from specify_cli.coordination.coherence import (
+    CoordRepairOutcome,
+    coord_incoherent_done_wps,
+    repair_coord_strand,
+)
+from specify_cli.merge.state import (
+    MergeAmbiguousStateError,
+    MergeState,
+    iter_pending_coord_reconcile_markers,
+    load_state,
+    save_state,
+)
+
+pytestmark = [pytest.mark.git_repo, pytest.mark.non_sandbox]
+
+MISSION_SLUG = "coherence-fixture-01KXTM59"
+_EVENTS_REL = f"kitty-specs/{MISSION_SLUG}/status.events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-qb", "main", str(repo)], check=True, capture_output=True)
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+
+
+def _event(wp_id: str, to_lane: str, *, at: str, event_id: str, from_lane: str) -> dict[str, object]:
+    return {
+        "actor": "reviewer-renata",
+        "at": at,
+        "event_id": event_id,
+        "evidence": None,
+        "execution_mode": "worktree",
+        "feature_slug": MISSION_SLUG,
+        "force": False,
+        "from_lane": from_lane,
+        "reason": None,
+        "review_ref": None,
+        "to_lane": to_lane,
+        "wp_id": wp_id,
+    }
+
+
+def _write_meta(feature_dir: Path) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": MISSION_SLUG,
+                "mission_id": "01KXTM59000000000000000000",
+                "mission_number": None,
+                "mission_type": "software-dev",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_events(feature_dir: Path, events: list[dict[str, object]]) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "status.events.jsonl").write_text(
+        "".join(json.dumps(e, sort_keys=True) + "\n" for e in events),
+        encoding="utf-8",
+    )
+
+
+def _seed_committed_coord_ref(
+    repo: Path, events: list[dict[str, object]], *, branch: str = "coord"
+) -> Path:
+    """Commit ``events`` onto ``branch`` and return the primary feature_dir."""
+    _init_repo(repo)
+    feature_dir = repo / "kitty-specs" / MISSION_SLUG
+    _write_meta(feature_dir)
+    _write_events(feature_dir, events)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "seed coord events")
+    _git(repo, "branch", branch)
+    return feature_dir
+
+
+# ---------------------------------------------------------------------------
+# T007 (a): ≥2-WP anti-fakeable specific-WP derivation
+# ---------------------------------------------------------------------------
+
+
+def test_returns_only_the_stranded_done_wp_not_the_approved_one(tmp_path: Path) -> None:
+    """WP-A is done-on-ref, WP-B is only approved. The derivation returns exactly
+    ``["WP-A"]`` — falsifying a hardcoded ``["WP01"]`` (wrong id) and an
+    ``== candidate_wps`` passthrough (would wrongly include WP-B)."""
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [
+            _event("WP-A", "approved", at="2026-07-18T10:00:00+00:00", event_id="01A00", from_lane="in_review"),
+            _event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved"),
+            _event("WP-B", "approved", at="2026-07-18T10:00:00+00:00", event_id="01B00", from_lane="in_review"),
+        ],
+    )
+
+    result = coord_incoherent_done_wps(
+        "coord", ["WP-A", "WP-B"], repo_root=repo, feature_dir=feature_dir
+    )
+
+    assert result == ["WP-A"]
+    # Anti-fakeability: neither a hardcoded literal nor the raw candidate list.
+    assert result != ["WP01"]
+    assert result != ["WP-A", "WP-B"]
+
+
+# ---------------------------------------------------------------------------
+# T007 (b): pre-existing-done exclusion — the ONLY test distinguishing the
+# write-set from ``all_wp_ids``.
+# ---------------------------------------------------------------------------
+
+
+def test_pre_existing_done_wp_outside_write_set_is_excluded(tmp_path: Path) -> None:
+    """WP-C is ``done`` on the ref from BEFORE this merge and is NOT in this
+    merge's write-set. Deriving over the write-set excludes it — proving that
+    passing ``run.all_wp_ids`` (which would include WP-C) is wrong."""
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [
+            # Pre-existing, legitimately-done WP from a prior merge.
+            _event("WP-C", "done", at="2026-07-18T09:00:00+00:00", event_id="01C01", from_lane="approved"),
+            # This merge's genuine strand.
+            _event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved"),
+            _event("WP-B", "approved", at="2026-07-18T10:00:00+00:00", event_id="01B00", from_lane="in_review"),
+        ],
+    )
+
+    # Sanity: WP-C really is done-on-ref (so exclusion is by write-set, not by
+    # absence of the done event).
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-C"], repo_root=repo, feature_dir=feature_dir
+    ) == ["WP-C"]
+
+    # The write-set for THIS merge excludes WP-C -> it is not healed.
+    write_set = ["WP-A", "WP-B"]
+    result = coord_incoherent_done_wps(
+        "coord", write_set, repo_root=repo, feature_dir=feature_dir
+    )
+    assert result == ["WP-A"]
+    assert "WP-C" not in result
+
+
+def test_empty_candidate_and_unresolvable_ref_return_empty(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [_event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved")],
+    )
+    # Empty write-set short-circuits.
+    assert coord_incoherent_done_wps("coord", [], repo_root=repo, feature_dir=feature_dir) == []
+    # A ref that does not exist -> no events -> empty (non-coord/legacy fallback).
+    assert (
+        coord_incoherent_done_wps(
+            "does-not-exist", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+        )
+        == []
+    )
+
+
+# ---------------------------------------------------------------------------
+# T007 (c): repair strand-gating + idempotency (byte-stable coord log)
+# ---------------------------------------------------------------------------
+
+
+def _committed_events_bytes(repo: Path, branch: str) -> bytes:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{branch}:{_EVENTS_REL}"],
+        check=True,
+        capture_output=True,
+    )
+    return proc.stdout
+
+
+def test_repair_reverts_strand_then_is_a_byte_stable_noop_on_reapply(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [_event("WP-A", "approved", at="2026-07-18T10:00:00+00:00", event_id="01A00", from_lane="in_review")],
+    )
+    # captured_sha = coord tip BEFORE the done bake.
+    captured_sha = _git(repo, "rev-parse", "coord").stdout.strip()
+
+    # Materialize a coord worktree with the branch checked out and bake the
+    # stranding ``done`` commit there (HEAD advances past captured_sha).
+    worktree = tmp_path / "coord-wt"
+    _git(repo, "worktree", "add", str(worktree), "coord")
+    wt_events = worktree / "kitty-specs" / MISSION_SLUG / "status.events.jsonl"
+    with wt_events.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                _event("WP-A", "done", at="2026-07-18T10:05:00+00:00", event_id="01A01", from_lane="approved"),
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    _git(worktree, "add", ".")
+    _git(worktree, "commit", "-m", "bake WP-A done (strands on rollback)")
+
+    # Pre-condition: WP-A is stranded done on the committed ref.
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == ["WP-A"]
+
+    # First repair: performs the git revert.
+    first = repair_coord_strand(
+        coord_ref="coord",
+        captured_sha=captured_sha,
+        coord_worktree=worktree,
+        candidate_wps=["WP-A"],
+        repo_root=repo,
+        feature_dir=feature_dir,
+    )
+    assert isinstance(first, CoordRepairOutcome)
+    assert first.healed is True
+    assert first.stranded_wp_ids == ["WP-A"]
+    assert first.error is None
+
+    # The committed ref is now coherent again (WP-A back to approved).
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == []
+    bytes_after_first = _committed_events_bytes(repo, "coord")
+
+    # Second + third repair: strand-gate short-circuits -> no-op, byte-stable.
+    for _ in range(2):
+        outcome = repair_coord_strand(
+            coord_ref="coord",
+            captured_sha=captured_sha,
+            coord_worktree=worktree,
+            candidate_wps=["WP-A"],
+            repo_root=repo,
+            feature_dir=feature_dir,
+        )
+        assert outcome.healed is False
+        assert outcome.stranded_wp_ids == []
+        assert _committed_events_bytes(repo, "coord") == bytes_after_first
+
+
+def test_repair_on_already_coherent_ref_is_a_noop(tmp_path: Path) -> None:
+    """A ref whose candidate WP is only ever ``approved`` heals to a no-op — the
+    repair never reverts the (non-existent) strand."""
+    repo = tmp_path / "repo"
+    feature_dir = _seed_committed_coord_ref(
+        repo,
+        [_event("WP-A", "approved", at="2026-07-18T10:00:00+00:00", event_id="01A00", from_lane="in_review")],
+    )
+    worktree = tmp_path / "coord-wt"
+    _git(repo, "worktree", "add", str(worktree), "coord")
+    head_before = _git(repo, "rev-parse", "coord").stdout.strip()
+
+    outcome = repair_coord_strand(
+        coord_ref="coord",
+        captured_sha=head_before,
+        coord_worktree=worktree,
+        candidate_wps=["WP-A"],
+        repo_root=repo,
+        feature_dir=feature_dir,
+    )
+    assert outcome.healed is False
+    assert outcome.stranded_wp_ids == []
+    # No revert commit was created.
+    assert _git(repo, "rev-parse", "coord").stdout.strip() == head_before
+
+
+# ---------------------------------------------------------------------------
+# T004/T007 (d): iter_pending_coord_reconcile_markers enumerates across >=2 dirs
+# ---------------------------------------------------------------------------
+
+
+def _marker() -> dict[str, object]:
+    return {
+        "coord_ref": "coord",
+        "captured_sha": "deadbeef",
+        "coord_worktree": "/tmp/coord-wt",
+        "stranded_wp_ids": ["WP-A"],
+        "revert_error": None,
+        "detected_at": "2026-07-18T10:05:00+00:00",
+    }
+
+
+def _make_state(mission_id: str, *, marker: dict[str, object] | None) -> MergeState:
+    return MergeState(
+        mission_id=mission_id,
+        mission_slug=mission_id,
+        target_branch="main",
+        wp_order=["WP-A"],
+        current_wp="WP-A",
+        pending_coord_reconcile=marker,
+    )
+
+
+def test_iter_markers_enumerates_across_multiple_runtime_state_dirs(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".kittify").mkdir(parents=True)
+
+    save_state(_make_state("01MID0000000000000000000A0", marker=_marker()), repo)
+    save_state(_make_state("01MID0000000000000000000B0", marker=_marker()), repo)
+    # A coherent (marker-absent) mission must be skipped.
+    save_state(_make_state("01MID0000000000000000000C0", marker=None), repo)
+
+    # load_state(None) cannot be used to enumerate: >=2 active states raise.
+    with pytest.raises(MergeAmbiguousStateError):
+        load_state(repo, None)
+
+    markers = list(iter_pending_coord_reconcile_markers(repo))
+    mission_ids = {s.mission_id for s in markers}
+    assert mission_ids == {"01MID0000000000000000000A0", "01MID0000000000000000000B0"}
+    assert all(s.pending_coord_reconcile is not None for s in markers)
+    # The marker round-trips as a plain dict via save/load.
+    assert markers[0].pending_coord_reconcile == _marker()
+
+
+def test_iter_markers_empty_when_no_runtime_dir(tmp_path: Path) -> None:
+    assert list(iter_pending_coord_reconcile_markers(tmp_path)) == []
+
+
+def test_pending_coord_reconcile_round_trips_and_old_files_rehydrate_to_none(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".kittify").mkdir(parents=True)
+    # Old state file: no pending_coord_reconcile key at all.
+    old = _make_state("01MIDOLD0000000000000000A0", marker=None)
+    data = old.to_dict()
+    del data["pending_coord_reconcile"]
+    from specify_cli.merge.workspace import get_merge_runtime_dir
+
+    runtime_dir = get_merge_runtime_dir(old.mission_id, repo)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "state.json").write_text(json.dumps(data), encoding="utf-8")
+
+    loaded = load_state(repo, old.mission_id)
+    assert loaded is not None
+    assert loaded.pending_coord_reconcile is None

--- a/tests/merge/test_executor_coord_reconcile.py
+++ b/tests/merge/test_executor_coord_reconcile.py
@@ -1,0 +1,293 @@
+"""Executor coord-reconcile marker/heal integration tests (WP03, #2786 + #2367-B).
+
+These cover the executor wiring WP03 adds on top of WP02's coordination
+primitives:
+
+* the ``pending_coord_reconcile`` marker is written at BOTH strand sites (the
+  #2367-B bake-mid-write-set failure and the #2786 revert-failure) via the
+  ``_restore_and_guard_coord_coherence`` restore primitive — mark-not-raise, so
+  the original fault still propagates and the leg-b byte-restore still runs;
+* the marker's ``stranded_wp_ids`` names the SPECIFIC stranded WP on a >=2-WP
+  fixture (the coherent, only-``approved`` WP excluded) AND excludes a
+  genuinely-pre-existing-``done`` WP — falsifying both a hardcoded list and
+  ``run.all_wp_ids`` (the derivation contract, data-model);
+* ``_heal_pending_coord_reconcile`` reconciles the committed coord ref back to
+  the byte-restored working tree and clears the marker atomically; a second
+  resume is a strand-gated no-op leaving the committed ``status.events.jsonl``
+  byte-stable (NFR-002).
+
+The heavy coord-topology full-merge harnesses (fixture bootstrap + failure
+injection + git-reducible committed/working readers) are REUSED verbatim from
+the WP01 red-first repros so this module never re-authors them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Import the status package before any coordination submodule (production import
+# order; see the #2711 harness docstring).
+import specify_cli.status  # noqa: F401  # import-order guard
+
+from specify_cli.merge import executor as ex
+from specify_cli.merge.state import MergeState, load_state
+from specify_cli.status import Lane
+
+# --- Reused bake-strand (#2367-B) harness -----------------------------------
+from tests.regression.test_issue_2367_bake_strand import (
+    COHERENT_WP,
+    COORD_BRANCH,
+    MISSION_ID,
+    MISSION_SLUG,
+    STRANDED_WP,
+    _bootstrap_two_wp_coord_mission,
+    _committed_coord_events,
+    _git,
+    _init_git_repo,
+    _lane_on,
+    _run_bake_failing_merge,
+    _working_coord_events,
+)
+
+# --- Reused revert-failure (#2786) harness ----------------------------------
+from tests.regression.test_issue_2786_revert_failure_split_brain import (
+    _reduce_coord_lanes,
+    _run_merge_with_target_and_revert_failing,
+)
+from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
+    MISSION_ID as REVERT_MISSION_ID,
+    WP_ID as REVERT_WP_ID,
+    _bootstrap_coord_mission as _bootstrap_revert_mission,
+    _init_git_repo as _init_revert_repo,
+)
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]
+
+
+def _committed_status_events_blob(repo: Path) -> str:
+    """Raw committed ``status.events.jsonl`` on the coordination branch."""
+    return _git(
+        repo, "show", f"{COORD_BRANCH}:kitty-specs/{MISSION_SLUG}/status.events.jsonl"
+    ).stdout
+
+
+def _marker(repo: Path, mission_id: str) -> dict[str, object] | None:
+    state = load_state(repo, mission_id)
+    assert state is not None, "merge state.json must exist after a strand pass"
+    return state.pending_coord_reconcile
+
+
+# ---------------------------------------------------------------------------
+# T011 — bake strand: marker names the SPECIFIC WP; mark-not-raise; leg-b ran
+# ---------------------------------------------------------------------------
+
+
+def test_bake_strand_marks_specific_wp_and_excludes_coherent(tmp_path: Path) -> None:
+    """A #2367-B bake-mid-write-set failure marks EXACTLY the stranded WP.
+
+    The >=2-WP fixture strands ``STRANDED_WP`` (its ``done`` committed before the
+    abort) while ``COHERENT_WP`` is only ever ``approved``. The marker's
+    ``stranded_wp_ids`` must name only the stranded WP — a hardcoded ``["WP01"]``
+    happens to match here, but the exclusion of the coherent WP is the load-bearing
+    half (the ``all_wp_ids`` falsification is pinned separately below).
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    exc, _calls = _run_bake_failing_merge(repo)
+
+    # Mark-not-raise: the ORIGINAL bake fault propagated (the mark did not swallow
+    # it nor raise a different error).
+    assert isinstance(exc, RuntimeError), f"expected the injected bake fault; got {exc!r}"
+
+    marker = _marker(repo, MISSION_ID)
+    assert marker is not None, "the bake strand must write a pending_coord_reconcile marker"
+    assert marker["stranded_wp_ids"] == [STRANDED_WP], marker["stranded_wp_ids"]
+    assert COHERENT_WP not in marker["stranded_wp_ids"]  # type: ignore[operator]
+    assert marker["revert_error"], "the marker should carry the swallowed fault text"
+    assert marker["captured_sha"], "the marker must carry the pre-bake coord tip"
+
+
+def test_bake_strand_leg_b_byte_restore_still_runs(tmp_path: Path) -> None:
+    """Mark-not-raise (FR-005): the working tree byte-restore still rolls back.
+
+    The stranded WP's committed coord ``done`` survives (the strand), but the
+    coordination worktree's WORKING event log is byte-restored to ``approved`` —
+    proving the mark did not short-circuit the leg-b restore.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    _run_bake_failing_merge(repo)
+
+    working_events = _working_coord_events(repo)
+    committed_events = _committed_coord_events(repo, repo / "kitty-specs" / MISSION_SLUG)
+    assert _lane_on(working_events, STRANDED_WP) == Lane.APPROVED, "leg-b restore must run"
+    assert _lane_on(committed_events, STRANDED_WP) == Lane.DONE, "the strand must exist pre-heal"
+
+
+# ---------------------------------------------------------------------------
+# T011 — pre-existing-done exclusion (falsifies an ``all_wp_ids`` candidate set)
+# ---------------------------------------------------------------------------
+
+
+def test_write_set_excludes_pre_existing_done_wp(tmp_path: Path) -> None:
+    """The marker candidate set is THIS merge's write-set, NOT ``all_wp_ids``.
+
+    After a bake strand, ``STRANDED_WP`` is durably ``done`` on the committed coord
+    ref. A *subsequent* merge over ``[STRANDED_WP, "WPZZ"]`` must treat
+    ``STRANDED_WP`` as pre-existing-``done`` and DROP it from the write-set — so a
+    strand of ``WPZZ`` would never re-revert the legitimately-done ``STRANDED_WP``.
+    This is the case a naive ``run.all_wp_ids`` candidate set fails (data-model
+    non-fakeable derivation contract).
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+    _run_bake_failing_merge(repo)  # leaves STRANDED_WP committed done on the coord ref
+
+    # STRANDED_WP is now durably done on the committed coord ref (pre-existing for
+    # any subsequent merge). Build a minimal run over [STRANDED_WP, WPZZ].
+    state = MergeState(
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        target_branch="main",
+        wp_order=[STRANDED_WP, "WPZZ"],
+    )
+    run = _make_min_run(repo, all_wp_ids=[STRANDED_WP, "WPZZ"], state=state)
+    run.pre_target_coord_ref = COORD_BRANCH
+
+    ex._capture_pre_target_done_write_set(run)
+
+    assert STRANDED_WP not in run.pre_target_done_write_set, (
+        "a genuinely-pre-existing-done WP must be excluded from the write-set — "
+        f"got {run.pre_target_done_write_set}"
+    )
+    assert run.pre_target_done_write_set == ["WPZZ"], run.pre_target_done_write_set
+
+
+def _make_min_run(
+    repo: Path, *, all_wp_ids: list[str], state: MergeState
+) -> ex._MergeRunState:
+    from types import SimpleNamespace
+
+    lanes_manifest = SimpleNamespace(
+        target_branch="main",
+        mission_branch=COORD_BRANCH,
+        lanes=[SimpleNamespace(lane_id="lane-a", wp_ids=all_wp_ids)],
+    )
+    return ex._MergeRunState(
+        main_repo=repo,
+        mission_slug=MISSION_SLUG,
+        canonical_id=MISSION_ID,
+        canonical_mission_id=MISSION_ID,
+        feature_dir=repo / "kitty-specs" / MISSION_SLUG,
+        target_feature_dir=repo / "kitty-specs" / MISSION_SLUG,
+        lanes_manifest=lanes_manifest,
+        all_wp_ids=all_wp_ids,
+        push=False,
+        delete_branch=False,
+        remove_worktree=False,
+        strategy=ex.MergeStrategy.SQUASH,
+        assume_yes=True,
+        planning_artifact_only=False,
+        state=state,
+        is_resume=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T011 — resume heal: committed == working + marker cleared; byte-stable resume
+# ---------------------------------------------------------------------------
+
+
+def test_bake_strand_resume_heals_and_clears(tmp_path: Path) -> None:
+    """A ``merge --resume`` heals the bake strand and clears the marker (FR-006)."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    _run_bake_failing_merge(repo)
+    assert _marker(repo, MISSION_ID) is not None, "pass 1 must strand + mark"
+
+    # Resume: the same injected fault re-raises, but the heal reconciles the strand.
+    _run_bake_failing_merge(repo)
+
+    feature_dir = repo / "kitty-specs" / MISSION_SLUG
+    committed = _lane_on(_committed_coord_events(repo, feature_dir), STRANDED_WP)
+    working = _lane_on(_working_coord_events(repo), STRANDED_WP)
+    assert committed == working == Lane.APPROVED, (
+        f"heal must reconcile committed=={working}; got committed={committed}"
+    )
+    assert _marker(repo, MISSION_ID) is None, "the marker must be cleared after the heal"
+
+
+def test_resume_twice_is_byte_stable(tmp_path: Path) -> None:
+    """Resuming twice yields a byte-identical committed coord ``status.events.jsonl``.
+
+    NFR-002 idempotency: the ``stranded+marked -> coherent`` and
+    ``already-coherent -> no-op clear`` edges converge — a second resume is a
+    strand-gated no-op, so the committed event-log bytes do not churn.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    _bootstrap_two_wp_coord_mission(repo)
+
+    _run_bake_failing_merge(repo)  # pass 1: strand
+    _run_bake_failing_merge(repo)  # pass 2: heal
+    blob_after_first_resume = _committed_status_events_blob(repo)
+
+    _run_bake_failing_merge(repo)  # pass 3: idempotent no-op heal
+    blob_after_second_resume = _committed_status_events_blob(repo)
+
+    assert blob_after_second_resume == blob_after_first_resume, (
+        "a second resume must leave the committed coord status.events.jsonl "
+        "byte-identical (idempotent heal, NFR-002)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T011 — revert-failure strand (#2786): marks, then a resume heals
+# ---------------------------------------------------------------------------
+
+
+def test_revert_failure_strand_marks_and_resume_reconciles(tmp_path: Path) -> None:
+    """A #2786 swallowed-revert failure marks the strand; a resume reconciles it.
+
+    Exercises the OTHER strand site (the target-advance rollback whose coord
+    ``git revert`` is forced to fail), driven through the same restore primitive.
+
+    The reproduction harness forces EVERY ``git revert`` to fail — including the
+    resume heal's forward revert — so this pins the coherence CONTRACT
+    (``committed == working``: no split-brain) that survives even a permanently
+    broken revert, rather than the ``approved``-specific outcome. In production the
+    resume heal's revert runs on the cleaned worktree and lands BOTH surfaces on
+    ``approved`` (the ``approved``-clears path is pinned by the bake-strand heal
+    test above, where the revert is NOT forced to fail). Because the revert here
+    cannot apply, the marker is deliberately NOT cleared (left for the next
+    resume / ``doctor --fix``), per the strand-gated atomic-clear contract.
+    """
+    repo = tmp_path / "repo"
+    _init_revert_repo(repo)
+    feature_dir = _bootstrap_revert_mission(repo)
+
+    _run_merge_with_target_and_revert_failing(repo)  # pass 1: swallowed revert -> strand
+    marker = _marker(repo, REVERT_MISSION_ID)
+    assert marker is not None, "the swallowed-revert failure must write a marker"
+    assert marker["stranded_wp_ids"] == [REVERT_WP_ID], marker["stranded_wp_ids"]
+
+    _run_merge_with_target_and_revert_failing(repo)  # pass 2: resume heal
+    committed_lane, working_lane = _reduce_coord_lanes(repo, feature_dir)
+    assert committed_lane == working_lane, (
+        "resume must reconcile the revert-failure strand to a coherent "
+        f"committed==working; got committed={committed_lane} working={working_lane}"
+    )
+    # A permanently-failing revert cannot clear the strand: the marker persists so
+    # a later resume / doctor can still repair it (atomic-clear only on heal).
+    assert _marker(repo, REVERT_MISSION_ID) is not None, (
+        "a revert that could not apply must leave the marker for the next pass"
+    )

--- a/tests/merge/test_executor_coord_reconcile.py
+++ b/tests/merge/test_executor_coord_reconcile.py
@@ -291,3 +291,42 @@ def test_revert_failure_strand_marks_and_resume_reconciles(tmp_path: Path) -> No
     assert _marker(repo, REVERT_MISSION_ID) is not None, (
         "a revert that could not apply must leave the marker for the next pass"
     )
+
+
+def test_resume_preserves_marker_when_coord_worktree_pruned(tmp_path: Path) -> None:
+    """A pruned coord worktree must PRESERVE the marker on resume (debugger-debbie HIGH).
+
+    ``repair_coord_strand`` short-circuits ``worktree_missing`` BEFORE its strand
+    gate, so its empty ``stranded_wp_ids`` means "strand UNCHECKED", NOT "coherent".
+    Clearing the marker on that empty set (the pre-fix ``not outcome.stranded_wp_ids``
+    condition) would erase an UNRESOLVED committed split-brain — invisible to a later
+    doctor/resume once the worktree is re-materialized. The heal must leave the marker.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / "kitty-specs" / MISSION_SLUG).mkdir(parents=True)
+    marker = {
+        "coord_ref": COORD_BRANCH,
+        "captured_sha": "deadbeef",
+        "coord_worktree": str(tmp_path / "pruned-coord-wt"),  # does NOT exist
+        "stranded_wp_ids": [STRANDED_WP],
+        "revert_error": "injected",
+        "detected_at": "2026-07-18T10:00:00+00:00",
+    }
+    state = MergeState(
+        mission_id=MISSION_ID,
+        mission_slug=MISSION_SLUG,
+        target_branch="main",
+        wp_order=[STRANDED_WP],
+        current_wp=STRANDED_WP,
+        pending_coord_reconcile=marker,
+    )
+    run = _make_min_run(repo, all_wp_ids=[STRANDED_WP], state=state)
+    run.is_resume = True
+
+    ex._heal_pending_coord_reconcile(run)
+
+    assert run.state.pending_coord_reconcile is not None, (
+        "a pruned coord worktree must PRESERVE the marker (worktree_missing is NOT "
+        "coherence) — clearing it erases an unresolved committed split-brain"
+    )

--- a/tests/regression/test_issue_2367_bake_strand.py
+++ b/tests/regression/test_issue_2367_bake_strand.py
@@ -1,0 +1,471 @@
+"""Scope: #2367 Mechanism B — the merge coord write-set is not atomic (INTENTIONAL red-first P0).
+
+This module is an INTENTIONAL, issue-pinned red-first P0 reproduction for
+**#2367 Mechanism B**. It is expected to FAIL on the mission base and stays RED
+until the unified #2786/#2367-B fix lands — per ADR ``docs/adr/3.x/2026-07-17-1``
+(a P0 defect carries an honest, main-breaking reproduction; it is NOT deselected
+or xfail-masked).
+
+Defect (#2367 Mechanism B)
+--------------------------
+``spec-kitty merge`` records the per-WP ``approved -> done`` transition for each
+merged WP through its OWN ``BookkeepingTransaction`` (N independent COMMITTED
+coordination-branch transactions) inside
+``specify_cli.merge.done_bookkeeping._record_merged_wps_done_for_merge``. That
+loop is not one atomic unit. When it FAILS mid write-set — after ≥1 per-WP
+``done`` has already COMMITTED to the coordination branch, before the remaining
+WPs are marked — the executor's failure branch
+(``specify_cli.merge.executor._phase_bake_and_pre_target_done``, the
+``except Exception:`` at ≈406-408) restores **working-tree bytes only**:
+it calls ``_restore_final_bookkeeping_snapshots`` and RE-RAISES. It does **NOT**
+call ``_revert_coord_done_commit`` (that runs only on the *target-advance* /
+*squash-conflict* rollback paths via ``_restore_pre_target_if_at_baseline``,
+executor ≈535-536 — which are therefore revert-covered and would repro
+VACUOUSLY GREEN).
+
+Consequently the already-committed per-WP ``done`` commits survive on the
+coordination ref while the working tree is byte-restored to ``approved`` — the
+identical byte-restore-**without**-revert mechanism as #2786 (#2786 = the revert
+itself *failed*; #2367-B = the revert was *never called* because the failure
+preceded it). The coordination worktree is left tracked-dirty, and the committed
+reduction (``done``) diverges from the working reduction (``approved``) — a
+split-brain the #1826 safe-resync guard then correctly refuses to ``reset --hard``
+over, blocking the next merge/resume.
+
+Reproduction strategy
+---------------------
+A ``>=2``-WP coordination-topology fixture (authored locally — the #2711
+``_bootstrap_coord_mission`` is single-WP and has NO bake-loop injection hook; it
+is in no WP's ``owned_files`` and is NEVER edited here; only the primitive
+``_init_git_repo`` / ``_git`` helpers are reused):
+
+* **WP01** commits its ``approved -> done`` to the coordination branch first, then
+* the failure is injected **inside** ``_record_merged_wps_done_for_merge`` by a
+  ``_mark_wp_merged_done`` ``side_effect`` that delegates to the real helper for
+  WP01 (so its ``done`` genuinely lands) and RAISES on **WP02** — exercising the
+  real ``executor.py:406-408`` byte-restore-without-revert branch;
+* **WP02** is only ever ``approved`` (never marked) — the *coherent* control that
+  falsifies both a hardcoded ``["WP01"]`` and an over-broad ``all_wp_ids`` strand
+  set.
+
+The stranded set is reduced from the COMMITTED coordination ref via
+``_durable_done_wps_on_coordination_ref`` (git-reducible authority; NOT a live
+worktree diff, which is empty at the mark point per data-model D7, and NOT any
+marker/doctor surface — those do not exist on the base and would red with
+``AttributeError`` = forbidden setup-red). The coherence CONTRACT then FAILS for
+the RIGHT reason: after a ``spec-kitty merge --resume`` heal (a no-op on the base
+until the WP03 repair lands), the committed reduction is stranded at ``done``
+while the working tree reduces to ``approved``.
+
+Do NOT fix the bake path here — the fix is the unified #2786/#2367-B marker +
+strand-gated heal; this module is the honest red that the fix flips green.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+# Import the status package before any coordination submodule (mirror the
+# production import order; see the #2711 harness module docstring for rationale).
+import specify_cli.status  # noqa: F401  # import-order guard
+
+import specify_cli.merge.done_bookkeeping as done_bookkeeping
+from specify_cli.cli.commands.merge import _run_lane_based_merge
+from specify_cli.coordination.status_service import (
+    EventLogReadContract,
+    read_event_log,
+    wp_lane_actor_from_events,
+)
+from specify_cli.coordination.workspace import CoordinationWorkspace
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.lanes.persistence import write_lanes_json
+from specify_cli.merge.config import MergeStrategy
+from specify_cli.merge.done_bookkeeping import _durable_done_wps_on_coordination_ref
+from specify_cli.status import Lane, StatusEvent
+
+# Reuse ONLY the primitive git helpers from the #2711 harness (never the
+# single-WP ``_bootstrap_coord_mission``, which has no bake-loop injection hook
+# and is in no WP's owned_files — WP01 authors its own >=2-WP bootstrap below).
+from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
+    _git,
+    _init_git_repo,
+    _merge_external_mocks,
+)
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]
+
+# ---------------------------------------------------------------------------
+# Mission identity (slug ends with ``-<mid8>`` so the coordination branch IS the
+# lanes-manifest mission branch — the production 083+ coord-topology layout).
+# ---------------------------------------------------------------------------
+
+MID8 = "01KXBAKE"
+MISSION_ID = "01KXBAKE000000000000000000"
+MISSION_SLUG = f"merge-bake-2367-{MID8}"
+COORD_BRANCH = f"kitty/mission-{MISSION_SLUG}"
+STRANDED_WP = "WP01"  # commits ``done`` before the injected failure -> stranded
+COHERENT_WP = "WP02"  # only ever ``approved`` -> the coherent control
+LANE_ID = "lane-a"
+
+_INJECTED_BAKE_FAILURE = "injected #2367-B bake-mid-write-set failure"
+
+
+# ---------------------------------------------------------------------------
+# Locally-authored >=2-WP coord-topology fixture (owned file — no shared-harness
+# edit). Only ``_init_git_repo`` / ``_git`` are reused as primitives.
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(feature_dir: Path) -> None:
+    meta = {
+        "mission_slug": MISSION_SLUG,
+        "mission_id": MISSION_ID,
+        "mid8": MID8,
+        "mission_number": None,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "coordination_branch": COORD_BRANCH,
+        "purpose_tldr": "#2367-B bake-mid-write-set strand regression",
+        "purpose_context": "an aborted multi-WP coord write-set must roll back atomically",
+    }
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _write_manifest(feature_dir: Path) -> None:
+    """One lane carrying BOTH WPs so a single merge pass bakes a multi-WP write-set."""
+    manifest = LanesManifest(
+        version=1,
+        mission_slug=MISSION_SLUG,
+        # mission_id == slug => legacy lane_branch_name form
+        # ``kitty/mission-<slug>-lane-a`` (the slug already carries ``-<mid8>``).
+        mission_id=MISSION_SLUG,
+        mission_branch=COORD_BRANCH,
+        target_branch="main",
+        lanes=[
+            ExecutionLane(
+                lane_id=LANE_ID,
+                wp_ids=(STRANDED_WP, COHERENT_WP),
+                write_scope=("src/wp01_code.py", "src/wp02_code.py"),
+                predicted_surfaces=("code",),
+                depends_on_lanes=(),
+                parallel_group=0,
+            )
+        ],
+        computed_at=datetime.now(UTC).isoformat(),
+        computed_from="test-fixture",
+    )
+    write_lanes_json(feature_dir, manifest)
+
+
+def _write_wp_file(feature_dir: Path, wp_id: str) -> None:
+    """Seed WP markdown with approved-review frontmatter so the real
+    ``approved -> done`` transition fires during merge bookkeeping."""
+    (feature_dir / "tasks" / f"{wp_id}-work.md").write_text(
+        "---\n"
+        f"work_package_id: {wp_id}\n"
+        f"title: {wp_id} work\n"
+        "agent: implementer-bot\n"
+        "review_status: approved\n"
+        "reviewed_by: reviewer-renata\n"
+        "---\n"
+        f"# {wp_id}\n",
+        encoding="utf-8",
+    )
+
+
+def _approved_event(wp_id: str, event_id: str) -> dict[str, object]:
+    return {
+        "actor": "reviewer-renata",
+        "at": datetime.now(UTC).isoformat(),
+        "event_id": event_id,
+        "evidence": None,
+        "execution_mode": "worktree",
+        "feature_slug": MISSION_SLUG,
+        "force": False,
+        "from_lane": "in_review",
+        "reason": None,
+        "review_ref": f"review-{wp_id}",
+        "to_lane": "approved",
+        "wp_id": wp_id,
+    }
+
+
+def _bootstrap_two_wp_coord_mission(repo: Path) -> Path:
+    """Bootstrap a coord-topology mission with TWO approved WPs on one lane.
+
+    Returns the primary-checkout feature_dir. Both WPs sit at ``approved`` so the
+    real merge bookkeeping has a genuine ``approved -> done`` transition to emit
+    for each through the coordination worktree.
+    """
+    feature_dir = repo / "kitty-specs" / MISSION_SLUG
+    (feature_dir / "tasks").mkdir(parents=True)
+    _write_meta(feature_dir)
+    _write_manifest(feature_dir)
+    _write_wp_file(feature_dir, STRANDED_WP)
+    _write_wp_file(feature_dir, COHERENT_WP)
+
+    # Pre-record the per-WP APPROVED events (NOT done) so the bake loop has a real
+    # ``approved -> done`` transition to commit for each WP.
+    (feature_dir / "status.events.jsonl").write_text(
+        json.dumps(_approved_event(STRANDED_WP, "01HXAPPR0000000000000000W1"), sort_keys=True)
+        + "\n"
+        + json.dumps(_approved_event(COHERENT_WP, "01HXAPPR0000000000000000W2"), sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", f"chore({MISSION_SLUG}): bootstrap 2-WP coord mission")
+
+    # Coordination/mission branch at the current tip.
+    _git(repo, "branch", COORD_BRANCH)
+
+    # Lane branch with REAL code diffs (both WPs' write-scope) not on the mission
+    # branch nor on main.
+    lane_branch = f"kitty/mission-{MISSION_SLUG}-{LANE_ID}"
+    _git(repo, "branch", lane_branch, COORD_BRANCH)
+    _git(repo, "checkout", lane_branch)
+    for rel in ("src/wp01_code.py", "src/wp02_code.py"):
+        code_path = repo / rel
+        code_path.parent.mkdir(parents=True, exist_ok=True)
+        code_path.write_text("def feature() -> int:\n    return 2367\n", encoding="utf-8")
+    _git(repo, "add", "src")
+    _git(repo, "commit", "-m", f"feat({MISSION_SLUG}): lane code for the 2-WP write-set")
+    _git(repo, "checkout", "main")
+
+    # Materialize the coordination worktree with the mission branch CHECKED OUT
+    # (the production topology): the pre-target ``done`` transactions commit
+    # through this worktree, and the rollback byte-restores only its working bytes.
+    CoordinationWorkspace.resolve(repo, MISSION_SLUG, MID8)
+
+    return feature_dir
+
+
+# ---------------------------------------------------------------------------
+# Bake-mid-write-set failure injection + git-reducible readers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _bake_failure_on_second_wp() -> Iterator[list[str]]:
+    """Inject the failure INSIDE ``_record_merged_wps_done_for_merge``.
+
+    Wraps ``done_bookkeeping._mark_wp_merged_done`` (the per-WP emit the bake loop
+    calls): the STRANDED WP delegates to the real helper (its ``done`` genuinely
+    COMMITS to the coordination branch), then the COHERENT WP RAISES — so the
+    exception propagates out of the bake loop after ≥1 committed ``done``, hitting
+    the real ``executor.py:406-408`` byte-restore-without-revert branch. Yields the
+    ordered per-WP call list so the caller can assert the failure was mid-loop
+    (non-vacuity: NOT a target-advance/squash-conflict rollback).
+    """
+    real_mark = done_bookkeeping._mark_wp_merged_done
+    calls: list[str] = []
+
+    def fake_mark(
+        repo_root: Path, mission_slug: str, wp_id: str, target_branch: str
+    ) -> None:
+        calls.append(wp_id)
+        if wp_id == COHERENT_WP:
+            raise RuntimeError(_INJECTED_BAKE_FAILURE)
+        real_mark(repo_root, mission_slug, wp_id, target_branch)
+
+    with patch(
+        "specify_cli.merge.done_bookkeeping._mark_wp_merged_done",
+        side_effect=fake_mark,
+    ):
+        yield calls
+
+
+def _run_bake_failing_merge(repo: Path) -> tuple[BaseException, list[str]]:
+    """Run one merge pass whose bake loop fails on the 2nd WP.
+
+    Returns the propagated exception (asserted to be the injected bake fault) and
+    the ordered per-WP mark calls (asserted to reach the 2nd WP).
+
+    Re-invoked as the ``spec-kitty merge --resume`` heal step: the second pass
+    detects ``is_resume`` from the persisted ``MergeState`` and re-drives the same
+    failing bake loop, so the injected fault re-raises (caught here) while the
+    pre-existing strand is left untouched — the resume no-ops the coherence heal
+    until the WP03 repair lands.
+    """
+    with _merge_external_mocks(), _bake_failure_on_second_wp() as calls:
+        try:
+            _run_lane_based_merge(
+                repo_root=repo,
+                mission_slug=MISSION_SLUG,
+                push=False,
+                delete_branch=False,
+                remove_worktree=False,
+                strategy=MergeStrategy.SQUASH,
+                allow_sparse_checkout=True,
+            )
+        except BaseException as exc:  # noqa: BLE001 — the act under test raises by design
+            return exc, calls
+    raise AssertionError(
+        "precondition: the injected bake-mid-write-set failure did not propagate — "
+        "the merge unexpectedly succeeded, so the #2367-B rollback path never ran."
+    )
+
+
+def _committed_coord_events(repo: Path, feature_dir: Path) -> list[StatusEvent]:
+    """Reduce the events COMMITTED to the coordination branch (contract-routed).
+
+    Uses ``EventLogReadContract.coordination_branch_ref`` — NEVER a hand-rolled
+    ``git show <branch>:...`` — so the committed-ref read stays on the canonical
+    authority.
+    """
+    # ``cast`` (not a suppression): mypy checks this test in isolation with
+    # ``follow_imports = skip`` for ``specify_cli.*`` (pyproject override), so the
+    # real ``read_event_log -> list[StatusEvent]`` signature is invisible here and
+    # collapses to ``Any``. The runtime type is genuinely ``list[StatusEvent]``.
+    return cast(
+        "list[StatusEvent]",
+        read_event_log(
+            EventLogReadContract.coordination_branch_ref(
+                repo_root=repo,
+                destination_ref=COORD_BRANCH,
+                feature_dir=feature_dir,
+                parser_feature_dir=feature_dir,
+            )
+        ),
+    )
+
+
+def _working_coord_events(repo: Path) -> list[StatusEvent]:
+    """Reduce the coordination worktree's rolled-back WORKING-tree event log."""
+    coord_worktree = CoordinationWorkspace.worktree_path(repo, MISSION_SLUG, MID8)
+    coord_feature_dir = coord_worktree / "kitty-specs" / MISSION_SLUG
+    return cast(
+        "list[StatusEvent]",
+        read_event_log(EventLogReadContract.coordination_worktree(coord_feature_dir)),
+    )
+
+
+def _lane_on(events: list[StatusEvent], wp_id: str) -> Lane:
+    lane, _actor = wp_lane_actor_from_events(events, wp_id)
+    return lane
+
+
+# ---------------------------------------------------------------------------
+# US1-S3 / US3-S1 / FR-002 / FR-003 / SC-001 / SC-007 — bake-mid-write-set strand
+# (RED on the mission base)
+# ---------------------------------------------------------------------------
+
+
+def test_bake_mid_write_set_failure_strands_committed_done(tmp_path: Path) -> None:
+    """#2367 Mechanism B / FR-003 (RED): a failure INSIDE
+    ``_record_merged_wps_done_for_merge`` after ≥1 committed ``done`` strands that
+    WP's committed coordination ``done`` against the byte-restored working
+    ``approved`` (the ``executor.py:406-408`` byte-restore-without-revert branch),
+    and a ``spec-kitty merge --resume`` heal does NOT reconcile it.
+
+    Committed-ref split-brain contract (FR-002 / SC-007). The stranded set is
+    reduced from the COMMITTED coordination ref via
+    ``_durable_done_wps_on_coordination_ref`` over THIS merge's write-set — it must
+    name EXACTLY the stranded WP (the coherent, only-ever-``approved`` WP
+    excluded), falsifying both a hardcoded ``["WP01"]`` and an over-broad
+    ``all_wp_ids``. After the heal, ``committed_lane == working_lane`` for the
+    stranded WP is RED on the mission base because the resume no-ops the strand;
+    the unified #2786/#2367-B fix (mark-not-raise at ≈406-408 + strand-gated
+    ``git revert`` heal on ``--resume``) flips it GREEN.
+
+    Git-reducible reds only: no ``pending_coord_reconcile`` / doctor surface is
+    referenced (they do not exist on the base — asserting them reds with
+    ``AttributeError`` = forbidden setup-red per ADR 2026-07-17-1).
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    feature_dir = _bootstrap_two_wp_coord_mission(repo)
+
+    exc, calls = _run_bake_failing_merge(repo)
+
+    # Non-vacuity witness A: the failure fired INSIDE the bake loop (the 2nd WP
+    # emit), AFTER the 1st WP's ``done`` was marked — i.e. the ``executor.py:406-408``
+    # byte-restore-without-revert branch, NOT a target-advance/squash-conflict
+    # rollback (those are revert-covered and would repro vacuously green).
+    assert isinstance(exc, RuntimeError) and _INJECTED_BAKE_FAILURE in str(exc), (
+        "precondition: the merge must fail via the injected bake-mid-write-set "
+        f"fault (RuntimeError, inside _record_merged_wps_done_for_merge); got {exc!r}"
+    )
+    assert calls == [STRANDED_WP, COHERENT_WP], (
+        "precondition: the bake loop must mark the stranded WP (committing its "
+        "``done``) BEFORE the injected failure on the coherent WP — proving ≥1 "
+        f"committed ``done`` preceded the abort; got mark order {calls}"
+    )
+
+    committed_events = _committed_coord_events(repo, feature_dir)
+    working_events = _working_coord_events(repo)
+
+    # Preconditions: the working tree byte-restored BOTH WPs to ``approved`` (the
+    # byte-restore leg runs), and the coherent WP was never marked anywhere.
+    assert _lane_on(working_events, STRANDED_WP) == Lane.APPROVED, (
+        "precondition: the byte-restored working tree should reduce the stranded "
+        f"WP to ``approved``; got {_lane_on(working_events, STRANDED_WP)}"
+    )
+    assert _lane_on(committed_events, COHERENT_WP) == Lane.APPROVED, (
+        "precondition: the coherent WP is only ever ``approved`` (never marked), "
+        f"so it is NOT stranded; got committed {_lane_on(committed_events, COHERENT_WP)}"
+    )
+
+    # Pre-heal WITNESS (the strand exists + names exactly the stranded WP): the
+    # committed coordination ref carries the 1st WP's ``done`` while the working
+    # tree rolled back to ``approved``. Reduced from the COMMITTED ref (git-
+    # reducible authority; NOT a worktree diff — empty at the mark point per
+    # data-model D7). GREEN on base AND after mark-not-raise (deliberate pre-repair
+    # strand); the coherent WP is EXCLUDED (SC-007 non-fakeability).
+    stranded = _durable_done_wps_on_coordination_ref(
+        repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        candidate_wps=[STRANDED_WP, COHERENT_WP],
+    )
+    assert stranded == {STRANDED_WP}, (
+        "precondition: the committed coordination ref must strand EXACTLY the WP "
+        "whose ``done`` committed before the abort (the coherent, only-ever-"
+        "``approved`` WP excluded) — this is the contract the fix's marker "
+        f"``stranded_wp_ids`` must satisfy; got {stranded}"
+    )
+
+    # Heal step — ``spec-kitty merge --resume``. On the mission base no coherence
+    # repair entry exists (it lands in WP03), so the resume re-drives the same
+    # failing bake loop: the injected fault re-raises and is caught, proving the
+    # resume RAN into the bake write-set (not an AttributeError/infra early-abort).
+    # The strand is left in place — the heal no-ops today.
+    resume_exc, _resume_calls = _run_bake_failing_merge(repo)
+    assert isinstance(resume_exc, RuntimeError) and _INJECTED_BAKE_FAILURE in str(
+        resume_exc
+    ), (
+        "the ``merge --resume`` heal step must RUN through to the injected "
+        "bake-mid-write-set fault (proving the resume reached the coord write-set, "
+        f"not an infra/AttributeError early-abort); got {resume_exc!r}"
+    )
+
+    committed_lane = _lane_on(_committed_coord_events(repo, feature_dir), STRANDED_WP)
+    working_lane = _lane_on(_working_coord_events(repo), STRANDED_WP)
+
+    # Coherence CONTRACT (RED on base, SC-001/US1-S3): after the heal the committed
+    # coordination reduction and the working-tree reduction of the stranded WP must
+    # AGREE. On the mission base they disagree because the bake failure branch
+    # byte-restored working bytes WITHOUT reverting the committed ``done``, and
+    # ``merge --resume`` did not reconcile it. The unified #2786/#2367-B fix
+    # (mark-not-raise + strand-gated ``git revert`` heal) flips this GREEN.
+    assert committed_lane == working_lane, (
+        "#2367-B bake-mid-write-set split-brain (post-heal): a failure inside "
+        "_record_merged_wps_done_for_merge left the 1st WP's committed "
+        "coordination ``done`` stranded (executor.py:406-408 byte-restore-without-"
+        "revert) and ``merge --resume`` did NOT reconcile it.\n"
+        f"  committed coord ref (git-tracked): {committed_lane}\n"
+        f"  byte-restored working tree:        {working_lane}\n"
+        "The merge coord write-set must roll back atomically (revert or "
+        "mark-and-heal) so an aborted multi-WP bake leaves no committed/working "
+        "split-brain (#2367 Mechanism B)."
+    )

--- a/tests/regression/test_issue_2367_bake_strand.py
+++ b/tests/regression/test_issue_2367_bake_strand.py
@@ -1,10 +1,13 @@
-"""Scope: #2367 Mechanism B — the merge coord write-set is not atomic (INTENTIONAL red-first P0).
+"""Scope: #2367 Mechanism B — the merge coord write-set is not atomic (regression guard; #2367-B FIXED).
 
-This module is an INTENTIONAL, issue-pinned red-first P0 reproduction for
-**#2367 Mechanism B**. It is expected to FAIL on the mission base and stays RED
-until the unified #2786/#2367-B fix lands — per ADR ``docs/adr/3.x/2026-07-17-1``
-(a P0 defect carries an honest, main-breaking reproduction; it is NOT deselected
-or xfail-masked).
+This module reproduces **#2367 Mechanism B** and now guards its fix. It began as
+an INTENTIONAL, issue-pinned red-first P0 reproduction (per ADR
+``docs/adr/3.x/2026-07-17-1``, expected to fail on the mission base while the P0
+was open). The unified #2786/#2367-B fix has now LANDED — mark-not-raise +
+strand-gated resume heal — so the reproduction drives the bake strand and asserts
+coherence AFTER the heal. The ``regression`` marker (which flagged the
+intentional-red phase) is removed now that the defect is closed; the test stays a
+green regression guard via its ``git_repo`` marker.
 
 Defect (#2367 Mechanism B)
 --------------------------
@@ -57,8 +60,11 @@ the RIGHT reason: after a ``spec-kitty merge --resume`` heal (a no-op on the bas
 until the WP03 repair lands), the committed reduction is stranded at ``done``
 while the working tree reduces to ``approved``.
 
-Do NOT fix the bake path here — the fix is the unified #2786/#2367-B marker +
-strand-gated heal; this module is the honest red that the fix flips green.
+#2367 Mechanism B is FIXED — the bake-path rollback marks-not-raises (durable
+``pending_coord_reconcile`` marker) and the resume heal reverts the stranded coord
+``done`` via a strand-gated ``git revert``; this module verifies coherence is
+restored after the heal and guards against regression. (Mechanism A — claim-time
+VCS-lock resync — is deferred to #2795.)
 """
 
 from __future__ import annotations
@@ -100,7 +106,7 @@ from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
     _merge_external_mocks,
 )
 
-pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]
+pytestmark = [pytest.mark.git_repo, pytest.mark.non_sandbox]
 
 # ---------------------------------------------------------------------------
 # Mission identity (slug ends with ``-<mid8>`` so the coordination branch IS the

--- a/tests/regression/test_issue_2786_revert_failure_split_brain.py
+++ b/tests/regression/test_issue_2786_revert_failure_split_brain.py
@@ -116,6 +116,22 @@ def _revert_forced_to_fail() -> Iterator[list[list[str]]]:
         yield intercepted
 
 
+def _reduce_coord_lanes(repo: Path, feature_dir: Path) -> tuple[Lane, Lane]:
+    """Reduce ``(committed_lane, working_lane)`` for the mission's WP.
+
+    ``committed_lane`` is the reduction of the events COMMITTED to the
+    coordination branch (contract-routed via
+    ``EventLogReadContract.coordination_branch_ref``); ``working_lane`` is the
+    reduction of the coordination worktree's rolled-back WORKING-tree event log.
+    Both legs are git-reducible — no marker/doctor surface is consulted.
+    """
+    committed_lane, _ = wp_lane_actor_from_events(
+        _committed_coord_events(repo, feature_dir), WP_ID
+    )
+    working_lane, _ = wp_lane_actor_from_events(_working_coord_events(repo), WP_ID)
+    return committed_lane, working_lane
+
+
 def _run_merge_with_target_and_revert_failing(
     repo: Path,
 ) -> tuple[BaseException, list[list[str]]]:
@@ -123,6 +139,12 @@ def _run_merge_with_target_and_revert_failing(
 
     Returns the propagated exception (asserted to be the injected target-advance
     fault) and the intercepted revert commands (asserted non-empty).
+
+    Re-invoked as the ``spec-kitty merge --resume`` heal step: on the mission
+    base the second pass detects ``is_resume`` from the persisted ``MergeState``
+    and re-drives the same failing merge, so the injected target-advance fault is
+    re-raised (and caught here) while the pre-existing strand is left untouched —
+    the resume no-ops the coherence heal until WP03 lands it.
     """
     with (
         _merge_external_mocks(),
@@ -153,14 +175,28 @@ def _run_merge_with_target_and_revert_failing(
 def test_swallowed_revert_failure_re_opens_2711_split_brain(tmp_path: Path) -> None:
     """#2786 (RED): a FAILED coord ``done`` revert during rollback is swallowed,
     leaving the committed coordination ``done`` opposed to the rolled-back working
-    ``approved`` — the #2711 split-brain re-opened along the revert-failure path.
+    ``approved`` — the #2711 split-brain re-opened along the revert-failure path —
+    and a ``spec-kitty merge --resume`` heal does NOT restore coherence.
 
-    RED-for-the-right-reason contract: the committed coordination reduction and the
-    working-tree reduction must AGREE after rollback. On ``main`` today they
-    disagree because ``_revert_coord_done_commit`` logs a warning and returns on a
-    non-zero ``git revert`` without raising or writing a durable reconcile marker.
-    The #2786 fix (fail-loud or durable reconcile marker on revert failure) flips
-    this GREEN.
+    Assert-after-heal contract (FR-001 / SC-006). The pre-fix synchronous
+    ``committed_lane == working_lane`` assertion had **no resume step**: under the
+    mark-not-raise fix (FR-005) the committed ``done`` is *deliberately* stranded
+    until repair, so a synchronous coherence assertion could never go green
+    (permanent red — violates SC-001/SC-004). This test instead:
+
+    1. drives the swallowed-revert strand and WITNESSES it (committed ``done`` vs
+       working ``approved``) — a state that survives the mark-not-raise fix;
+    2. invokes the ``spec-kitty merge --resume`` heal (a no-op on the mission base
+       — the coherence-repair entry lands in WP03, so the resume merely re-drives
+       the still-failing merge and is caught, leaving the strand untouched);
+    3. asserts ``committed_lane == working_lane`` **re-reduced from the coord ref
+       AFTER the heal** — RED on the mission base because the no-op resume leaves
+       the strand; GREEN once WP03's strand-gated ``git revert`` heal reconciles
+       the committed ``done`` back to ``approved``.
+
+    A bare deletion of the coherence assertion would fail SC-006 — it is
+    *modified* (moved past the heal step + paired with the pre-heal witness), not
+    removed. No marker/doctor surface is referenced (git-reducible reds only).
     """
     repo = tmp_path / "repo"
     _init_git_repo(repo)
@@ -187,28 +223,58 @@ def test_swallowed_revert_failure_re_opens_2711_split_brain(tmp_path: Path) -> N
         "the reproduction would be vacuous."
     )
 
-    committed_events = _committed_coord_events(repo, feature_dir)
-    working_events = _working_coord_events(repo)
-    committed_lane, _ = wp_lane_actor_from_events(committed_events, WP_ID)
-    working_lane, _ = wp_lane_actor_from_events(working_events, WP_ID)
+    committed_lane_pre, working_lane_pre = _reduce_coord_lanes(repo, feature_dir)
 
     # Precondition: the working tree DID roll back to ``approved`` (the byte-restore
     # leg still runs after the swallowed revert failure).
-    assert working_lane == Lane.APPROVED, (
+    assert working_lane_pre == Lane.APPROVED, (
         "precondition: the rolled-back working tree should reduce to ``approved``; "
-        f"got {working_lane}"
+        f"got {working_lane_pre}"
     )
 
-    # Coherence CONTRACT (RED on main): a swallowed revert failure must NOT strand
-    # the committed coordination ``done`` opposed to the working ``approved``.
+    # Pre-heal WITNESS (the strand exists): the swallowed revert leaves the
+    # committed coordination reduction stranded at ``done`` — the exact incoherence
+    # the mark-not-raise fix records durably and the heal must reconcile. GREEN on
+    # base AND after the mark-not-raise fix (the strand is deliberate pre-repair).
+    assert committed_lane_pre == Lane.DONE, (
+        "precondition: the swallowed-revert strand must exist — the committed "
+        "coordination ``done`` should survive the rollback while the working tree "
+        f"rolls back to ``approved``; got committed={committed_lane_pre}"
+    )
+
+    # Heal step — ``spec-kitty merge --resume``. On the mission base no coherence
+    # repair entry exists (it lands in WP03), so the resume re-drives the same
+    # failing merge: the injected target-advance fault re-raises and is caught
+    # here, proving the resume RAN through to the rollback path (not an
+    # AttributeError/infra early-abort). The strand is left in place — the heal
+    # no-ops today.
+    resume_exc, _resume_reverts = _run_merge_with_target_and_revert_failing(repo)
+    assert isinstance(resume_exc, RuntimeError) and _INJECTED_TARGET_FAILURE in str(
+        resume_exc
+    ), (
+        "the ``merge --resume`` heal step must RUN through to the injected "
+        "target-advance fault (proving the resume reached the rollback path, not "
+        f"an infra/AttributeError early-abort); got {resume_exc!r}"
+    )
+
+    committed_lane, working_lane = _reduce_coord_lanes(repo, feature_dir)
+
+    # Coherence CONTRACT (RED on base, SC-006): after the heal the committed
+    # coordination reduction and the working-tree reduction must AGREE. On the
+    # mission base they still disagree because the no-op resume left the swallowed
+    # ``done`` stranded (``_revert_coord_done_commit`` logged a warning and
+    # returned; no durable reconcile marker; no strand-gated heal). The #2786 fix
+    # (mark-not-raise + strand-gated ``git revert`` heal on ``--resume``) flips
+    # this GREEN.
     assert committed_lane == working_lane, (
-        "#2786 swallowed-revert split-brain: the coord-worktree ``git revert`` "
-        "FAILED during rollback and _revert_coord_done_commit swallowed it "
-        "(warning + return, no raise, no durable reconcile marker), so the "
-        "committed coordination ``done`` was left stranded against the rolled-back "
-        "working ``approved``.\n"
+        "#2786 swallowed-revert split-brain (post-heal): the coord-worktree "
+        "``git revert`` FAILED during rollback and _revert_coord_done_commit "
+        "swallowed it (warning + return, no raise, no durable reconcile marker), "
+        "and ``merge --resume`` did NOT reconcile the strand, so the committed "
+        "coordination ``done`` remains stranded against the rolled-back working "
+        "``approved``.\n"
         f"  committed coord ref (git-tracked): {committed_lane}\n"
         f"  rolled-back working tree:          {working_lane}\n"
-        "The revert-failure path must fail loud or record a durable reconcile "
-        "marker so the divergence is never silent (#2786)."
+        "The revert-failure path must record a durable reconcile marker and "
+        "``--resume`` must heal it so the divergence is never silent (#2786)."
     )

--- a/tests/regression/test_issue_2786_revert_failure_split_brain.py
+++ b/tests/regression/test_issue_2786_revert_failure_split_brain.py
@@ -1,9 +1,13 @@
-"""Scope: #2786 — a FAILED coord ``done`` revert during rollback is swallowed (INTENTIONAL red-first P0).
+"""Scope: #2786 — a FAILED coord ``done`` revert during rollback is swallowed (regression guard; #2786 FIXED).
 
-This module is an INTENTIONAL, issue-pinned red-first P0 reproduction for
-**#2786**. It is expected to FAIL on ``main`` and stays RED until #2786 is fixed
-— per ADR ``docs/adr/3.x/2026-07-17-1`` (a P0 defect must carry an honest,
-main-breaking reproduction; it is NOT deselected or xfail-masked).
+This module reproduces **#2786** and now guards its fix. It began as an
+INTENTIONAL, issue-pinned red-first P0 reproduction (per ADR
+``docs/adr/3.x/2026-07-17-1``, expected to fail on ``main`` while the P0 was
+open). #2786 is now **FIXED** — the rollback marks-not-raises and a strand-gated
+``git revert`` heal on ``--resume`` restores coherence — so the reproduction
+drives the strand and asserts coherence AFTER the heal. The ``regression`` marker
+(which flagged the intentional-red-on-``main`` phase) is removed now that the
+defect is closed; the test stays a green regression guard via its ``git_repo`` marker.
 
 Defect (#2786)
 --------------
@@ -42,8 +46,10 @@ the rolled-back working tree reduces to ``approved`` — the swallowed-revert
 split-brain. A non-vacuity witness proves the revert branch was actually hit and
 returned non-zero, so the red cannot pass as a setup artefact.
 
-Do NOT fix ``_revert_coord_done_commit`` here — the fix is deferred to #2786; this
-module is the honest red that the fix will flip green.
+#2786 is FIXED — the rollback marks-not-raises (durable ``pending_coord_reconcile``
+marker) and the resume heal reverts the stranded coord ``done`` via a strand-gated
+``git revert``; this module verifies coherence is restored after the heal and guards
+against regression.
 """
 
 from __future__ import annotations
@@ -77,7 +83,7 @@ from tests.regression.test_issue_2711_merge_rollback_resume_coherence import (
     _working_coord_events,
 )
 
-pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]
+pytestmark = [pytest.mark.git_repo, pytest.mark.non_sandbox]
 
 MISSION_SLUG = "merge-rollback-2711-01KXRRB7"  # harness slug (isolated per tmp repo)
 _INJECTED_REVERT_FAILURE = "injected #2786 coord revert conflict"

--- a/tests/specify_cli/cli/commands/test_coordination_doctor.py
+++ b/tests/specify_cli/cli/commands/test_coordination_doctor.py
@@ -1091,13 +1091,13 @@ def test_stranded_check_bare_handle_false_negative_under_raw_resolver(
 
 @pytest.mark.git_repo
 @pytest.mark.non_sandbox
-def test_stranded_check_pruned_worktree_emits_stuck_warning(tmp_path: Path) -> None:
-    """A live strand whose coord worktree is PRUNED → a ``warning`` STUCK finding.
+def test_stranded_check_pruned_worktree_emits_stuck_error(tmp_path: Path) -> None:
+    """A live strand whose coord worktree is PRUNED → a distinct STUCK ``error``.
 
-    ``--fix`` cannot revert a strand whose coordination worktree no longer exists
-    (there is nothing to run the revert in). Rather than emit the healable ``error``
-    (whose ``next_step`` loops the user back to a ``--fix`` that can never succeed),
-    the check surfaces a distinct ``warning`` with a manual-recovery hint.
+    It is STILL a committed-ref split-brain, so it stays an ``error`` (the doctor
+    must not report the mission healthy — debugger-debbie HIGH). Only the
+    ``next_step`` differs: a manual-recovery hint instead of the healable hint that
+    would loop the user back to a ``--fix`` that can never succeed.
     """
     repo = tmp_path / "repo"
     _seed_doctor_coord_ref(
@@ -1115,19 +1115,19 @@ def test_stranded_check_pruned_worktree_emits_stuck_warning(tmp_path: Path) -> N
 
     assert len(findings) == 1
     finding = findings[0]
-    assert finding.severity == "warning"
+    assert finding.severity == "error"  # still a committed split-brain → exit 1
     assert finding.error_code == cd._STRANDED_COORD_REVERT_STUCK_CODE
     # The recovery hint must NOT loop the user back at plain `--fix`.
-    assert finding.next_step is not None
+    assert finding.next_step == cd._STRANDED_COORD_REVERT_STUCK_HINT
     assert "no longer exists" in finding.message
 
 
 @pytest.mark.git_repo
 @pytest.mark.non_sandbox
-def test_run_coordination_health_pruned_worktree_exits_0_with_warning(
+def test_run_coordination_health_pruned_worktree_exits_1_with_stuck_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A pruned-worktree STUCK strand is a ``warning`` (exit 0), surfaced in output."""
+    """A pruned-worktree STUCK strand is a committed split-brain → ``error``, exit 1."""
     repo = tmp_path / "repo"
     _seed_doctor_coord_ref(
         repo,
@@ -1147,21 +1147,23 @@ def test_run_coordination_health_pruned_worktree_exits_0_with_warning(
 
     with pytest.raises(typer.Exit) as exc:
         cd.run_coordination_health(json_output=True)
-    # A warning does not fail the gate, but the STUCK code IS surfaced (not dropped).
-    assert exc.value.exit_code == 0
+    # A stuck strand is an unresolved committed split-brain — the gate MUST fail
+    # (exit 1); a warning/exit-0 would report the mission healthy and hide it.
+    assert exc.value.exit_code == 1
     assert cd._STRANDED_COORD_REVERT_STUCK_CODE in capsys.readouterr().out
 
 
 @pytest.mark.git_repo
 @pytest.mark.non_sandbox
-def test_fix_stranded_reverts_pruned_worktree_yields_warning_not_silent(
+def test_fix_stranded_reverts_pruned_worktree_yields_stuck_error_not_silent(
     tmp_path: Path,
 ) -> None:
-    """`_fix_stranded_reverts` on a strand finding whose worktree is pruned WARNS.
+    """`_fix_stranded_reverts` on a strand finding whose worktree is pruned → STUCK error.
 
     Directly exercises the fix-path defensive branch (a worktree pruned between the
     check and the fix): the shared primitive returns ``worktree_missing`` and the
-    fixer surfaces a ``warning`` rather than silently dropping the marker.
+    fixer surfaces a STUCK ``error`` (exit 1 — still a committed split-brain) rather
+    than silently dropping the marker or reporting healthy.
     """
     repo = tmp_path / "repo"
     (repo / ".kittify").mkdir(parents=True)
@@ -1181,10 +1183,11 @@ def test_fix_stranded_reverts_pruned_worktree_yields_warning_not_silent(
         },
     )
 
-    healed, warnings = cd._fix_stranded_reverts([finding], repo)
+    healed, extra = cd._fix_stranded_reverts([finding], repo)
 
     assert healed == []
-    assert [w.error_code for w in warnings] == [cd._STRANDED_COORD_REVERT_STUCK_CODE]
+    assert [w.error_code for w in extra] == [cd._STRANDED_COORD_REVERT_STUCK_CODE]
+    assert [w.severity for w in extra] == ["error"]  # exit-1, not a hidden warning
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/cli/commands/test_coordination_doctor.py
+++ b/tests/specify_cli/cli/commands/test_coordination_doctor.py
@@ -9,6 +9,7 @@ invariant: the ``merge.path_is_under_worktrees`` import is function-local and no
 
 from __future__ import annotations
 
+import json as _json
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,8 @@ import pytest
 import typer
 
 from specify_cli.cli.commands import _coordination_doctor as cd
+from specify_cli.coordination.coherence import coord_incoherent_done_wps
+from specify_cli.merge.state import MergeState, load_state, save_state
 
 pytestmark = [pytest.mark.fast]
 
@@ -480,3 +483,357 @@ def test_collect_injects_meta_path_for_never_created_findings(
     assert never_created, "expected NEVER_CREATED finding from monkeypatched check"
     assert "meta_path" in never_created[0].extra
     assert never_created[0].extra["meta_path"].endswith("meta.json")
+
+
+# ---------------------------------------------------------------------------
+# WP04 (#2786 / #2367-B, FR-007): stranded-coord-revert check + --fix.
+#
+# The load-bearing separator is the NEGATIVE AC (US2-S5): a marker present but a
+# committed coord ref that re-derives COHERENT must yield NO finding. A
+# marker-presence-only implementation passes the positive test and FAILS this.
+# These tests build a real committed coord ref so re-verification is genuine.
+# ---------------------------------------------------------------------------
+
+_DOCTOR_MISSION_SLUG = "coord-doctor-fixture-01KXTM59"
+_DOCTOR_MISSION_ID = "01MIDDOCTOR00000000000000A0"
+_DOCTOR_EVENTS_REL = f"kitty-specs/{_DOCTOR_MISSION_SLUG}/status.events.jsonl"
+
+
+def _git_doctor(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _init_doctor_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-qb", "main", str(repo)], check=True, capture_output=True
+    )
+    _git_doctor(repo, "config", "user.email", "test@test.com")
+    _git_doctor(repo, "config", "user.name", "Test")
+    _git_doctor(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    _git_doctor(repo, "add", ".")
+    _git_doctor(repo, "commit", "-m", "init")
+
+
+def _doctor_event(
+    wp_id: str, to_lane: str, *, event_id: str, from_lane: str
+) -> dict[str, object]:
+    return {
+        "actor": "reviewer-renata",
+        "at": "2026-07-18T10:00:00+00:00",
+        "event_id": event_id,
+        "evidence": None,
+        "execution_mode": "worktree",
+        "feature_slug": _DOCTOR_MISSION_SLUG,
+        "force": False,
+        "from_lane": from_lane,
+        "reason": None,
+        "review_ref": None,
+        "to_lane": to_lane,
+        "wp_id": wp_id,
+    }
+
+
+def _seed_doctor_coord_ref(
+    repo: Path, events: list[dict[str, object]], *, branch: str = "coord"
+) -> None:
+    """Init ``repo`` and commit ``events`` as the mission's coord event log on ``branch``.
+
+    The mission meta deliberately omits ``coordination_branch`` (legacy shape) so
+    the unrelated worktree-health check skips it — the exit code then reflects the
+    stranded-revert check alone.
+    """
+    _init_doctor_repo(repo)
+    feature_dir = repo / "kitty-specs" / _DOCTOR_MISSION_SLUG
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "meta.json").write_text(
+        _json.dumps(
+            {
+                "mission_slug": _DOCTOR_MISSION_SLUG,
+                "mission_id": _DOCTOR_MISSION_ID,
+                "mission_number": None,
+                "mission_type": "software-dev",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "status.events.jsonl").write_text(
+        "".join(_json.dumps(e, sort_keys=True) + "\n" for e in events),
+        encoding="utf-8",
+    )
+    _git_doctor(repo, "add", ".")
+    _git_doctor(repo, "commit", "-m", "seed coord events")
+    _git_doctor(repo, "branch", branch)
+
+
+def _save_marker_state(
+    repo: Path,
+    *,
+    stranded_wp_ids: list[str],
+    coord_ref: str = "coord",
+    captured_sha: str = "deadbeef",
+    coord_worktree: str = "/tmp/coord-wt",
+) -> None:
+    marker = {
+        "coord_ref": coord_ref,
+        "captured_sha": captured_sha,
+        "coord_worktree": coord_worktree,
+        "stranded_wp_ids": stranded_wp_ids,
+        "revert_error": None,
+        "detected_at": "2026-07-18T10:05:00+00:00",
+    }
+    save_state(
+        MergeState(
+            mission_id=_DOCTOR_MISSION_ID,
+            mission_slug=_DOCTOR_MISSION_SLUG,
+            target_branch="main",
+            wp_order=stranded_wp_ids or ["WP-A"],
+            current_wp=(stranded_wp_ids or ["WP-A"])[0],
+            pending_coord_reconcile=marker,
+        ),
+        repo,
+    )
+
+
+# --- T014 (a) POSITIVE: live strand -> error finding + exit 1 ----------------
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_stranded_check_emits_error_for_live_strand(tmp_path: Path) -> None:
+    """A marker whose committed ref STILL reduces WP-A to done -> one error finding."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [
+            _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+            _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+            _doctor_event("WP-B", "approved", event_id="01B00", from_lane="in_review"),
+        ],
+    )
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+
+    findings = cd._check_stranded_coord_revert(repo)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "error"
+    assert finding.error_code == cd._STRANDED_COORD_REVERT_CODE
+    # Re-derived from the committed ref, not echoed from the marker.
+    assert finding.extra["stranded_wp_ids"] == ["WP-A"]
+    assert finding.extra["mission_slug"] == _DOCTOR_MISSION_SLUG
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_run_coordination_health_json_exits_1_on_live_strand(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`doctor coordination --json` exits 1 and surfaces the stable error_code."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [
+            _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+            _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+        ],
+    )
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+
+    # Isolate the exit code to the stranded-revert check (git-version/tracked
+    # checks are environment-dependent and never emit errors here).
+    monkeypatch.setattr(cd, "locate_project_root", lambda: repo)
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+
+    with pytest.raises(typer.Exit) as exc:
+        cd.run_coordination_health(json_output=True)
+    assert exc.value.exit_code == 1
+    assert cd._STRANDED_COORD_REVERT_CODE in capsys.readouterr().out
+
+
+# --- T014 (b) NEGATIVE (the separator): stale marker, coherent ref -> exit 0 --
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_stranded_check_no_finding_for_stale_marker_over_coherent_ref(
+    tmp_path: Path,
+) -> None:
+    """Marker present, but the committed ref re-derives COHERENT -> NO finding.
+
+    This is the AC that separates re-verification from marker-presence: WP-A is
+    only ever ``approved`` on the ref, so a marker-presence-only implementation
+    would (wrongly) emit a finding here.
+    """
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [_doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review")],
+    )
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+
+    # Sanity: the marker IS present and non-empty.
+    st = load_state(repo, _DOCTOR_MISSION_ID)
+    assert st is not None and st.pending_coord_reconcile is not None
+
+    assert cd._check_stranded_coord_revert(repo) == []
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_run_coordination_health_exits_0_for_stale_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The entrypoint exits 0 when every marker's ref re-derives coherent."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [_doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review")],
+    )
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+
+    monkeypatch.setattr(cd, "locate_project_root", lambda: repo)
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+
+    with pytest.raises(typer.Exit) as exc:
+        cd.run_coordination_health(json_output=True)
+    assert exc.value.exit_code == 0
+
+
+def test_parse_reconcile_marker_rejects_empty_strand() -> None:
+    """An empty strand is not a strand (data-model): the marker is unusable."""
+    base = {
+        "coord_ref": "coord",
+        "captured_sha": "deadbeef",
+        "coord_worktree": "/tmp/wt",
+        "stranded_wp_ids": [],
+    }
+    assert cd._parse_reconcile_marker(base) is None
+    assert cd._parse_reconcile_marker(None) is None
+    assert cd._parse_reconcile_marker({**base, "coord_ref": ""}) is None
+    assert cd._parse_reconcile_marker({**base, "stranded_wp_ids": ["WP-A"]}) == (
+        "coord",
+        "deadbeef",
+        "/tmp/wt",
+        ["WP-A"],
+    )
+
+
+# --- T014 (c) --fix heals coherence + idempotency (byte-stable, marker once) --
+
+
+def _bake_stranding_done(repo: Path, tmp_path: Path) -> tuple[str, Path]:
+    """Materialize a coord worktree and bake a stranding WP-A ``done`` commit.
+
+    Returns ``(captured_sha, coord_worktree)`` where ``captured_sha`` is the coord
+    tip BEFORE the bake (the ``git revert`` base).
+    """
+    captured_sha = _git_doctor(repo, "rev-parse", "coord").stdout.strip()
+    worktree = tmp_path / "coord-wt"
+    _git_doctor(repo, "worktree", "add", str(worktree), "coord")
+    wt_events = worktree / "kitty-specs" / _DOCTOR_MISSION_SLUG / "status.events.jsonl"
+    with wt_events.open("a", encoding="utf-8") as fh:
+        fh.write(
+            _json.dumps(
+                _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+                sort_keys=True,
+            )
+            + "\n"
+        )
+    _git_doctor(worktree, "add", ".")
+    _git_doctor(worktree, "commit", "-m", "bake WP-A done (strands on rollback)")
+    return captured_sha, worktree
+
+
+def _committed_coord_events(repo: Path) -> bytes:
+    return subprocess.run(
+        ["git", "-C", str(repo), "show", f"coord:{_DOCTOR_EVENTS_REL}"],
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_run_coordination_health_fix_heals_then_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`--fix` reverts the strand, clears the marker, and re-running is byte-stable."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [_doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review")],
+    )
+    captured_sha, worktree = _bake_stranding_done(repo, tmp_path)
+    _save_marker_state(
+        repo,
+        stranded_wp_ids=["WP-A"],
+        captured_sha=captured_sha,
+        coord_worktree=str(worktree),
+    )
+    feature_dir = repo / "kitty-specs" / _DOCTOR_MISSION_SLUG
+
+    # Pre-condition: WP-A is genuinely stranded done on the committed ref.
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == ["WP-A"]
+
+    monkeypatch.setattr(cd, "locate_project_root", lambda: repo)
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+
+    # First --fix: reverts the strand -> coherent -> exit 0.
+    with pytest.raises(typer.Exit) as exc:
+        cd.run_coordination_health(json_output=True, fix=True)
+    assert exc.value.exit_code == 0
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == []
+    # Marker cleared exactly once.
+    healed_state = load_state(repo, _DOCTOR_MISSION_ID)
+    assert healed_state is not None
+    assert healed_state.pending_coord_reconcile is None
+    bytes_after_first = _committed_coord_events(repo)
+
+    # Second --fix: marker gone -> no finding, no revert, byte-stable coord log.
+    with pytest.raises(typer.Exit) as exc2:
+        cd.run_coordination_health(json_output=True, fix=True)
+    assert exc2.value.exit_code == 0
+    assert _committed_coord_events(repo) == bytes_after_first
+    second_state = load_state(repo, _DOCTOR_MISSION_ID)
+    assert second_state is not None
+    assert second_state.pending_coord_reconcile is None
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_fix_stranded_reverts_direct_returns_healed_slug(tmp_path: Path) -> None:
+    """`_fix_stranded_reverts` heals and returns the mission slug; a 2nd call is a no-op."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [_doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review")],
+    )
+    captured_sha, worktree = _bake_stranding_done(repo, tmp_path)
+    _save_marker_state(
+        repo,
+        stranded_wp_ids=["WP-A"],
+        captured_sha=captured_sha,
+        coord_worktree=str(worktree),
+    )
+
+    findings = cd._check_stranded_coord_revert(repo)
+    assert [f.error_code for f in findings] == [cd._STRANDED_COORD_REVERT_CODE]
+
+    assert cd._fix_stranded_reverts(findings, repo) == [_DOCTOR_MISSION_SLUG]
+    # Marker cleared -> re-checking finds nothing -> a second fix heals nothing.
+    assert cd._check_stranded_coord_revert(repo) == []
+    assert cd._fix_stranded_reverts(findings, repo) == []

--- a/tests/specify_cli/cli/commands/test_coordination_doctor.py
+++ b/tests/specify_cli/cli/commands/test_coordination_doctor.py
@@ -617,7 +617,9 @@ def test_stranded_check_emits_error_for_live_strand(tmp_path: Path) -> None:
             _doctor_event("WP-B", "approved", event_id="01B00", from_lane="in_review"),
         ],
     )
-    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+    # An EXISTING coord worktree so the live strand surfaces as a healable `error`
+    # (a pruned worktree is the distinct STUCK-warning case, covered separately).
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"], coord_worktree=str(repo))
 
     findings = cd._check_stranded_coord_revert(repo)
 
@@ -644,7 +646,8 @@ def test_run_coordination_health_json_exits_1_on_live_strand(
             _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
         ],
     )
-    _save_marker_state(repo, stranded_wp_ids=["WP-A"])
+    # Existing coord worktree → the live strand is a healable `error` (exit 1).
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"], coord_worktree=str(repo))
 
     # Isolate the exit code to the stranded-revert check (git-version/tracked
     # checks are environment-dependent and never emit errors here).
@@ -753,12 +756,99 @@ def _bake_stranding_done(repo: Path, tmp_path: Path) -> tuple[str, Path]:
     return captured_sha, worktree
 
 
+def _bake_stranding_done_dirty(repo: Path, tmp_path: Path) -> tuple[str, Path]:
+    """Bake a stranding ``done`` commit, then leave the coord worktree DIRTY.
+
+    Reuses :func:`_bake_stranding_done` (HEAD advances to the committed ``done``)
+    and then rolls the WORKING ``status.events.jsonl`` back to ``approved`` WITHOUT
+    committing — reproducing the realistic post-rollback state where the byte
+    restore leaves the coord worktree DIRTY (working ``approved`` vs HEAD ``done``).
+    ``git revert`` refuses over that divergence (exit 128), so a heal that does not
+    clean-to-HEAD first cannot repair it.
+    """
+    captured_sha, worktree = _bake_stranding_done(repo, tmp_path)
+    wt_events = worktree / "kitty-specs" / _DOCTOR_MISSION_SLUG / "status.events.jsonl"
+    # Roll the working tree back to the pre-``done`` (``approved``) content, mirroring
+    # the rollback byte-restore, without committing → the worktree is now dirty.
+    wt_events.write_text(
+        _json.dumps(
+            _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return captured_sha, worktree
+
+
+def _porcelain(worktree: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 def _committed_coord_events(repo: Path) -> bytes:
     return subprocess.run(
         ["git", "-C", str(repo), "show", f"coord:{_DOCTOR_EVENTS_REL}"],
         check=True,
         capture_output=True,
     ).stdout
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_run_coordination_health_fix_heals_dirty_coord_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`--fix` heals a strand whose coord worktree is DIRTY (the HIGH, #2786/#2367-B).
+
+    The realistic post-rollback state: the coord worktree's WORKING
+    ``status.events.jsonl`` is byte-restored to ``approved`` while HEAD is still the
+    committed ``done``. ``git revert`` refuses over that dirty tree, so the pre-fix
+    ``repair_coord_strand`` (no clean-to-HEAD) leaves the marker + strand and
+    ``doctor coordination --fix`` returns exit 1. The self-sufficient primitive
+    scoped-cleans the mission status paths to HEAD first, so ``--fix`` HEALS it:
+    committed ref coherent, worktree clean, marker cleared.
+    """
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [_doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review")],
+    )
+    captured_sha, worktree = _bake_stranding_done_dirty(repo, tmp_path)
+    _save_marker_state(
+        repo,
+        stranded_wp_ids=["WP-A"],
+        captured_sha=captured_sha,
+        coord_worktree=str(worktree),
+    )
+    feature_dir = repo / "kitty-specs" / _DOCTOR_MISSION_SLUG
+
+    # Preconditions: the coord worktree is genuinely DIRTY and WP-A is stranded done.
+    assert _porcelain(worktree), "fixture precondition: coord worktree must be dirty"
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == ["WP-A"]
+
+    monkeypatch.setattr(cd, "locate_project_root", lambda: repo)
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+
+    with pytest.raises(typer.Exit) as exc:
+        cd.run_coordination_health(json_output=True, fix=True)
+
+    # Healed: exit 0, committed ref coherent, worktree clean, marker cleared.
+    assert exc.value.exit_code == 0
+    assert coord_incoherent_done_wps(
+        "coord", ["WP-A"], repo_root=repo, feature_dir=feature_dir
+    ) == []
+    assert _porcelain(worktree) == "", "the heal must leave the coord worktree clean"
+    healed_state = load_state(repo, _DOCTOR_MISSION_ID)
+    assert healed_state is not None
+    assert healed_state.pending_coord_reconcile is None
 
 
 @pytest.mark.git_repo
@@ -833,10 +923,14 @@ def test_fix_stranded_reverts_direct_returns_healed_slug(tmp_path: Path) -> None
     findings = cd._check_stranded_coord_revert(repo)
     assert [f.error_code for f in findings] == [cd._STRANDED_COORD_REVERT_CODE]
 
-    assert cd._fix_stranded_reverts(findings, repo) == [_DOCTOR_MISSION_SLUG]
+    healed, warnings = cd._fix_stranded_reverts(findings, repo)
+    assert healed == [_DOCTOR_MISSION_SLUG]
+    assert warnings == []
     # Marker cleared -> re-checking finds nothing -> a second fix heals nothing.
     assert cd._check_stranded_coord_revert(repo) == []
-    assert cd._fix_stranded_reverts(findings, repo) == []
+    healed_again, warnings_again = cd._fix_stranded_reverts(findings, repo)
+    assert healed_again == []
+    assert warnings_again == []
 
 
 # ---------------------------------------------------------------------------
@@ -907,7 +1001,9 @@ def _seed_bare_handle_fixture(repo: Path) -> None:
     marker = {
         "coord_ref": "coord",
         "captured_sha": "deadbeef",
-        "coord_worktree": "/tmp/coord-wt",
+        # An existing worktree path so the live strand stays a healable `error`
+        # (the pruned-worktree STUCK-warning case is covered by its own test).
+        "coord_worktree": str(repo),
         "stranded_wp_ids": ["WP-A"],
         "revert_error": None,
         "detected_at": "2026-07-18T10:05:00+00:00",
@@ -985,3 +1081,155 @@ def test_stranded_check_bare_handle_false_negative_under_raw_resolver(
     monkeypatch.setattr(rpr, "resolve_planning_read_dir", _raw)
 
     assert cd._check_stranded_coord_revert(repo) == []
+
+
+# ---------------------------------------------------------------------------
+# FR-007 pruned/unresolvable coord worktree → distinct STUCK diagnostic
+# (not a silent skip, not a looping `error` whose hint points back at `--fix`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_stranded_check_pruned_worktree_emits_stuck_warning(tmp_path: Path) -> None:
+    """A live strand whose coord worktree is PRUNED → a ``warning`` STUCK finding.
+
+    ``--fix`` cannot revert a strand whose coordination worktree no longer exists
+    (there is nothing to run the revert in). Rather than emit the healable ``error``
+    (whose ``next_step`` loops the user back to a ``--fix`` that can never succeed),
+    the check surfaces a distinct ``warning`` with a manual-recovery hint.
+    """
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [
+            _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+            _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+        ],
+    )
+    pruned = tmp_path / "does-not-exist-coord-wt"
+    assert not pruned.exists()
+    _save_marker_state(repo, stranded_wp_ids=["WP-A"], coord_worktree=str(pruned))
+
+    findings = cd._check_stranded_coord_revert(repo)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "warning"
+    assert finding.error_code == cd._STRANDED_COORD_REVERT_STUCK_CODE
+    # The recovery hint must NOT loop the user back at plain `--fix`.
+    assert finding.next_step is not None
+    assert "no longer exists" in finding.message
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_run_coordination_health_pruned_worktree_exits_0_with_warning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A pruned-worktree STUCK strand is a ``warning`` (exit 0), surfaced in output."""
+    repo = tmp_path / "repo"
+    _seed_doctor_coord_ref(
+        repo,
+        [
+            _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+            _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+        ],
+    )
+    _save_marker_state(
+        repo,
+        stranded_wp_ids=["WP-A"],
+        coord_worktree=str(tmp_path / "pruned-coord-wt"),
+    )
+    monkeypatch.setattr(cd, "locate_project_root", lambda: repo)
+    monkeypatch.setattr(cd, "_check_git_version", lambda: [])
+    monkeypatch.setattr(cd, "_check_tracked_worktrees_content", lambda _r: [])
+
+    with pytest.raises(typer.Exit) as exc:
+        cd.run_coordination_health(json_output=True)
+    # A warning does not fail the gate, but the STUCK code IS surfaced (not dropped).
+    assert exc.value.exit_code == 0
+    assert cd._STRANDED_COORD_REVERT_STUCK_CODE in capsys.readouterr().out
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_fix_stranded_reverts_pruned_worktree_yields_warning_not_silent(
+    tmp_path: Path,
+) -> None:
+    """`_fix_stranded_reverts` on a strand finding whose worktree is pruned WARNS.
+
+    Directly exercises the fix-path defensive branch (a worktree pruned between the
+    check and the fix): the shared primitive returns ``worktree_missing`` and the
+    fixer surfaces a ``warning`` rather than silently dropping the marker.
+    """
+    repo = tmp_path / "repo"
+    (repo / ".kittify").mkdir(parents=True)
+    finding = cd.DoctorFinding(
+        severity="error",
+        message="live strand",
+        next_step=cd._STRANDED_COORD_REVERT_HINT,
+        error_code=cd._STRANDED_COORD_REVERT_CODE,
+        extra={
+            "mission_id": _DOCTOR_MISSION_ID,
+            "mission_slug": _DOCTOR_MISSION_SLUG,
+            "coord_ref": "coord",
+            "captured_sha": "deadbeef",
+            "coord_worktree": str(tmp_path / "pruned"),
+            "candidate_wps": ["WP-A"],
+            "stranded_wp_ids": ["WP-A"],
+        },
+    )
+
+    healed, warnings = cd._fix_stranded_reverts([finding], repo)
+
+    assert healed == []
+    assert [w.error_code for w in warnings] == [cd._STRANDED_COORD_REVERT_STUCK_CODE]
+
+
+# ---------------------------------------------------------------------------
+# Safety-net warning: an un-parseable marker must not be silently dropped.
+# ---------------------------------------------------------------------------
+
+
+def _save_raw_marker(repo: Path, marker: dict[str, object]) -> None:
+    """Persist a merge state carrying an arbitrary (possibly malformed) marker."""
+    (repo / ".kittify").mkdir(parents=True, exist_ok=True)
+    save_state(
+        MergeState(
+            mission_id=_DOCTOR_MISSION_ID,
+            mission_slug=_DOCTOR_MISSION_SLUG,
+            target_branch="main",
+            wp_order=["WP-A"],
+            current_wp="WP-A",
+            pending_coord_reconcile=marker,
+        ),
+        repo,
+    )
+
+
+def test_stranded_check_unparseable_marker_emits_warning(tmp_path: Path) -> None:
+    """An enumerated-but-unparseable marker yields a ``warning``, not a silent skip.
+
+    The marker is present (so the enumeration yields it) but malformed (empty
+    ``captured_sha``), so ``_parse_reconcile_marker`` returns ``None``. A safety-net
+    checker must surface a ``warning`` (reviewer-renata LOW) rather than ``continue``.
+    """
+    repo = tmp_path / "repo"
+    _save_raw_marker(
+        repo,
+        {
+            "coord_ref": "coord",
+            "captured_sha": "",  # malformed → unparseable.
+            "coord_worktree": "/tmp/wt",
+            "stranded_wp_ids": ["WP-A"],
+            "revert_error": None,
+            "detected_at": "2026-07-18T10:05:00+00:00",
+        },
+    )
+
+    findings = cd._check_stranded_coord_revert(repo)
+
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].error_code == cd._MARKER_UNPARSEABLE_CODE

--- a/tests/specify_cli/cli/commands/test_coordination_doctor.py
+++ b/tests/specify_cli/cli/commands/test_coordination_doctor.py
@@ -837,3 +837,151 @@ def test_fix_stranded_reverts_direct_returns_healed_slug(tmp_path: Path) -> None
     # Marker cleared -> re-checking finds nothing -> a second fix heals nothing.
     assert cd._check_stranded_coord_revert(repo) == []
     assert cd._fix_stranded_reverts(findings, repo) == []
+
+
+# ---------------------------------------------------------------------------
+# Bare-handle feature_dir canonicalization in the coord strand check (paula LOW).
+#
+# paula-patterns pre-merge finding: `_check_stranded_coord_revert` /
+# `_fix_stranded_reverts` resolve the mission ``feature_dir`` via the
+# canonicalizing ``resolve_planning_read_dir(..., kind=WORK_PACKAGE_TASK)`` — the
+# SAME read seam the executor's mark/heal use — instead of the raw
+# ``primary_feature_dir_for_mission``. When a saved marker's ``state.mission_slug``
+# is a BARE handle (``foo``) while the on-disk mission dir is the canonical
+# ``foo-<mid8>``, the raw resolver composes ``kitty-specs/foo/...`` (non-existent)
+# → no events → ``coord_incoherent_done_wps`` returns ``[]`` → the doctor silently
+# declares the marker stale: a split-brain safety-net FALSE-NEGATIVE. The
+# canonicalizing resolver folds ``foo`` → ``foo-<mid8>`` (via
+# ``_canonicalize_bare_modern_handle`` / ``resolve_bare_modern_mission_dir_name``)
+# and reads the right dir. This is the resolver-unification: check, fix, and the
+# executor's mark/heal all resolve the IDENTICAL feature_dir.
+# ---------------------------------------------------------------------------
+
+_BARE_HANDLE = "bare-handle-fixture"
+_BARE_MID8 = "01KXTM60"
+_BARE_COMPOSED = f"{_BARE_HANDLE}-{_BARE_MID8}"
+_BARE_MISSION_ID = "01MIDBAREHANDLE0000000000A0"
+
+
+def _seed_bare_handle_fixture(repo: Path) -> None:
+    """Seed a mission whose on-disk dir is canonical ``<slug>-<mid8>`` but whose
+    saved reconcile marker carries the BARE handle.
+
+    The committed ``coord`` ref holds a live WP-A ``done`` strand under the CANONICAL
+    dir name (``kitty-specs/<slug>-<mid8>/status.events.jsonl``), so only a resolver
+    that folds the bare handle → the canonical dir name reads the events and derives
+    the strand. The marker's ``mission_slug`` is deliberately the bare handle (no
+    ``-<mid8>`` suffix). The seeded events reuse :func:`_doctor_event`; their
+    ``feature_slug`` field is cosmetic — the coherence reduction keys on
+    ``wp_id`` + lane only.
+    """
+    _init_doctor_repo(repo)
+    feature_dir = repo / "kitty-specs" / _BARE_COMPOSED
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    (feature_dir / "meta.json").write_text(
+        _json.dumps(
+            {
+                "mission_slug": _BARE_COMPOSED,
+                "mission_id": _BARE_MISSION_ID,
+                "mission_number": None,
+                "mission_type": "software-dev",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    events = [
+        _doctor_event("WP-A", "approved", event_id="01A00", from_lane="in_review"),
+        _doctor_event("WP-A", "done", event_id="01A01", from_lane="approved"),
+    ]
+    (feature_dir / "status.events.jsonl").write_text(
+        "".join(_json.dumps(e, sort_keys=True) + "\n" for e in events),
+        encoding="utf-8",
+    )
+    _git_doctor(repo, "add", ".")
+    _git_doctor(repo, "commit", "-m", "seed coord events (canonical dir)")
+    _git_doctor(repo, "branch", "coord")
+
+    marker = {
+        "coord_ref": "coord",
+        "captured_sha": "deadbeef",
+        "coord_worktree": "/tmp/coord-wt",
+        "stranded_wp_ids": ["WP-A"],
+        "revert_error": None,
+        "detected_at": "2026-07-18T10:05:00+00:00",
+    }
+    save_state(
+        MergeState(
+            mission_id=_BARE_MISSION_ID,
+            mission_slug=_BARE_HANDLE,  # BARE handle — no -<mid8> suffix.
+            target_branch="main",
+            wp_order=["WP-A"],
+            current_wp="WP-A",
+            pending_coord_reconcile=marker,
+        ),
+        repo,
+    )
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_stranded_check_folds_bare_handle_to_canonical_feature_dir(
+    tmp_path: Path,
+) -> None:
+    """A marker with a BARE ``mission_slug`` STILL yields the strand finding.
+
+    The on-disk mission dir is the canonical ``<slug>-<mid8>``; the canonicalizing
+    ``resolve_planning_read_dir(..., kind=WORK_PACKAGE_TASK)`` folds ``bare`` →
+    ``<slug>-<mid8>`` so the committed coord ref is read from the right dir and the
+    live WP-A ``done`` strand is derived (paula-patterns pre-merge finding —
+    resolver-unification with the executor mark/heal). The non-vacuity companion
+    (:func:`test_stranded_check_bare_handle_false_negative_under_raw_resolver`)
+    proves this REDs under the pre-fix raw resolver.
+    """
+    repo = tmp_path / "repo"
+    _seed_bare_handle_fixture(repo)
+
+    findings = cd._check_stranded_coord_revert(repo)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "error"
+    assert finding.error_code == cd._STRANDED_COORD_REVERT_CODE
+    # Re-derived from the committed ref read at the CANONICAL dir, not echoed.
+    assert finding.extra["stranded_wp_ids"] == ["WP-A"]
+    assert finding.extra["mission_slug"] == _BARE_HANDLE
+
+
+@pytest.mark.git_repo
+@pytest.mark.non_sandbox
+def test_stranded_check_bare_handle_false_negative_under_raw_resolver(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-vacuity guard: the SAME fixture yields ZERO findings under the raw resolver.
+
+    Simulates the pre-fix code path by swapping the canonicalizing
+    ``resolve_planning_read_dir`` for the raw ``primary_feature_dir_for_mission``,
+    which composes ``kitty-specs/<bare>`` — a directory that does not exist. The
+    committed ref is then unreadable → no events → ``coord_incoherent_done_wps``
+    returns ``[]`` → the split-brain safety net silently declares the marker stale.
+    This proves the positive test above genuinely distinguishes the canonicalizing
+    resolver from the broken raw one (it would RED before the resolver-unification
+    fix). ``_check_stranded_coord_revert`` imports the resolver function-locally, so
+    patching the module attribute swaps in the pre-fix behaviour.
+    """
+    from specify_cli.missions import _read_path_resolver as rpr
+
+    repo = tmp_path / "repo"
+    _seed_bare_handle_fixture(repo)
+
+    def _raw(repo_root: Path, mission_slug: str, **_kwargs: object) -> Path:
+        # Bind explicitly: the resolver crosses the ``follow_imports=skip``
+        # boundary, so mypy widens the ``-> Path`` primitive to ``Any``.
+        resolved: Path = rpr.primary_feature_dir_for_mission(repo_root, mission_slug)
+        return resolved
+
+    monkeypatch.setattr(rpr, "resolve_planning_read_dir", _raw)
+
+    assert cd._check_stranded_coord_revert(repo) == []


### PR DESCRIPTION
## P0: coordination-`done` rollback transactionality (#2786 + #2367 Mechanism B)

Closes the split-brain that the #2711 fix's follow-up flagged: when a merge rollback's coordination-`done` `git revert` **itself fails** (#2786), or when a merge aborts **mid-`_record_merged_wps_done_for_merge`** before any revert runs (#2367 Mechanism B), rollback restored only working-tree bytes and left a committed `done` opposed to a reverted working `approved` — a **silently-stranded split-brain** that broke resume-dedup and the safe-resync guard.

Both are the **same mechanism**: byte-restore-of-working-tree *without* reverting the committed coord commit.

### The fix
- **Mark-not-raise** (`WP03`): rollback now persists a durable `MergeState.pending_coord_reconcile` marker naming the stranded WP(s) instead of swallowing the strand — the original failure still propagates, and leg-b byte-restore still runs.
- **Committed-ref derivation** (`WP02`): the strand is derived from the **committed coordination ref** (`coord_incoherent_done_wps`), not a working-tree diff (which is empty at the revert-failure point), scoped to *this merge's own* pre-target `done` write-set (a new `_MergeRunState` field) — so a legitimately pre-existing-`done` WP is never re-stranded.
- **Strand-gated idempotent heal** (`WP03`): `spec-kitty merge --resume` heals via `repair_coord_strand` (forward `git revert`, byte-stable on re-run, no-op when already coherent).
- **Operator detectability** (`WP04`): `spec-kitty doctor coordination` detects the strand — **re-verifying incoherence from the committed ref, not marker-presence** (the load-bearing negative AC: marker-present + ref-coherent → exit 0) — with a `--fix` that delegates to the same repair primitive.
- **Class-closing guard** (`WP05`): a behavioral guard that **reds if any of the seven `_restore_final_bookkeeping_snapshots` rollback sites strands without marking** (incl. a previously-unenumerated coord-reachable site). Programmatic AST enumeration — not a source grep; it reds when the mark is stubbed to a no-op.

INV-5 (#1827) merge-phase ordering preserved (heal is inner-only, not in `expected_order`); a non-aborting merge is byte-identical (NFR-001); no compensating SaaS emit (fenced, FR-010).

### Work packages (each independently reviewed; disjoint file ownership)
| WP | Scope | Reviewer verdict |
|----|-------|------------------|
| WP01 | red-first repros for both mechanisms | reviewer-renata ✅ |
| WP02 | marker + `coord_incoherent_done_wps` owner + `repair_coord_strand` | reviewer-renata ✅ |
| WP03 | executor mark/heal/restore-primitive (7-site routing) | **dual-lens** (reviewer-renata contracts + architect-alphonso git-safety) ✅ |
| WP04 | doctor check + `--fix` (canonical surface) | reviewer-renata ✅ (2 cycles) |
| WP05 | behavioral class-closing guard | python-pedro ✅ (non-vacuity independently verified) |

**Pre-merge integration review** (paula-patterns): **SAFE-TO-MERGE** — the fix is coherent as one artifact (single derivation authority, single repair primitive, single restore/mark owner with structural test enforcement, clean marker producer↔consumer contract); #2786 closes end-to-end with no seam gap.

### Testing
- Red-first repros for both mechanisms (`test_issue_2786_*`, `test_issue_2367_bake_strand`) — RED on base for the product reason, GREEN here.
- Consolidated suite: **81 passed** on the clean base; WP03's broad sweep: 661 passed.
- Architectural gates green on this branch: terminology, marker-convention, gate-coverage, same-tier-uniqueness, dead-modules (42 passed). New test files are gate-selected and marked.
- `ruff` clean.

### Tracker
- **Fixes #2786.**
- **Partially addresses #2367** (Mechanism B fixed) — **does NOT close it**: Mechanism A (claim-time VCS-lock resync) is deferred to **#2795**.
- Deferred follow-ups: **#2795** (#2367-A), **#2797** (unify the two `git revert` transport legs into one shared helper + narrow the heal's `git reset --hard` to a scoped `git checkout` + unify the doctor's `feature_dir` resolver — all documented DIR-044/defense-in-depth residuals from review, none blocking).

### Notes for reviewers
- **Pre-existing baseline:** `mypy` reports 2 `no-any-return` errors in `merge/state.py` (`get_merge_runtime_dir`) — these **pre-exist on upstream/main** (lines 148/318, shifted to 157/358 by this diff's added lines), confirmed by two independent reviewers; not introduced here and out of scope to drive-by fix.
- **Sonar:** no code hotspots expected; the loopback/HTTPS and suppression rules were honored (no new `# noqa`/`# type: ignore` beyond one narrowly-justified import-order guard in a test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-consolidation remediation (2nd adversarial squad)

After consolidation, a fresh adversarial pass (debugger-debbie + reviewer-renata) plus the deferred pre-merge LOW were remediated on this branch:

- **Regression-marker cleanup:** the `regression` marker is removed from the now-GREEN #2786/#2367-B P0 repros (they were intentional red-first on `main` per ADR 2026-07-17-1; the defects are closed). Docstrings updated to "FIXED / regression guard"; they stay CI-covered + permanent guards via `git_repo`.
- **Doctor `feature_dir` resolver (paula LOW):** both doctor sites now use the canonicalizing `resolve_planning_read_dir(...WORK_PACKAGE_TASK)` — one seam across all three strand sites; shipped with a bare-handle non-vacuity regression test.
- **[HIGH — both squads, fixed] `doctor coordination --fix` no-op on the dirty coord worktree.** A real rollback leaves the coord worktree dirty (`git revert` refuses); the doctor path didn't clean it. Fixed by making `repair_coord_strand` **self-sufficient**: worktree-existence short-circuit → strand-gate → HEAD-freshness guard (closes a concurrent `--fix`/`--resume` double-revert TOCTOU) → **scoped** `git checkout HEAD -- <status paths>` (subsumes #2797's reset-narrowing) → revert. Both callers now thin.
- **[HIGH ×2 — debbie re-review, fixed] the remediation initially *moved* the pruned-worktree failure.** (a) resume silently erased the marker when the worktree was pruned (`worktree_missing` empty-strand ≠ coherent) → guarded the clear + resume-path regression test; (b) a pruned-worktree strand was downgraded to `warning`/exit-0, hiding a live committed split-brain → kept it `error`/exit-1 with a manual-recovery hint, re-pinned the tests. Both verified red-without-fix.
- **Safety-net swallows → `warning` findings** (renata LOW): unparseable/ambiguous markers now surface a finding instead of a silent `continue`.

Deferred (tracked): **#2797** now scoped to just the `git revert` transport-dedup + the hard-crash pre-mark durability window (narrower than pre-fix).

**Post-remediation verification:** mission suites **85 passed**; broader `tests/merge/` 620 passed; arch gates green; `ruff`/`mypy` clean; NFR-001 byte-identical holds.
