### PR TITLE
docs(doctrine): /spec-kitty.analyze is a REQUIRED pre-implement gate, not optional

### DIFF
--- a/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
+++ b/src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md
@@ -582,11 +582,11 @@ After reporting, ask the user directly:
 > **Should I use the `/spec-kitty-implement-review` skill to fully implement all WPs until completion?**
 > This will dispatch implementing and reviewing agents for every WP, handle rejection cycles, and merge all lanes when done.
 >
-> Optional quality control gate before implementation: run `/spec-kitty.analyze` first to persist an `analysis-report.md` and review spec/plan/task consistency before any WP implementation starts.
+> **Required pre-implementation gate:** `/spec-kitty.analyze` must run before any WP implementation. It persists an `analysis-report.md` and reviews spec/plan/task consistency; the implement gate refuses to start (`analysis_report_required`) until that report exists. This is not optional — it is the readiness gate `/spec-kitty.implement` enforces.
 
-- If the user says **yes**: invoke the `spec-kitty-implement-review` skill with the mission slug. The user may also specify which agents to use for implementation and review (e.g., "yes, use sonnet for implementing and opus for reviewing").
-- If the user says **no** or wants to do it manually: end here and let them run `/spec-kitty.implement` at their own pace.
-- If the user wants the optional quality gate first: run `/spec-kitty.analyze --mission <mission-slug>` and wait for the user's decision on whether to address findings before invoking implementation.
+- If the user says **yes**: first ensure `/spec-kitty.analyze` has been run for this mission (run it now if `analysis-report.md` is missing — implementation cannot claim a WP without it), then invoke the `spec-kitty-implement-review` skill with the mission slug. The user may also specify which agents to use for implementation and review (e.g., "yes, use sonnet for implementing and opus for reviewing").
+- If the user says **no** or wants to do it manually: end here and let them run `/spec-kitty.implement` at their own pace — reminding them that `/spec-kitty.analyze` is a required prerequisite the implement gate enforces.
+- If the user wants to review consistency findings first: run `/spec-kitty.analyze --mission <mission-slug>` (also the required gate) and wait for the user's decision on whether to address findings before invoking implementation.
 - If the user asks for a subset (e.g., "just WP01 and WP02 for now"): invoke the skill with that scope.
 
 This handoff is the natural transition from planning to execution. Do NOT skip the question — always offer it explicitly so the user can choose their execution strategy.


### PR DESCRIPTION
## What

The `/spec-kitty.tasks` Step-10 handoff in the canonical source template described `/spec-kitty.analyze` as an **"optional quality control gate."** But the implement gate hard-requires `analysis-report.md`: `spec-kitty agent action implement WP##` refuses to claim a WP with `analysis_report_required` until `/spec-kitty.analyze` + `record-analysis` have run. The "optional" wording misleads operators and agents into hitting that gate error mid-flow (it bit a real implement-review run).

## Change

Reword the Step-10 handoff in `src/doctrine/missions/mission-steps/software-dev/tasks/prompt.md` (the canonical SOURCE, not a generated agent copy) so `/spec-kitty.analyze` is stated as the **required pre-implementation gate**, and the "yes"/"no" branches reflect that implementation cannot start without the recorded report. Doctrine/prose only — no behavior change.

## Verification

- `pytest tests/architectural/test_no_legacy_terminology.py` — 4 passed.
- Grep-verified that only the software-dev tasks template carried the "optional" wording; the documentation/research tasks templates and `tasks-finalize` do not (they reference analyze neutrally as a next command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYG4JHbHudbGAHpRKw5Pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333227&installation_model_id=427282&pr_number=2863&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2863&signature=6469ce5e81d1878f83ab409d9d4f9c2fc304b4f97dd2d99822d1cad0b7058ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->