### PR TITLE
fix(merge): split lane-state and review-cycle reads to their real partitions

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -2,7 +2,7 @@
 title: Changelog
 description: Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release.
 doc_status: active
-updated: '2026-07-18'
+updated: '2026-07-21'
 ---
 # Changelog
 
@@ -110,6 +110,9 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   baseline is regenerated accordingly.
 
 ### 🐛 Fixed
+
+- **The review-artifact consistency gate resolves lane state and review-cycle content from separate, correctly-partitioned directories.**
+  For a coord-topology mission, `find_rejected_review_artifact_conflicts` (shared by `merge`, `merge --dry-run`, and `spec-kitty review`'s lane gate) used one caller-supplied directory for both a WP's lane state (`STATUS_STATE`, coordination-branch-owned) and its review-cycle artifacts (`WORK_PACKAGE_TASK`, PRIMARY-partition for every topology) — a single directory can only ever be correct for one of the two. A stale or untracked stray review-cycle file on the coordination worktree could falsely block an already-approved WP (reported via field retrospective); conversely, resolving everything to the PRIMARY checkout would have silently defeated lane-state detection instead. Both partitions now resolve independently by kind.
 
 - **Honest force-provenance on evidence-gated backward edges (#2684, #2736, #2810).**
   Persisted `StatusEvent.force` is now truthful — falsy on the evidence-gated

--- a/src/specify_cli/cli/commands/review/__init__.py
+++ b/src/specify_cli/cli/commands/review/__init__.py
@@ -225,12 +225,13 @@ def _record_gate(
 def _run_lane_gate(
     feature_dir: Path,
     repo_root: Path,
+    mission_slug: str,
     console: Console,
     findings: list[dict[str, str]],
     gates_recorded: list[GateRecord],
 ) -> None:
     findings_before = len(findings)
-    check_wp_lanes(feature_dir, repo_root, console, findings)
+    check_wp_lanes(feature_dir, repo_root, mission_slug, console, findings)
     result: Literal["pass", "fail"] = "fail" if len(findings) > findings_before else "pass"
     _record_gate(gates_recorded, gate_id="gate_1", name="wp_lane_check", result=result)
 
@@ -408,7 +409,7 @@ def review_mission(
     gates_recorded: list[GateRecord] = []
     _mission_id_raw = meta.get("mission_id")
     _mission_id: str | None = str(_mission_id_raw) if _mission_id_raw else None
-    _run_lane_gate(feature_dir, repo_root, console, findings, gates_recorded)
+    _run_lane_gate(feature_dir, repo_root, mission_slug, console, findings, gates_recorded)
     _run_dead_code_gate(
         baseline_merge_commit=baseline_merge_commit,
         repo_root=repo_root,

--- a/src/specify_cli/cli/commands/review/_lane_gate.py
+++ b/src/specify_cli/cli/commands/review/_lane_gate.py
@@ -23,6 +23,7 @@ from specify_cli.status import materialize
 def check_wp_lanes(
     feature_dir: Path,
     repo_root: Path,
+    mission_slug: str,
     console: Console,
     findings: list[dict[str, str]],
 ) -> None:
@@ -51,7 +52,9 @@ def check_wp_lanes(
             f"  [green]✓[/green]  WP lane check: all {len(snapshot.work_packages)} WP(s) in done"
         )
 
-    review_artifact_conflicts = find_rejected_review_artifact_conflicts(feature_dir)
+    review_artifact_conflicts = find_rejected_review_artifact_conflicts(
+        repo_root, mission_slug
+    )
     if review_artifact_conflicts:
         console.print(
             "  [red]✗[/red]  Review artifact consistency: blocking latest review "

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -1235,7 +1235,6 @@ def _run_lane_based_merge_locked(
     # must not write merge state).
     _enforce_review_artifact_consistency(
         repo_root=main_repo,
-        feature_dir=feature_dir,
         mission_slug=mission_slug,
         wp_ids=all_wp_ids,
     )

--- a/src/specify_cli/merge/forecast.py
+++ b/src/specify_cli/merge/forecast.py
@@ -167,10 +167,9 @@ def run_dry_run_forecast(
         _emit_dry_run_error(error_msg=str(exc), json_output=json_output)
         raise typer.Exit(1) from exc
 
-    # FR-001 (#2185): the review-artifact consistency preflight reads ``tasks/``
-    # review-cycle artifacts (WORK_PACKAGE_TASK, PRIMARY-partition) and the
-    # ``would_assign_mission_number`` scan reads ``meta.json`` — both live on the
-    # PRIMARY checkout. Resolve by the WP-task kind so neither lands on the husk.
+    # FR-001 (#2185): the ``would_assign_mission_number`` scan reads
+    # ``meta.json``, which lives on the PRIMARY checkout for every topology.
+    # Resolve by the WP-task kind so it never lands on the coord husk.
     feature_dir_for_preview = resolve_planning_read_dir(
         get_main_repo_root(repo_root),
         resolved_feature,
@@ -182,12 +181,15 @@ def run_dry_run_forecast(
     # artifact still sits on an approved/done WP, real merge exits with
     # REJECTED_REVIEW_ARTIFACT_CONFLICT — dry-run must surface the same
     # blocker in both human and JSON output, so operators can trust the
-    # preview as a readiness signal.
+    # preview as a readiness signal. The preflight resolves its own
+    # WORK_PACKAGE_TASK / STATUS_STATE directories internally (see its
+    # docstring) rather than taking one from this caller.
     dry_run_all_wp_ids: list[str] = [
         wp for lane in lanes_manifest.lanes for wp in lane.wp_ids
     ]
     review_artifact_preflight = run_review_artifact_consistency_preflight(
-        feature_dir_for_preview,
+        get_main_repo_root(repo_root),
+        resolved_feature,
         wp_ids=dry_run_all_wp_ids,
     )
     if not review_artifact_preflight.passed:

--- a/src/specify_cli/merge/preflight.py
+++ b/src/specify_cli/merge/preflight.py
@@ -361,12 +361,22 @@ def _enforce_canonical_status_history(
 def _enforce_review_artifact_consistency(
     *,
     repo_root: Path,
-    feature_dir: Path,
     mission_slug: str,
     wp_ids: list[str],
 ) -> None:
-    """Block terminal signoff when the latest review artifact is rejected."""
-    preflight = run_review_artifact_consistency_preflight(feature_dir, wp_ids=wp_ids)
+    """Block terminal signoff when the latest review artifact is rejected.
+
+    ``run_review_artifact_consistency_preflight`` resolves the review-cycle
+    (WORK_PACKAGE_TASK, PRIMARY-partition) and lane-state (STATUS_STATE,
+    coord-aware) directories independently -- see its docstring. This function
+    no longer resolves or threads a single ``feature_dir``: a coord-topology
+    mission's coordination worktree can carry a stale or untracked stray copy
+    of a WP's review artifacts, and its primary checkout carries no
+    authoritative status log, so one directory can never correctly serve both.
+    """
+    preflight = run_review_artifact_consistency_preflight(
+        repo_root, mission_slug, wp_ids=wp_ids
+    )
     if preflight.passed:
         return
     findings = list(preflight.findings)

--- a/src/specify_cli/post_merge/review_artifact_consistency.py
+++ b/src/specify_cli/post_merge/review_artifact_consistency.py
@@ -9,9 +9,11 @@ from pathlib import Path
 from typing import Any
 import re
 
+from specify_cli.missions._read_path_resolver import resolve_planning_read_dir
 from specify_cli.review.artifacts import rejected_review_artifact_for_terminal_lane
 from specify_cli.status import materialize
 from specify_cli.status import ReviewOverride
+from mission_runtime import MissionArtifactKind
 
 REJECTED_REVIEW_ARTIFACT_CONFLICT = "REJECTED_REVIEW_ARTIFACT_CONFLICT"
 REJECTED_REVIEW_ARTIFACT_INVARIANT = (
@@ -126,11 +128,31 @@ def _schema_error_message(exc: ValueError, artifact_path: Path) -> str:
 
 
 def find_rejected_review_artifact_conflicts(
-    feature_dir: Path,
+    repo_root: Path,
+    mission_slug: str,
     wp_ids: list[str] | None = None,
 ) -> list[ReviewArtifactFinding]:
-    """Return review artifact findings that block merge readiness."""
-    snapshot = materialize(feature_dir)
+    """Return review artifact findings that block merge readiness.
+
+    Resolves two independent partitions rather than reading both off one
+    caller-supplied ``feature_dir`` (#2412-adjacent field report): review-cycle
+    artifacts under ``tasks/`` are ``WORK_PACKAGE_TASK``, PRIMARY-partition for
+    every topology; WP lane state comes from ``STATUS_STATE``, which stays on
+    the coordination branch for a coord-topology mission. A single shared
+    directory can only ever be correct for one of the two -- for a
+    coord-topology mission the PRIMARY checkout carries no authoritative
+    status log, and the coordination worktree's on-disk copy of a WP's review
+    artifacts can be stale or an untracked stray file. Resolving each by its
+    own kind is what keeps a stale/wrong copy on either side from silently
+    shadowing the truth on the other.
+    """
+    task_dir = resolve_planning_read_dir(
+        repo_root, mission_slug, kind=MissionArtifactKind.WORK_PACKAGE_TASK
+    )
+    status_dir = resolve_planning_read_dir(
+        repo_root, mission_slug, kind=MissionArtifactKind.STATUS_STATE
+    )
+    snapshot = materialize(status_dir)
     selected_wp_ids = wp_ids or sorted(snapshot.work_packages)
     findings: list[ReviewArtifactFinding] = []
 
@@ -140,7 +162,7 @@ def find_rejected_review_artifact_conflicts(
             continue
         lane = str(state.get("lane", ""))
         snapshot_override = _snapshot_review_override(state)
-        for artifact_dir in _artifact_dirs_for_wp(feature_dir, wp_id):
+        for artifact_dir in _artifact_dirs_for_wp(task_dir, wp_id):
             latest_path = _latest_review_artifact_path(artifact_dir)
             if latest_path is None:
                 continue
@@ -290,7 +312,8 @@ class ReviewArtifactPreflightResult:
 
 
 def run_review_artifact_consistency_preflight(
-    feature_dir: Path,
+    repo_root: Path,
+    mission_slug: str,
     *,
     wp_ids: list[str] | None = None,
 ) -> ReviewArtifactPreflightResult:
@@ -300,5 +323,5 @@ def run_review_artifact_consistency_preflight(
     ``merge --dry-run`` so the two surfaces cannot drift. Callers that need
     rendering can call ``ReviewArtifactPreflightResult.diagnostics()``.
     """
-    findings = find_rejected_review_artifact_conflicts(feature_dir, wp_ids)
+    findings = find_rejected_review_artifact_conflicts(repo_root, mission_slug, wp_ids)
     return ReviewArtifactPreflightResult(findings=tuple(findings))

--- a/tests/integration/test_merge_cluster_coord_read.py
+++ b/tests/integration/test_merge_cluster_coord_read.py
@@ -29,7 +29,8 @@ WP02 ROUTE / KEEP map (re-resolved on the lane-b tree, verified)
 | Site (re-resolved)                                          | Verdict | Kind            |
 |-------------------------------------------------------------|---------|-----------------|
 | forecast.py `require_lanes_json` (dry-run)                  | ROUTE   | LANE_STATE      |
-| forecast.py review-artifact preflight `feature_dir_for_preview` | ROUTE | WORK_PACKAGE_TASK |
+| forecast.py `feature_dir_for_preview` (mission-number scan only) | ROUTE | WORK_PACKAGE_TASK |
+| review_artifact_consistency.py preflight (dry-run + real merge + lane-gate, shared) | ROUTE (split) | WORK_PACKAGE_TASK (artifacts) + STATUS_STATE (lane) |
 | executor.py `_run_lane_based_merge` preflight identity      | ROUTE   | PRIMARY_METADATA|
 | executor.py `_run_lane_based_merge` `require_lanes_json`    | ROUTE   | LANE_STATE      |
 | executor.py `_run_lane_based_merge` canonical identity      | ROUTE   | PRIMARY_METADATA|
@@ -53,11 +54,12 @@ from specify_cli.merge.config import MergeStrategy
 from tests.integration.coord_topology_fixture import (
     SENTINEL_HUSK_MISSION_ID,
     CoordTopologyContext,
+    coord_topology_mission,
     coord_topology_mission_sentinel_meta,
 )
 
-# Re-export the fixture so pytest discovers it in this module.
-__all__ = ["coord_topology_mission_sentinel_meta"]
+# Re-export the fixtures so pytest discovers them in this module.
+__all__ = ["coord_topology_mission", "coord_topology_mission_sentinel_meta"]
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
@@ -118,7 +120,7 @@ def test_dry_run_forecast_reads_primary_lane_set(
     ctx = coord_topology_mission_sentinel_meta
     captured: dict[str, Any] = {}
 
-    def _fake_preflight(feature_dir: Any, *, wp_ids: Any) -> NoReturn:
+    def _fake_preflight(repo_root: Any, mission_slug: Any, *, wp_ids: Any) -> NoReturn:
         captured["wp_ids"] = list(wp_ids)
         raise _StopProbe
 
@@ -447,3 +449,157 @@ def test_executor_baseline_identity_reads_primary_mission_id(
         "run.feature_dir STATUS leg."
     )
     assert captured["baseline_mission_id"] != SENTINEL_HUSK_MISSION_ID
+
+
+# ---------------------------------------------------------------------------
+# review_artifact_consistency.py — split WORK_PACKAGE_TASK / STATUS_STATE read
+# ---------------------------------------------------------------------------
+
+
+def test_review_artifact_gate_catches_genuine_rejection_on_coord_topology(
+    coord_topology_mission: CoordTopologyContext,
+) -> None:
+    """A genuinely-rejected review-cycle artifact on a terminal WP is caught.
+
+    Requires BOTH partitions to resolve correctly at once: the WP's lane
+    (terminal) must come from the coord husk's real status log
+    (STATUS_STATE), and the review-cycle verdict must come from the PRIMARY
+    checkout (WORK_PACKAGE_TASK). Reading lane state from PRIMARY (which has
+    no authoritative status log for a coord-topology mission) never reaches a
+    terminal lane; reading the review-cycle from the coord husk finds no
+    tasks/ dir there at all (the base fixture invariant) — either wrong leg
+    makes this silently find nothing.
+    """
+    from specify_cli.post_merge.review_artifact_consistency import (
+        find_rejected_review_artifact_conflicts,
+    )
+    from specify_cli.review.artifacts import ReviewCycleArtifact
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.store import append_event
+
+    ctx = coord_topology_mission
+
+    # The fixture's own pre-seeded marker line (evidence: <bare marker string>)
+    # is a raw-text probe, not a schema-valid StatusEvent -- it is never meant
+    # to survive materialize() (see coord_topology_fixture.py's module
+    # docstring). Replace it with a real, well-formed terminal transition so
+    # this test exercises production materialization end to end.
+    ctx.status_events_path.write_text("", encoding="utf-8")
+
+    # WP01 reaches a terminal lane on the REAL (coord husk) status log.
+    append_event(
+        ctx.coord_feature_dir,
+        StatusEvent(
+            event_id="01KW2E7A0TERMINAL00000001",
+            mission_slug=ctx.slug,
+            mission_id=ctx.mission_id,
+            wp_id="WP01",
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.APPROVED,
+            at="2026-06-26T01:00:00+00:00",
+            actor="reviewer-renata",
+            force=False,
+            execution_mode="worktree",
+            reason="approved for merge",
+        ),
+    )
+
+    # The genuine, rejected review-cycle artifact lives on PRIMARY.
+    artifact_dir = ctx.primary_feature_dir / "tasks" / "WP01-fixture"
+    ReviewCycleArtifact(
+        cycle_number=1,
+        wp_id="WP01",
+        mission_slug=ctx.slug,
+        reviewer_agent="reviewer-renata",
+        verdict="rejected",
+        reviewed_at="2026-06-26T00:30:00+00:00",
+        body="# Review\n\nVerdict: rejected.\n",
+    ).write(artifact_dir / "review-cycle-1.md")
+
+    findings = find_rejected_review_artifact_conflicts(ctx.repo, ctx.slug, ["WP01"])
+
+    assert len(findings) == 1, (
+        "Expected the genuine rejection to be caught. An empty result means "
+        "either the lane read missed the coord husk's terminal status, or the "
+        f"review-cycle read missed the PRIMARY checkout's tracked artifact. Got: {findings}"
+    )
+    assert findings[0].wp_id == "WP01"
+    assert findings[0].verdict == "rejected"
+
+
+def test_review_artifact_gate_ignores_stray_artifact_on_coord_husk(
+    coord_topology_mission: CoordTopologyContext,
+) -> None:
+    """Field-report regression: a stray review-cycle file on the coord husk
+    must never shadow the real, tracked content on the PRIMARY checkout.
+
+    Reproduces the reported failure mode: the coordination worktree carries a
+    stale REJECTED review-cycle artifact, as if left over from an earlier
+    cycle that was never forwarded there; the PRIMARY checkout carries the
+    real, correct APPROVED artifact. WP01's lane (approved) is read from the
+    coord husk's real status log. Before this fix, review-cycle content was
+    ALSO read from the husk, so the stale rejected artifact falsely blocked
+    an already-approved WP. After the fix, review-cycle content resolves to
+    PRIMARY (WORK_PACKAGE_TASK) -- the husk's stray copy is never opened.
+    """
+    from specify_cli.post_merge.review_artifact_consistency import (
+        find_rejected_review_artifact_conflicts,
+    )
+    from specify_cli.review.artifacts import ReviewCycleArtifact
+    from specify_cli.status.models import Lane, StatusEvent
+    from specify_cli.status.store import append_event
+
+    ctx = coord_topology_mission
+
+    # Replace the fixture's raw-text marker probe with a schema-valid event
+    # (see the sibling test above for why).
+    ctx.status_events_path.write_text("", encoding="utf-8")
+
+    # WP01 reaches a terminal lane on the REAL (coord husk) status log.
+    append_event(
+        ctx.coord_feature_dir,
+        StatusEvent(
+            event_id="01KW2E7A0TERMINAL00000002",
+            mission_slug=ctx.slug,
+            mission_id=ctx.mission_id,
+            wp_id="WP01",
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.APPROVED,
+            at="2026-06-26T01:00:00+00:00",
+            actor="reviewer-renata",
+            force=False,
+            execution_mode="worktree",
+            reason="approved for merge",
+        ),
+    )
+
+    # The real, correct artifact on PRIMARY: approved.
+    primary_artifact_dir = ctx.primary_feature_dir / "tasks" / "WP01-fixture"
+    ReviewCycleArtifact(
+        cycle_number=1,
+        wp_id="WP01",
+        mission_slug=ctx.slug,
+        reviewer_agent="reviewer-renata",
+        verdict="approved",
+        reviewed_at="2026-06-26T00:30:00+00:00",
+        body="# Review\n\nVerdict: approved.\n",
+    ).write(primary_artifact_dir / "review-cycle-1.md")
+
+    # A stale, stray artifact on the COORD HUSK: rejected. Must never be read.
+    husk_artifact_dir = ctx.coord_feature_dir / "tasks" / "WP01-fixture"
+    ReviewCycleArtifact(
+        cycle_number=1,
+        wp_id="WP01",
+        mission_slug=ctx.slug,
+        reviewer_agent="reviewer-renata",
+        verdict="rejected",
+        reviewed_at="2026-06-25T00:00:00+00:00",
+        body="# Review\n\nVerdict: rejected (stale, never forwarded).\n",
+    ).write(husk_artifact_dir / "review-cycle-1.md")
+
+    findings = find_rejected_review_artifact_conflicts(ctx.repo, ctx.slug, ["WP01"])
+
+    assert findings == [], (
+        "The coord husk's stray rejected artifact must not shadow PRIMARY's "
+        f"real approved one. Got: {findings}"
+    )

--- a/tests/merge/test_preflight_seam.py
+++ b/tests/merge/test_preflight_seam.py
@@ -140,7 +140,7 @@ def test_enforce_review_artifact_consistency_passes(tmp_path: Path) -> None:
     with patch.object(preflight, "run_review_artifact_consistency_preflight", return_value=_Result()):
         # No exception means the gate passed.
         preflight._enforce_review_artifact_consistency(
-            repo_root=tmp_path, feature_dir=tmp_path, mission_slug="m", wp_ids=["WP01"]
+            repo_root=tmp_path, mission_slug="m", wp_ids=["WP01"]
         )
 
 
@@ -163,7 +163,7 @@ def test_enforce_review_artifact_consistency_blocks(tmp_path: Path) -> None:
         pytest.raises(typer.Exit) as exc,
     ):
         preflight._enforce_review_artifact_consistency(
-            repo_root=tmp_path, feature_dir=tmp_path, mission_slug="m", wp_ids=["WP01"]
+            repo_root=tmp_path, mission_slug="m", wp_ids=["WP01"]
         )
     assert exc.value.exit_code == 1
 
@@ -432,7 +432,7 @@ def test_enforce_review_artifact_blocks_with_optional_keys(tmp_path: Path) -> No
         pytest.raises(typer.Exit) as exc,
     ):
         preflight._enforce_review_artifact_consistency(
-            repo_root=tmp_path, feature_dir=tmp_path, mission_slug="m", wp_ids=["WP01"]
+            repo_root=tmp_path, mission_slug="m", wp_ids=["WP01"]
         )
     assert exc.value.exit_code == 1
 

--- a/tests/post_merge/test_review_artifact_consistency.py
+++ b/tests/post_merge/test_review_artifact_consistency.py
@@ -107,7 +107,9 @@ def test_latest_rejected_review_artifact_conflicts_with_approved_wp(
     artifact_dir = mission.tasks_dir / "WP01-regression-harness"
     rejected = _write_review_artifact(artifact_dir, cycle_number=2, verdict="rejected")
 
-    findings = find_rejected_review_artifact_conflicts(mission.mission_dir)
+    findings = find_rejected_review_artifact_conflicts(
+        mission.repo_root, mission.mission_slug
+    )
 
     assert len(findings) == 1
     assert findings[0].wp_id == "WP01"
@@ -149,7 +151,9 @@ def test_latest_rejected_review_artifact_conflicts_with_done_wp(
     _write_review_artifact(artifact_dir, cycle_number=1, verdict="approved")
     _write_review_artifact(artifact_dir, cycle_number=2, verdict="rejected")
 
-    findings = find_rejected_review_artifact_conflicts(mission.mission_dir)
+    findings = find_rejected_review_artifact_conflicts(
+        mission.repo_root, mission.mission_slug
+    )
 
     assert len(findings) == 1
     assert findings[0].lane == "done"
@@ -171,7 +175,10 @@ def test_later_approved_review_artifact_clears_rejected_conflict(
     _write_review_artifact(artifact_dir, cycle_number=1, verdict="rejected")
     _write_review_artifact(artifact_dir, cycle_number=2, verdict="approved")
 
-    assert find_rejected_review_artifact_conflicts(mission.mission_dir) == []
+    assert (
+        find_rejected_review_artifact_conflicts(mission.repo_root, mission.mission_slug)
+        == []
+    )
 
 
 def test_merge_review_artifact_consistency_gate_blocks_done_signoff(
@@ -192,7 +199,6 @@ def test_merge_review_artifact_consistency_gate_blocks_done_signoff(
     with pytest.raises(typer.Exit) as exc_info:
         _enforce_review_artifact_consistency(
             repo_root=mission.repo_root,
-            feature_dir=mission.mission_dir,
             mission_slug=mission.mission_slug,
             wp_ids=["WP01"],
         )
@@ -224,7 +230,8 @@ def test_malformed_review_artifact_frontmatter_becomes_schema_diagnostic(
     malformed = _write_malformed_review_artifact(artifact_dir)
 
     findings = find_rejected_review_artifact_conflicts(
-        mission.mission_dir,
+        mission.repo_root,
+        mission.mission_slug,
         wp_ids=["WP01"],
     )
 
@@ -264,7 +271,8 @@ def test_invalid_top_level_review_artifact_field_becomes_schema_diagnostic(
     malformed = _write_review_artifact_with_invalid_verdict(artifact_dir)
 
     findings = find_rejected_review_artifact_conflicts(
-        mission.mission_dir,
+        mission.repo_root,
+        mission.mission_slug,
         wp_ids=["WP01"],
     )
 
@@ -298,7 +306,6 @@ def test_merge_review_artifact_consistency_gate_blocks_malformed_artifact(
     with pytest.raises(typer.Exit) as exc_info:
         _enforce_review_artifact_consistency(
             repo_root=mission.repo_root,
-            feature_dir=mission.mission_dir,
             mission_slug=mission.mission_slug,
             wp_ids=["WP01"],
         )

--- a/tests/regression/test_2684_review_override_recognition.py
+++ b/tests/regression/test_2684_review_override_recognition.py
@@ -149,7 +149,7 @@ def test_event_sourced_complete_override_does_not_block_merge(tmp_path: Path) ->
     assert ReviewOverride.from_dict(review_slot).complete
 
     # (c) Read half + merge gate: the override is honored — gate does NOT fire.
-    findings = find_rejected_review_artifact_conflicts(feature_dir, [_WP_ID])
+    findings = find_rejected_review_artifact_conflicts(tmp_path, _MISSION_SLUG, [_WP_ID])
     assert findings == [], (
         f"Event-sourced complete override must clear the gate, got: {findings}"
     )
@@ -166,7 +166,7 @@ def test_rejected_without_override_still_blocks_merge(tmp_path: Path) -> None:
     _append_approved_event(feature_dir, "01KXWN13WP09REGRESSION0002")
     _write_rejected_artifact(feature_dir)  # no override emitted anywhere
 
-    findings = find_rejected_review_artifact_conflicts(feature_dir, [_WP_ID])
+    findings = find_rejected_review_artifact_conflicts(tmp_path, _MISSION_SLUG, [_WP_ID])
 
     assert findings, "Genuine rejection with no override must block merge"
     assert findings[0].wp_id == _WP_ID
@@ -213,6 +213,6 @@ def test_incomplete_event_sourced_override_still_blocks_merge(tmp_path: Path) ->
         "Override with a blank field must be incomplete"
     )
 
-    findings = find_rejected_review_artifact_conflicts(feature_dir, [_WP_ID])
+    findings = find_rejected_review_artifact_conflicts(tmp_path, _MISSION_SLUG, [_WP_ID])
     assert findings, "Incomplete override must NOT be honored — merge still blocked"
     assert findings[0].wp_id == _WP_ID

--- a/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
+++ b/tests/specify_cli/cli/commands/test_merge_dry_run_review_artifact.py
@@ -153,7 +153,8 @@ def test_preflight_detects_rejected_review_artifact_on_approved_wp(
     )
 
     result = run_review_artifact_consistency_preflight(
-        mission.mission_dir,
+        mission.repo_root,
+        mission.mission_slug,
         wp_ids=["WP01"],
     )
 
@@ -189,7 +190,8 @@ def test_preflight_passes_on_clean_mission(tmp_path: Path) -> None:
     )
 
     result = run_review_artifact_consistency_preflight(
-        mission.mission_dir,
+        mission.repo_root,
+        mission.mission_slug,
         wp_ids=["WP01"],
     )
 


### PR DESCRIPTION
## The problem

An operator running `spec-kitty merge` on a coordination-topology mission hit a false block: the CLI reported an already-approved WP as "still rejected," even though the real, correctly-approved review-cycle artifact existed — just on a different branch that hadn't been forwarded into the coordination branch yet. The coordination worktree's on-disk copy of that WP's review-cycle file was stale (an untracked stray leftover from an earlier cycle), and the merge gate treated it as ground truth.

## The fix in plain terms

The gate that checks "does this approved/done WP still have a rejected review" was reading two different kinds of information — a WP's current lane, and its review-cycle file content — from the same single directory. Those two things live in different places for a coordination-topology mission (lane state on the coordination branch, review-cycle files on the primary checkout), so one directory can never be correct for both. The fix makes it resolve each independently, from the right place.

## Technical details

`find_rejected_review_artifact_conflicts()` (`src/specify_cli/post_merge/review_artifact_consistency.py`) called `materialize(feature_dir)` for lane state and read `tasks/**` under that same `feature_dir` for review-cycle content — one caller-supplied directory serving both. Review-cycle content is `WORK_PACKAGE_TASK`, a PRIMARY-partition kind (lives on the primary checkout for every topology); lane state is `STATUS_STATE`, which stays on the coordination branch for a coord-topology mission. `resolve_planning_read_dir`'s own docstring already describes this exact failure mode almost verbatim: "a stale pre-mission copy would SHADOW the real primary planning truth."

The function now takes `(repo_root, mission_slug, wp_ids)` and resolves both directories internally by kind — `WORK_PACKAGE_TASK` for `tasks/` reads, `STATUS_STATE` for the `materialize()` lane read. Threaded through its three real callers:
- `merge/executor.py`'s `_enforce_review_artifact_consistency` (the real-merge gate that produced the field report)
- `merge/forecast.py`'s dry-run preview, which had the **identical latent defect**, just never exercised (every existing coord-topology test mocks this specific check away — I found an explicit comment admitting as much: "the full status materialize is skipped... not representative")
- `cli/commands/review/_lane_gate.py`'s post-merge lane-gate report (`spec-kitty review`)

**Tests:** two new integration tests in `tests/integration/test_merge_cluster_coord_read.py` using the shared `coord_topology_mission` fixture (the canonical home for this bug class):
- `test_review_artifact_gate_catches_genuine_rejection_on_coord_topology` — proves a genuine rejection is still caught when both partitions resolve correctly (positive control — the fix doesn't just make the gate a no-op).
- `test_review_artifact_gate_ignores_stray_artifact_on_coord_husk` — reproduces the literal field-reported shape: a stale rejected artifact on the coord husk, the real approved one on primary. Asserts no finding.

I manually verified the second scenario against the pre-fix code (temporarily reverted the core change) and confirmed it reproduces the exact reported false block — the old code returns a `RejectedReviewArtifactFinding` for the same fixture data my fix returns `[]` for.

All five existing call sites across `tests/merge/`, `tests/post_merge/`, `tests/regression/`, and `tests/specify_cli/cli/commands/` updated for the new signature. Full sweep (`tests/merge/`, `tests/post_merge/`, the coord-topology integration suite, `tests/regression/test_2684_review_override_recognition.py`, `tests/specify_cli/cli/commands/`, `tests/docs/`, terminology guard): 4264 passed. Ruff and mypy clean on every touched file.

## Why this approach

The obvious "just point everything at primary" fix (mirroring what `forecast.py` already does) would have traded a loud false-positive for a silent one: primary carries no authoritative status log for a coord-topology mission, so `materialize()` would never see a terminal lane, and the whole gate would quietly stop firing for genuinely-rejected WPs on *every* coord-topology mission — worse than the bug being fixed. I verified this concretely before committing to the design (confirmed via the write-side code and the shared test fixture's own "decoy" status log, deliberately seeded to catch exactly this class of wrong-leg read).

Splitting the resolution inside the one shared function — rather than patching each caller separately — fixes the bug class once instead of three times, and closes the gap between `run_review_artifact_consistency_preflight`'s own docstring claim ("the single implementation path shared by `merge` and `merge --dry-run` so the two surfaces cannot drift") and its actual prior behavior, where the *directory* passed to that shared function silently drifted between callers even though the function itself was shared.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787244464&installation_model_id=427282&pr_number=2834&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2834&signature=803de52555aceeaa6cc5d9dd50f13f467c39bcf10527b155cf90dfb4af1b342a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->