### PR TITLE
fix(merge): stale-lane remediation is aware of repo-root/planning lanes

### DIFF
--- a/src/specify_cli/lanes/stale_check.py
+++ b/src/specify_cli/lanes/stale_check.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from specify_cli.core.vcs.git import git_diff_names, git_merge_base
+from specify_cli.lanes.compute import is_planning_lane
 from specify_cli.lanes.models import ExecutionLane
 
 
@@ -75,8 +76,27 @@ def check_lane_staleness(
     return StaleCheckResult(
         is_stale=True,
         stale_files=overlap,
-        remediation=(
+        remediation=_stale_remediation(lane, lane_branch, mission_branch),
+    )
+
+
+def _stale_remediation(lane: ExecutionLane, lane_branch: str, mission_branch: str) -> str:
+    """Build the operator-facing fix-it command for a stale lane.
+
+    The canonical planning lane (:func:`is_planning_lane`) never has a
+    ``.worktrees/`` entry -- it resolves to the repository-root checkout on
+    the mission's target branch (see ``lane_branch_name``'s ``lane-planning``
+    special case). Pointing that lane's remediation at a worktree glob names a
+    directory that cannot exist by construction.
+    """
+    if is_planning_lane(lane):
+        return (
             f"Lane {lane.lane_id} must incorporate mission changes before merging. "
-            f"Run: cd .worktrees/*-{lane.lane_id} && git merge {mission_branch}"
-        ),
+            f"This lane runs in the repository-root checkout (no worktree) on "
+            f"branch '{lane_branch}'. From the repository root: "
+            f"git checkout {lane_branch} && git merge {mission_branch}"
+        )
+    return (
+        f"Lane {lane.lane_id} must incorporate mission changes before merging. "
+        f"Run: cd .worktrees/*-{lane.lane_id} && git merge {mission_branch}"
     )

--- a/tests/lanes/test_merge.py
+++ b/tests/lanes/test_merge.py
@@ -176,6 +176,48 @@ class TestMergeLaneToMission:
         assert result.lane_id == "lane-planning"
         assert result.merged_into == "kitty/mission-010-feat"
 
+    def test_stale_planning_lane_blocked_with_repo_root_remediation(self, tmp_path):
+        """The `lane-planning` lane has no `.worktrees/` entry by design -- a
+        stale-block error must not send the operator to a directory that
+        cannot exist there (mirrors test_stale_lane_blocked for lane-a)."""
+        repo = _make_repo(tmp_path)
+        _run(["git", "checkout", "-b", "release/3.1.1"], repo)
+        _commit(repo, "kitty-specs/WP00.md", "planning base\n", "planning base")
+        _run(["git", "checkout", "main"], repo)
+        _run(["git", "branch", "kitty/mission-010-feat", "release/3.1.1"], repo)
+
+        # Mission and the planning lane's own branch (release/3.1.1) both
+        # change the same file after their common base.
+        _run(["git", "checkout", "kitty/mission-010-feat"], repo)
+        _commit(repo, "kitty-specs/WP00.md", "mission change\n", "mission change")
+
+        _run(["git", "checkout", "release/3.1.1"], repo)
+        _commit(repo, "kitty-specs/WP00.md", "planning-branch change\n", "planning change")
+        _run(["git", "checkout", "main"], repo)
+
+        manifest = _make_manifest(
+            target_branch="release/3.1.1",
+            lanes=[
+                ExecutionLane(
+                    lane_id="lane-planning",
+                    wp_ids=("WP00",),
+                    write_scope=("kitty-specs/**",),
+                    predicted_surfaces=(),
+                    depends_on_lanes=(),
+                    parallel_group=0,
+                )
+            ],
+        )
+
+        result = consolidate_lane_into_mission(repo, "010-feat", "lane-planning", manifest)
+
+        assert result.success is False
+        assert result.stale_check is not None
+        assert result.stale_check.is_stale is True
+        assert ".worktrees/" not in result.errors[0]
+        assert "repository-root checkout" in result.errors[0]
+        assert "git checkout release/3.1.1 && git merge kitty/mission-010-feat" in result.errors[0]
+
 
 class TestMergeMissionToTarget:
     def test_successful_mission_merge(self, tmp_path):

--- a/tests/lanes/test_stale_check.py
+++ b/tests/lanes/test_stale_check.py
@@ -8,7 +8,7 @@ import subprocess
 import pytest
 
 from specify_cli.lanes.models import ExecutionLane
-from specify_cli.lanes.stale_check import check_lane_staleness
+from specify_cli.lanes.stale_check import _stale_remediation, check_lane_staleness
 
 pytestmark = pytest.mark.git_repo
 
@@ -101,6 +101,36 @@ class TestCheckLaneStaleness:
         assert result.remediation is not None
         assert "git merge" in result.remediation
 
+    def test_stale_planning_lane_remediation_has_no_worktree_path(self, tmp_path):
+        """The canonical planning lane has no ``.worktrees/`` entry by design --
+        remediation must not send the operator to a directory that can't exist."""
+        repo = _make_repo(tmp_path)
+        # lane_branch_name() returns the target branch itself for lane-planning
+        # (no synthetic kitty/mission-*-lane-planning branch), so the fixture
+        # branch here stands in for that target branch.
+        _run(["git", "branch", "kitty/mission-feat"], repo)
+        _run(["git", "branch", "target-branch"], repo)
+
+        _run(["git", "checkout", "kitty/mission-feat"], repo)
+        _commit(repo, "kitty-specs/feat/WP10.md", "mission version\n", "mission change")
+
+        _run(["git", "checkout", "target-branch"], repo)
+        _commit(repo, "kitty-specs/feat/WP10.md", "target version\n", "target change")
+
+        _run(["git", "checkout", "main"], repo)
+
+        result = check_lane_staleness(
+            _lane(lane_id="lane-planning"),
+            "target-branch",
+            "kitty/mission-feat",
+            repo,
+        )
+        assert result.is_stale is True
+        assert result.remediation is not None
+        assert ".worktrees/" not in result.remediation
+        assert "repository-root checkout" in result.remediation
+        assert "git checkout target-branch && git merge kitty/mission-feat" in result.remediation
+
     def test_stale_reports_only_overlapping_files(self, tmp_path):
         repo = _make_repo(tmp_path)
         _run(["git", "branch", "kitty/mission-feat"], repo)
@@ -123,3 +153,22 @@ class TestCheckLaneStaleness:
         )
         assert result.is_stale is True
         assert result.stale_files == ["src/a.py"]
