### PR TITLE
docs(engineering-notes): coord-branch trust root-cause + mission scope (#2841)

### DIFF
--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -8552,6 +8552,38 @@ pages:
     - {slug: "5-multi-mission-approach-the-strangler-sequenced", text: "5. Multi-mission approach (the strangler, sequenced)", level: 2}
     - {slug: "6-net-new-missed-surfaces-debbie-fold-into-mission-a", text: "6. Net-new missed surfaces (debbie, fold into Mission A)", level: 2}
     - {slug: "7-decisions-of-record", text: "7. Decisions of record", level: 2}
+  - path: "docs/plans/engineering-notes/coord-splitbrain-rootcause.md"
+    title: "Coord-branch bookkeeping: read/write split-brain root-cause"
+    divio_type: "none"
+    abstract: "Root-cause analysis of the coordination-branch drift (#2841) as an unenforced write-placement split-brain, and the single placement-port seam that prevents it."
+    anchors:
+    - {slug: "0-the-one-paragraph-answer", text: "0. The one-paragraph answer", level: 2}
+    - {slug: "1-artifact-by-artifact-table", text: "1. Artifact-by-artifact table", level: 2}
+    - {slug: "2-the-single-load-bearing-seam", text: "2. The single load-bearing seam", level: 2}
+    - {slug: "3-what-prevention-makes-structurally-impossible-vs-the-residual-fail-loud-net", text: "3. What prevention makes structurally impossible vs. the residual fail-loud net", level: 2}
+    - {slug: "4-blunt-verdict", text: "4. Blunt verdict", level: 2}
+    - {slug: "composition-notes", text: "Composition notes", level: 3}
+    - {slug: "branch-caveat-verify-before-scoping-mechanical-fixes", text: "Branch caveat (verify before scoping mechanical fixes)", level: 3}
+  - path: "docs/plans/engineering-notes/coord-trust-mission-scope.md"
+    title: "Coordination-branch trust & reconciliation model — mission scope (#2841)"
+    divio_type: "none"
+    abstract: "Pre-spec scope for the coord-branch trust friction-remediation mission (#2841): the missing write-placement model, the solution shape, and the locked design decisions."
+    anchors:
+    - {slug: "1-problem-model-one-missing-model-three-symptoms", text: "1. Problem model — one missing model, three symptoms", level: 2}
+    - {slug: "2-evidence-the-real-surfaces-file-line", text: "2. Evidence — the real surfaces (file:line)", level: 2}
+    - {slug: "2-1-gap-1-bootstrap-snapshot-no-re-sync", text: "2.1 Gap 1 — bootstrap snapshot, no re-sync", level: 3}
+    - {slug: "2-2-gap-2-the-narrow-reconciliation-that-already-exists-the-extension-point", text: "2.2 Gap 2 — the narrow reconciliation that already exists (the extension point)", level: 3}
+    - {slug: "2-3-the-single-workspace-rebase-why-it-does-not-cover-gap-2", text: "2.3 The single-workspace rebase (why it does NOT cover Gap 2)", level: 3}
+    - {slug: "2-4-symptom-b-diff-compliance-gate-blocks-on-the-mission-s-own-runtime-state", text: "2.4 Symptom B — diff-compliance gate blocks on the mission's own runtime state", level: 3}
+    - {slug: "2-5-symptom-a-out-of-scope-composes-with-pr-2612", text: "2.5 Symptom A (out of scope — composes with PR#2612)", level: 3}
+    - {slug: "3-proposed-solution-shape-component-by-component", text: "3. Proposed solution shape (component by component)", level: 2}
+    - {slug: "c1-gate-auto-exemption-for-mission-owned-runtime-state-symptom-b", text: "C1 — Gate auto-exemption for mission-owned runtime state (Symptom B)", level: 3}
+    - {slug: "c2-coord-vs-target-freshness-check-safe-re-sync-gap-1", text: "C2 — Coord-vs-target freshness check + safe re-sync (Gap 1)", level: 3}
+    - {slug: "c3-generalized-reconciliation-engine-mission-repair-gap-2", text: "C3 — Generalized reconciliation engine + `mission repair` (Gap 2)", level: 3}
+    - {slug: "c4-cadence-wiring-gap-1-ux", text: "C4 — Cadence wiring (Gap 1 UX)", level: 3}
+    - {slug: "4-open-design-decisions-needing-an-operator-call", text: "4. Open design decisions needing an operator call", level: 2}
+    - {slug: "5-rough-wp-ic-shape-size", text: "5. Rough WP/IC shape & size", level: 2}
+    - {slug: "6-risk-blast-radius", text: "6. Risk / blast-radius", level: 2}
   - path: "docs/plans/engineering-notes/doctrine-drg-missing-links-analysis.md"
     title: "Built-in Doctrine DRG — missing / under-specified links analysis"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2810,6 +2810,18 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/plans/engineering-notes/coord-splitbrain-rootcause.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/plans/engineering-notes/coord-trust-mission-scope.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/plans/engineering-notes/doctrine-drg-missing-links-analysis.md
   tag: current
   divio_type: none

--- a/docs/plans/engineering-notes/coord-splitbrain-rootcause.md
+++ b/docs/plans/engineering-notes/coord-splitbrain-rootcause.md
@@ -1,0 +1,157 @@
+---
+title: 'Coord-branch bookkeeping: read/write split-brain root-cause'
+description: 'Root-cause analysis of the coordination-branch drift (#2841) as an unenforced write-placement split-brain, and the single placement-port seam that prevents it.'
+doc_status: draft
+updated: '2026-07-22'
+related:
+- docs/adr/3.x/2026-06-27-1-common-docs-reconciliation.md
+- docs/plans/engineering-notes/index.md
+---
+
+# Coord-branch bookkeeping: read/write split-brain root-cause
+
+**Scope:** ground a PREVENTION-first re-scope of #2841 (coord-branch drift). READ-ONLY analysis; no product code changed.
+**Thesis under test:** coord drift is a read/write split-brain — coord bookkeeping is a *second, independently-writable copy* of a truth whose authority lives elsewhere. Confirmed, with one precise refinement (below).
+
+---
+
+## 0. The one-paragraph answer
+
+The partition **contract** is already correct and symmetric. `artifact_home_for(kind, ...)`
+(`src/mission_runtime/artifacts.py:194-232`) returns `read_surface == write_surface` for
+*every* kind, keyed on the single disjoint-and-total partition
+(`_PRIMARY_ARTIFACT_KINDS` `artifacts.py:110-126`, `_PLACEMENT_ARTIFACT_KINDS` (=COORD)
+`artifacts.py:132-139`, guarded exhaustive by `assert_partition_invariant` `artifacts.py:235-263`).
+The canonical **write** seam `resolve_placement_only(kind=...)` (`src/mission_runtime/resolution.py:1219`)
+and the canonical **read** seam `resolve_planning_read_dir(kind=...)`
+(`src/specify_cli/missions/_read_path_resolver.py:1349`) both key on that *same* partition via
+`is_primary_artifact_kind` (`artifacts.py:294-304`).
+
+The split-brain is **not** in the contract. It is that **there is no enforced invariant that a
+mission artifact is physically written to its `artifact_home_for(kind).write_surface`.** Individual
+writers pick their own directory — some through a kind-*blind* resolver, some hard-anchored to the
+wrong partition, some by writing to primary and then *copying* to coord. Wherever a writer bypasses
+the kind-keyed placement seam, the on-disk/committed copy forks from the partition every reader
+resolves. That is the recurring boundary leak.
+
+---
+
+## 1. Artifact-by-artifact table
+
+Partition legend: **COORD** = `_PLACEMENT_ARTIFACT_KINDS` (lives on the coordination branch under
+coord topology); **PRIMARY** = `_PRIMARY_ARTIFACT_KINDS` (lives on `target_branch` for every topology).
+
+| Artifact | Authored / Derived | Write site(s) | Read site(s) | Authority partition | Where it forks (split-brain risk) | Prevention shape |
+|---|---|---|---|---|---|---|
+| **status.events.jsonl** | **Authored** — the sole append-only authority | `emit_status_transition` → `append_event`; physical dir via `canonicalize_feature_dir` (`root_resolver.py:83`), committed to coord only via `BookkeepingTransaction` (`status_transition.py:900,943`) | coord-anchored: `resolve_status_surface`/`read_event_log(coordination_branch_ref)` (`agent_utils/status.py:125`, `done_bookkeeping.py:581`) | COORD (`STATUS_STATE`, `artifacts.py:136`) | **Write-authority fork:** `_transaction_topology_available` False (`status_transition.py:924`) falls back to a bare **primary-checkout, uncommitted** write; the copy-stager *deliberately skips* status files (`commit_router.py:687-688`, `COORD_OWNED_STATUS_FILES` `status/__init__.py:222`). Reader always reads coord → stale. | single-write-authority + partition-discipline (force the coord-worktree commit path; no primary-uncommitted arm) |
+| **status.json** | **Derived** — pure `reduce()`/`materialize()` output | written only as the reduction output inside the emit/save transaction (`aggregate.py:820-824`); never independently authored | `MissionStatus.load` / views | COORD (`STATUS_STATE`) | **None** — this is the reference pattern (authoritative log → derived view). It cannot drift because it is never authored. | already make-derived (the model to copy) |
+| **review-cycle-N.md** | **Authored** (reviewer verdict + prose) **AND the verdict is *also* event-sourced** as a `review_ref` pointer → **dual authority** | `create_rejected_review_cycle` `cycle.py:272,299` → `artifacts.py:199,214`, dir via kind-**blind** `candidate_feature_dir_for_mission` (→ **COORD** husk for coord topology) | dry-run: **PRIMARY** (`forecast.py:175`, `resolve_planning_read_dir(WORK_PACKAGE_TASK)`); real-merge: **COORD** (`executor.py:1327` → `preflight.py:369` → `review_artifact_consistency.py:128-174`); done: event slot only (`done_bookkeeping.py:109-121`) | **PRIMARY** (inherited: `tasks/` → `WORK_PACKAGE_TASK`, `artifacts.py:157,118`) | **Two forks.** (a) Written to COORD but declared PRIMARY. (b) Same gate reads *different partitions per entry point* — a rejected cycle on COORD is invisible to `merge --dry-run` (false-green) yet blocks real merge. (c) Verdict duplicated: authored markdown vs event-log `review` override — the very existence of `find_rejected_review_artifact_conflicts` (a cross-store reconciliation, `review_artifact_consistency.py:77-94,148`) is the fingerprint of split-brain. | single-write-authority (route write + *all* reads through `resolve_planning_read_dir(WORK_PACKAGE_TASK)`); longer term collapse the *verdict* into the event log (make-derived), keep prose authored |
+| **issue-matrix.md** | **Authored** verdicts; rows derivable from `spec.md` issue refs | scaffold at finalize onto **PRIMARY** `planning_dir` (`mission_finalize.py:361`, `issue_matrix.py:124`), then **copied primary→coord** (`commit_router.py:701`); per-issue verdicts updated during review/move-task | doctor (`status/doctor.py:342,368`), accept, review report | COORD (`ISSUE_MATRIX`, `artifacts.py:135`) | Authored on **two** partitions (primary scaffold + coord lifecycle updates); stale **primary residue** drifts (#2841), papered over by `is_coordination_artifact_residue_path` declaring the primary copy non-dirt (`artifacts.py:266-291`) | single-write-authority + partition-discipline (write directly into the coord home; rows may be derived from `spec.md`, verdicts stay authored) |
+| **acceptance-matrix.json** | **Authored** `pass_fail`/`evidence`/`verified_by`; only `overall_verdict` derived (`matrix.py:120-137`) | `write_acceptance_matrix(feature_dir)` (`matrix.py:182`) — caller-supplied dir (PRIMARY at finalize `mission_finalize.py:1246`, accept-time re-persist `gates_core.py:258`); `commit_for_mission(kind=ACCEPTANCE_MATRIX)` copies to coord (`accept.py:218-224`) | coord via `placement_seam.read_dir` (`accept.py:97`) + `read_acceptance_matrix(feature_dir)` | COORD (`ACCEPTANCE_MATRIX`, `artifacts.py:134`) | Historical write(primary)/read(coord) fork **reconciled for accept** (#2404: `_commit_coord_residuals` + dual-worktree dirty scan `accept.py:117-232`); residual **write-then-copy** residue shape remains (same class as issue-matrix) | single-write-authority + partition-discipline (write directly into coord home; drop the copy) |
+| **analysis-report.md** | **Authored** (analysis prose + `analysis-findings/v1` carrier) | writer anchors **PRIMARY** (`mission_record_analysis.py:307`, `resolve_planning_read_dir(kind=spec)`); coord copy under `contextlib.suppress(Exception)` (`:324-342`) | implement freshness gate reads **PRIMARY** (`workflow.py:850`, `check_analysis_report_current`); COORD placement authority also declared | COORD (`ANALYSIS_REPORT`, `artifacts.py:137`) | **LIVE split-brain.** Writer *and* freshness gate both anchor PRIMARY; the coord commit is best-effort/swallowed. SSOT says COORD (residue predicate calls the primary copy disposable, `artifacts.py:266`), the gate says the primary copy is *required* — mutually contradictory. | single-write-authority + partition-discipline: pick ONE home and make writer+gate+SSOT agree (write directly to coord + move gate read to coord, OR reclassify the kind to PRIMARY) |
+| **notes** (status snapshot slot) | **Derived** — reduced per-WP slot (`reducer.py:50,188-191`) | source `note` events via emit (`tasks.py:944`, `tasks_move_task.py:1670`, `tasks_transition_core.py:598`) → coord log | materialized snapshot / views | COORD (`STATUS_STATE`) | **None** — pure reduction of the event log, one authority | already derived |
+| **traces/\*.md** | **Authored** (agent tracer prose) | no Python writer; agent-authored, cross-branch reconciled by the **union merge driver** (`merge_driver.py:180-215`, registered `init.py:60`, `lanes/merge.py:74-77`) | retrospective home = **PRIMARY** (`retrospective_terminus.py:79-81`, `generator.py:224-242`) | **Unclassified in SSOT** (doctrine/glossary label it COORD — `docs/context/orchestration.md:506`) | **Partition GAP** — `traces/` is absent from `_COORD_RESIDUE_DIRS` (`artifacts.py:156-159`), so `_artifact_kind_for_path` returns `None` and a primary `traces/*.md` is "real dirt," not residue. Code sites it PRIMARY/lane + union-merge; doctrine says coord. Doc-vs-SSOT mismatch. | classify it (add a `TRACE` kind + residue-dir entry, OR correct the glossary to PRIMARY/lane); union-merge already prevents lane drift |
+
+---
+
+## 2. The single load-bearing seam
+
+**There is no enforced write-placement invariant.** Concretely: nothing forces a writer to physically
+land an artifact in `artifact_home_for(kind_for_mission_file(path)).write_surface`. The pieces to enforce
+it already exist and are *unused by the drifting writers*:
+
+- `kind_for_mission_file(path)` — the single public file→kind classifier (`artifacts.py:307-326`).
+- `resolve_placement_only(kind=...)` — the single kind-keyed write-placement projection (`resolution.py:1219`);
+  byte-identical topology classification to the full resolver (`resolution.py:1238-1258`).
+- `safe_commit` — already **structurally asserts** the write-root's HEAD equals `destination_ref`
+  before staging (`git/commit_helpers.py:867-868`, `SafeCommitHeadMismatch`) — the #2868/#2612 guard.
+
+The drift is entirely upstream of that guard, at the point a writer *chooses its directory*:
+
+- `cycle.py:272` and `cycle.py:193` use kind-**blind** `candidate_feature_dir_for_mission` (topology-aware → COORD husk) for a PRIMARY-partition kind.
+- `mission_record_analysis.py:307` hard-anchors PRIMARY for a COORD kind; coord copy swallowed.
+- `commit_router._stage_artifacts_in_coord_worktree` (`commit_router.py:666-724`) `shutil.copy2` (`:701`) the matrices/report **from primary into coord** — this copy *is the residue factory*: it manufactures the second, independently-writable primary copy that #2841 observes drifting.
+- `emit`/`canonicalize_feature_dir` (`root_resolver.py:104-142`) rewrites the status write to PRIMARY unless a *registered* coord worktree is present, and the coord-commit only happens on the `_transaction_topology_available` True arm (`status_transition.py:924`).
+
+**One seam collapses shapes 2, 3, and 4:** route *every* mission-artifact write through a single
+placement port keyed on `kind_for_mission_file(path) → resolve_placement_only(kind).ref`, and **stage the
+bytes directly in that ref's worktree** (never write-to-primary-then-copy). The `safe_commit`
+worktree/HEAD guard then makes a wrong-partition write *unrepresentable at commit time* rather than a
+silent divergence discovered at merge.
+
+---
+
+## 3. What prevention makes structurally impossible vs. the residual fail-loud net
+
+**Made structurally impossible by "one kind-keyed placement port + write-in-home + safe_commit guard":**
+
+1. **Wrong-partition authorship (shape 2).** A `WORK_PACKAGE_TASK` review-cycle can only land PRIMARY; an
+   `ANALYSIS_REPORT` can only land COORD. `cycle.py:272` / `mission_record_analysis.py:307` can no longer
+   choose a divergent dir.
+2. **Second-copy / residue drift (shape 3).** Writing in-place removes the `shutil.copy2` primary→coord
+   stager (`commit_router.py:701`) that manufactures the drifting primary residue for issue-matrix /
+   acceptance-matrix / analysis-report. No second writable copy ⇒ nothing to reconcile ⇒
+   `is_coordination_artifact_residue_path` (`artifacts.py:266`) becomes vestigial rather than load-bearing.
+3. **Status primary-uncommitted fork (shape 4).** Removing the `_transaction_topology_available` False
+   fallback (or making emit target the coord worktree unconditionally for coord topology) means a status
+   event cannot land primary-uncommitted while readers read coord.
+4. **Per-entry-point read disagreement.** If write and *all* reads share the one kind-keyed resolver,
+   `merge --dry-run` (PRIMARY) and real merge (COORD) can no longer see different review-cycle truth.
+
+**Genuinely irreducible — the minimized residual that still needs a fail-LOUD net:**
+
+- **Bootstrap staleness (#2841 Gap 1).** The coordination branch is a one-time snapshot of `target_branch`
+  at `mission create`; `target_branch` moves afterward. This is **not** a coord-bookkeeping split-brain at
+  all — it is a *base-ref freshness* problem. No single-authority derivation touches it. It needs a
+  detect-and-resync (surfaced at plan/tasks or an explicit `doctor coordination --check-staleness`). This
+  is the *only* place a reconciliation/cure command legitimately survives.
+- **Dual authority of the review *verdict*.** Until the verdict is collapsed into the event log, the
+  authored `verdict:` frontmatter and the event-sourced `review` override remain two stores. The
+  existing cross-store gate (`review_artifact_consistency.py`) should stay as a **fail-loud** check, not
+  be deleted — it is the safety net for the one artifact whose authored/derived halves genuinely coexist
+  during the transition.
+- The existing narrow cure `doctor coordination --fix` (`_coordination_doctor.py:80-120,579-601`) — today
+  keyed to the `pending_coord_reconcile` marker for stranded-`done` reverts + stale-worktree
+  fast-forward — is the correct *shrunken* residual: keep it fail-loud, do **not** grow it into the
+  general "repair arbitrary drifted content" command the field report proposed. Prevention removes the
+  need for that generalization.
+
+---
+
+## 4. Blunt verdict
+
+**"Prevent via single-authority derivation" is achievable for the derived subset and is already the
+model** — `status.json` and `notes` are pure `reduce()` outputs of `status.events.jsonl` and cannot
+drift. Nothing else should be a second authored copy of state that the log already owns.
+
+**But most coord bookkeeping genuinely cannot be made derived, and it does not need to be.**
+review-cycle prose, issue-matrix verdicts, acceptance-matrix evidence/`verified_by`, analysis-report
+findings, and traces all carry human/agent judgement no reduction can reconstruct from the event log or
+tracker. Trying to "derive" them is a category error.
+
+The load-bearing insight for the re-scope: **the drift is not caused by these artifacts being authored —
+it is caused by them being authored to the *wrong partition* and/or *copied to a second partition*.** The
+right prevention for the authored set is therefore **single-WRITE-authority + partition discipline**, not
+derivation: one kind-keyed placement port, write-in-home, `safe_commit`-guarded — so wrong-partition
+authorship and second-copy residue become structurally impossible. That subsumes the "staleness" and
+"reconciliation" symptoms for every artifact *except* the #2841 Gap-1 bootstrap-snapshot freshness
+problem, which is a base-ref sync concern and is the sole surviving home for a minimized, fail-loud
+detect/resync — never a broad "repair the drift after the fact" cure.
+
+### Composition notes
+- **Builds ON PR#2868/#2612** (`safe_commit` sub-worktree-root + HEAD==destination_ref assertion,
+  `commit_helpers.py:867-868`): that is the *enforcement primitive*. This prevention feeds it a
+  correct write-root by construction; it does not redo the write-path mechanics.
+- **#2160 (unify coord artifact authority):** the single kind-keyed placement port *is* the "one
+  authority" — route all writers through it.
+- **#2400 (metadata single canonical source):** same shape applied to `meta.json`/profile — a
+  partition already correct (`PRIMARY_METADATA`), the discipline is identical.
+- **#2173 (infra-as-ports):** express the placement port as an injected port so writers depend on the
+  resolver, not on ad-hoc `candidate_feature_dir_for_mission` / hard-coded primary anchors.
+
+### Branch caveat (verify before scoping mechanical fixes)
+On this branch (`doctrine/drg-completeness-2843`), `find_rejected_review_artifact_conflicts`
+(`review_artifact_consistency.py:128-174`) still takes a single `feature_dir` and serves *both* the
+`materialize()` STATUS_STATE read (`:133`) and the `tasks/` WORK_PACKAGE_TASK read (`:143`, `:57-58`)
+from it — the exact pre-#2834 shape. Confirm the #2834 split has actually landed here before assuming
+the review-cycle read is kind-correct; the write side (`cycle.py:272`) is *not* kind-routed regardless.

--- a/docs/plans/engineering-notes/coord-trust-mission-scope.md
+++ b/docs/plans/engineering-notes/coord-trust-mission-scope.md
@@ -1,0 +1,234 @@
+---
+title: 'Coordination-branch trust & reconciliation model — mission scope (#2841)'
+description: 'Pre-spec scope for the coord-branch trust friction-remediation mission (#2841): the missing write-placement model, the solution shape, and the locked design decisions.'
+doc_status: draft
+updated: '2026-07-22'
+related:
+- docs/adr/3.x/2026-06-27-1-common-docs-reconciliation.md
+- docs/plans/engineering-notes/index.md
+---
+
+# Mission-scoping brief — Coordination-branch trust & reconciliation model (#2841)
+
+Status: **pre-spec, for operator sign-off**. READ-ONLY analysis; no product code changed.
+Grounded in the code at the state of branch `doctrine/drg-completeness-2843` (worktree copy).
+
+---
+
+## 1. Problem model — one missing model, three symptoms
+
+**The single underlying gap: a mission's coordination-branch content has no trust or
+reconciliation model.** The coord branch is minted as a *one-time snapshot* and thereafter
+the toolchain has no notion of (a) whether that snapshot is still fresh relative to the
+target it was cut from, (b) whether the bookkeeping written onto it still matches where the
+real work landed, or (c) that the mission's *own* runtime state on that branch is trusted
+self-managed content rather than a foreign surface to be policed. All three of #2841's
+symptoms are facets of that one absence:
+
+| Facet | What's missing | Direction |
+|---|---|---|
+| **Gap 1 — bootstrap staleness** | No *freshness contract*: coord branch is snapshotted once and never compared to target again. | Prevention |
+| **Gap 2 — no reconciliation command** | No *content-trust contract*: nothing reconciles stale/corrupted coord bookkeeping (`review-cycle-N.md`, etc.) against where the WP's real commits live. | Cure |
+| **Symptom B — gate blocks on own runtime state** | No *ownership contract*: the diff-compliance gate treats the mission's own `status.events.jsonl`/`status.json` as an unclassified foreign surface, forcing a hand-commit into coord to register an exception — itself an act of unreconciled coord mutation. | Friction |
+
+They compose because each one is the system failing to answer *"is this coord content trusted,
+current, and mine?"* — Gap 1 for freshness, Gap 2 for correctness, Symptom B for ownership.
+#2841 explicitly asks that Gap 1 + Gap 2 be designed as **one canonical fix on the
+`doctor coordination --fix` seam** (citing #2392's consolidation precedent), not two point patches.
+
+---
+
+## 2. Evidence — the real surfaces (file:line)
+
+### 2.1 Gap 1 — bootstrap snapshot, no re-sync
+- `ensure_coordination_branch()` — `src/specify_cli/missions/_create.py:195-260`. On the
+  happy path it does exactly `_create_branch(repo_root, branch, target_branch)` (L259): a
+  one-shot branch off target at create time.
+- The only staleness guard is `_is_ancestor()` (`_create.py:268-289`), and it only fires when
+  an existing branch is **re-encountered** on a *re-run* of `mission create` (L249-257):
+  ancestor → reusable, diverged → `CoordinationBranchDiverged`. It never asks "has target
+  moved since I was cut."
+- Nothing downstream (`specify`/`plan`/`tasks`/`finalize-tasks`) checks coord-vs-target.
+- The only related doctor check, `_coord_worktree_stale_finding()`
+  (`_coordination_doctor.py:312-359`), compares the coord **worktree HEAD** to **its own
+  coord branch tip** (`refs/heads/{coord_branch}`, L328-332) — *not* to target/main. Confirms
+  #2841's claim: no surface anywhere compares coord to the branch it was forked from.
+
+### 2.2 Gap 2 — the narrow reconciliation that already exists (the extension point)
+- `doctor coordination --fix` reconciles exactly **one** split-brain today: a stranded `done`
+  status after a merge rollback. Driven by `pending_coord_reconcile` markers via
+  `_check_stranded_coord_revert()` (`_coordination_doctor.py:780-802`) →
+  `_finding_for_reconcile_marker()` (L680-777) → heal by `_heal_one_strand()` (L815) /
+  `_fix_stranded_reverts()` (L892) / `_apply_stranded_revert_fix()` (L942).
+- The staleness derivation is `coord_incoherent_done_wps(coord_ref, candidate_wps, ...)`
+  (L742) — it re-derives from the **committed coord ref**, never from marker presence. That
+  detect→re-verify→heal-or-fail-loud shape is precisely the engine to generalize: today it is
+  hard-wired to *one status enum*; Gap 2 needs it to cover **arbitrary bookkeeping content**
+  (a WP's `review-cycle-N.md`, issue-matrix rows, notes) reconciled against the real WP commit.
+- The heal path already models the two non-happy terminals #2841 asks for: a healable live
+  strand (`error`, `--fix` forwards) vs a pruned-worktree strand that stays `error` but
+  becomes a manual-recovery hint (L749-766) — i.e. "forward when safe, fail loud otherwise."
+
+### 2.3 The single-workspace rebase (why it does NOT cover Gap 2)
+- `GitVCS.sync_workspace()` — `src/specify_cli/core/vcs/git.py:362` (CLI `sync.py:1745`).
+  Fetches, resolves the workspace's own tracking/upstream branch (L398-401), and rebases
+  **that workspace's own commits** onto it. No sibling-branch / coord-vs-target awareness.
+  It is a per-workspace freshness tool, not a cross-branch content reconciler.
+
+### 2.4 Symptom B — diff-compliance gate blocks on the mission's own runtime state
+- Gate: `src/specify_cli/bulk_edit/diff_check.py`. `assess_file()` (L237) classifies each
+  changed file via `classify_path()` (L118) against ordered `_PATH_RULES` (L41-110):
+  - `.json` → `serialized_keys` (L77-85) — in a terminology bulk-edit this category is
+    typically `do_not_change`/`manual_review`, so a churning `status.json` **violates**.
+  - `.jsonl` → **matches no rule** → `classify_path` returns `None` → the FR-008
+    "does not match any standard occurrence category ... unclassified surface touched"
+    violation (L279-291). So `status.events.jsonl` blocks unconditionally.
+- Runtime-state filenames are fixed constants: `EVENTS_FILENAME = "status.events.jsonl"`
+  (`status/store.py:45`), `SNAPSHOT_FILENAME = "status.json"` (`status/reducer.py:83`); they
+  live at `kitty-specs/<mission>/`.
+- The caller has the mission context the classifier lacks: `check_review_diff_compliance(
+  feature_dir, base_ref, head_ref, ...)` (`bulk_edit/gate.py:199-245`) collects **every**
+  changed path via `_git_diff_files()` → `git diff --name-only base..head` (L129-196) and
+  passes the raw list to `check_diff_compliance` (L245). The mission's own runtime writes are
+  in that diff, so the only escape today is a hand-authored `occurrence_map.yaml` exception —
+  which is itself a coord-content mutation. **This is the auto-exemption seam.**
+
+### 2.5 Symptom A (out of scope — composes with PR#2612)
+- `safe_commit()` (`git/commit_helpers.py:843`) path policy step **6a** rejects any staged
+  path under `.worktrees/` → `SafeCommitPathPolicyError` (~L985-995). This is the failure
+  where a status commit can't land in the coord **sub-worktree** from the primary root.
+- **PR#2612 (OPEN, maintainer take-over)** — "auto-commit during agent action review fails on
+  missions using a coordination worktree" — fixes the *write* path by threading
+  `_worktree_root_for_feature_dir` (the sub-worktree root) into `safe_commit`. **This mission
+  must NOT redo that.** It builds on top: once writes land correctly, this mission stops the
+  gate from flagging them (B), detects when they've gone stale (Gap 2), and keeps the branch
+  fresh (Gap 1).
+
+---
+
+## 3. Proposed solution shape (component by component)
+
+### C1 — Gate auto-exemption for mission-owned runtime state (Symptom B)
+Thread a *mission-owned runtime-state* predicate into the classifier. `check_review_diff_compliance`
+already holds `feature_dir`; pass an allowlist of runtime-state basenames anchored to the
+mission's **own** `feature_dir` into `assess_file`/`check_diff_compliance`. Add an exemption
+branch **before** the path-heuristic (mirroring the existing move/exception exemptions at
+`diff_check.py:239-275`): a path that is (mission's own feature_dir) + (runtime-state basename)
+→ `FileAssessment(source="runtime-state", violation=False)`. No `occurrence_map` entry, no
+hand-commit into coord ever needed.
+- Extension points: `diff_check.py` `assess_file` (L237), `classify_path` (L118); `gate.py`
+  `check_review_diff_compliance` (L199) to supply `feature_dir` + the allowlist.
+- Composes with PR#2612: independent (gate is read-side); can land first.
+
+### C2 — Coord-vs-target freshness check + safe re-sync (Gap 1)
+A new `_coord_branch_stale_vs_target_finding()` in `_coordination_doctor.py` that compares the
+**coord branch tip** against **target** (reusing the `merge-base --is-ancestor` plumbing that
+`_is_ancestor` at `_create.py:268` and `_coord_worktree_stale_finding` at L338 already use):
+- coord strict-ancestor of target → **stale, fast-forwardable** (safe auto-fix under `--fix`);
+- diverged → **warn, fail loud**, no auto-mutation.
+Surfaced through a new `spec-kitty doctor coordination --check-staleness` mode and (per cadence
+decision, §4-D1) an optional non-blocking warn woven into `finalize-tasks`.
+- Composes with PR#2612: reads only; fast-forward re-sync of the coord worktree must honor the
+  sub-worktree root PR#2612 establishes.
+
+### C3 — Generalized reconciliation engine + `mission repair` (Gap 2)
+Generalize the existing `_finding_for_reconcile_marker` / `_heal_one_strand` engine
+(`_coordination_doctor.py:680-942`) from "one `done`-status split-brain" to a pluggable
+*bookkeeping-artifact reconciler*: detect(coord content vs real WP commit) →
+forward-when-safe → fail-loud-with-unified-diff otherwise. Expose it as
+`spec-kitty agent mission repair --mission <slug>` **as a thin entry over the same engine**
+(one reconciliation authority, not two — this is #2841's "design as one canonical fix").
+- Extension points: the marker/heal functions above; `coord_incoherent_done_wps` (L742)
+  becomes one detector among several.
+- Composes with PR#2612: forwarding correct content is a coord write → must go through
+  `safe_commit` with the sub-worktree root PR#2612 threads. Hard dependency on #2612 landing.
+
+### C4 — Cadence wiring (Gap 1 UX)
+A warn-only hook at `finalize-tasks` (and/or `tasks`) that calls C2's detector. Non-blocking;
+prints the suggested `doctor coordination --check-staleness`/`--fix` recovery command.
+
+---
+
+## 4. Open design decisions needing an operator call
+
+**D1 — Gap 1 re-sync cadence/UX** *(the #2841 open question)*
+- (a) explicit `doctor coordination --check-staleness` only (opt-in, read-only report);
+- (b) + non-blocking warn woven into `finalize-tasks`/`tasks`;
+- (c) automatic silent fast-forward at plan time.
+- **Recommendation: (b).** Explicit doctor flag + a warn (not block) at finalize-tasks. Offer
+  fast-forward *only* under an explicit `--fix` and *only* when coord is a strict ancestor of
+  target (no divergence risk). Never mutate silently (rules out c).
+
+**D2 — `mission repair` command surface**
+- (a) a brand-new standalone reconciliation engine under `agent mission repair`;
+- (b) generalize `doctor coordination --fix`'s engine and expose `mission repair` as a thin
+  mission-scoped entry over it.
+- **Recommendation: (b).** #2841 explicitly wants one canonical fix on the doctor seam. Two
+  engines would re-fork the split-brain logic. `mission repair --mission <slug>` = single-mission
+  view of the shared reconciler.
+
+**D3 — Reconciliation "safe to auto-forward" policy**
+- (a) auto-forward only when coord content is a strict-ancestor/subset of the real committed
+  content (coord behind, real ahead) **and** the coord worktree has no uncommitted edits;
+- (b) content-hash equality gate;
+- (c) always require operator confirmation.
+- **Recommendation: (a).** Fail loud with a unified diff in every other case (matches the
+  existing pruned-worktree "stays error, manual hint" terminal at `_coordination_doctor.py:749-766`).
+  This is the data-loss-sensitive decision — keep it conservative.
+
+**D4 — Symptom B exemption scope**
+- (a) exempt only `status.events.jsonl` + `status.json`;
+- (b) a named allowlist of mission-owned runtime bookkeeping (status files **plus**
+  `review-cycle-N.md`, issue-matrix, notes, trace);
+- (c) exempt everything under the mission's own `feature_dir`.
+- **Recommendation: (b), anchored to the mission's OWN feature_dir.** Not (c): `spec.md`/
+  `plan.md`/`tasks.md` **are** reviewable product surface a bulk-edit legitimately touches and
+  must keep classifying. Anchoring to the mission's own feature_dir stops a bulk-edit that
+  renames *another* mission's files from being silently exempted.
+
+**D5 — Freshness scope: coord-only vs coord + lane branches**
+- #2841's Gap 1 field report also cites a **lane** branch missing a CLI flag added to main.
+- (a) this mission covers coord only; (b) coord + lane branches.
+- **Recommendation: (a).** Coord is the trust anchor and the shared `--fix` seam. Lane-branch
+  freshness is `sync workspace`'s domain — file a scoped follow-up rather than widen blast radius.
+
+---
+
+## 5. Rough WP/IC shape & size
+
+| WP | Scope | Size | Depends on |
+|---|---|---|---|
+| **WP-A** | C1 gate auto-exemption (D4) — runtime-state allowlist threaded through `assess_file`/`check_diff_compliance`, new exemption branch + focused tests (incl. negative: a non-runtime file under feature_dir still classifies). | **S** | none (gate read-side; independent of #2612) |
+| **WP-B** | C2 coord-vs-target staleness detector + `doctor coordination --check-staleness` + safe `--fix` fast-forward (D1). | **M** | #2612 for the FF write path |
+| **WP-C** | C3 generalize the doctor reconcile engine to arbitrary bookkeeping + `agent mission repair` (D2, D3). | **L** | #2612 (writes), WP-B (shared detector plumbing) |
+| **WP-D** | C4 cadence warn hook at finalize-tasks/tasks (D1-b). | **S** | WP-B |
+| **WP-E** | Docs + runbook (`docs/architecture/execution-lanes.md`, coordination doctor reference). | **S** | WP-A..C |
+
+**Suggested mission type: `software-dev`** (brownfield structural remediation). Given the four
+open forks — especially D3's data-loss-sensitive auto-forward policy — **run a short research
+step first** (or route through `/spec-kitty.research`) to lock the reconciliation-safety policy
+before spec. WP-A is the fast, high-value, dependency-free slice and could ship as the first
+increment even ahead of #2612.
+
+---
+
+## 6. Risk / blast-radius
+
+- **WP-A touches the diff-compliance gate every bulk-edit mission depends on.** A too-broad
+  exemption (esp. choosing D4-c) would let real surface changes slip past review. Mitigate:
+  anchor to the mission's own feature_dir + a named allowlist; add a regression asserting a
+  non-runtime file under the same feature_dir still gets classified/violated.
+- **WP-B/WP-C touch the commit + reconciliation path.** Auto-forwarding coord content is
+  data-loss-adjacent. Must fail-loud-by-default (D3-a), reuse `safe_commit`, and honor the
+  sub-worktree root PR#2612 threads — bypassing it re-triggers the `SafeCommitPathPolicyError`
+  at `commit_helpers.py:~985`.
+- **Coord vs primary partition correctness.** Reconciliation must read/write the *right*
+  partition (coord = lifecycle: status/notes/trace/matrix/review-cycle; primary = planning +
+  meta.json). Getting this wrong re-introduces a #2834-class split-brain — treat the partition
+  boundary as a hard invariant with tests.
+- **Squash-merge "unreachable commits" is NOT a bug and NOT in scope.** #2841 flags the 11
+  unreachable coord commits as an inherent consequence of the default squash strategy. Do not
+  attempt to "fix" reachability; only freshness/reconciliation/ownership are in scope.
+- **Hard sequencing dependency on PR#2612.** WP-C's forwarding writes depend on #2612's
+  sub-worktree threading. Land WP-A independently; gate WP-C on #2612 to avoid re-solving the
+  write path.

--- a/docs/plans/engineering-notes/index.md
+++ b/docs/plans/engineering-notes/index.md
@@ -58,6 +58,8 @@ resume without re-running the squad:
 Durable design investigations that inform a convention or a future mission:
 
 - [Agent knowledge: canonical homes](agent-knowledge-canonical-homes.md) — where rules (charter), practices (doctrine), reference (Common Docs), and learned facts (`.kittify/memory/`) belong; how to stop a per-agent memory duplicating the repo.
+- [Coord-branch bookkeeping: read/write split-brain root-cause](coord-splitbrain-rootcause.md) — #2841 drift is unenforced write-placement (writers pick their own dir), not a broken partition contract; the single placement-port seam that makes wrong-partition writes unrepresentable at commit.
+- [Coordination-branch trust & reconciliation model — mission scope](coord-trust-mission-scope.md) — the pre-spec scope for the coord-trust friction-remediation mission: Gap-1 staleness, Symptom-B gate exemption, and why reconciliation is a minimized fail-loud residual, not the centerpiece.
 
 ## See also
 


### PR DESCRIPTION
## Coordination-branch trust — root-cause & mission scope (findings docs)

Persists the two pre-spec analysis notes produced while root-causing the #2841 coord-branch friction (the `safe_commit`/drift we hit live, and the closed-in-favor #2612/#2868 takeover analysis fed into this):

- **`coord-splitbrain-rootcause.md`** — the drift is a read/write split-brain, but the fork is **unenforced write-placement realization**, not a broken partition contract (which is already correct+symmetric). Three recurring shapes (wrong-partition authorship, second-copy residue, status write-authority fork) collapse under **one placement-port seam**: route every mission-artifact write through `resolve_placement_only(kind).ref`, staging bytes directly in that ref's worktree — `safe_commit`'s `worktree HEAD == destination_ref` assertion then makes a wrong-partition write unrepresentable at commit.
- **`coord-trust-mission-scope.md`** — the pre-spec scope: Gap-1 bootstrap staleness (the only irreducible fail-loud residual), Symptom-B diff-compliance gate exemption for the mission's own runtime state, and why the reconciliation command should stay minimized (its existence is the split-brain fingerprint). Locked design decisions D1/D3/D4.

Indexed under engineering-notes → Design notes; page-inventory regenerated; relative-link + terminology gates green. These ground a dedicated coord-trust friction-remediation mission. No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYG4JHbHudbGAHpRKw5Pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336688&installation_model_id=427282&pr_number=2870&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2870&signature=bd1f43b066250ab83f612e2b870ad728b723a2af545d1ca925f39952c9d3e1fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->