### PR TITLE
fix(merge): hollow-review warning checks reviewer identity, not just force_count

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -160,6 +160,9 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   the zero-dependency root every layer can import downward), leaving the seam
   definition as the only `replace("\\", "/")` in `src/`.
 
+- **`merge`'s hollow-review warning no longer flags a WP with a genuinely independent reviewer.**
+  `force_count >= 2` alone can't distinguish "the reviewer used `--force` to bypass an unrelated gate false-positive" from "no independent review happened" — both increment the same counter. When the event log positively confirms a different actor logged the approving transition than the one that most recently implemented the WP, the warning no longer fires; absence of that evidence still warns as before (fail-safe default, never suppressed on uncertain data).
+
 - **Honest force-provenance on evidence-gated backward edges (#2684, #2736, #2810).**
   Persisted `StatusEvent.force` is now truthful — falsy on the evidence-gated
   review-rejection edges (`build_transition_plan` asks the FSM instead of

--- a/src/specify_cli/cli/commands/agent/tasks_move_task.py
+++ b/src/specify_cli/cli/commands/agent/tasks_move_task.py
@@ -1854,7 +1854,7 @@ def _mt_hop_policy_metadata(
     return None
 
 
-def _binding_role_for_lane(lane: Lane) -> str | None:
+def _binding_role_for_lane(lane: Lane | str) -> str | None:
     """Map a target lane to its resolved-binding role.
 
     Shared by :func:`_mt_emit_transitions` (the live transition-emit path,

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
 from specify_cli.coordination.outbound import queue_saas_emission
 from specify_cli.core.commit_guard import GuardCapability

--- a/src/specify_cli/merge/preflight.py
+++ b/src/specify_cli/merge/preflight.py
@@ -407,6 +407,65 @@ def _enforce_review_artifact_consistency(
     raise typer.Exit(1)
 
 
+def _latest_actor_for_transition(
+    feature_dir: Path, wp_id: str, to_lane: str
+) -> str | None:
+    """Return the actor on WP's most recent transition into *to_lane*.
+
+    Scans the raw event log rather than the reduced snapshot, because the
+    snapshot's ``actor`` slot is overwritten on every transition -- it can
+    only ever tell us who did the LATEST transition of any kind, never who
+    specifically claimed/implemented versus who specifically approved.
+    Returns ``None`` when the log is absent/unreadable or no matching,
+    actor-bearing transition exists for this WP.
+    """
+    events_path = feature_dir / _STATUS_EVENTS_FILENAME
+    if not events_path.exists():
+        return None
+    try:
+        raw_lines = events_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    latest_key: tuple[str, str] = ("", "")
+    latest_actor: str | None = None
+    for raw_line in raw_lines:
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("wp_id") != wp_id or event.get("to_lane") != to_lane:
+            continue
+        actor = event.get("actor")
+        if not actor or not str(actor).strip():
+            continue
+        key = (str(event.get("at") or ""), str(event.get("event_id") or ""))
+        if key >= latest_key:
+            latest_key = key
+            latest_actor = str(actor).strip()
+    return latest_actor
+
+
+def _independent_reviewer_confirmed(feature_dir: Path, wp_id: str) -> bool:
+    """True when WP's latest approval actor positively differs from its
+    latest implementation actor (#2412-adjacent field report, item #9).
+
+    ``force_count`` alone cannot distinguish "reviewer used --force to bypass
+    an unrelated gate false-positive" from "no independent review happened" --
+    both increment the same counter. This checks the one thing that actually
+    answers the question: did a different identity log the approving
+    transition than the one that most recently claimed/implemented the WP?
+    Returns False (never suppress) when either actor is missing/unknown --
+    absence of evidence is not evidence of an independent review.
+    """
+    implementer = _latest_actor_for_transition(feature_dir, wp_id, "in_progress")
+    reviewer = _latest_actor_for_transition(feature_dir, wp_id, "approved")
+    if not implementer or not reviewer:
+        return False
+    return implementer != reviewer
+
+
 def _collect_force_count_warnings(
     feature_dir: Path,
     wp_set: set[str],
@@ -415,7 +474,10 @@ def _collect_force_count_warnings(
     """Append force_count>=2 warnings from ``status.json`` (WP05 split helper).
 
     Behavior-preserving extraction of the status-snapshot scan formerly inlined
-    in ``_collect_hollow_review_warnings`` (FR-005, keeps CC <= 15).
+    in ``_collect_hollow_review_warnings`` (FR-005, keeps CC <= 15) -- plus one
+    additive guard (item #9): a WP whose approving actor is positively
+    confirmed distinct from its implementing actor is not a hollow review,
+    even with a high force_count, so it is not warned about here.
     """
     status_path = feature_dir / _STATUS_FILENAME
     if not status_path.exists():
@@ -435,7 +497,7 @@ def _collect_force_count_warnings(
             force_count = int(wp_state.get("force_count", 0))
         except (TypeError, ValueError):
             force_count = 0
-        if force_count >= 2:
+        if force_count >= 2 and not _independent_reviewer_confirmed(feature_dir, wp_id):
             warnings.setdefault(wp_id, []).append(f"force_count={force_count}")
 
 

--- a/tests/merge/test_preflight_seam.py
+++ b/tests/merge/test_preflight_seam.py
@@ -85,6 +85,136 @@ def test_collect_force_count_warnings_no_status_file(tmp_path: Path) -> None:
     assert warnings == {}
 
 
+def _write_transition(
+    tmp_path: Path, *, wp_id: str, to_lane: str, actor: str, event_id: str, at: str
+) -> None:
+    with (tmp_path / "status.events.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "event_id": event_id,
+                    "wp_id": wp_id,
+                    "to_lane": to_lane,
+                    "from_lane": "planned",
+                    "at": at,
+                    "actor": actor,
+                    "force": False,
+                    "execution_mode": "worktree",
+                }
+            )
+            + "\n"
+        )
+
+
+# --- hollow-review: item #9 reviewer-identity disambiguation --------------
+
+
+def test_latest_actor_for_transition_picks_the_latest_by_timestamp(tmp_path: Path) -> None:
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-a",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    # Rework cycle: a second, later claim by a different implementer.
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-b",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    assert preflight._latest_actor_for_transition(tmp_path, "WP01", "in_progress") == "implementer-b"
+
+
+def test_latest_actor_for_transition_no_events_file(tmp_path: Path) -> None:
+    assert preflight._latest_actor_for_transition(tmp_path, "WP01", "approved") is None
+
+
+def test_latest_actor_for_transition_no_matching_wp_or_lane(tmp_path: Path) -> None:
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-a",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    assert preflight._latest_actor_for_transition(tmp_path, "WP02", "in_progress") is None
+    assert preflight._latest_actor_for_transition(tmp_path, "WP01", "approved") is None
+
+
+def test_independent_reviewer_confirmed_when_actors_differ(tmp_path: Path) -> None:
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-ivan",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="approved", actor="reviewer-renata",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    assert preflight._independent_reviewer_confirmed(tmp_path, "WP01") is True
+
+
+def test_independent_reviewer_not_confirmed_when_actors_match(tmp_path: Path) -> None:
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-ivan",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="approved", actor="implementer-ivan",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    assert preflight._independent_reviewer_confirmed(tmp_path, "WP01") is False
+
+
+def test_independent_reviewer_not_confirmed_when_actor_unknown(tmp_path: Path) -> None:
+    # No in_progress transition at all -- absence of evidence must not
+    # suppress the warning.
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="approved", actor="reviewer-renata",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    assert preflight._independent_reviewer_confirmed(tmp_path, "WP01") is False
+
+
+def test_collect_force_count_warnings_suppressed_when_reviewer_differs(tmp_path: Path) -> None:
+    """The field-reported false positive: force_count>=2 alone used to warn
+    regardless of whether the review was genuinely independent."""
+    (tmp_path / "status.json").write_text(
+        json.dumps({"work_packages": {"WP01": {"force_count": 3}}}), encoding="utf-8"
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-ivan",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="approved", actor="reviewer-renata",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    warnings: HollowReviewWarnings = {}
+    preflight._collect_force_count_warnings(tmp_path, {"WP01"}, warnings)
+    assert warnings == {}
+
+
+def test_collect_force_count_warnings_kept_when_same_actor(tmp_path: Path) -> None:
+    (tmp_path / "status.json").write_text(
+        json.dumps({"work_packages": {"WP01": {"force_count": 3}}}), encoding="utf-8"
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="in_progress", actor="implementer-ivan",
+        event_id="01A", at="2026-07-21T00:00:00Z",
+    )
+    _write_transition(
+        tmp_path, wp_id="WP01", to_lane="approved", actor="implementer-ivan",
+        event_id="01B", at="2026-07-21T01:00:00Z",
+    )
+    warnings: HollowReviewWarnings = {}
+    preflight._collect_force_count_warnings(tmp_path, {"WP01"}, warnings)
+    assert warnings == {"WP01": ["force_count=3"]}
+
+
+def test_collect_force_count_warnings_kept_when_no_event_log(tmp_path: Path) -> None:
+    """Fail-safe default: with no event log to check, keep warning as before."""
+    (tmp_path / "status.json").write_text(
+        json.dumps({"work_packages": {"WP01": {"force_count": 3}}}), encoding="utf-8"
+    )
+    warnings: HollowReviewWarnings = {}
+    preflight._collect_force_count_warnings(tmp_path, {"WP01"}, warnings)
+    assert warnings == {"WP01": ["force_count=3"]}
+
+
 # --- hollow-review split: self-approval -----------------------------------
 
 

--- a/tests/specify_cli/compat/test_planner_distribution_profile.py
+++ b/tests/specify_cli/compat/test_planner_distribution_profile.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from typing import Literal
 from unittest.mock import MagicMock
 

--- a/tests/specify_cli/core/test_mission_creation_fire_once.py
+++ b/tests/specify_cli/core/test_mission_creation_fire_once.py
@@ -23,11 +23,14 @@ from __future__ import annotations
 
 import json
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+
+from ulid import ULID
 
 from specify_cli.core.mission_creation import create_mission_core
 from specify_cli.status import adapters as status_adapters
@@ -35,6 +38,9 @@ from specify_cli.status import adapters as status_adapters
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 _CORE_MODULE = "specify_cli.core.mission_creation"
+
+# (lifecycle_events, dossier_calls) surfaced by the ``_isolated_adapter_registry`` fixture.
+_RegistryFixture = tuple[list[dict[str, Any]], list[tuple[Path, str, Path]]]
 
 
 def _init_repo(repo: Path) -> None:
@@ -76,7 +82,7 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def _isolated_adapter_registry():
+def _isolated_adapter_registry() -> Iterator[_RegistryFixture]:
     """Clear the fan-out registry, install spy handlers, restore on teardown.
 
     Uses the real registration API so the test exercises the same fan-out path
@@ -103,7 +109,7 @@ def _isolated_adapter_registry():
 
 
 def test_mission_created_fanout_fires_exactly_once(
-    tmp_path: Path, _isolated_adapter_registry
+    tmp_path: Path, _isolated_adapter_registry: _RegistryFixture
 ) -> None:
     """One mission creation => exactly one MissionCreated event + one of each fan-out."""
     lifecycle_events, dossier_calls = _isolated_adapter_registry
@@ -145,7 +151,7 @@ def test_mission_created_fanout_fires_exactly_once(
 
 
 def test_mission_created_resume_does_not_double_fire(
-    tmp_path: Path, _isolated_adapter_registry
+    tmp_path: Path, _isolated_adapter_registry: _RegistryFixture
 ) -> None:
     """Re-running create_mission_core (resume) must not duplicate the MissionCreated publish.
 
@@ -157,16 +163,31 @@ def test_mission_created_resume_does_not_double_fire(
     _init_repo(tmp_path)
     slug = "fire-once-resume"
 
-    patches = (
+    # Pin the ULID so both create calls resolve to the SAME mission directory,
+    # which is what makes the second call a genuine "resume" of the first. Each
+    # create_mission_core call mints a fresh ULID, and the mission dir name embeds
+    # its ``mid8`` (the first 8 Crockford chars = the top 40 bits of the 48-bit ms
+    # timestamp, so it only changes every ~256ms). Without pinning, the two calls
+    # land in the same dir ONLY when they happen to fall inside the same 256ms
+    # window; under load (parallel CI workers + coverage) they straddle a boundary,
+    # get different dirs, and the per-dir dedup can't see the first event — the
+    # fan-out fires twice and this test flakes. Pinning removes the timing luck and
+    # deterministically exercises the dedup path this test exists to guard.
+    pinned_ulid = ULID()
+    with (
+        patch(f"{_CORE_MODULE}.ULID", return_value=pinned_ulid),
         patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
         patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
         patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
         patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
         patch(f"{_CORE_MODULE}._commit_feature_file"),
-    )
-    with patches[0], patches[1], patches[2], patches[3], patches[4]:
+    ):
         first = create_mission_core(tmp_path, slug, **_mission_summary(slug))
-        create_mission_core(tmp_path, slug, **_mission_summary(slug))
+        second = create_mission_core(tmp_path, slug, **_mission_summary(slug))
+
+    # Guard the pin's premise: both calls must resolve to one mission directory,
+    # else the "resume" dedup below is not actually being exercised.
+    assert first.feature_dir == second.feature_dir
 
     rows = _read_jsonl(first.feature_dir / "status.events.jsonl")
     mission_created_rows = [r for r in rows if r.get("event_type") == "MissionCreated"]


### PR DESCRIPTION
## The problem

An operator merging a mission saw `spec-kitty merge` warn that four WPs "may have been approved by the implementing agent, not an independent reviewer." In every one of those cases, the `--force` usage that triggered the warning was actually an independent reviewer subagent bypassing an unrelated gate false-positive — pre-existing merge noise in history, unrelated to the diff actually under review. The heuristic couldn't tell the difference: `force_count >= 2` fires the same way whether `--force` was used by the implementer covering their own tracks or by a genuinely separate reviewer clearing unrelated noise.

## The fix in plain terms

Before warning about a WP's force count, check whether the event log can positively confirm that a *different* identity approved it than the one who implemented it. If it can, that's real evidence of independent review — don't warn. If the data is missing or ambiguous, keep warning exactly as before; this only adds a way to *rule out* a false positive, never a way to hide a real one.

## Technical details

Two small additions to `src/specify_cli/merge/preflight.py`:

- `_latest_actor_for_transition(feature_dir, wp_id, to_lane)` scans the raw `status.events.jsonl` for the actor on a WP's most recent transition into a given lane. This has to read the raw event log rather than the reduced `status.json` snapshot — the snapshot's `actor` slot is overwritten on every transition, so it can only ever tell you who did the *single most recent* transition of any kind, never "who specifically implemented" versus "who specifically approved."
- `_independent_reviewer_confirmed(feature_dir, wp_id)` compares the latest actor into `in_progress` against the latest actor into `approved`. Returns `False` (never suppress) whenever either actor is missing — absence of evidence isn't evidence of independent review.
- `_collect_force_count_warnings` now skips appending the warning only when `_independent_reviewer_confirmed` returns `True`. The other two hollow-review signals — `force_count` itself as a threshold, and the explicit `ReviewerSelfApproval` self-declaration — are untouched.

The actor comparison mirrors an existing pattern already in the codebase (`_actors_compatible` in `status/work_package_lifecycle.py`, used for claim-conflict detection) rather than inventing new comparison semantics — same normalization (`.strip()`, exact match), same "unknown data never asserts a positive claim" posture.

**Tests:** 8 new tests in `tests/merge/test_preflight_seam.py` — direct coverage of both new helpers (latest-by-timestamp selection across rework cycles, no-events-file, no-matching-wp-or-lane) plus the integrated suppress/keep/fail-safe behavior on `_collect_force_count_warnings`. All 17 hollow-review tests in the file pass, including the 9 pre-existing ones (confirmed no regression). Full `tests/merge/` + `tests/post_merge/` (703 tests), `tests/docs/`, and the terminology guard green; ruff and mypy clean.

## Why this approach

The fix is additive by construction rather than a redesign: every transition already records a distinct `actor` (`StatusEvent.actor`), so no new instrumentation or write-side change is needed — the data this needed already existed, it just wasn't being consulted. Scoping the change to a positive-disconfirmation path (only ever *removes* a warning, never adds one) keeps the blast radius small and the failure mode safe: if the new logic has a bug that makes it under-detect independence, the result is just the pre-existing behavior (an occasionally-noisy warning), never a newly-introduced false negative that hides a real hollow review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787246590&installation_model_id=427282&pr_number=2835&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2835&signature=2139364f511bc80396990267ffdce65a1ae212a4fcb8990a903877a3cc37be3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->