### PR TITLE
fix: agent-action-review auto-commit fails on coord worktree (rebase/takeover of #2612)

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from specify_cli.core.constants import (
     MISSION_TYPE_RESEARCH,
+    WORKTREES_DIR,
 )
 from specify_cli.missions._read_path_resolver import (
     _canonicalize_primary_read_handle,
@@ -575,9 +576,27 @@ def _resolve_workflow_read_dir(
     return read_dir
 
 
+def _worktree_root_for_feature_dir(repo_root: Path, feature_dir: Path) -> Path:
+    """Return the correct worktree_root for safe_commit, derived from feature_dir.
+
+    When feature_dir lives inside .worktrees/<name>/..., returns
+    .worktrees/<name> so that absolute paths under that worktree normalize
+    correctly (preventing SafeCommitPathPolicyError on paths whose first
+    component is .worktrees/).  For primary-checkout feature_dirs, returns
+    repo_root unchanged.
+    """
+    worktrees_parent = repo_root / WORKTREES_DIR
+    try:
+        rel = feature_dir.resolve().relative_to(worktrees_parent.resolve())
+        return worktrees_parent / rel.parts[0]
+    except ValueError:
+        return repo_root
+
+
 def _commit_via_legacy_safe_commit(
     *,
     repo_root: Path,
+    worktree_root: Path,
     target_branch: str,
     paths: list[Path],
     message: str,
@@ -622,7 +641,7 @@ def _commit_via_legacy_safe_commit(
     # tracking ``main``) is REFUSED by the guard, never waived (FR-008).
     result = safe_commit(
         repo_root=repo_root,
-        worktree_root=repo_root,
+        worktree_root=worktree_root,
         target=CommitTarget(ref=target_branch),
         message=message,
         paths=tuple(paths),
@@ -635,8 +654,6 @@ def _commit_via_legacy_safe_commit(
         sha=getattr(result, "sha", None),
         wp_id=wp_id,
     )
-
-
 
 
 def _print_commit_summary(*, command_name: str, json_output: bool = False) -> None:

--- a/src/specify_cli/cli/commands/agent/workflow_executor.py
+++ b/src/specify_cli/cli/commands/agent/workflow_executor.py
@@ -280,9 +280,11 @@ def commit_workflow_change(
         return
 
     # Legacy fallback (TODO(WP08): replace with the legacy bridge).
+    legacy_worktree_root = w._worktree_root_for_feature_dir(repo_root, feature_dir)
     try:
         w._commit_via_legacy_safe_commit(
             repo_root=repo_root,
+            worktree_root=legacy_worktree_root,
             target_branch=placement.ref,
             paths=paths,
             message=message,

--- a/tests/git/test_guard_capability_regression.py
+++ b/tests/git/test_guard_capability_regression.py
@@ -263,6 +263,7 @@ def test_legacy_workflow_commit_refused_on_protected_target(
     with pytest.raises(ProtectedBranchRefused):
         workflow._commit_via_legacy_safe_commit(
             repo_root=repo.repo_root,
+            worktree_root=repo.repo_root,
             target_branch=repo.target_branch,
             paths=[changed],
             message="chore: workflow status bookkeeping",

--- a/tests/specify_cli/cli/commands/agent/test_workflow_placement_routing.py
+++ b/tests/specify_cli/cli/commands/agent/test_workflow_placement_routing.py
@@ -357,6 +357,108 @@ def test_commit_workflow_change_legacy_path_routes_through_the_seam(
     )
 
 
+def test_worktree_root_for_feature_dir_inside_worktrees(tmp_path: Path) -> None:
+    """_worktree_root_for_feature_dir returns the worktree root for coord dirs."""
+    from specify_cli.cli.commands.agent.workflow import _worktree_root_for_feature_dir
+
+    worktree_dir = tmp_path / ".worktrees" / "my-mission-abc123-coord"
+    feature_dir = worktree_dir / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+
+    result = _worktree_root_for_feature_dir(tmp_path, feature_dir)
+
+    assert result == worktree_dir
+
+
+def test_worktree_root_for_feature_dir_in_primary_checkout(tmp_path: Path) -> None:
+    """_worktree_root_for_feature_dir returns repo_root for primary-checkout dirs."""
+    from specify_cli.cli.commands.agent.workflow import _worktree_root_for_feature_dir
+
+    feature_dir = tmp_path / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+
+    result = _worktree_root_for_feature_dir(tmp_path, feature_dir)
+
+    assert result == tmp_path
+
+
+def test_commit_workflow_change_legacy_path_uses_coord_worktree_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy path passes the coord worktree root (not repo_root) to safe_commit.
+
+    When feature_dir is inside .worktrees/<name>/..., the legacy fallback must
+    supply worktree_root=.worktrees/<name> so that absolute paths under the coord
+    worktree normalise correctly and do not trigger SafeCommitPathPolicyError.
+    """
+    import mission_runtime
+    from mission_runtime import CommitTarget, MissionArtifactKind
+    from specify_cli.cli.commands.agent import workflow
+
+    worktree_name = "001-demo-abc123-coord"
+    coord_worktree = tmp_path / ".worktrees" / worktree_name
+    feature_dir = coord_worktree / "kitty-specs" / "001-demo"
+    feature_dir.mkdir(parents=True)
+    events_path = feature_dir / "status.events.jsonl"
+    status_path = feature_dir / "status.json"
+    events_path.write_text('{"event_id":"before"}\n', encoding="utf-8")
+    status_path.write_text('{"before":true}\n', encoding="utf-8")
+
+    class _StubSeam:
+        def __init__(self, repo_root: Path, mission_slug: str) -> None:
+            del repo_root, mission_slug
+
+        def write_target(self, kind: MissionArtifactKind) -> CommitTarget:
+            assert kind is MissionArtifactKind.STATUS_STATE
+            return CommitTarget(ref="lane-branch")
+
+        def read_dir(self, kind: MissionArtifactKind) -> Path:
+            # #2508 fix (FR-010): _commit_workflow_change also resolves the
+            # PRIMARY_METADATA read dir (to anchor _load_coord_branch_meta on
+            # primary, not the STATUS_STATE-partition feature_dir) before the
+            # write-side seam call this test exercises. _load_coord_branch_meta
+            # is monkeypatched below and ignores its argument, so the returned
+            # path is unused by this test -- only the method needs to exist.
+            assert kind is MissionArtifactKind.PRIMARY_METADATA
+            return tmp_path / "primary-meta-dir"
+
+    monkeypatch.setattr(mission_runtime, "placement_seam", _StubSeam)
+    monkeypatch.setattr(workflow, "_load_coord_branch_meta", lambda _fd: (None, None, None))
+
+    captured: dict[str, object] = {}
+
+    class _StubResult:
+        sha = "cafebabe"
+
+    def _fake_safe_commit(**kwargs: object) -> _StubResult:
+        captured.update(kwargs)
+        return _StubResult()
+
+    monkeypatch.setattr(workflow, "safe_commit", _fake_safe_commit)
+    workflow._reset_workflow_receipts()
+
+    workflow._commit_workflow_change(
+        repo_root=tmp_path,
+        feature_dir=feature_dir,
+        mission_slug="001-demo",
+        target_branch="lane-branch",
+        paths=[events_path, status_path],
+        message="chore: WP01 in_review [claude]",
+        operation="for_review -> in_review for WP01",
+        wp_id="WP01",
+        pre_emit_event_size=len('{"event_id":"before"}\n'),
+        pre_emit_status_bytes=b'{"before":true}\n',
+    )
+
+    assert "worktree_root" in captured, "safe_commit was never invoked"
+    assert captured["worktree_root"] == coord_worktree, (
+        f"legacy path passed worktree_root={captured['worktree_root']!r}; "
+        f"expected coord worktree root {coord_worktree!r}. "
+        "Paths under .worktrees/ will raise SafeCommitPathPolicyError when "
+        "normalised against repo_root."
+    )
+
+
 # ---------------------------------------------------------------------------
 # T021 campsite regression anchor — empty except at the dossier-sync site
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Maintainer take-over / rebase of #2612** (thanks @rayjohnson — this carries your fix forward). Opened because #2612 had gone `CONFLICTING` against `main`.

## Why this matters now
This fixes the acute half of the #2841 coord-bookkeeping friction: on a **coordination-topology** mission, `spec-kitty agent action review WP##` fails to commit its status artifacts with `SafeCommitPathPolicyError` because the legacy `safe_commit` fallback passed `worktree_root=repo_root` while the artifacts live under `.worktrees/<coord>/…`. We hit this live and it stalled an implement-review loop (repro on #2841). Refs #2841 (the coord-commit bug). NOTE: this does NOT close #2607 — that is an unrelated GC-2b coverage-baseline issue; the branch name is misleading.

## What the rebase entailed (non-trivial — main moved)
`main` refactored `workflow.py` since the PR: `_commit_workflow_change` was extracted into `workflow_executor.py`. The fix was **re-applied onto main's post-refactor call site**, not blindly re-added:
- Kept the PR's `_worktree_root_for_feature_dir(repo_root, feature_dir)` helper and the `worktree_root` kwarg threaded into `_commit_via_legacy_safe_commit` → `safe_commit(...)`.
- **`workflow_executor.py`'s legacy leaf was calling `_commit_via_legacy_safe_commit` without `worktree_root` at all** (a latent break given the now-required kwarg) — fixed to derive and pass `_worktree_root_for_feature_dir(...)`.
- Resolved the arch-test conflict by keeping main's drift-proof `ContentDescriptor` allow-list (discarding the PR's obsolete line-number bookkeeping); added a `read_dir` stub the PR's new test needed for main's #2508 PRIMARY_METADATA anchoring.

## Verification
- `uv run pytest` on the 3 touched suites → **47 passed**.
- `uv run ruff check` on both changed modules → clean.
- `uv run mypy` → clean on the diff (the 1 reported error is in a zero-diff pre-existing-baseline file, `runtime/next/_internal_runtime/schema.py`).

Supersedes #2612 (kept open for its discussion; close in favor of this once reviewed). Part of a two-track coord-trust remediation — the structural half (#2841 Gap 1+2 + the diff-compliance runtime-exemption) is being specced separately and composes on top of this write-path fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYG4JHbHudbGAHpRKw5Pr