+
+
+class TestStaleRemediation:
+    """Pure-function coverage for the remediation-text branch (no git needed)."""
+
+    def test_lane_workspace_gets_worktree_remediation(self):
+        remediation = _stale_remediation(
+            _lane(lane_id="lane-a"), "kitty/mission-feat-lane-a", "kitty/mission-feat",
+        )
+        assert "cd .worktrees/*-lane-a" in remediation
+        assert "git merge kitty/mission-feat" in remediation
+
+    def test_planning_lane_gets_repo_root_remediation(self):
+        remediation = _stale_remediation(
+            _lane(lane_id="lane-planning"), "main", "kitty/mission-feat",
+        )
+        assert ".worktrees/" not in remediation
+        assert "repository-root checkout" in remediation
+        assert "git checkout main && git merge kitty/mission-feat" in remediation


### PR DESCRIPTION
## The problem

A mission's planning-artifact WPs are grouped into the canonical `lane-planning` lane, which by design has no `.worktrees/` entry — it resolves to the repository-root checkout, on the mission's own target branch (`lane_branch_name()`'s own documented special case: for `lane-planning` it returns the target branch itself, e.g. `main` or `release/3.1.1`, never a synthetic `kitty/mission-*-lane-planning` branch).

When that lane goes stale relative to the mission branch, `spec-kitty merge` generates its remediation unconditionally for every lane, regardless of kind:

```
Lane lane-planning must incorporate mission changes before merging.
Run: cd .worktrees/*-lane-planning && git merge kitty/mission-<slug>
```

`.worktrees/*-lane-planning` cannot exist, by construction, for this lane kind. An operator hitting this has to independently figure out that "lane-planning" means the repo-root checkout, then hand-craft the equivalent merge command themselves — the tool's own printed fix requires going around the tool. (Reported via an internal field retrospective from a 10-WP mission run; happy to share details on request.)

## The fix in plain terms

Teach the stale-lane remediation message about the one lane kind that never gets a worktree, so it points the operator at the real location instead of a nonexistent directory.

## Technical details

- `check_lane_staleness()` in `src/specify_cli/lanes/stale_check.py` now branches on `is_planning_lane(lane)` — the existing, documented classification seam (its own docstring: "the single seam where 'what counts as a planning lane' is decided... callers must keep asking the semantic question rather than comparing against the constant directly"), already used at three other call sites in `merge/executor.py`. The remediation-building logic is extracted into `_stale_remediation()` for direct unit testing.
- For `is_planning_lane(lane)`: emits `git checkout <lane_branch> && git merge <mission_branch>` from the repository root, naming the actual branch (already available as the `lane_branch` parameter — it's the resolved target branch for this lane kind).
- For every other lane (the vast majority): output is byte-for-byte unchanged.
- Tests: a fast pure-function suite on `_stale_remediation` (`tests/lanes/test_stale_check.py`) covering both branches with no git needed; an integration test through `check_lane_staleness` itself with real git branches; and a new test in `tests/lanes/test_merge.py` — `test_stale_planning_lane_blocked_with_repo_root_remediation` — that reproduces the literal field-reported symptom end-to-end through `consolidate_lane_into_mission` and asserts the fixed error text.
- Verification: full `tests/lanes/` suite (354 tests) green, `tests/merge/` stale-related tests green, ruff clean, mypy clean, terminology guard green.

## Why this approach

The distinction this fix needs — repo-root vs. worktree-backed lane — isn't new to the codebase; it's already resolved at merge time via `resolve_workspace_for_wp()` and already correctly consulted by a *different* stale-check module, `core/stale_detection.py` (WP-inactivity staleness), which returns `"not_applicable"` for repo-root workspaces instead of generating worktree-relative remediation. This PR brings `lanes/stale_check.py`'s mission-vs-lane *content* staleness check to parity with that existing, working pattern, using the even more direct `is_planning_lane()` seam that's purpose-built for exactly this classification and already threaded through the merge executor — rather than inventing a new detection mechanism. The blast radius is deliberately one-sided: only the `is_planning_lane` branch's output changes; the common `lane_workspace` path is untouched, so there's no realistic regression path for the vast majority of lanes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787239630&installation_model_id=427282&pr_number=2832&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2832&signature=efa1d9a96a14631fc28bf21c068e21ab90fefe3e5a8966315efd9d5c6f16c81b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->