### PR TITLE
fix(#2412): deliver projected skills as copies, never absolute symlinks (ask 3)

### DIFF
--- a/docs/adr/3.x/2026-04-08-3-global-skill-installation-per-project-symlinks.md
+++ b/docs/adr/3.x/2026-04-08-3-global-skill-installation-per-project-symlinks.md
@@ -1,8 +1,14 @@
 ---
 title: 'ADR 3 (2026-04-08): Global Skill Installation with Per-Project Symlinks'
-status: Accepted
+status: Superseded
 date: '2026-04-08'
 ---
+
+> **Superseded (2026-07-19):** the per-project **symlink** wiring decided here is
+> replaced by copy delivery — absolute symlinks dangle in dev-containers and are
+> unreadable to sandboxed agent harnesses (#2412). The **global canonical
+> install** half of this decision stands unchanged and is reaffirmed in
+> [ADR 2026-07-19-1](2026-07-19-1-skill-projection-copies-not-symlinks.md).
 
 ## Context and Problem Statement
 

--- a/docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md
+++ b/docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md
@@ -1,0 +1,85 @@
+---
+title: 'Skill projection delivers copies, not symlinks'
+status: Accepted
+date: '2026-07-19'
+---
+
+# Skill projection delivers copies, not symlinks
+
+**Status:** Accepted · **Date:** 2026-07-19 · **Supersedes:** the per-project wiring half of [ADR 2026-04-08-3](2026-04-08-3-global-skill-installation-per-project-symlinks.md) (its global-canonical-install decision stands and is reaffirmed here) · **Related:** [#2412](https://github.com/Priivacy-ai/spec-kitty/issues/2412), [ADR 2026-07-07-1](2026-07-07-1-ignored-surface-backfill-migration-pattern.md) (IGNORED-surface backfill pattern)
+
+## Context and Problem Statement
+
+ADR 2026-04-08-3 established two things: canonical skills live in user-global roots (`~/.kittify/agent-skills/`, later `~/.agents/skills/` and per-agent homes), and per-project agent directories reference them **via absolute symlinks**, with a copy fallback for filesystems that cannot symlink.
+
+Issue #2412 first surfaced the commit-side hazard of that wiring: an absolute symlink whose blob is `/Users/<name>/...` is machine-local by construction, and nothing gitignored it. That half was fixed by PR #2423 (contract-registered `IGNORED` surfaces + backfill migration). The issue's remaining ask — *should skills be delivered into the repo root as symlinks at all?* — is what this ADR decides.
+
+The gitignore fix made symlinks safe to **commit**. It did not make them safe to **use**:
+
+1. **Dev-containers and remote mounts.** Mount the repo into a container or sync it to a remote box and every projected skill points at a home directory that does not exist there. The agent sees a dangling link; skills silently vanish with no diagnosable error.
+2. **Sandboxed agent harnesses.** Harnesses that restrict file reads to the repo root refuse to resolve a symlink whose target is outside it. The whole point of `.agents/skills/` is to feed third-party agent tooling whose sandboxing spec-kitty does not control.
+3. **Global-root moves.** Uninstalling or relocating the CLI's canonical root dangles every projected skill in every repo on the machine simultaneously, until each runs a repair.
+
+## Decision Drivers
+
+* **Skills must be readable wherever the repo is readable.** The projection exists for third-party agents; delivery must not assume the reader can escape the project root or see the author's `$HOME`.
+* **Freshness must not regress.** The original symlink rationale — one upgrade touch-point — must be preserved in practice.
+* **No per-project state divergence.** Projected files remain managed, regenerated artifacts, never hand-edited project content.
+* **Minimal mechanism.** Prefer deleting a delivery mode over adding configuration for one.
+
+## Considered Options
+
+* **Option A: Deliver copies, always (chosen)**
+* **Option B: Keep absolute symlinks (status quo, post-#2423)**
+* **Option C: Configurable delivery mode (symlink opt-in)**
+
+## Decision Outcome
+
+**Chosen option: Option A — `_project_skill_file` always delivers a copy; the symlink preference is removed rather than made optional.**
+
+The freshness argument that justified symlinks in ADR 2026-04-08-3 is weaker than it looked: the installer re-projects the **full skill set on every init/upgrade/repair run**, so copies refresh whenever the project itself is touched. What symlinks added on top was *cross-project action-at-a-distance* — refreshing the global root silently changed the skill content of every repo on the machine, including repos whose generated command surfaces still matched an older CLI. Per-project refresh on that project's own upgrade is the more correct semantic, not a compromise.
+
+### Mechanics
+
+* `skills/installer.py::_project_skill_file` copies (`shutil.copy2`), never symlinks. A destination file whose content hash already matches the source is left untouched (idempotent re-runs); divergent content is archived to the migration backup root exactly as before.
+* A pre-existing projection **symlink** found at the destination is unlinked and replaced with a copy — conversion of existing projects happens organically on their next init/upgrade run, with **no dedicated migration**.
+* `skills/verifier.py::repair_skills` always repairs to a copy and records `delivery_mode: "copy"`, healing legacy manifest entries as they are repaired. Verify-side tolerance for not-yet-converted symlinks remains.
+* Copies inherit the canonical root's read-only mode (`copy2` preserves it) — deliberate: the projection is not user-editable, matching the symlink-era semantics. Local edits are drift, detected and repairable as before.
+* The `delivery_mode` manifest field and its `"symlink"` value remain readable for pre-conversion manifests; new entries are always `"copy"`.
+
+### Consequences
+
+#### Positive
+
+* Projected skills work in dev-containers, remote mounts, and repo-root-restricted sandboxes.
+* A global-root move no longer breaks existing projects; their copies keep working until the next refresh.
+* Net code deletion: the verifier's symlink repair branch and its global-root resync helper are gone.
+
+#### Negative
+
+* A global-root refresh no longer propagates to a project until that project's next init/upgrade/repair run.
+* Duplicate markdown bytes per project (negligible at skill-pack scale).
+
+#### Neutral
+
+* `.agents/skills/` and friends remain `IGNORED` state surfaces (#2423): copies are still per-machine regenerated content, not project content.
+
+## Pros and Cons of the Options
+
+### Option B: Keep absolute symlinks
+
+**Pros:** instant cross-project freshness; zero migration motion.
+**Cons:** dangles in containers/remote mounts; unreadable to repo-root sandboxes; global-root moves break every repo at once; the failure mode is always *silent* skill absence.
+**Why rejected:** the projection's consumers are exactly the tools most likely to run containerized or sandboxed.
+
+### Option C: Configurable delivery mode
+
+**Pros:** preserves symlink freshness for users who want it.
+**Cons:** a config knob, two persistent code paths, and doc/test surface for a mode whose only benefit is marginal freshness; the hazard cases are environmental, not preferential — the user in a dev-container did not choose to be there.
+**Why rejected:** minimal-mechanism driver; nobody should have to configure their skills to be readable.
+
+## More Information
+
+* **Issue:** [#2412](https://github.com/Priivacy-ai/spec-kitty/issues/2412) — ask 3 (asks 1–2 landed via PR #2423)
+* **Code locations:** `src/specify_cli/skills/installer.py::_project_skill_file`, `src/specify_cli/skills/verifier.py::repair_skills`
+* **Superseded wiring:** [ADR 2026-04-08-3](2026-04-08-3-global-skill-installation-per-project-symlinks.md) — the global canonical install target it defines is unchanged

--- a/docs/adr/3.x/README.md
+++ b/docs/adr/3.x/README.md
@@ -112,6 +112,7 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-07-17 | [Red main is honest signal; CI status is the release authority](2026-07-17-1-red-main-is-honest-ci-is-release-authority.md) |
 | 2026-07-18 | [charter.yaml is the authoritative structured source; charter.md is a curated companion; retire the prose→triad extractor](2026-07-18-1-charter-yaml-authoring-authority-and-extractor-retirement.md) |
 | 2026-07-19 | [Evict runtime-mutable WP state into the event log via a single generic InnerStateChanged annotation event](2026-07-19-1-wp-runtime-state-event-log-eviction-via-innerstatechanged.md) |
+| 2026-07-19 | [Skill projection delivers copies, not symlinks](2026-07-19-1-skill-projection-copies-not-symlinks.md) |
 | 2026-07-21 | [in_tension_with and reconciles_tension DRG edges (retiring opposed_by)](2026-07-21-1-in-tension-with-drg-edge.md) |
 | 2026-07-21 | [promote the glossary to a first-order doctrine artefact (GLOSSARY_PACK kind), retire the runtime glossary, and deliver terminology enforcement as an executable ASSET gate](2026-07-21-1-glossary-first-order-doctrine-artefact.md) |
 | 2026-07-22 | [gate bindings reuse `mission_step_contract` — the content-vs-relationship principle](2026-07-22-1-gate-binding-content-vs-relationship.md) |

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -414,6 +414,20 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   best-effort), and flips `meta.json` `status_phase` to snapshot-authority only for verified
   missions; the same seed→verify→flip path ships as an auto-discovered upgrade migration for
   consumer repos.
+- **Skill projection delivers copies, never absolute symlinks (#2412, ADR 2026-07-19-1).**
+  Projected skill files under `.claude/skills/`, `.agents/skills/`, etc. used to be
+  absolute symlinks into the user-global canonical root — which dangle when the repo
+  is mounted into a dev-container or synced to a remote box, are unreadable to agent
+  harnesses sandboxed to the repo root, and all break at once if the global root
+  moves. `_project_skill_file` now always delivers a real copy (the pre-existing
+  Windows fallback path, promoted): hash-equal destinations are left untouched
+  (idempotent re-runs), legacy symlinks are replaced with copies organically on each
+  project's next init/upgrade/repair run (no migration needed), and `repair_skills`
+  always repairs to a copy, healing pre-existing `delivery_mode: symlink` manifest
+  entries as it goes. Freshness is preserved because every install run re-projects
+  the full skill set; copies inherit the canonical root's read-only mode. Supersedes
+  the per-project-symlink half of ADR 2026-04-08-3 (the global canonical root is
+  unchanged).
 - **`charter generate` seeds a starter `charter.md` companion when absent (#2800).**
   After the #2773 inversion `charter generate` produced no `charter.md` at all, leaving a
   fresh project without the display-only rationale companion and no signal one should exist.

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -1115,7 +1115,7 @@ pages:
   - path: "docs/adr/3.x/2026-04-08-3-global-skill-installation-per-project-symlinks.md"
     title: "ADR 3 (2026-04-08): Global Skill Installation with Per-Project Symlinks"
     divio_type: "none"
-    abstract: "Skills are markdown files that extend agent capabilities — they encode domain-specific workflows, patterns, and shortcuts that agents invoke during mission execution. Examples include `spec-kitty-git-workflow.md`, `spec-kitty-charter-doctrine.md`, and `spec-kitty-implement-review.md`."
+    abstract: "> **Superseded (2026-07-19):** the per-project **symlink** wiring decided here is > replaced by copy delivery — absolute symlinks dangle in dev-containers and are > unreadable to sandboxed agent harnesses (#2412). The **global canonical > install** half of this decision stands unchanged and is reaffirmed in > [ADR 2026-07-19-1](2026-07-19-1-skill-projection-copies-not-symlinks.md)."
     anchors:
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
     - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
@@ -2315,6 +2315,21 @@ pages:
     - {slug: "option-y-adr-first-then-shape-2773", text: "Option Y — ADR-first, then shape #2773", level: 3}
     - {slug: "option-z-keep-2773-bounded-invert-separately", text: "Option Z — keep #2773 bounded; invert separately", level: 3}
     - {slug: "option-b-charter-md-fully-generated-from-charter-yaml-rationale-fields", text: "Option (b) — charter.md fully generated from charter.yaml rationale fields", level: 3}
+    - {slug: "more-information", text: "More Information", level: 2}
+  - path: "docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md"
+    title: "Skill projection delivers copies, not symlinks"
+    divio_type: "none"
+    abstract: "**Status:** Accepted · **Date:** 2026-07-19 · **Supersedes:** the per-project wiring half of [ADR 2026-04-08-3](2026-04-08-3-global-skill-installation-per-project-symlinks.md) (its global-canonical-install decision stands and is reaffirmed here) · **Related:** [#2412](https://github.com/Priivacy-ai/spec-kitty/issues/2412), [ADR 2026-07-07-1](2026-07-07-1-ignored-surface-backfill-migration-pattern.md) (IGNORED-surface backfill pattern)"
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "mechanics", text: "Mechanics", level: 3}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "pros-and-cons-of-the-options", text: "Pros and Cons of the Options", level: 2}
+    - {slug: "option-b-keep-absolute-symlinks", text: "Option B: Keep absolute symlinks", level: 3}
+    - {slug: "option-c-configurable-delivery-mode", text: "Option C: Configurable delivery mode", level: 3}
     - {slug: "more-information", text: "More Information", level: 2}
   - path: "docs/adr/3.x/2026-07-19-1-wp-runtime-state-event-log-eviction-via-innerstatechanged.md"
     title: "ADR: Evict runtime-mutable WP state into the event log via a single generic InnerStateChanged annotation event"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -812,6 +812,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -788,6 +788,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/2026-07-19-1-wp-runtime-state-event-log-eviction-via-innerstatechanged.md
   tag: current
   divio_type: none
@@ -807,12 +813,6 @@
   current_target: true
   notes: null
 - path: docs/adr/3.x/2026-07-22-1-gate-binding-content-vs-relationship.md
-  tag: current
-  divio_type: none
-  owning_workstream: none
-  current_target: true
-  notes: null
-- path: docs/adr/3.x/2026-07-19-1-skill-projection-copies-not-symlinks.md
   tag: current
   divio_type: none
   owning_workstream: none

--- a/src/doctrine/skills/spec-kitty-setup-doctor/references/agent-path-matrix.md
+++ b/src/doctrine/skills/spec-kitty-setup-doctor/references/agent-path-matrix.md
@@ -56,9 +56,12 @@ exclusively through wrapper slash commands in the wrapper root.
 
 ## Notes
 
-- The shared root `.agents/skills/` is created once and symlinked or referenced
-  by all shared-root-capable agents. The canonical managed copy lives in
-  `~/.agents/skills/`; project roots should project to it rather than snapshot it.
+- The shared root `.agents/skills/` is created once and referenced by all
+  shared-root-capable agents. Files are projected from the canonical managed
+  copy in `~/.agents/skills/` as plain copies, never symlinks — an absolute
+  symlink dangles when the repo is mounted into a dev-container and is
+  unreadable to sandboxed harnesses (#2412). The projection is refreshed on
+  every init/upgrade/repair run.
 - Managed canonical files under the user home are read-only. If a project replaces
   one of its projected files locally, that is treated as drift and can be repaired.
 - Wrapper roots contain slash-command files (e.g., `spec-kitty.implement.md`)

--- a/src/specify_cli/skills/installer.py
+++ b/src/specify_cli/skills/installer.py
@@ -134,25 +134,23 @@ def _project_skill_file(
 ) -> tuple[str, Path | None]:
     """Project a global canonical skill file into the project.
 
-    Prefers a symlink so future CLI upgrades only need to refresh the
-    global canonical roots. Falls back to a copy when symlinks are unavailable.
+    Delivers a copy, never a symlink (#2412): an absolute symlink into the
+    user-global canonical root dangles when the repo is mounted into a
+    dev-container or read by a sandboxed agent harness that cannot resolve
+    paths outside the project root. Copies stay fresh because every
+    init/upgrade/repair run re-projects the full skill set. Pre-#2412
+    symlinks found at the destination are replaced with copies here.
     """
     if dest.is_symlink():
-        try:
-            if dest.resolve() == source_file.resolve():
-                return DELIVERY_SYMLINK, backup_root
-        except OSError:
-            pass
         _safe_unlink(dest)
     elif dest.exists():
         try:
             if dest.is_file() and compute_content_hash(dest) == compute_content_hash(source_file):
-                _safe_unlink(dest)
-            else:
-                backup_root = _ensure_backup_root(project_path, backup_root)
-                if archived_paths is not None:
-                    archived_paths.append(backup_root / dest.relative_to(project_path))
-                backup_root = _archive_existing_path(dest, project_path, backup_root)
+                return DELIVERY_COPY, backup_root
+            backup_root = _ensure_backup_root(project_path, backup_root)
+            if archived_paths is not None:
+                archived_paths.append(backup_root / dest.relative_to(project_path))
+            backup_root = _archive_existing_path(dest, project_path, backup_root)
         except OSError:
             backup_root = _ensure_backup_root(project_path, backup_root)
             if archived_paths is not None:
@@ -160,12 +158,8 @@ def _project_skill_file(
             backup_root = _archive_existing_path(dest, project_path, backup_root)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        dest.symlink_to(source_file)
-        return DELIVERY_SYMLINK, backup_root
-    except OSError:
-        shutil.copy2(source_file, dest)
-        return DELIVERY_COPY, backup_root
+    shutil.copy2(source_file, dest)
+    return DELIVERY_COPY, backup_root
 
 
 def _project_skill_files(

--- a/src/specify_cli/skills/verifier.py
+++ b/src/specify_cli/skills/verifier.py
@@ -8,9 +8,7 @@ import shutil
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
-from specify_cli.core.paths import assert_safe_path_segment
 from specify_cli.skills.manifest import (
     ManagedFileEntry,
     ManagedSkillManifest,
@@ -218,6 +216,8 @@ def repair_skills(
 
     Returns ``(repaired_count, failed_count)``; retirements count as repairs.
     """
+    from specify_cli.skills.installer import _safe_unlink
+
     manifest = load_manifest(project_path)
     if manifest is None:
         manifest = ManagedSkillManifest()
@@ -266,39 +266,34 @@ def repair_skills(
             failed += 1
             continue
         try:
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            delivery_mode = entry.delivery_mode
-            if entry.delivery_mode == "symlink":
-                global_root = get_primary_global_skill_root(entry.agent_key)
-                if global_root is None:
-                    raise OSError(f"No global skill root configured for agent {entry.agent_key}")
-                global_source = global_root / entry.skill_name / entry.source_file
-                if not global_source.exists() or entry.source_file == SKILL_MANIFEST_FILENAME:
-                    _sync_skill_to_global_root(skill, global_root)
-                if dest.exists() or dest.is_symlink():
-                    if dest.is_symlink() or dest.is_file():
-                        dest.unlink()
-                    else:
-                        shutil.rmtree(dest)
-                try:
-                    dest.symlink_to(global_source)
-                except OSError:
-                    _copy_skill_file(
-                        source_path,
-                        dest,
-                        project_path,
-                        entry.skill_name,
-                        entry.source_file,
-                    )
-                    delivery_mode = "copy"
-            else:
-                _copy_skill_file(
-                    source_path,
-                    dest,
-                    project_path,
-                    entry.skill_name,
-                    entry.source_file,
+            # An ancestor directory that is a symlink escaping the project
+            # root would make every operation below act on out-of-repo
+            # paths — refuse before touching anything.
+            if is_external_symlink(dest.parent, project_path):
+                raise OSError(
+                    f"Refusing to repair through out-of-repo symlinked directory: {dest.parent}"
                 )
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            # Repairs always land a copy (#2412) — a symlink into the
+            # machine-local global root dangles in dev-containers and is
+            # unreadable to sandboxed agent harnesses. Clear any existing
+            # destination first: unlinking a symlink at dest removes only
+            # the link inode (its target is never written), a pre-#2412
+            # projection symlink would make _copy_skill_file refuse the
+            # write, and an installer-delivered copy may carry the
+            # canonical root's read-only mode.
+            if dest.exists() or dest.is_symlink():
+                if dest.is_symlink() or dest.is_file():
+                    _safe_unlink(dest)
+                else:
+                    shutil.rmtree(dest)
+            _copy_skill_file(
+                source_path,
+                dest,
+                project_path,
+                entry.skill_name,
+                entry.source_file,
+            )
             new_hash = compute_content_hash(dest)
             # Update the manifest entry with the new hash
             manifest.add_entry(
@@ -310,7 +305,7 @@ def repair_skills(
                     agent_key=entry.agent_key,
                     content_hash=new_hash,
                     installed_at=entry.installed_at,
-                    delivery_mode=delivery_mode,
+                    delivery_mode="copy",
                 )
             )
             repaired += 1
@@ -381,25 +376,6 @@ def _expected_hash(entry: ManagedFileEntry, registry: SkillRegistry | None) -> s
         return None
 
     return _expected_content_hash(source_path, entry.skill_name, entry.source_file)
-
-
-def _sync_skill_to_global_root(skill: Any, global_root: Path) -> None:
-    """Refresh one global canonical skill directory before relinking a project file."""
-    safe_skill_name = assert_safe_path_segment(skill.name)
-    dest_dir = global_root / safe_skill_name
-    dest_dir.parent.mkdir(parents=True, exist_ok=True)
-    if dest_dir.exists() or dest_dir.is_symlink():
-        if dest_dir.is_symlink() or dest_dir.is_file():
-            dest_dir.unlink()
-        else:
-            shutil.rmtree(dest_dir)
-    shutil.copytree(skill.skill_dir, dest_dir)
-    skill_md = dest_dir / SKILL_MANIFEST_FILENAME
-    if skill_md.is_file():
-        content = skill_md.read_text(encoding="utf-8")
-        normalized = ensure_skill_frontmatter(content, skill.name)
-        if normalized != content:
-            skill_md.write_text(normalized, encoding="utf-8")
 
 
 def _project_managed_path(project_path: Path, installed_path: str) -> Path:

--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -363,9 +363,11 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         creation_trigger="spec-kitty init/upgrade skill projection",
         notes=(
             "Shared Agent-Skills projection root for codex/vibe/pi/letta. "
-            "Files are projected from the user-global canonical root, "
-            "preferring absolute symlinks (delivery_mode: symlink) -- "
-            "machine-local by construction, never commit (#2412). Unlike "
+            "Files are projected from the user-global canonical root as "
+            "copies (delivery_mode: copy) -- absolute symlinks were retired "
+            "because they dangle in dev-containers and defeat sandboxed "
+            "harnesses (#2412, ADR 2026-07-19-1). Still machine-generated "
+            "state regenerated on every init/upgrade, never commit. Unlike "
             ".claude/ etc., .agents/ is NOT in GitignoreManager's "
             "AGENT_DIRECTORIES, so this surface is its only ignore coverage. "
             "Collapses to the .agents/skills/ gitignore entry."

--- a/tests/specify_cli/skills/test_e2e.py
+++ b/tests/specify_cli/skills/test_e2e.py
@@ -74,11 +74,14 @@ def test_full_lifecycle(tmp_path: Path) -> None:
     """Install skills, verify ok, delete a file, verify detects missing, repair, verify ok again."""
     project, skills_root = _setup_project(tmp_path)
 
-    # Create a canonical skill with SKILL.md and a reference
+    # Create a canonical skill with SKILL.md and a reference. The name must
+    # NOT collide with a real packaged skill: verify's drift detection
+    # compares copy-delivered entries against the package registry, so a
+    # fixture reusing a real name with fake content reports as drifted.
     _create_skill_on_disk(
         skills_root,
-        "spec-kitty-setup-doctor",
-        skill_md_content="---\nname: spec-kitty-setup-doctor\n---\n# Setup Doctor\nDiagnostic skill.\n",
+        "e2e-doctor-skill",
+        skill_md_content="---\nname: e2e-doctor-skill\n---\n# Setup Doctor\nDiagnostic skill.\n",
         references={"troubleshooting.md": "# Troubleshooting\nCommon fixes.\n"},
     )
 
@@ -100,7 +103,7 @@ def test_full_lifecycle(tmp_path: Path) -> None:
     assert result.drifted == []
 
     # Step 3: Delete one installed file
-    skill_file = project / ".claude" / "skills" / "spec-kitty-setup-doctor" / "SKILL.md"
+    skill_file = project / ".claude" / "skills" / "e2e-doctor-skill" / "SKILL.md"
     assert skill_file.exists()
     skill_file.unlink()
 
@@ -109,7 +112,7 @@ def test_full_lifecycle(tmp_path: Path) -> None:
     assert result.ok is False
     assert len(result.missing) == 1
     assert result.missing[0].source_file == "SKILL.md"
-    assert result.missing[0].skill_name == "spec-kitty-setup-doctor"
+    assert result.missing[0].skill_name == "e2e-doctor-skill"
 
     # Step 5: Repair
     repaired, failed = repair_skills(project, result, registry)
@@ -360,10 +363,11 @@ def test_multi_skill_pack_installs_all_skills(tmp_path: Path) -> None:
     """Two skills in the pack are both discovered and installed correctly."""
     project, skills_root = _setup_project(tmp_path)
 
-    _create_skill_on_disk(skills_root, "spec-kitty-setup-doctor")
+    # Names must not collide with real packaged skills (see test_full_lifecycle).
+    _create_skill_on_disk(skills_root, "e2e-doctor-skill")
     _create_skill_on_disk(
         skills_root,
-        "spec-kitty-runtime-next",
+        "e2e-runtime-skill",
         references={"runtime-result-taxonomy.md": "# Taxonomy\nResult types.\n"},
     )
 
@@ -376,13 +380,13 @@ def test_multi_skill_pack_installs_all_skills(tmp_path: Path) -> None:
     save_manifest(manifest, project)
 
     # Both skills should be installed
-    assert (project / ".claude" / "skills" / "spec-kitty-setup-doctor" / "SKILL.md").is_file()
-    assert (project / ".claude" / "skills" / "spec-kitty-runtime-next" / "SKILL.md").is_file()
-    assert (project / ".claude" / "skills" / "spec-kitty-runtime-next" / "references" / "runtime-result-taxonomy.md").is_file()
+    assert (project / ".claude" / "skills" / "e2e-doctor-skill" / "SKILL.md").is_file()
+    assert (project / ".claude" / "skills" / "e2e-runtime-skill" / "SKILL.md").is_file()
+    assert (project / ".claude" / "skills" / "e2e-runtime-skill" / "references" / "runtime-result-taxonomy.md").is_file()
 
     # Manifest should track all files for both skills
-    doctor_entries = manifest.find_by_skill("spec-kitty-setup-doctor")
-    runtime_entries = manifest.find_by_skill("spec-kitty-runtime-next")
+    doctor_entries = manifest.find_by_skill("e2e-doctor-skill")
+    runtime_entries = manifest.find_by_skill("e2e-runtime-skill")
     assert len(doctor_entries) >= 1
     assert len(runtime_entries) >= 2  # SKILL.md + reference
 

--- a/tests/specify_cli/skills/test_installer.py
+++ b/tests/specify_cli/skills/test_installer.py
@@ -207,8 +207,8 @@ class TestInstallSharedRootAgent:
         project = tmp_path / "project"
         project.mkdir()
 
-        def raise_symlink_unavailable(self: Path, target: str | Path, target_is_directory: bool = False) -> None:
-            raise OSError("symlinks unavailable")
+        def fail_if_symlinked(self: Path, target: str | Path, target_is_directory: bool = False) -> None:
+            pytest.fail("skill projection must never create symlinks (#2412)")
 
         real_unlink = Path.unlink
 
@@ -217,7 +217,7 @@ class TestInstallSharedRootAgent:
                 raise PermissionError(self)
             real_unlink(self, missing_ok=missing_ok)
 
-        monkeypatch.setattr(Path, "symlink_to", raise_symlink_unavailable)
+        monkeypatch.setattr(Path, "symlink_to", fail_if_symlinked)
         monkeypatch.setattr(Path, "unlink", windows_like_unlink)
 
         skill = _make_skill(skills_root, "my-skill")
@@ -583,3 +583,120 @@ class TestInstallCopiesReferencesAndScripts:
         assert "SKILL.md" in source_files
         assert "references/arch.md" in source_files
         assert "scripts/run.sh" in source_files
+
+
+# ── #2412: copy delivery, never symlinks ─────────────────────────────
+
+
+class TestCopyDelivery:
+    """Skill projection delivers copies, never symlinks (#2412 / ADR 2026-07-19-1)."""
+
+    def test_projection_is_copy_never_symlink(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+        def fail_if_symlinked(self: Path, target: str | Path, target_is_directory: bool = False) -> None:
+            pytest.fail("skill projection must never create symlinks (#2412)")
+
+        monkeypatch.setattr(Path, "symlink_to", fail_if_symlinked)
+
+        skills_root = tmp_path / "skills_src"
+        project = tmp_path / "project"
+        project.mkdir()
+
+        skill = _make_skill(skills_root, "my-skill", references=["arch.md"])
+        entries = install_skills_for_agent(project, "codex", [skill])
+
+        for entry in entries:
+            installed = project / entry.installed_path
+            assert not installed.is_symlink()
+            assert installed.is_file()
+            assert entry.delivery_mode == "copy"
+
+    def test_reinstall_replaces_legacy_symlink_with_copy(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A pre-#2412 project carries absolute symlinks into the global root;
+        the next install run converts them to copies — no migration needed."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+        skills_root = tmp_path / "skills_src"
+        project = tmp_path / "project"
+        project.mkdir()
+
+        skill = _make_skill(skills_root, "my-skill")
+
+        # Simulate the legacy projection: dest is an absolute symlink to a
+        # (machine-local) canonical file outside the repo.
+        legacy_target = tmp_path / "home" / ".agents" / "skills" / "my-skill" / "SKILL.md"
+        legacy_target.parent.mkdir(parents=True, exist_ok=True)
+        legacy_target.write_text("legacy canonical content\n", encoding="utf-8")
+        dest = project / ".agents" / "skills" / "my-skill" / "SKILL.md"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.symlink_to(legacy_target)
+
+        entries = install_skills_for_agent(project, "codex", [skill])
+
+        assert not dest.is_symlink()
+        assert dest.is_file()
+        assert dest.read_text(encoding="utf-8") == skill.skill_md.read_text(encoding="utf-8")
+        assert entries[0].delivery_mode == "copy"
+
+    def test_reinstall_leaves_hash_equal_copy_untouched(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Re-running install over an up-to-date copy is a no-op for that file
+        (idempotent — no rewrite churn on every upgrade)."""
+        from specify_cli.skills.installer import _project_skill_file
+
+        source = tmp_path / "global" / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("canonical\n", encoding="utf-8")
+        project = tmp_path / "project"
+        dest = project / ".agents" / "skills" / "my-skill" / "SKILL.md"
+        dest.parent.mkdir(parents=True)
+
+        mode, _ = _project_skill_file(source, dest, project)
+        assert mode == "copy"
+
+        import shutil as shutil_module
+
+        def fail_if_copied(src: object, dst: object, **kwargs: object) -> None:
+            pytest.fail("hash-equal destination must not be rewritten")
+
+        monkeypatch.setattr(shutil_module, "copy2", fail_if_copied)
+        mode, _ = _project_skill_file(source, dest, project)
+        assert mode == "copy"
+        assert dest.read_text(encoding="utf-8") == "canonical\n"
+
+    def test_divergent_copy_archived_then_replaced(self, tmp_path: Path) -> None:
+        """User-modified content at the destination is archived to the backup
+        root before the fresh copy lands (behavior preserved from symlink era)."""
+        from specify_cli.skills.installer import _project_skill_file
+
+        source = tmp_path / "global" / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("canonical\n", encoding="utf-8")
+        project = tmp_path / "project"
+        dest = project / ".agents" / "skills" / "my-skill" / "SKILL.md"
+        dest.parent.mkdir(parents=True)
+        dest.write_text("user edited\n", encoding="utf-8")
+
+        archived: list[Path] = []
+        mode, backup_root = _project_skill_file(
+            source, dest, project, archived_paths=archived
+        )
+
+        assert mode == "copy"
+        assert dest.read_text(encoding="utf-8") == "canonical\n"
+        assert backup_root is not None
+        assert len(archived) == 1
+        assert archived[0].read_text(encoding="utf-8") == "user edited\n"
+
+    def test_copy_preserves_read_only_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Copies inherit the canonical root's read-only mode — the projection
+        is managed content, not user-editable (drift is detected and repaired)."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+        skills_root = tmp_path / "skills_src"
+        project = tmp_path / "project"
+        project.mkdir()
+
+        skill = _make_skill(skills_root, "my-skill")
+        install_skills_for_agent(project, "codex", [skill])
+
+        installed = project / ".agents" / "skills" / "my-skill" / "SKILL.md"
+        assert not installed.stat().st_mode & stat.S_IWRITE

--- a/tests/specify_cli/skills/test_installer.py
+++ b/tests/specify_cli/skills/test_installer.py
@@ -684,7 +684,7 @@ class TestCopyDelivery:
         assert mode == "copy"
         assert dest.read_text(encoding="utf-8") == "canonical\n"
         assert backup_root is not None
-        assert len(archived) == 1
+        assert len(archived) == 1  # golden-count: cardinality-is-contract
         assert archived[0].read_text(encoding="utf-8") == "user edited\n"
 
     def test_copy_preserves_read_only_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/specify_cli/skills/test_verifier.py
+++ b/tests/specify_cli/skills/test_verifier.py
@@ -259,8 +259,9 @@ def test_repair_handles_missing_source(tmp_path: Path) -> None:
     assert failed == 1
 
 
-def test_repair_rejects_external_symlink_destination(tmp_path: Path) -> None:
-    """Repair must not write through a managed-skill symlink escaping the repo."""
+def test_repair_heals_external_symlink_destination(tmp_path: Path) -> None:
+    """A symlink at the managed path is replaced with a copy; its target is
+    never written (#2412 — repairs always land copies)."""
     canonical = "---\nname: test-skill\n---\n# Canonical\nCorrect content.\n"
     registry = _create_registry(tmp_path, "test-skill", {"SKILL.md": canonical})
 
@@ -285,9 +286,107 @@ def test_repair_rejects_external_symlink_destination(tmp_path: Path) -> None:
     verify_result = VerifyResult(ok=False, missing=[entry])
 
     repaired, failed = repair_skills(repo, verify_result, registry)
+    assert repaired == 1
+    assert failed == 0
+    # The security property: the symlink target is never written.
+    assert external.read_text(encoding="utf-8") == "EXTERNAL"
+    # The link itself is replaced by a real, repo-local copy.
+    assert not link_path.is_symlink()
+    assert link_path.read_text(encoding="utf-8") == canonical
+
+
+def test_repair_refuses_external_symlinked_ancestor(tmp_path: Path) -> None:
+    """An ancestor directory that symlink-escapes the repo makes every path
+    operation act outside the repo — repair must refuse, not heal."""
+    canonical = "---\nname: test-skill\n---\n# Canonical\nCorrect content.\n"
+    registry = _create_registry(tmp_path, "test-skill", {"SKILL.md": canonical})
+
+    external_dir = tmp_path / "home" / "hijacked-skills" / "test-skill"
+    external_dir.mkdir(parents=True, exist_ok=True)
+    external_file = external_dir / "SKILL.md"
+    external_file.write_text("EXTERNAL", encoding="utf-8")
+
+    repo = tmp_path / "repo"
+    skills_root = repo / ".claude" / "skills"
+    skills_root.mkdir(parents=True, exist_ok=True)
+    # The skill DIRECTORY is a symlink out of the repo.
+    os.symlink(external_dir, skills_root / "test-skill", target_is_directory=True)
+
+    entry = _make_entry(
+        skill_name="test-skill",
+        source_file="SKILL.md",
+        installed_path=".claude/skills/test-skill/SKILL.md",
+        content_hash="sha256:stale",
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), repo)
+
+    verify_result = VerifyResult(ok=False, missing=[entry])
+
+    repaired, failed = repair_skills(repo, verify_result, registry)
     assert repaired == 0
     assert failed == 1
-    assert external.read_text(encoding="utf-8") == "EXTERNAL"
+    assert external_file.read_text(encoding="utf-8") == "EXTERNAL"
+
+
+def test_repair_converts_legacy_symlink_entry_to_copy(tmp_path: Path) -> None:
+    """A pre-#2412 manifest entry (delivery_mode=symlink, dangling link on
+    disk) repairs to a real copy and the manifest entry flips to copy."""
+    canonical = "---\nname: test-skill\n---\n# Canonical\nCorrect content.\n"
+    registry = _create_registry(tmp_path, "test-skill", {"SKILL.md": canonical})
+
+    repo = tmp_path / "repo"
+    installed_path = ".agents/skills/test-skill/SKILL.md"
+    dest = repo / installed_path
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Dangling absolute symlink — the classic dev-container failure mode.
+    os.symlink(tmp_path / "gone-global-root" / "SKILL.md", dest)
+
+    entry = _make_entry(
+        skill_name="test-skill",
+        source_file="SKILL.md",
+        installed_path=installed_path,
+        agent_key="codex",
+        content_hash="sha256:stale",
+        delivery_mode="symlink",
+    )
+    save_manifest(ManagedSkillManifest(entries=[entry]), repo)
+
+    verify_result = VerifyResult(ok=False, missing=[entry])
+
+    repaired, failed = repair_skills(repo, verify_result, registry)
+    assert repaired == 1
+    assert failed == 0
+    assert not dest.is_symlink()
+    assert dest.read_text(encoding="utf-8") == canonical
+
+    reloaded = load_manifest(repo)
+    assert reloaded is not None
+    assert reloaded.entries[0].delivery_mode == "copy"
+
+
+def test_repair_overwrites_read_only_copy(tmp_path: Path) -> None:
+    """Installer-delivered copies inherit the canonical root's read-only
+    mode; repair must still be able to replace a drifted one."""
+    canonical = "---\nname: test-skill\n---\n# Canonical\nCorrect content.\n"
+    registry = _create_registry(tmp_path, "test-skill", {"SKILL.md": canonical})
+
+    installed_path = ".claude/skills/test-skill/SKILL.md"
+    entry = _setup_manifest_and_file(
+        tmp_path,
+        installed_path=installed_path,
+        content="drifted content",
+    )
+    dest = tmp_path / installed_path
+    dest.chmod(0o444)
+    actual_hash = compute_content_hash(dest)
+    save_manifest(ManagedSkillManifest(entries=[entry]), tmp_path)
+
+    verify_result = VerifyResult(ok=False, drifted=[(entry, actual_hash)])
+
+    repaired, failed = repair_skills(tmp_path, verify_result, registry)
+    assert repaired == 1
+    assert failed == 0
+    assert dest.read_text(encoding="utf-8") == canonical
 
 
 def test_repair_updates_manifest(tmp_path: Path) -> None:
@@ -372,8 +471,15 @@ def test_repair_rejects_path_traversal(tmp_path: Path) -> None:
     assert failed == 1
 
 
-def test_repair_rejects_unsafe_skill_name_for_global_sync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Repair refuses global-root sync when the manifest skill name is unsafe."""
+def test_repair_unsafe_skill_name_never_touches_global_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repair never builds global-root paths from the manifest skill name.
+
+    Pre-#2412, repairing a delivery_mode=symlink entry resynced the global
+    root using the skill name as a path segment, so an unsafe name had to be
+    rejected. Copy-only repair takes source from the registry (traversal-
+    guarded) and dest from installed_path (traversal-guarded); the skill name
+    is never a filesystem path, and the global root is never written.
+    """
     registry = _create_registry(tmp_path, "..evil", {"SKILL.md": "# bad\n"})
     entry = _make_entry(
         skill_name="..evil",
@@ -388,8 +494,13 @@ def test_repair_rejects_unsafe_skill_name_for_global_sync(tmp_path: Path, monkey
 
     repaired, failed = repair_skills(tmp_path, verify_result, registry)
 
-    assert repaired == 0
-    assert failed == 1
+    assert repaired == 1
+    assert failed == 0
+    # The repaired copy stays inside the repo under the literal dirname...
+    dest = tmp_path / ".claude" / "skills" / "..evil" / "SKILL.md"
+    assert dest.is_file() and not dest.is_symlink()
+    # ...and the global root is never created or written.
+    assert not (tmp_path / "_global").exists()
 
 
 # ── retired-skill reconciliation (#2409) ─────────────────────────────


### PR DESCRIPTION
## The problem

Mount a spec-kitty project into a dev-container, and every skill under `.agents/skills/` and `.claude/skills/` silently vanishes: each one is an absolute symlink to `/Users/<you>/...` — a path that doesn't exist inside the container. The same thing happens to an agent harness sandboxed to the repo root (it refuses to resolve a link whose target escapes the project), and to every repo on a machine at once if the global canonical root is ever moved or reinstalled. There's no error anywhere — the agent just doesn't see its skills.

#2423 (asks 1+2 of #2412) made these surfaces safe to **commit**. This PR closes ask 3: it makes them safe to **use**.

## The fix in plain terms

Projected skill files are now always real copies, never symlinks. The copy path already existed (it was the Windows fallback) — this promotes it to the only mode and deletes the symlink machinery.

## Technical details

- `skills/installer.py::_project_skill_file` always `shutil.copy2`s. A destination whose content hash already matches the source is left untouched (idempotent re-runs, no churn); divergent content keeps the existing archive-to-backup behavior. A legacy projection symlink found at the destination is unlinked and replaced with a copy.
- **No migration needed**: the installer re-projects the full skill set on every init/upgrade/repair run, so existing projects convert organically the next time they're touched.
- `skills/verifier.py::repair_skills` always repairs to a copy and flips legacy `delivery_mode: symlink` manifest entries as it heals them. Net code deletion: the symlink repair branch and `_sync_skill_to_global_root` are gone.
- **Security posture preserved and tightened**: repair clears a symlink at the destination by unlinking the link inode (its target is never written), and gains an explicit refusal when an *ancestor* directory symlink-escapes the repo (previously only reachable via the `_copy_skill_file` write guard). The old `test_repair_rejects_external_symlink_destination` expectation changes accordingly: repair now *heals* a link at the managed path instead of failing, with the external target untouched — asserted explicitly.
- Copies inherit the canonical root's read-only mode (`copy2` preserves it) — deliberate: the projection stays non-editable, drift stays detectable/repairable.
- e2e fixtures were renamed off real pack skill names (`spec-kitty-setup-doctor` → `e2e-doctor-skill`): copy-mode verify compares entries against the package registry, so a fixture reusing a real name with fake content reports as drifted. (Symlink entries previously short-circuited to the global root, masking the collision.)
- Docs: new **ADR 2026-07-19-1** records the decision; ADR 2026-04-08-3 is marked superseded *for the wiring half only* (its global-canonical-install decision stands, reaffirmed in the new ADR). Also updated: the setup-doctor `agent-path-matrix.md` reference, `state/contract.py` surface notes, changelog. The ADR index row for 2026-04-08-3 was missing entirely; `freshen_adr_inventory` added it while indexing the new ADR.

## Why this approach

The symlink rationale in ADR 2026-04-08-3 was freshness — one global refresh updates all projects. But the installer already re-projects everything on every per-project run, so what symlinks actually added was cross-project action-at-a-distance: refreshing the global root silently changed skill content in repos whose generated command surfaces still matched an older CLI. Per-project refresh on that project's own upgrade is the more correct semantic. A config knob (symlink opt-in) was considered and rejected: the hazard cases are environmental, not preferential — the user in a dev-container didn't choose to be there, and nobody should have to configure their skills to be readable.

Verification: `tests/specify_cli/skills/` + provider + migration + contract + architectural + `tests/docs/` suites green (312 + 58 + 525); `ruff` clean; `mypy` reports only the two pre-existing file-scope artifacts also present on unmodified `main` (verified against the base). Terminology guard green.

Note for triage: this touches the skills installer/verifier surface, not the dashboard/mission-lifecycle/status surfaces named in the 3.2.x merge-hold.

Fixes #2412 (remaining scope — asks 1+2 landed in #2423).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787077955&installation_id=146454894&pr_number=2818&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2818&signature=93affd4e4f90acc4cb076be572dd4666e35245c8112bfff239421dff87c5609b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->