### PR TITLE
feat(sync): spec-kitty sync import-history — materialize local history into the SaaS projection (#2262)

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -4098,13 +4098,13 @@ _Synchronization commands_
  or incomplete missions the dry-run reports before the first ``--apply``.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --apply                Materialize the selected missions into the SaaS       │
-│                        projection (default is a dry-run plan).               │
-│ --dry-run              Preview what would be imported without emitting       │
-│                        anything (this is the default).                       │
-│ --mission        TEXT  Import only this mission (slug / mid8 / ULID);        │
-│                        default imports all eligible missions.                │
-│ --help                 Show this message and exit.                           │
+│ --apply                  Materialize the selected missions into the SaaS     │
+│                          projection (default is a dry-run plan).             │
+│ --dry-run                Preview what would be imported without emitting     │
+│                          anything (this is the default).                     │
+│ --mission          TEXT  Import only this mission (slug / mid8 / ULID);      │
+│                          default imports all eligible missions.              │
+│ --help     -h            Show this message and exit.                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -3963,26 +3963,29 @@ _Synchronization commands_
 │ --help  -h        Show this message and exit.                                │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ routes     Show where the current checkout sends data and which teams it is  │
-│            shared with.                                                      │
-│ share      Share the current repository from Private Teamspace into a team.  │
-│ unshare    Stop sharing the current repository from this developer to one    │
-│            team.                                                             │
-│ opt-out    Disable SaaS sync for this checkout and purge its pending         │
-│            uploads.                                                          │
-│ opt-in     Enable SaaS sync for this checkout.                               │
-│ workspace  Synchronize workspace with upstream changes.                      │
-│ server     Show or set sync server URL.                                      │
-│ now        Trigger immediate sync of all queued events.                      │
-│ gc         Purge event payloads delivered to all known targets (explicit,    │
-│            destructive).                                                     │
-│ archive    Archive retained event payloads (explicit, non-destructive).      │
-│ migrate    Migrate legacy hash-scoped queue DBs into the append-only event   │
-│            journal.                                                          │
-│ mode       Show or set the event-sync retention x delivery mode.             │
-│ status     Show sync queue status, connection state, and auth info.          │
-│ diagnose   Validate queued events locally against the event schema.          │
-│ doctor     Diagnose sync health: queue, auth, and server connectivity.       │
+│ routes          Show where the current checkout sends data and which teams   │
+│                 it is shared with.                                           │
+│ share           Share the current repository from Private Teamspace into a   │
+│                 team.                                                        │
+│ unshare         Stop sharing the current repository from this developer to   │
+│                 one team.                                                    │
+│ opt-out         Disable SaaS sync for this checkout and purge its pending    │
+│                 uploads.                                                     │
+│ opt-in          Enable SaaS sync for this checkout.                          │
+│ import-history  Materialize existing local mission/WP history into the SaaS  │
+│                 projection (#2262).                                          │
+│ workspace       Synchronize workspace with upstream changes.                 │
+│ server          Show or set sync server URL.                                 │
+│ now             Trigger immediate sync of all queued events.                 │
+│ gc              Purge event payloads delivered to all known targets          │
+│                 (explicit, destructive).                                     │
+│ archive         Archive retained event payloads (explicit, non-destructive). │
+│ migrate         Migrate legacy hash-scoped queue DBs into the append-only    │
+│                 event journal.                                               │
+│ mode            Show or set the event-sync retention x delivery mode.        │
+│ status          Show sync queue status, connection state, and auth info.     │
+│ diagnose        Validate queued events locally against the event schema.     │
+│ doctor          Diagnose sync health: queue, auth, and server connectivity.  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4065,6 +4068,37 @@ _Synchronization commands_
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help  -h        Show this message and exit.                                │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## spec-kitty sync import-history
+
+```
+ Usage: spec-kitty sync import-history [OPTIONS]
+
+ Materialize existing local mission/WP history into the SaaS projection
+ (#2262).
+
+ A first sync registers a remote project/build but leaves it with zero
+ materialized missions — the SaaS materializer deliberately refuses to
+ fabricate a WorkPackage from a status event with no prior create. This
+ command emits the missing ``MissionCreated → WPCreated[] → WPStatusChanged[]``
+ stream (INV-3) so historical work populates the projection.
+
+ Dry-run (default) runs the full read-only pipeline — SELECT → AUDIT
+ (fail-closed) → SCAN → IDENTITY → SYNTHESIZE — and previews the envelope
+ stream that would be materialized. ``--apply`` additionally attaches
+ provenance, server-preflights the whole stream (fail-closed), and uploads it
+ in chunks to the SaaS projection under the real persisted project UUID.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --apply                Materialize the selected missions into the SaaS       │
+│                        projection (default is a dry-run plan).               │
+│ --dry-run              Preview what would be imported without emitting       │
+│                        anything (this is the default).                       │
+│ --mission        TEXT  Import only this mission (slug / mid8 / ULID);        │
+│                        default imports all eligible missions.                │
+│ --help                 Show this message and exit.                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -4091,6 +4091,12 @@ _Synchronization commands_
  provenance, server-preflights the whole stream (fail-closed), and uploads it
  in chunks to the SaaS projection under the real persisted project UUID.
 
+ Import is once-and-frozen: each event carries a deterministic id, so
+ re-running after the on-disk facts change (e.g. after fixing a malformed WP
+ the dry-run flagged as skipped) re-sends the same id and the server drops the
+ updated payload as a duplicate rather than overwriting. Resolve any skipped
+ or incomplete missions the dry-run reports before the first ``--apply``.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --apply                Materialize the selected missions into the SaaS       │
 │                        projection (default is a dry-run plan).               │

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -33,6 +33,19 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
     every subcommand.
   - **The root `--help` command list is now sorted alphabetically**, and a bare
     `spec-kitty` invocation renders the same ordered help.
+- **`spec-kitty sync import-history` materializes existing local mission history
+  into the SaaS projection (#2262).** A first sync registers a remote
+  project/build but leaves it with zero materialized missions — the SaaS
+  materializer refuses to fabricate a work package from a status event with no
+  prior create. The new command synthesizes the missing
+  `MissionCreated → WPCreated[] → WPStatusChanged[]` prefix (INV-3) from local
+  history so historical work populates the projection. `--dry-run` (default)
+  runs the whole read-only pipeline and previews the stream; `--apply` attaches
+  a sha256 provenance manifest, runs the offline envelope contract gate, then
+  server-preflights the entire stream before uploading anything (fail-closed —
+  a rejection leaves the projection untouched) and uploads in chunks.
+  Deterministic event ids make re-runs idempotent (the server dedups on
+  `event_id`). Buildable slices Y1–Y5 ship here; Y6/Y7/Y8 remain gated.
 - **Doctrine packs can now ship supporting files to consumer repos — the first
   is a docs structural-lint that keeps a project's documentation organized
   (#2302, #2864–#2867).** A doctrine pack can now carry an arbitrary

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2853,6 +2853,7 @@ pages:
     - {slug: "spec-kitty-sync-diagnose", text: "spec-kitty sync diagnose", level: 2}
     - {slug: "spec-kitty-sync-doctor", text: "spec-kitty sync doctor", level: 2}
     - {slug: "spec-kitty-sync-gc", text: "spec-kitty sync gc", level: 2}
+    - {slug: "spec-kitty-sync-import-history", text: "spec-kitty sync import-history", level: 2}
     - {slug: "spec-kitty-sync-migrate", text: "spec-kitty sync migrate", level: 2}
     - {slug: "spec-kitty-sync-mode", text: "spec-kitty sync mode", level: 2}
     - {slug: "spec-kitty-sync-now", text: "spec-kitty sync now", level: 2}

--- a/kitty-specs/decompose-mission-god-module-01KVXHF8/contracts/cli-surface-contract.md
+++ b/kitty-specs/decompose-mission-god-module-01KVXHF8/contracts/cli-surface-contract.md
@@ -4,7 +4,15 @@ This is the **immutable** contract the golden characterization test (WP01) pins.
 names, flag names, flag defaults, positional args, exit codes, or JSON-envelope keys is a **regression**,
 not a refactor. Source of truth: `mission.py` on base `c3814ec5a` (research.md §1).
 
-`app = typer.Typer(name="mission", no_args_is_help=True)` — exposes exactly **8 subcommands**.
+`app = typer.Typer(name="mission", no_args_is_help=True)` — exposes exactly **8 subcommands** at
+the original #2056 base (`c3814ec5a`).
+
+> **Amendment (coord-write-placement-closure-01KYCF83 WP08, FR-005/NFR-005):** a 9th subcommand,
+> `repair`, was added afterward (the Gap-2 cross-partition content repair cure — distinct from
+> `doctor coordination --fix` and `doctor mission-state --fix`; see
+> `kitty-specs/coord-write-placement-closure-01KYCF83/tracers/design-decisions.md`). The table
+> below is amended in place to track the live 9-subcommand surface rather than treated as
+> append-only drift, per DIRECTIVE_044 (canonical sources / no split-brain contract copies).
 
 ## Subcommands, args, flags
 
@@ -18,6 +26,7 @@ not a refactor. Source of truth: `mission.py` on base `c3814ec5a` (research.md �
 | `accept` | `accept_feature` | — | `--mission`, `--mode`, `--json`, `--lenient`, `--no-commit`, `--diagnose` |
 | `merge` | `merge_feature` | — | `--mission`, `--target`, `--strategy`, `--push`, `--dry-run`, `--keep-branch`, `--keep-worktree`, `--auto-retry/--no-auto-retry` |
 | `finalize-tasks` | `finalize_tasks` | — | `--mission`, `--json`, `--validate-only`, `--target-branch` |
+| `repair` | `repair` | — | `--mission` |
 
 ## Envelope & exit-code invariants (must also be pinned)
 
@@ -33,7 +42,7 @@ not a refactor. Source of truth: `mission.py` on base `c3814ec5a` (research.md �
 
 ## Golden test assertions (WP01)
 
-1. `CliRunner` invoking `app` with `--help` lists exactly the 8 command names above.
+1. `CliRunner` invoking `app` with `--help` lists exactly the 9 command names above.
 2. For each subcommand, `--help` lists exactly the flags in the table above (names + defaults).
 3. Representative success JSON envelope keys are asserted for at least `branch-context --json` and
    `check-prerequisites --json`.

--- a/kitty-specs/mission-lifecycle-dispatch-drg-closeout-01KV0S99/drg-orphan-residual.md
+++ b/kitty-specs/mission-lifecycle-dispatch-drg-closeout-01KV0S99/drg-orphan-residual.md
@@ -139,3 +139,26 @@ is in scope for that follow-up unless an artifact is shown to be genuinely retir
 > row at the merge/accept gate. The residual ceiling is pinned at **29** by
 > `test_shipped_graph_orphan_count_within_documented_residual` (raised from 14 by the
 > 2026-07-23 mission_step_contract entry above).
+
+## 2026-07-26 — `toolguide:powershell-syntax` accepted as an edge-less residual (PR #2936 fold)
+
+PR #2936 (`fix(#2934) + doctrine canonical structure`, commit `1a15bcf6c`) promoted
+`toolguides/built-in/powershell-syntax.toolguide.yaml` from a dead, unreachable-since-first-
+commit file into a live, graph-tracked node (`toolguide:powershell-syntax`) — the file's
+245-line PowerShell guide is real content, and the toolguide tests already named the
+`built-in/` path, so the artifact was made reachable rather than deleted. The node ships with
+no inbound or outbound edge: no directive, procedure, or agent profile in the shipped tree
+cites it by URN — it is consumed by agents authoring PowerShell commands at runtime (same
+class as the existing `toolguide:rtk-search-tooling` / `toolguide:python-review-checks`
+residuals below: operator/runtime tooling, no doctrinal static referent).
+
+Per D-C2 / C-003 this is documented as an accepted residual rather than wired with a
+manufactured edge (no existing artifact has a genuine doctrinal reason to cite a PowerShell
+syntax guide) or deleted (the content is valid and current). This raises the documented
+residual ceiling **29 → 30** (empirical 30, no slack). The ceiling constant lives in
+`tests/specify_cli/cli/commands/test_doctrine_regenerate_graph.py`
+(`DOCUMENTED_ORPHAN_RESIDUAL = 30`).
+
+| URN | Artifact | Why residual (not wired, not deleted) |
+|-----|----------|----------------------------------------|
+| `toolguide:powershell-syntax` | PowerShell Syntax Guide | Promoted from dead to live by #2936; real content, consumed by agents at runtime, no built-in artifact statically references it. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ Changelog = "https://github.com/Priivacy-ai/spec-kitty/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = [
-    "pytest>=9.0.3",  # CVE-2025-71176 fix
+    "pytest>=9.0.3,<9.1",  # CVE-2025-71176 fix (>=9.0.3); <9.1 avoids the pytest 9.1.x reorder_items INTERNALERROR ('Function' not subscriptable) that trips CI's pip-resolved collection order (#2884). Aligns CI pip jobs with uv.lock's 9.0.3.
     "pytest-asyncio>=0.21.0",  # Required for async tests
     "pytest-cov>=4.1.0",  # Required by CI coverage flags
     "pytest-timeout>=2.2.0",  # Required by mutmut pytest_add_cli_args --timeout flag

--- a/src/specify_cli/_completion_manifest.json
+++ b/src/specify_cli/_completion_manifest.json
@@ -104,6 +104,11 @@
        "help": "Parse dependencies from tasks.md and update WP frontmatter, then commit to target branch.\n\nThis command is designed to be called after LLM generates WP files via /spec-kitty.tasks.\nIt post-processes the generated files to add dependency information and commits everything.\n\nUse --validate-only to check for issues (missing requirement mappings, ownership overlaps,\ndependency cycles) without making any changes or committing.\n\nBootstrap Mutation Surface (FR-003 / SC-002)\n=============================================\nThe 8 frontmatter fields below may be written or overwritten by this command.\nWhen ``--validate-only`` is active, ALL writes are skipped — the\n``frontmatter_changed and not validate_only`` guard ensures zero bytes of\nmutation on disk (INV-6). In validate-only mode the bootstrap loop still\ninfers all 8 fields in memory so downstream validation operates against the\npost-bootstrap state — not the stale on-disk frontmatter.\n\nSee also: ``tasks.py:finalize-tasks()`` which writes ``dependencies`` via\n``build_document() + write_text()`` — guarded the same way (T002).\n\nExamples:\n    spec-kitty agent mission finalize-tasks --mission 020-my-feature --json\n    spec-kitty agent mission finalize-tasks --mission 020-my-feature --validate-only --json",
        "hidden": false,
        "deprecated": false
+      },
+      "repair": {
+       "help": "Detect and forward-only repair a pre-existing cross-partition content\nsplit-brain for one mission (FR-005, NFR-005).\n\nFast-forwards under strict-ancestor + clean worktree, zero data loss.\nRefuses with a unified diff (scoped to the mission's own content) and\nmutates NOTHING on genuine (non-ancestor) divergence.\n\nExamples:\n    spec-kitty agent mission repair --mission 020-my-mission",
+       "hidden": false,
+       "deprecated": false
       }
      }
     },
@@ -1193,6 +1198,11 @@
     },
     "opt-in": {
      "help": "Enable SaaS sync for this checkout.",
+     "hidden": false,
+     "deprecated": false
+    },
+    "import-history": {
+     "help": "Materialize existing local mission/WP history into the SaaS projection (#2262).\n\nA first sync registers a remote project/build but leaves it with zero\nmaterialized missions — the SaaS materializer deliberately refuses to\nfabricate a WorkPackage from a status event with no prior create. This\ncommand emits the missing ``MissionCreated → WPCreated[] → WPStatusChanged[]``\nstream (INV-3) so historical work populates the projection.\n\nDry-run (default) runs the full read-only pipeline — SELECT → AUDIT\n(fail-closed) → SCAN → IDENTITY → SYNTHESIZE — and previews the envelope\nstream that would be materialized. ``--apply`` additionally attaches\nprovenance, server-preflights the whole stream (fail-closed), and uploads it\nin chunks to the SaaS projection under the real persisted project UUID.\n\nImport is once-and-frozen: each event carries a deterministic id, so\nre-running after the on-disk facts change (e.g. after fixing a malformed WP\nthe dry-run flagged as skipped) re-sends the same id and the server drops the\nupdated payload as a duplicate rather than overwriting. Resolve any skipped\nor incomplete missions the dry-run reports before the first ``--apply``.",
      "hidden": false,
      "deprecated": false
     },

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1776,6 +1776,7 @@ def import_history(
     from specify_cli.migration.mission_state import MissionStateRepairError
     from specify_cli.sync.history_import import (
         ImportAuditBlocked,
+        MissionScanError,
         build_import_plan,
         describe_plan,
     )
@@ -1792,7 +1793,7 @@ def import_history(
 
     try:
         plan = build_import_plan(repo_root, mission=mission, apply=False)
-    except MissionStateRepairError as exc:
+    except (MissionStateRepairError, MissionScanError) as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
     except ImportAuditBlocked as exc:
@@ -1822,6 +1823,7 @@ def _run_import_apply(mission: str | None) -> None:
     from specify_cli.sync.history_import import (
         ImportAuditBlocked,
         ImportIdentityError,
+        MissionScanError,
         PreflightRejected,
         apply_import,
         describe_plan,
@@ -1847,7 +1849,7 @@ def _run_import_apply(mission: str | None) -> None:
         result = apply_import(
             repo_root, mission=mission, receiver=receiver, server_url=server_url, auth_token=token
         )
-    except MissionStateRepairError as exc:
+    except (MissionStateRepairError, MissionScanError) as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
     except ImportIdentityError as exc:
@@ -1877,6 +1879,15 @@ def _run_import_apply(mission: str | None) -> None:
         for sample in report.rejected_samples:
             console.print(f"  [red]✗[/red] {sample}")
         raise typer.Exit(1)
+    if report.pending:
+        # Pending = queued locally, not yet confirmed materialized. For a
+        # "did my history show up?" tool this is a distinct, non-final signal
+        # (not the same as confirmed success) — surface it plainly.
+        console.print(
+            f"[yellow]Note:[/yellow] {report.pending} event(s) are queued (pending), not yet "
+            "confirmed in the projection. They deliver on the next `spec-kitty sync now`; "
+            "re-check the dashboard after."
+        )
 
 
 @app.command(name="workspace")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1875,6 +1875,16 @@ def _run_import_apply(mission: str | None) -> None:
         f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "
         f"{report.pending} pending, {report.rejected} rejected ({report.total} total)."
     )
+    if report.partial:
+        # Distinct third state: neither success nor total failure. Delivery
+        # stopped at the first failed chunk, so everything delivered is a safe
+        # ordered prefix of whole missions; the rest was never attempted.
+        console.print(
+            f"[yellow]Partial upload:[/yellow] delivery stopped at a failed chunk — a safe ordered "
+            f"prefix was delivered ({report.delivered_through_chunk} full chunk(s)); "
+            f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
+            "--apply: the server dedups on event_id, so the re-run resumes idempotently."
+        )
     if not report.ok:
         for sample in report.rejected_samples:
             console.print(f"  [red]✗[/red] {sample}")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1767,56 +1767,51 @@ def import_history(
     command emits the missing ``MissionCreated → WPCreated[] → WPStatusChanged[]``
     stream (INV-3) so historical work populates the projection.
 
-    WP-Y1 (this slice): the command + mission selection + the fail-closed
-    TeamSpace audit gate, reusing the migration helpers rather than
-    re-deriving them. Envelope synthesis and the pre-sync log re-drain
-    (§3.6b) land in the following slices.
+    Dry-run (default) runs the full read-only pipeline — SELECT → AUDIT
+    (fail-closed) → SCAN → IDENTITY → SYNTHESIZE — and previews the envelope
+    stream that would be materialized. ``--apply`` (upload) lands in WP-Y5;
+    until then it is an honest non-zero stub.
     """
-    from specify_cli.migration.mission_state import (
-        MissionStateRepairError,
-        _select_mission_dirs,
-        _teamspace_audit_blockers,
+    from specify_cli.migration.mission_state import MissionStateRepairError
+    from specify_cli.sync.history_import import (
+        ImportAuditBlocked,
+        build_import_plan,
+        describe_plan,
     )
 
     if apply and dry_run:
         console.print("[red]Error:[/red] --apply and --dry-run are mutually exclusive.")
         raise typer.Exit(2)
 
+    if apply:
+        # WP-Y5 wires provenance + preflight + upload. Until then --apply must
+        # not claim a materialize it can't perform — no work, honest exit.
+        console.print(
+            "[yellow]--apply is not available yet.[/yellow] Run without --apply to preview the "
+            "plan; provenance + preflight + upload land in the next slice of #2262."
+        )
+        raise typer.Exit(3)
+
     repo_root = _require_active_checkout().repo_root
 
-    # Stage 1 — SELECT: which missions are in scope.
     try:
-        mission_dirs = _select_mission_dirs(repo_root, scan_root=None, mission=mission)
+        plan = build_import_plan(repo_root, mission=mission, apply=False)
     except MissionStateRepairError as exc:
         console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from exc
-    if not mission_dirs:
+    except ImportAuditBlocked as exc:
+        console.print(f"[red]Import blocked:[/red] {len(exc.blockers)} audit finding(s) must be resolved first:")
+        for blocker in exc.blockers[:20]:
+            console.print(f"  [yellow]•[/yellow] {blocker['mission_slug']}: {blocker['message']}")
+        raise typer.Exit(1) from exc
+
+    if plan.is_empty:
         console.print("[yellow]No missions found to import.[/yellow]")
         raise typer.Exit(0)
 
-    # Stage 2 — AUDIT (fail-closed): a mission with blocking findings must not
-    # be half-imported. `_teamspace_audit_blockers` already returns only genuine
-    # TeamSpace blockers — out-of-scope side logs are excluded at the source.
-    blockers = _teamspace_audit_blockers(repo_root, scan_root=None, mission_dirs=mission_dirs)
-    if blockers:
-        console.print(f"[red]Import blocked:[/red] {len(blockers)} audit finding(s) must be resolved first:")
-        for b in blockers[:20]:
-            console.print(f"  [yellow]•[/yellow] {b['mission_slug']}: {b['message']}")
-        raise typer.Exit(1)
-
-    console.print(f"[green]✓[/green] {len(mission_dirs)} mission(s) eligible for import; audit clean.")
-    for path in mission_dirs:
-        console.print(f"  • {path.name}")
-
-    if apply:
-        # WP-Y1 is fail-closed and honest: the synthesizer + pre-sync re-drain
-        # (§3.6a/b) are not built yet, so --apply must not claim a materialize
-        # it can't perform. Report the plan and exit non-zero until the next slice.
-        console.print(
-            "\n[yellow]--apply is not available yet.[/yellow] Envelope synthesis and the pre-sync "
-            "log re-drain land in the next slice of #2262. The selection + audit above is the plan."
-        )
-        raise typer.Exit(3)
+    for line in describe_plan(plan):
+        console.print(line)
+    console.print("\n[dim]Dry-run: nothing uploaded. Re-run with --apply to materialize.[/dim]")
 
 
 @app.command(name="workspace")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1741,6 +1741,84 @@ def _git_repair(workspace_path: Path) -> bool:
         return False
 
 
+@app.command(name="import-history")
+def import_history(
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Materialize the selected missions into the SaaS projection (default is a dry-run plan).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview what would be imported without emitting anything (this is the default).",
+    ),
+    mission: str | None = typer.Option(
+        None,
+        "--mission",
+        help="Import only this mission (slug / mid8 / ULID); default imports all eligible missions.",
+    ),
+) -> None:
+    """Materialize existing local mission/WP history into the SaaS projection (#2262).
+
+    A first sync registers a remote project/build but leaves it with zero
+    materialized missions — the SaaS materializer deliberately refuses to
+    fabricate a WorkPackage from a status event with no prior create. This
+    command emits the missing ``MissionCreated → WPCreated[] → WPStatusChanged[]``
+    stream (INV-3) so historical work populates the projection.
+
+    WP-Y1 (this slice): the command + mission selection + the fail-closed
+    TeamSpace audit gate, reusing the migration helpers rather than
+    re-deriving them. Envelope synthesis and the pre-sync log re-drain
+    (§3.6b) land in the following slices.
+    """
+    from specify_cli.migration.mission_state import (
+        MissionStateRepairError,
+        _select_mission_dirs,
+        _teamspace_audit_blockers,
+    )
+
+    if apply and dry_run:
+        console.print("[red]Error:[/red] --apply and --dry-run are mutually exclusive.")
+        raise typer.Exit(2)
+
+    repo_root = _require_active_checkout().repo_root
+
+    # Stage 1 — SELECT: which missions are in scope.
+    try:
+        mission_dirs = _select_mission_dirs(repo_root, scan_root=None, mission=mission)
+    except MissionStateRepairError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    if not mission_dirs:
+        console.print("[yellow]No missions found to import.[/yellow]")
+        raise typer.Exit(0)
+
+    # Stage 2 — AUDIT (fail-closed): a mission with blocking findings must not
+    # be half-imported. `_teamspace_audit_blockers` already returns only genuine
+    # TeamSpace blockers — out-of-scope side logs are excluded at the source.
+    blockers = _teamspace_audit_blockers(repo_root, scan_root=None, mission_dirs=mission_dirs)
+    if blockers:
+        console.print(f"[red]Import blocked:[/red] {len(blockers)} audit finding(s) must be resolved first:")
+        for b in blockers[:20]:
+            console.print(f"  [yellow]•[/yellow] {b['mission_slug']}: {b['message']}")
+        raise typer.Exit(1)
+
+    console.print(f"[green]✓[/green] {len(mission_dirs)} mission(s) eligible for import; audit clean.")
+    for path in mission_dirs:
+        console.print(f"  • {path.name}")
+
+    if apply:
+        # WP-Y1 is fail-closed and honest: the synthesizer + pre-sync re-drain
+        # (§3.6a/b) are not built yet, so --apply must not claim a materialize
+        # it can't perform. Report the plan and exit non-zero until the next slice.
+        console.print(
+            "\n[yellow]--apply is not available yet.[/yellow] Envelope synthesis and the pre-sync "
+            "log re-drain land in the next slice of #2262. The selection + audit above is the plan."
+        )
+        raise typer.Exit(3)
+
+
 @app.command(name="workspace")
 def sync_workspace(  # noqa: C901
     repair: bool = typer.Option(

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1769,8 +1769,9 @@ def import_history(
 
     Dry-run (default) runs the full read-only pipeline — SELECT → AUDIT
     (fail-closed) → SCAN → IDENTITY → SYNTHESIZE — and previews the envelope
-    stream that would be materialized. ``--apply`` (upload) lands in WP-Y5;
-    until then it is an honest non-zero stub.
+    stream that would be materialized. ``--apply`` additionally attaches
+    provenance, server-preflights the whole stream (fail-closed), and uploads it
+    in chunks to the SaaS projection under the real persisted project UUID.
     """
     from specify_cli.migration.mission_state import MissionStateRepairError
     from specify_cli.sync.history_import import (
@@ -1784,13 +1785,8 @@ def import_history(
         raise typer.Exit(2)
 
     if apply:
-        # WP-Y5 wires provenance + preflight + upload. Until then --apply must
-        # not claim a materialize it can't perform — no work, honest exit.
-        console.print(
-            "[yellow]--apply is not available yet.[/yellow] Run without --apply to preview the "
-            "plan; provenance + preflight + upload land in the next slice of #2262."
-        )
-        raise typer.Exit(3)
+        _run_import_apply(mission)
+        return
 
     repo_root = _require_active_checkout().repo_root
 
@@ -1812,6 +1808,75 @@ def import_history(
     for line in describe_plan(plan):
         console.print(line)
     console.print("\n[dim]Dry-run: nothing uploaded. Re-run with --apply to materialize.[/dim]")
+
+
+def _run_import_apply(mission: str | None) -> None:
+    """The ``import-history --apply`` path: preflight + upload under the real UUID.
+
+    Resolves the authed Teamspace receiver (fail-closed when unauthenticated /
+    unconfigured), then delegates to ``apply_import`` which builds the plan with
+    the real persisted project UUID, server-preflights the whole stream, and
+    uploads it. The server dedups on ``event_id`` so a re-run is idempotent.
+    """
+    from specify_cli.migration.mission_state import MissionStateRepairError
+    from specify_cli.sync.history_import import (
+        ImportAuditBlocked,
+        ImportIdentityError,
+        PreflightRejected,
+        apply_import,
+        describe_plan,
+    )
+
+    token = _event_sync_access_token()
+    if not token:
+        console.print(
+            "[red]Not authenticated.[/red] Run `spec-kitty auth login` before importing with --apply."
+        )
+        raise typer.Exit(1)
+
+    config = _load_event_sync_config()
+    runtime = _open_event_sync_runtime()
+    receiver = _resolve_active_receiver(runtime.target, config, auth_token=token)
+    if receiver is None or not getattr(receiver, "endpoint_url", ""):
+        console.print("[red]Event sync is not configured for this checkout.[/red] Cannot upload.")
+        raise typer.Exit(1)
+    server_url = config.resolve_runtime_target().resolved_server_url
+    repo_root = _require_active_checkout().repo_root
+
+    try:
+        result = apply_import(
+            repo_root, mission=mission, receiver=receiver, server_url=server_url, auth_token=token
+        )
+    except MissionStateRepairError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    except ImportIdentityError as exc:
+        console.print(f"[red]Identity error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+    except ImportAuditBlocked as exc:
+        console.print(f"[red]Import blocked:[/red] {len(exc.blockers)} audit finding(s) must be resolved first:")
+        for blocker in exc.blockers[:20]:
+            console.print(f"  [yellow]•[/yellow] {blocker['mission_slug']}: {blocker['message']}")
+        raise typer.Exit(1) from exc
+    except PreflightRejected as exc:
+        console.print(f"[red]Server preflight rejected the import:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    if result.plan.is_empty:
+        console.print("[yellow]No missions found to import.[/yellow]")
+        raise typer.Exit(0)
+
+    for line in describe_plan(result.plan):
+        console.print(line)
+    report = result.report
+    console.print(
+        f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "
+        f"{report.pending} pending, {report.rejected} rejected ({report.total} total)."
+    )
+    if not report.ok:
+        for sample in report.rejected_samples:
+            console.print(f"  [red]✗[/red] {sample}")
+        raise typer.Exit(1)
 
 
 @app.command(name="workspace")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1772,6 +1772,12 @@ def import_history(
     stream that would be materialized. ``--apply`` additionally attaches
     provenance, server-preflights the whole stream (fail-closed), and uploads it
     in chunks to the SaaS projection under the real persisted project UUID.
+
+    Import is once-and-frozen: each event carries a deterministic id, so
+    re-running after the on-disk facts change (e.g. after fixing a malformed WP
+    the dry-run flagged as skipped) re-sends the same id and the server drops the
+    updated payload as a duplicate rather than overwriting. Resolve any skipped
+    or incomplete missions the dry-run reports before the first ``--apply``.
     """
     from specify_cli.migration.mission_state import MissionStateRepairError
     from specify_cli.sync.history_import import (
@@ -1819,6 +1825,7 @@ def _run_import_apply(mission: str | None) -> None:
     the real persisted project UUID, server-preflights the whole stream, and
     uploads it. The server dedups on ``event_id`` so a re-run is idempotent.
     """
+    from specify_cli.core.contract_gate import ContractViolationError
     from specify_cli.migration.mission_state import MissionStateRepairError
     from specify_cli.sync.history_import import (
         ImportAuditBlocked,
@@ -1860,6 +1867,11 @@ def _run_import_apply(mission: str | None) -> None:
         for blocker in exc.blockers[:20]:
             console.print(f"  [yellow]•[/yellow] {blocker['mission_slug']}: {blocker['message']}")
         raise typer.Exit(1) from exc
+    except ContractViolationError as exc:
+        # The offline outbound-envelope gate refused a synthesized envelope
+        # before any upload — fail closed with the contract detail (#2884).
+        console.print(f"[red]Envelope contract violation:[/red] {exc}")
+        raise typer.Exit(1) from exc
     except PreflightRejected as exc:
         console.print(f"[red]Server preflight rejected the import:[/red] {exc}")
         raise typer.Exit(1) from exc
@@ -1870,6 +1882,10 @@ def _run_import_apply(mission: str | None) -> None:
 
     for line in describe_plan(result.plan):
         console.print(line)
+    console.print(
+        f"[dim]Provenance: {len(result.manifest)} envelope(s) hashed into the sha256 import "
+        "audit manifest.[/dim]"
+    )
     report = result.report
     console.print(
         f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1817,6 +1817,29 @@ def import_history(
     console.print("\n[dim]Dry-run: nothing uploaded. Re-run with --apply to materialize.[/dim]")
 
 
+def _resolve_history_import_receiver(
+    runtime: _EventSyncRuntime, *, token: str
+) -> tuple[DeliveryReceiver, str]:
+    """Resolve one gated Teamspace authority for preflight and delivery."""
+    from specify_cli.delivery.config import EventSyncConfig, Mode
+    from specify_cli.delivery.receivers import evaluate_gates
+
+    config = EventSyncConfig.from_mode(Mode.TEAMSPACE)
+    receiver = _resolve_active_receiver(runtime.target, config, auth_token=token)
+    if receiver is None or not getattr(receiver, "endpoint_url", ""):
+        console.print("[red]Event sync is not configured for this checkout.[/red] Cannot upload.")
+        raise typer.Exit(1)
+    gate_decision = evaluate_gates(
+        receiver,
+        _event_sync_gate_context(receiver, runtime.target, auth_token=token),
+    )
+    if gate_decision.blocked:
+        names = ", ".join(gate.name for gate in gate_decision.unsatisfied)
+        console.print(f"[red]Event sync is gated:[/red] {names}. Cannot upload.")
+        raise typer.Exit(1)
+    return receiver, runtime.target.resolved_server_url
+
+
 def _run_import_apply(mission: str | None) -> None:
     """The ``import-history --apply`` path: preflight + upload under the real UUID.
 
@@ -1843,13 +1866,8 @@ def _run_import_apply(mission: str | None) -> None:
         )
         raise typer.Exit(1)
 
-    config = _load_event_sync_config()
     runtime = _open_event_sync_runtime()
-    receiver = _resolve_active_receiver(runtime.target, config, auth_token=token)
-    if receiver is None or not getattr(receiver, "endpoint_url", ""):
-        console.print("[red]Event sync is not configured for this checkout.[/red] Cannot upload.")
-        raise typer.Exit(1)
-    server_url = config.resolve_runtime_target().resolved_server_url
+    receiver, server_url = _resolve_history_import_receiver(runtime, token=token)
     repo_root = _require_active_checkout().repo_root
 
     try:
@@ -1901,19 +1919,17 @@ def _run_import_apply(mission: str | None) -> None:
             f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
             "--apply: the server dedups on event_id, so the re-run resumes idempotently."
         )
+    if report.pending:
+        # Direct import delivery does not journal or ledger pending outcomes.
+        # Never claim that ``sync now`` can retry work that was not persisted.
+        console.print(
+            f"[yellow]Incomplete:[/yellow] {report.pending} event(s) remain pending and are not "
+            "confirmed in the projection. Re-run --apply after resolving the receiver issue."
+        )
     if not report.ok:
         for sample in report.rejected_samples:
             console.print(f"  [red]✗[/red] {sample}")
         raise typer.Exit(1)
-    if report.pending:
-        # Pending = queued locally, not yet confirmed materialized. For a
-        # "did my history show up?" tool this is a distinct, non-final signal
-        # (not the same as confirmed success) — surface it plainly.
-        console.print(
-            f"[yellow]Note:[/yellow] {report.pending} event(s) are queued (pending), not yet "
-            "confirmed in the projection. They deliver on the next `spec-kitty sync now`; "
-            "re-check the dashboard after."
-        )
 
 
 @app.command(name="workspace")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from specify_cli.delivery.retention import RetentionResult
     from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
     from specify_cli.event_journal.journal import EventJournal
+    from specify_cli.sync.history_import import UploadReport
     from specify_cli.sync.migrate_journal import (
         CleanupResult,
         ConflictResolution,
@@ -1873,6 +1874,46 @@ def _resolve_history_import_receiver(
     return receiver, runtime.target.resolved_server_url
 
 
+def _render_upload_report(report: UploadReport) -> bool:
+    """Render the partial / pending / rejected tail of an upload report.
+
+    Returns ``True`` when the run is fully clean (no partial delivery, no
+    pending events, no rejections) and ``False`` when the caller must exit
+    non-zero. The return value mirrors ``UploadReport.ok`` exactly, so the
+    exit code the caller raises always agrees with the message just printed.
+    """
+    if report.partial:
+        # Distinct third state: neither success nor total failure. Delivery
+        # stopped at the first failed chunk, so everything delivered is a safe
+        # ordered prefix of whole missions; the rest was never attempted.
+        console.print(
+            f"[yellow]Partial upload:[/yellow] delivery stopped at a failed chunk — a safe ordered "
+            f"prefix was delivered ({report.delivered_through_chunk} full chunk(s)); "
+            f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
+            "--apply: the server dedups on event_id, so the re-run resumes idempotently."
+        )
+    if report.pending:
+        # Direct import delivery does not journal or ledger pending outcomes,
+        # and import event ids are deterministic (frozen at synthesis time), so
+        # the server dedups a re-run onto these same ids. That means re-running
+        # --apply will report them as `duplicate` and exit 0 regardless of
+        # whether they ever materialized in the projection — "pending" can also
+        # arise from a 200 response that merely omits an entry, which is not
+        # necessarily anything the operator can act on. Never suggest a re-run
+        # as the fix; point at the authoritative surface instead.
+        console.print(
+            f"[yellow]Incomplete:[/yellow] {report.pending} event(s) remain pending and are not "
+            "confirmed in the projection. Re-running --apply will report these events as "
+            "duplicates (the server dedups on event_id) and exit 0 whether or not they were "
+            "ever materialized — verify the outcome in the dashboard/projection instead."
+        )
+    if not report.ok:
+        for sample in report.rejected_samples:
+            console.print(f"  [red]✗[/red] {sample}")
+        return False
+    return True
+
+
 def _run_import_apply(mission: str | None) -> None:
     """The ``import-history --apply`` path: preflight + upload under the real UUID.
 
@@ -1949,26 +1990,7 @@ def _run_import_apply(mission: str | None) -> None:
             f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "
             f"{report.pending} pending, {report.rejected} rejected ({report.total} total)."
         )
-        if report.partial:
-            # Distinct third state: neither success nor total failure. Delivery
-            # stopped at the first failed chunk, so everything delivered is a safe
-            # ordered prefix of whole missions; the rest was never attempted.
-            console.print(
-                f"[yellow]Partial upload:[/yellow] delivery stopped at a failed chunk — a safe ordered "
-                f"prefix was delivered ({report.delivered_through_chunk} full chunk(s)); "
-                f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
-                "--apply: the server dedups on event_id, so the re-run resumes idempotently."
-            )
-        if report.pending:
-            # Direct import delivery does not journal or ledger pending outcomes.
-            # Never claim that ``sync now`` can retry work that was not persisted.
-            console.print(
-                f"[yellow]Incomplete:[/yellow] {report.pending} event(s) remain pending and are not "
-                "confirmed in the projection. Re-run --apply after resolving the receiver issue."
-            )
-        if not report.ok:
-            for sample in report.rejected_samples:
-                console.print(f"  [red]✗[/red] {sample}")
+        if not _render_upload_report(report):
             raise typer.Exit(1)
     finally:
         runtime.close()

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from specify_cli.delivery.config import EventSyncConfig, Mode
     from specify_cli.delivery.dispatcher import DispatchSummary
     from specify_cli.delivery.ledger import SqliteDeliveryLedger
-    from specify_cli.delivery.receivers import DeliveryReceiver
+    from specify_cli.delivery.receivers import DeliveryReceiver, GateDecision
     from specify_cli.delivery.retention import RetentionResult
     from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
     from specify_cli.event_journal.journal import EventJournal
@@ -685,6 +685,31 @@ def _event_sync_gate_context(
     )
 
 
+def _resolve_gated_receiver(
+    target: ResolvedSyncTarget, config: EventSyncConfig, *, auth_token: str
+) -> tuple[DeliveryReceiver | None, GateDecision | None]:
+    """Resolve the active receiver and evaluate its gates — data only, no policy.
+
+    Shared by ``sync now`` (:func:`_run_event_sync_dispatch`) and
+    ``import-history --apply`` (:func:`_resolve_history_import_receiver`); the
+    two callers previously duplicated this resolve+evaluate sequence and had
+    already diverged (#2884 P2). Returns ``(None, None)`` when the mode has no
+    receiver (retention-only). Otherwise returns the receiver and its
+    :class:`GateDecision` — each caller decides what a blocked decision means:
+    ``sync now`` degrades to a dim best-effort notice, ``import-history`` fails
+    closed with ``typer.Exit(1)``. Neither policy lives here.
+    """
+    from specify_cli.delivery.receivers import evaluate_gates
+
+    receiver = _resolve_active_receiver(target, config, auth_token=auth_token)
+    if receiver is None:
+        return None, None
+    gate_decision = evaluate_gates(
+        receiver, _event_sync_gate_context(receiver, target, auth_token=auth_token)
+    )
+    return receiver, gate_decision
+
+
 def _count_retained_events(runtime: _EventSyncRuntime) -> int:
     with contextlib.suppress(Exception):
         return len(runtime.journal.read_all())
@@ -988,24 +1013,22 @@ def _run_event_sync_dispatch() -> DispatchSummary | None:
 
         return DispatchSummary.empty()
     from specify_cli.delivery.dispatcher import DispatchSummary
-    from specify_cli.delivery.receivers import evaluate_gates
 
     runtime: _EventSyncRuntime | None = None
     try:
         runtime = _open_event_sync_runtime()
         config = _load_event_sync_config()
         auth_token = _event_sync_access_token()
-        receiver = _resolve_active_receiver(runtime.target, config, auth_token=auth_token)
+        receiver, gate_decision = _resolve_gated_receiver(
+            runtime.target, config, auth_token=auth_token
+        )
         if receiver is None:
             console.print(
                 f"[dim]Event sync mode {config.mode.name}: retention only; "
                 f"no delivery attempted.[/dim]"
             )
             return DispatchSummary.empty()
-        gate_decision = evaluate_gates(
-            receiver,
-            _event_sync_gate_context(receiver, runtime.target, auth_token=auth_token),
-        )
+        assert gate_decision is not None  # a resolved receiver always carries a decision
         if gate_decision.blocked:
             names = ", ".join(gate.name for gate in gate_decision.unsatisfied)
             console.print(f"[dim]Event sync gated: {names}[/dim]")
@@ -1820,19 +1843,29 @@ def import_history(
 def _resolve_history_import_receiver(
     runtime: _EventSyncRuntime, *, token: str
 ) -> tuple[DeliveryReceiver, str]:
-    """Resolve one gated Teamspace authority for preflight and delivery."""
-    from specify_cli.delivery.config import EventSyncConfig, Mode
-    from specify_cli.delivery.receivers import evaluate_gates
+    """Resolve one gated Teamspace authority for preflight and delivery.
 
-    config = EventSyncConfig.from_mode(Mode.TEAMSPACE)
-    receiver = _resolve_active_receiver(runtime.target, config, auth_token=token)
+    Fails closed on the operator's *persisted* event-sync mode (#2884 P1):
+    import-history uploads a mission's full history, so it must honor
+    ``spec-kitty sync mode`` like every other sync surface, not silently
+    override it to TEAMSPACE. An operator on EXTERNAL_RECEIVER, LOCAL_RETENTION,
+    or OPT_OUT gets a clear refusal instead of an unwanted upload.
+    """
+    from specify_cli.delivery.config import Mode
+
+    config = _load_event_sync_config()
+    if config.mode is not Mode.TEAMSPACE:
+        console.print(
+            "[red]import-history requires event-sync mode TEAMSPACE;[/red] "
+            f"current mode is {config.mode.name}. Run `spec-kitty sync mode TEAMSPACE` "
+            "to switch, then retry."
+        )
+        raise typer.Exit(1)
+    receiver, gate_decision = _resolve_gated_receiver(runtime.target, config, auth_token=token)
     if receiver is None or not getattr(receiver, "endpoint_url", ""):
         console.print("[red]Event sync is not configured for this checkout.[/red] Cannot upload.")
         raise typer.Exit(1)
-    gate_decision = evaluate_gates(
-        receiver,
-        _event_sync_gate_context(receiver, runtime.target, auth_token=token),
-    )
+    assert gate_decision is not None  # a resolved receiver always carries a decision
     if gate_decision.blocked:
         names = ", ".join(gate.name for gate in gate_decision.unsatisfied)
         console.print(f"[red]Event sync is gated:[/red] {names}. Cannot upload.")
@@ -1867,69 +1900,78 @@ def _run_import_apply(mission: str | None) -> None:
         raise typer.Exit(1)
 
     runtime = _open_event_sync_runtime()
-    receiver, server_url = _resolve_history_import_receiver(runtime, token=token)
-    repo_root = _require_active_checkout().repo_root
-
     try:
-        result = apply_import(
-            repo_root, mission=mission, receiver=receiver, server_url=server_url, auth_token=token
-        )
-    except (MissionStateRepairError, MissionScanError) as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1) from exc
-    except ImportIdentityError as exc:
-        console.print(f"[red]Identity error:[/red] {exc}")
-        raise typer.Exit(1) from exc
-    except ImportAuditBlocked as exc:
-        console.print(f"[red]Import blocked:[/red] {len(exc.blockers)} audit finding(s) must be resolved first:")
-        for blocker in exc.blockers[:20]:
-            console.print(f"  [yellow]•[/yellow] {blocker['mission_slug']}: {blocker['message']}")
-        raise typer.Exit(1) from exc
-    except ContractViolationError as exc:
-        # The offline outbound-envelope gate refused a synthesized envelope
-        # before any upload — fail closed with the contract detail (#2884).
-        console.print(f"[red]Envelope contract violation:[/red] {exc}")
-        raise typer.Exit(1) from exc
-    except PreflightRejected as exc:
-        console.print(f"[red]Server preflight rejected the import:[/red] {exc}")
-        raise typer.Exit(1) from exc
+        receiver, server_url = _resolve_history_import_receiver(runtime, token=token)
+        repo_root = _require_active_checkout().repo_root
 
-    if result.plan.is_empty:
-        console.print("[yellow]No missions found to import.[/yellow]")
-        raise typer.Exit(0)
+        try:
+            result = apply_import(
+                repo_root,
+                mission=mission,
+                receiver=receiver,
+                server_url=server_url,
+                auth_token=token,
+            )
+        except (MissionStateRepairError, MissionScanError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        except ImportIdentityError as exc:
+            console.print(f"[red]Identity error:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        except ImportAuditBlocked as exc:
+            console.print(
+                f"[red]Import blocked:[/red] {len(exc.blockers)} audit finding(s) must be resolved first:"
+            )
+            for blocker in exc.blockers[:20]:
+                console.print(f"  [yellow]•[/yellow] {blocker['mission_slug']}: {blocker['message']}")
+            raise typer.Exit(1) from exc
+        except ContractViolationError as exc:
+            # The offline outbound-envelope gate refused a synthesized envelope
+            # before any upload — fail closed with the contract detail (#2884).
+            console.print(f"[red]Envelope contract violation:[/red] {exc}")
+            raise typer.Exit(1) from exc
+        except PreflightRejected as exc:
+            console.print(f"[red]Server preflight rejected the import:[/red] {exc}")
+            raise typer.Exit(1) from exc
 
-    for line in describe_plan(result.plan):
-        console.print(line)
-    console.print(
-        f"[dim]Provenance: {len(result.manifest)} envelope(s) hashed into the sha256 import "
-        "audit manifest.[/dim]"
-    )
-    report = result.report
-    console.print(
-        f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "
-        f"{report.pending} pending, {report.rejected} rejected ({report.total} total)."
-    )
-    if report.partial:
-        # Distinct third state: neither success nor total failure. Delivery
-        # stopped at the first failed chunk, so everything delivered is a safe
-        # ordered prefix of whole missions; the rest was never attempted.
+        if result.plan.is_empty:
+            console.print("[yellow]No missions found to import.[/yellow]")
+            raise typer.Exit(0)
+
+        for line in describe_plan(result.plan):
+            console.print(line)
         console.print(
-            f"[yellow]Partial upload:[/yellow] delivery stopped at a failed chunk — a safe ordered "
-            f"prefix was delivered ({report.delivered_through_chunk} full chunk(s)); "
-            f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
-            "--apply: the server dedups on event_id, so the re-run resumes idempotently."
+            f"[dim]Provenance: {len(result.manifest)} envelope(s) hashed into the sha256 import "
+            "audit manifest.[/dim]"
         )
-    if report.pending:
-        # Direct import delivery does not journal or ledger pending outcomes.
-        # Never claim that ``sync now`` can retry work that was not persisted.
+        report = result.report
         console.print(
-            f"[yellow]Incomplete:[/yellow] {report.pending} event(s) remain pending and are not "
-            "confirmed in the projection. Re-run --apply after resolving the receiver issue."
+            f"\n[green]Imported:[/green] {report.success} created, {report.duplicate} duplicate, "
+            f"{report.pending} pending, {report.rejected} rejected ({report.total} total)."
         )
-    if not report.ok:
-        for sample in report.rejected_samples:
-            console.print(f"  [red]✗[/red] {sample}")
-        raise typer.Exit(1)
+        if report.partial:
+            # Distinct third state: neither success nor total failure. Delivery
+            # stopped at the first failed chunk, so everything delivered is a safe
+            # ordered prefix of whole missions; the rest was never attempted.
+            console.print(
+                f"[yellow]Partial upload:[/yellow] delivery stopped at a failed chunk — a safe ordered "
+                f"prefix was delivered ({report.delivered_through_chunk} full chunk(s)); "
+                f"{report.undelivered_event_count} event(s) not attempted. Fix the failure and re-run "
+                "--apply: the server dedups on event_id, so the re-run resumes idempotently."
+            )
+        if report.pending:
+            # Direct import delivery does not journal or ledger pending outcomes.
+            # Never claim that ``sync now`` can retry work that was not persisted.
+            console.print(
+                f"[yellow]Incomplete:[/yellow] {report.pending} event(s) remain pending and are not "
+                "confirmed in the projection. Re-run --apply after resolving the receiver issue."
+            )
+        if not report.ok:
+            for sample in report.rejected_samples:
+                console.print(f"  [red]✗[/red] {sample}")
+            raise typer.Exit(1)
+    finally:
+        runtime.close()
 
 
 @app.command(name="workspace")

--- a/src/specify_cli/delivery/config.py
+++ b/src/specify_cli/delivery/config.py
@@ -48,7 +48,7 @@ from specify_cli.delivery.receivers import (
     ExternalReceiver,
     HttpPoster,
     TeamspaceReceiver,
-    _requests_post,
+    default_http_poster,
 )
 
 # -- Audit-visible reason strings (S1192: referenced across helpers/tests) ------
@@ -207,7 +207,7 @@ class DefaultReceiverFactory:
     """
 
     teamspace_auth_token: str = ""
-    poster: HttpPoster = _requests_post
+    poster: HttpPoster = default_http_poster
 
     def build_teamspace(self, *, resolved_server_url: str) -> DeliveryReceiver:
         return TeamspaceReceiver(

--- a/src/specify_cli/delivery/receivers.py
+++ b/src/specify_cli/delivery/receivers.py
@@ -247,17 +247,16 @@ class HttpPoster(Protocol):
     ) -> HttpResponse: ...
 
 
-def _requests_post(
+def default_http_poster(
     url: str, *, data: bytes, headers: Mapping[str, str], timeout: float
 ) -> HttpResponse:
-    """Default poster: a thin, typed wrapper over ``requests.post`` (mirrors batch.py)."""
+    """Default poster: a thin, typed wrapper over ``requests.post`` (mirrors batch.py).
+
+    The single public name for the default poster (#2884) — cross-package
+    callers (e.g. ``sync.history_import``) and in-module default-arg sites
+    all bind this one name rather than an underscore-private alias.
+    """
     return requests.post(url, data=data, headers=dict(headers), timeout=timeout)
-
-
-# Public name for the default poster. Cross-package callers (e.g.
-# ``sync.history_import``) bind this rather than reaching for the
-# underscore-private ``_requests_post`` across a package boundary (#2884).
-default_http_poster: HttpPoster = _requests_post
 
 
 # -- The shared result mapper (one mapper, reused by all three receivers) -------
@@ -616,7 +615,7 @@ class TeamspaceReceiver(_HttpReceiver):
         *,
         resolved_server_url: str,
         auth_token: str,
-        poster: HttpPoster = _requests_post,
+        poster: HttpPoster = default_http_poster,
     ) -> None:
         self._server_url = resolved_server_url.rstrip("/")
         self._auth_token = auth_token
@@ -647,7 +646,7 @@ class ExternalReceiver(_HttpReceiver):
         *,
         endpoint_url: str,
         auth_headers: Mapping[str, str] | None = None,
-        poster: HttpPoster = _requests_post,
+        poster: HttpPoster = default_http_poster,
     ) -> None:
         self._endpoint_url = endpoint_url
         self._auth_headers = dict(auth_headers) if auth_headers else {}

--- a/src/specify_cli/delivery/receivers.py
+++ b/src/specify_cli/delivery/receivers.py
@@ -254,6 +254,12 @@ def _requests_post(
     return requests.post(url, data=data, headers=dict(headers), timeout=timeout)
 
 
+# Public name for the default poster. Cross-package callers (e.g.
+# ``sync.history_import``) bind this rather than reaching for the
+# underscore-private ``_requests_post`` across a package boundary (#2884).
+default_http_poster: HttpPoster = _requests_post
+
+
 # -- The shared result mapper (one mapper, reused by all three receivers) -------
 
 
@@ -724,6 +730,7 @@ __all__ = [
     "BATCH_ENDPOINT_PATH",
     "BATCH_TIMEOUT_SECONDS",
     "STUB_ENDPOINT_URL",
+    "default_http_poster",
     "DeliveryOutcome",
     "OutboundEvent",
     "DeliveryResult",

--- a/src/specify_cli/git/bookkeeping_commit.py
+++ b/src/specify_cli/git/bookkeeping_commit.py
@@ -1,19 +1,24 @@
 """The single sanctioned protected-flow bookkeeping-commit surface (#2280 / PR #2281).
 
-Two flows land a post-completion bookkeeping commit on a (possibly protected)
-target branch:
+Three flows land a post-completion bookkeeping commit on a (possibly protected)
+branch:
 
 * the **merge executor** (``merge/executor.py``) — the done-transition
-  bookkeeping that persists status events before worktree teardown (INV-5); and
+  bookkeeping that persists status events before worktree teardown (INV-5);
 * the **retrospective terminus** (``post_merge/retrospective_terminus.py``) —
   which commits the auto-captured ``retrospective.yaml`` + its event-log append
   and runs from BOTH the ``spec-kitty merge`` path AND the ``mission close``
-  path.
+  path; and
+* the **birth-cutover coord seed** (``merge/executor.py`` again) — the
+  ``STATUS_STATE`` coord-partition seed-events reconcile.
 
-Both route their guarded commit through THIS one function so there is a SINGLE
-``GuardCapability.MERGE_BOOKKEEPING`` protected-flow commit surface, rather than
-a second guard-capability call site outside the merge executor (the #1850
-guard-bypass class the architectural ratchet in
+The first two go through :func:`commit_merge_bookkeeping` (PRIMARY partition);
+the third goes through :func:`commit_coord_seed_bookkeeping` (COORD partition).
+Both are thin named entry points that fill in a partition ``kind`` and delegate
+to the ONE shared :func:`_commit_bookkeeping` core — so there is still a SINGLE
+``GuardCapability.MERGE_BOOKKEEPING`` protected-flow commit surface (one guarded
+call site, kind-parameterized), rather than a second guard-capability call site
+outside this module (the #1850 guard-bypass class the architectural ratchet in
 ``tests/architectural/test_guard_capability_call_sites.py`` defends against).
 
 The seam is a thin, policy-free wrapper: it performs the guarded commit and
@@ -46,16 +51,17 @@ from specify_cli.missions._read_path_resolver import (
 # error below.
 _FEATURE_CONTEXT_UNRESOLVED_CODE = "FEATURE_CONTEXT_UNRESOLVED"
 
-# coord-write-placement-closure-01KYCF83 WP03 / FR-003: this surface's OWN
-# contract (module docstring above) is that BOTH flows land their commit on
-# the PRIMARY ``target_branch`` for every topology — never the coordination
-# branch. Any PRIMARY-partition kind therefore resolves the identical
-# ``target_branch`` ref via :func:`resolve_placement_only`;
-# ``PRIMARY_METADATA`` is used as the selector because this surface commits
-# mission bookkeeping metadata (status/meta/baseline artifacts, the captured
-# retrospective). This is NOT a re-classification of the committed paths —
-# it is the fixed partition this seam has always targeted, now derived
-# through the placement port instead of an ambient/CWD-derived ref.
+# The DEFAULT partition selector: the PRIMARY done-transitions bookkeeping the
+# merge executor and retrospective terminus land (status/meta/baseline
+# artifacts, the captured retrospective) all resolve the PRIMARY ``target_branch``
+# ref via :func:`resolve_placement_only` for every topology, because
+# ``PRIMARY_METADATA`` is a primary-partition kind. Callers that commit a
+# NON-primary artifact (e.g. the birth-cutover ``STATUS_STATE`` coord-seed
+# events) pass their own ``kind`` so ``resolve_placement_only`` routes to the
+# topology-correct destination (the coordination branch under coordination
+# topology) — one kind-parameterized seam, not a duplicated write path. The
+# committed paths are never re-classified; ``kind`` selects the destination the
+# placement port already owns.
 _BOOKKEEPING_COMMIT_KIND = MissionArtifactKind.PRIMARY_METADATA
 
 
@@ -101,7 +107,73 @@ def commit_merge_bookkeeping(
         when ``mission_slug`` cannot be resolved and no ``branch`` degrade
         path was supplied.
     """
-    target = _resolve_bookkeeping_commit_target(repo_root, mission_slug, branch)
+    return _commit_bookkeeping(
+        repo_root=repo_root,
+        worktree_root=worktree_root,
+        mission_slug=mission_slug,
+        message=message,
+        paths=paths,
+        branch=branch,
+        kind=_BOOKKEEPING_COMMIT_KIND,
+    )
+
+
+def commit_coord_seed_bookkeeping(
+    *,
+    repo_root: Path,
+    worktree_root: Path,
+    mission_slug: str,
+    message: str,
+    paths: tuple[Path, ...],
+    branch: str | None = None,
+) -> CommitResult:
+    """Commit ``paths`` as the COORD-partition birth-cutover seed bookkeeping.
+
+    The same authorized ``GuardCapability.MERGE_BOOKKEEPING`` flow as
+    :func:`commit_merge_bookkeeping`, but selects
+    ``MissionArtifactKind.STATUS_STATE`` so the placement port routes the
+    destination to the topology-correct COORD ref (the coordination branch under
+    coordination topology) instead of the PRIMARY ``target_branch``. That is why
+    the birth-cutover seed commit lands on the coord worktree's own HEAD with no
+    ``SafeCommitHeadMismatch`` -- ONE kind-parameterized seam, not a second
+    guard-capability call site (#2884, superseding PR #2920 review F1's direct
+    ``safe_commit`` workaround, which had wrongly concluded this surface could
+    not serve a non-primary partition).
+
+    ``branch`` is the same degrade-path-only fallback as the sibling entry point
+    (used solely if placement resolution cannot resolve ``mission_slug``).
+    """
+    return _commit_bookkeeping(
+        repo_root=repo_root,
+        worktree_root=worktree_root,
+        mission_slug=mission_slug,
+        message=message,
+        paths=paths,
+        branch=branch,
+        kind=MissionArtifactKind.STATUS_STATE,
+    )
+
+
+def _commit_bookkeeping(
+    *,
+    repo_root: Path,
+    worktree_root: Path,
+    mission_slug: str,
+    message: str,
+    paths: tuple[Path, ...],
+    branch: str | None,
+    kind: MissionArtifactKind,
+) -> CommitResult:
+    """Shared core for the two named bookkeeping entry points.
+
+    Resolves the destination for ``kind`` through the placement port
+    (:func:`_resolve_bookkeeping_commit_target`) and lands the single guarded
+    ``GuardCapability.MERGE_BOOKKEEPING`` commit. ``kind`` selects only the
+    partition destination (``PRIMARY_METADATA`` -> primary ``target_branch`` for
+    every topology; a non-primary kind -> the topology-routed ``destination_ref``)
+    -- it never re-classifies the committed paths.
+    """
+    target = _resolve_bookkeeping_commit_target(repo_root, mission_slug, branch, kind)
     return safe_commit(
         repo_root=repo_root,
         worktree_root=worktree_root,
@@ -136,9 +208,14 @@ def _mission_meta_exists(repo_root: Path, mission_slug: str) -> bool:
 
 
 def _resolve_bookkeeping_commit_target(
-    repo_root: Path, mission_slug: str, branch: str | None
+    repo_root: Path, mission_slug: str, branch: str | None, kind: MissionArtifactKind
 ) -> CommitTarget:
     """Resolve this surface's commit target via the placement port (FR-003).
+
+    ``kind`` selects the partition: ``PRIMARY_METADATA`` resolves the primary
+    ``target_branch``; a non-primary kind (e.g. ``STATUS_STATE``) resolves the
+    topology-routed ``destination_ref`` (the coordination branch under
+    coordination topology).
 
     Degrades to ``CommitTarget(ref=branch)`` ONLY when the mission cannot be
     resolved (no ``meta.json`` yet, or an ad-hoc fixture outside a resolvable
@@ -156,9 +233,7 @@ def _resolve_bookkeeping_commit_target(
             "resolvable meta.json and no degrade-path 'branch' was supplied.",
         )
     try:
-        return resolve_placement_only(
-            repo_root, mission_slug, kind=_BOOKKEEPING_COMMIT_KIND
-        )
+        return resolve_placement_only(repo_root, mission_slug, kind=kind)
     except (ActionContextError, StatusReadPathNotFound, FileNotFoundError):
         if branch is not None:
             return CommitTarget(ref=branch)

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -53,10 +53,11 @@ from specify_cli.coordination.surface_resolver import (
 from specify_cli.core.git_ops import has_remote, run_command
 from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.core.paths import get_main_repo_root
-from mission_runtime import CommitTarget
-from specify_cli.core.commit_guard import GuardCapability
-from specify_cli.git.bookkeeping_commit import commit_merge_bookkeeping
-from specify_cli.git.commit_helpers import SafeCommitRecoveryFailed, safe_commit
+from specify_cli.git.bookkeeping_commit import (
+    commit_coord_seed_bookkeeping,
+    commit_merge_bookkeeping,
+)
+from specify_cli.git.commit_helpers import SafeCommitRecoveryFailed
 from specify_cli.merge.git_probes import _paths_have_status_changes
 from specify_cli.git.sparse_checkout import require_no_sparse_checkout
 from specify_cli.lanes.persistence import require_lanes_json
@@ -1021,14 +1022,19 @@ def _commit_coord_seed_events(run: _MergeRunState, status_feature_dir: Path) -> 
 
     Closes three faults in the original inline commit:
 
-    1. **Wrong partition (F1).** ``status.events.jsonl`` is a ``STATUS_STATE`` =
-       COORD-partition artifact, but ``commit_merge_bookkeeping`` bakes
-       ``PRIMARY_METADATA`` and resolves the destination to the PRIMARY
-       ``target_branch``. Committing it from the coord worktree (HEAD = the
-       coordination branch) tripped ``safe_commit``'s HEAD-must-match-destination
-       guard → ``SafeCommitHeadMismatch``. We target the coordination ref
-       explicitly (``run.pre_target_coord_ref`` — the ref the coord worktree is
-       actually on, mirroring :func:`_revert_coord_done_commit`).
+    1. **Right partition through the seam (F1, #2884).** ``status.events.jsonl``
+       is a ``STATUS_STATE`` = COORD-partition artifact. It routes through
+       :func:`commit_coord_seed_bookkeeping`, which selects
+       ``MissionArtifactKind.STATUS_STATE`` so the placement port resolves the
+       COORD ref (the coordination branch under coordination topology) — the ref
+       the coord worktree's HEAD is already on, so ``safe_commit``'s
+       HEAD-must-match-destination guard is satisfied (no
+       ``SafeCommitHeadMismatch``). ``run.pre_target_coord_ref`` is passed only as
+       the degrade-path fallback (used solely if placement resolution fails).
+       This is ONE kind-parameterized bookkeeping seam, not a duplicated
+       guard-capability call site: PR #2920's earlier direct-``safe_commit``
+       workaround wrongly assumed the seam could only serve the PRIMARY partition
+       (it merely hardcoded ``PRIMARY_METADATA``).
 
     2. **Resume-heal asymmetry (F2).** The old guard ``result.seeded_count > 0``
        is a PER-RUN delta that is 0 on ``merge --resume`` — so an interrupted
@@ -1050,13 +1056,13 @@ def _commit_coord_seed_events(run: _MergeRunState, status_feature_dir: Path) -> 
     try:
         if not _paths_have_status_changes(coord_worktree_root, [events_path]):
             return  # nothing seeded/uncommitted — resume-safe no-op
-        safe_commit(
+        commit_coord_seed_bookkeeping(
             repo_root=run.main_repo,
             worktree_root=coord_worktree_root,
-            target=CommitTarget(ref=coord_ref),
+            mission_slug=run.mission_slug,
             message=f"chore({run.mission_slug}): birth-cutover seed events reconciled",
             paths=(events_path,),
-            capability=GuardCapability.MERGE_BOOKKEEPING,
+            branch=coord_ref,
         )
     except Exception as exc:  # noqa: BLE001 — best-effort, must never abort the merge
         logger.warning(

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -1056,6 +1056,8 @@ def _commit_coord_seed_events(run: _MergeRunState, status_feature_dir: Path) -> 
     try:
         if not _paths_have_status_changes(coord_worktree_root, [events_path]):
             return  # nothing seeded/uncommitted — resume-safe no-op
+        # Intentionally exercised UN-mocked by tests/regression/test_birth_cutover.py
+        # (the real git write) — do not add this call to a mock stack.
         commit_coord_seed_bookkeeping(
             repo_root=run.main_repo,
             worktree_root=coord_worktree_root,

--- a/src/specify_cli/migration/envelope_seam.py
+++ b/src/specify_cli/migration/envelope_seam.py
@@ -1,0 +1,46 @@
+"""The deliberate shared surface between migration replay and history import.
+
+``migration.mission_state`` owns the TeamSpace envelope machinery — the
+canonical schema version, deterministic id minting, the envelope body
+checksum, the ``WPStatusChanged`` envelope builder, and the mission
+selection / fail-closed audit seams. Its ``__all__`` deliberately demoted
+those names as migration-internal ("no cross-module src/ from-import
+callers", WP01 harden-dead-symbol-gate-01KW0RJR).
+
+Two src/ consumers now share that machinery:
+
+* :mod:`specify_cli.migration` itself — the ``doctor mission-state``
+  teamspace dry-run (the original owner; it calls the underscore internals
+  in-module and is unaffected by this seam).
+* :mod:`specify_cli.sync.history_import` — the ``sync import-history``
+  pipeline (#2262), which replays the exact same envelope shapes for
+  historical import and reuses the same selection/audit gates.
+
+This module is the ONE sanctioned exception to the demotion: it hoists
+exactly the shared subset under public names, so the cross-module surface is
+explicit, declared in ``__all__``, and ratcheted by the dead-symbol gate —
+instead of scattered underscore imports reaching into mission_state
+(the #2884 review's A1). Tests that need to stub the selection/audit seams
+patch them HERE (the import-history pipeline binds them lazily from this
+module at call time).
+"""
+
+from __future__ import annotations
+
+from specify_cli.migration.mission_state import (
+    CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    _select_mission_dirs as select_mission_dirs,
+    _status_event_to_teamspace_envelope as status_event_to_teamspace_envelope,
+    _teamspace_audit_blockers as teamspace_audit_blockers,
+    deterministic_ulid,
+    envelope_sha256,
+)
+
+__all__ = [
+    "CANONICAL_ENVELOPE_SCHEMA_VERSION",
+    "deterministic_ulid",
+    "envelope_sha256",
+    "select_mission_dirs",
+    "status_event_to_teamspace_envelope",
+    "teamspace_audit_blockers",
+]

--- a/src/specify_cli/migration/envelope_seam.py
+++ b/src/specify_cli/migration/envelope_seam.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from specify_cli.migration.mission_state import (
     CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    _build_teamspace_envelope as build_teamspace_envelope,
     _select_mission_dirs as select_mission_dirs,
     _status_event_to_teamspace_envelope as status_event_to_teamspace_envelope,
     _teamspace_audit_blockers as teamspace_audit_blockers,
@@ -38,6 +39,7 @@ from specify_cli.migration.mission_state import (
 
 __all__ = [
     "CANONICAL_ENVELOPE_SCHEMA_VERSION",
+    "build_teamspace_envelope",
     "deterministic_ulid",
     "envelope_sha256",
     "select_mission_dirs",

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -481,6 +481,18 @@ def deterministic_ulid(seed: bytes | str) -> str:
     return "".join(reversed(chars))
 
 
+def envelope_sha256(envelope: Mapping[str, Any]) -> str:
+    """Canonical-JSON SHA-256 of a TeamSpace envelope (single recipe owner).
+
+    Both the migration dry-run's ``TeamspaceDryRunRowMapping.envelope_sha256``
+    and the import-history provenance manifest (#2262, via
+    :mod:`specify_cli.migration.envelope_seam`) hash envelopes with this exact
+    shape; hoisted here so the two recipes cannot drift (#2884).
+    """
+    canonical = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()  # noqa: TID251 - production raw SHA-256 owner (canonical envelope body checksum)
+
+
 def _anchor_repair_root(repo_root: Path, *, scan_root: Path | None) -> Path:
     """Re-anchor the invocation root to the canonical PRIMARY main-checkout.
 
@@ -653,9 +665,7 @@ def teamspace_dry_run(
                         if row_location is not None
                         else None
                     ),
-                    envelope_sha256=hashlib.sha256(  # noqa: TID251 - production raw SHA-256 owner
-                        json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
-                    ).hexdigest(),
+                    envelope_sha256=envelope_sha256(envelope),
                 )
             )
             try:
@@ -1973,6 +1983,12 @@ __all__ = [
     # MissionEventRebuildResult, RepairReport, TeamspaceDryRunRowMapping,
     # deterministic_ulid: demoted — migration-internal; no cross-module
     # src/ from-import callers (WP01 harden-dead-symbol-gate-01KW0RJR).
+    # The ONE sanctioned cross-module surface is migration/envelope_seam.py
+    # (#2262/#2884), which re-exports the shared subset (envelope constants,
+    # deterministic_ulid, envelope_sha256, the status-envelope builder, and the
+    # selection/audit seams) under public names for the import-history
+    # pipeline. Any new cross-module consumer must go through that seam, not
+    # import these internals directly.
     "MissionStateDryRunError",
     "MissionStateRepairError",
     "TeamspaceDryRunReport",

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -23,6 +23,7 @@ from typing import Any, Literal, cast
 from urllib.parse import urlsplit
 
 from packaging.version import Version
+from pydantic import BaseModel, ConfigDict
 
 from specify_cli.core.atomic import atomic_write
 from specify_cli.core.paths import (
@@ -835,7 +836,50 @@ def _load_events_contract() -> tuple[type[Any], Any, str]:
     return Event, validate_event, str(package_version)
 
 
-# canonical-producer-exempt: #2891 -- the ONE TeamSpace replay-envelope shell.
+class _TeamspaceEnvelope(BaseModel):
+    """The SINGLE TeamSpace replay-envelope shape (#2891, CP001/CP002 #2884).
+
+    The migration ``WPStatusChanged`` builder and the history-import
+    creation-prefix builder (``sync.history_import.synthesize._envelope``, via
+    the ``envelope_seam`` re-export) both assemble the identical 15-key envelope.
+    This model is their one owner, so a new envelope-level field cannot be added
+    to one producer and silently forgotten in the other -- ``extra="forbid"``
+    turns a mismatched key set into a construction-time error instead of a
+    silent drift. Callers compute the field VALUES (``build_id`` /
+    ``correlation_id`` / ... differ per producer); the KEY SET and
+    ``schema_version`` live here.
+
+    Fields deliberately keep their raw wire types (``str`` for ``timestamp``
+    and ``project_uuid``, not ``datetime``/``UUID``): this is a structural
+    shape guard for the replay/synthesis producers, not the
+    ``spec_kitty_events.Event`` wire contract (that separate validation
+    already happens via ``event_cls.model_validate(envelope)`` in
+    ``teamspace_dry_run``). Constructing through ``Event`` here instead would
+    silently drop ``aggregate_type``/``repo_slug`` -- fields ``Event`` does not
+    declare -- and coerce ``timestamp``/``project_uuid`` to
+    ``datetime``/``UUID``, changing the on-wire envelope shape asserted by
+    ``tests/sync/test_history_import_synthesize.py``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    event_id: str
+    event_type: str
+    aggregate_id: str
+    aggregate_type: str
+    payload: dict[str, Any]
+    timestamp: str
+    build_id: str
+    node_id: str
+    lamport_clock: int
+    causation_id: str | None = None
+    project_uuid: str
+    project_slug: str
+    repo_slug: str | None
+    correlation_id: str
+    schema_version: str = CANONICAL_ENVELOPE_SCHEMA_VERSION
+
+
 def _build_teamspace_envelope(
     *,
     event_id: str,
@@ -852,35 +896,31 @@ def _build_teamspace_envelope(
     repo_slug: str | None,
     correlation_id: str,
     causation_id: str | None = None,
-) -> dict[str, Any]:
-    """The SINGLE TeamSpace replay-envelope shell (#2891).
+) -> _TeamspaceEnvelope:
+    """Construct the SINGLE TeamSpace replay-envelope shell (#2891).
 
-    The migration ``WPStatusChanged`` builder and the history-import
-    creation-prefix builder (``sync.history_import.synthesize._envelope``, via
-    the ``envelope_seam`` re-export) both assemble the identical 15-key envelope.
-    This is their one owner, so a new envelope-level field cannot be added to one
-    producer and silently forgotten in the other. Callers compute the field
-    VALUES (``build_id`` / ``correlation_id`` / ... differ per producer); the KEY
-    SET and ``schema_version`` live here. Replay/synthesis producers, not
-    live-path emitters — hence canonical-producer-exempt.
+    Callers that need the wire-format dict (JSONL rows, hashing, upload
+    payloads) call ``.model_dump()`` at their own serialization boundary --
+    this builder's job is only to close the "hand-rolled dict, key typo, or
+    forgotten key" defect class by construction.
     """
-    return {
-        "event_id": event_id,
-        "event_type": event_type,
-        "aggregate_id": aggregate_id,
-        "aggregate_type": aggregate_type,
-        "payload": payload,
-        "timestamp": timestamp,
-        "build_id": build_id,
-        "node_id": node_id,
-        "lamport_clock": lamport_clock,
-        "causation_id": causation_id,
-        "project_uuid": project_uuid,
-        "project_slug": project_slug,
-        "repo_slug": repo_slug,
-        "correlation_id": correlation_id,
-        "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
-    }
+    return _TeamspaceEnvelope(
+        event_id=event_id,
+        event_type=event_type,
+        aggregate_id=aggregate_id,
+        aggregate_type=aggregate_type,
+        payload=payload,
+        timestamp=timestamp,
+        build_id=build_id,
+        node_id=node_id,
+        lamport_clock=lamport_clock,
+        causation_id=causation_id,
+        project_uuid=project_uuid,
+        project_slug=project_slug,
+        repo_slug=repo_slug,
+        correlation_id=correlation_id,
+        schema_version=CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    )
 
 
 # canonical-producer-exempt: #1198 -- historical migration-replay envelope builder.
@@ -935,7 +975,7 @@ def _status_event_to_teamspace_envelope(
         correlation_id=deterministic_ulid(
             f"teamspace-dry-run:{status_event.mission_slug}:{status_event.event_id}"
         ),
-    )
+    ).model_dump()
 
 
 def _historical_teamspace_evidence(

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -835,6 +835,54 @@ def _load_events_contract() -> tuple[type[Any], Any, str]:
     return Event, validate_event, str(package_version)
 
 
+# canonical-producer-exempt: #2891 -- the ONE TeamSpace replay-envelope shell.
+def _build_teamspace_envelope(
+    *,
+    event_id: str,
+    event_type: str,
+    aggregate_id: str,
+    aggregate_type: str,
+    payload: dict[str, Any],
+    timestamp: str,
+    build_id: str,
+    node_id: str,
+    lamport_clock: int,
+    project_uuid: str,
+    project_slug: str,
+    repo_slug: str | None,
+    correlation_id: str,
+    causation_id: str | None = None,
+) -> dict[str, Any]:
+    """The SINGLE TeamSpace replay-envelope shell (#2891).
+
+    The migration ``WPStatusChanged`` builder and the history-import
+    creation-prefix builder (``sync.history_import.synthesize._envelope``, via
+    the ``envelope_seam`` re-export) both assemble the identical 15-key envelope.
+    This is their one owner, so a new envelope-level field cannot be added to one
+    producer and silently forgotten in the other. Callers compute the field
+    VALUES (``build_id`` / ``correlation_id`` / ... differ per producer); the KEY
+    SET and ``schema_version`` live here. Replay/synthesis producers, not
+    live-path emitters — hence canonical-producer-exempt.
+    """
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "aggregate_id": aggregate_id,
+        "aggregate_type": aggregate_type,
+        "payload": payload,
+        "timestamp": timestamp,
+        "build_id": build_id,
+        "node_id": node_id,
+        "lamport_clock": lamport_clock,
+        "causation_id": causation_id,
+        "project_uuid": project_uuid,
+        "project_slug": project_slug,
+        "repo_slug": repo_slug,
+        "correlation_id": correlation_id,
+        "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    }
+
+
 # canonical-producer-exempt: #1198 -- historical migration-replay envelope builder.
 def _status_event_to_teamspace_envelope(
     status_event: StatusEvent,
@@ -871,25 +919,23 @@ def _status_event_to_teamspace_envelope(
         "review_ref": status_event.review_ref,
         "evidence": evidence,
     }
-    return {  # canonical-producer-exempt: #1198 — see function-level comment
-        "event_id": status_event.event_id,
-        "event_type": "WPStatusChanged",
-        "aggregate_id": status_event.wp_id,
-        "aggregate_type": "WorkPackage",
-        "payload": payload,
-        "timestamp": status_event.at,
-        "build_id": "mission-state-dry-run",
-        "node_id": "mission-state-dry-run",
-        "lamport_clock": lamport_clock,
-        "causation_id": None,
-        "project_uuid": str(project_uuid),
-        "project_slug": project_slug,
-        "repo_slug": repo_slug,
-        "correlation_id": deterministic_ulid(
+    return _build_teamspace_envelope(
+        event_id=status_event.event_id,
+        event_type="WPStatusChanged",
+        aggregate_id=status_event.wp_id,
+        aggregate_type="WorkPackage",
+        payload=payload,
+        timestamp=status_event.at,
+        build_id="mission-state-dry-run",
+        node_id="mission-state-dry-run",
+        lamport_clock=lamport_clock,
+        project_uuid=str(project_uuid),
+        project_slug=project_slug,
+        repo_slug=repo_slug,
+        correlation_id=deterministic_ulid(
             f"teamspace-dry-run:{status_event.mission_slug}:{status_event.event_id}"
         ),
-        "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
-    }
+    )
 
 
 def _historical_teamspace_evidence(

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -187,7 +187,10 @@ from .aggregate import (
     MissionStatus,
 )
 from .lifecycle_events import (
+    FOLLOW_UP_RECORDED,
     LIFECYCLE_EVENT_TYPES,
+    MISSION_CREATED,
+    MISSION_REOPENED,
     PLAN_COMPLETED,
     PLAN_STARTED,
     REVIEWER_SELF_APPROVAL,
@@ -195,6 +198,7 @@ from .lifecycle_events import (
     SPECIFY_STARTED,
     TASKS_COMPLETED,
     TASKS_STARTED,
+    WP_CREATED,
     MissionNotCompletedError,
     build_saas_lifecycle_queue_event,
     emit_artifact_phase,
@@ -205,6 +209,8 @@ from .lifecycle_events import (
     emit_reviewer_self_approval,
     emit_wp_created_local,
     has_non_bootstrap_status_history,
+    mission_event_log_path,
+    read_lifecycle_events,
     repo_root_for_lifecycle_log,
 )
 from .views import (
@@ -278,6 +284,12 @@ __all__ = [
     "InvalidMissionSlug",
     "MissionMetadataUnavailable",
     "LIFECYCLE_EVENT_TYPES",
+    "FOLLOW_UP_RECORDED",
+    "MISSION_CREATED",
+    "MISSION_REOPENED",
+    "WP_CREATED",
+    "mission_event_log_path",
+    "read_lifecycle_events",
     "MissionStatus",
     "PLAN_COMPLETED",
     "PLAN_STARTED",

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -189,6 +189,7 @@ from .aggregate import (
 from .lifecycle_events import (
     FOLLOW_UP_RECORDED,
     LIFECYCLE_EVENT_TYPES,
+    LOCAL_ONLY_LIFECYCLE_EVENT_TYPES,
     MISSION_CREATED,
     MISSION_REOPENED,
     PLAN_COMPLETED,
@@ -284,6 +285,7 @@ __all__ = [
     "InvalidMissionSlug",
     "MissionMetadataUnavailable",
     "LIFECYCLE_EVENT_TYPES",
+    "LOCAL_ONLY_LIFECYCLE_EVENT_TYPES",
     "FOLLOW_UP_RECORDED",
     "MISSION_CREATED",
     "MISSION_REOPENED",

--- a/src/specify_cli/status/lifecycle.py
+++ b/src/specify_cli/status/lifecycle.py
@@ -17,6 +17,7 @@ from typing import Any
 from specify_cli.mission_metadata import load_meta, resolve_mission_identity
 from specify_cli.status.lifecycle_events import (
     FOLLOW_UP_RECORDED,
+    LOCAL_ONLY_LIFECYCLE_EVENT_TYPES,
     MISSION_REOPENED,
     mission_event_log_path,
     read_lifecycle_events,
@@ -162,7 +163,9 @@ def _derive_last_transition_at(snapshot: StatusSnapshot) -> datetime | None:
     return _parse_dt(snapshot.materialized_at)
 
 
-_POST_MISSION_EVENT_TYPES = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+# Post-mission events (reopen / follow-up) ARE the local-only lifecycle set by
+# design; alias the single public owner rather than re-declaring the membership.
+_POST_MISSION_EVENT_TYPES = LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
 
 
 def _event_sort_key(event: dict[str, Any]) -> tuple[str, str]:

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -96,6 +96,16 @@ REVIEWER_SELF_APPROVAL = "ReviewerSelfApproval"
 MISSION_REOPENED = "MissionReopened"
 FOLLOW_UP_RECORDED = "FollowUpRecorded"
 
+# The lifecycle event types that are LOCAL-ONLY: emitted after a mission's active
+# lifecycle (reopen / follow-up) and deliberately kept OFF the SaaS strict-
+# validation delivery path. The SINGLE public owner of this membership (#2884),
+# consumed by the post-mission ordering in ``status/lifecycle.py`` and the import
+# scan in ``sync/history_import/scan.py`` — replacing two hand-mirrored frozenset
+# copies. NOTE: this is NOT the installed ``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES``,
+# which is empty in the package while both types ARE in its model map, so trusting
+# it would let these reach strict validation and reject the whole batch.
+LOCAL_ONLY_LIFECYCLE_EVENT_TYPES = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+
 LIFECYCLE_EVENT_TYPES = frozenset({
     PROJECT_INITIALIZED,
     MISSION_CREATED,

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -266,7 +266,12 @@ def _validate_lifecycle_payload(event_type: str, payload: Mapping[str, Any]) -> 
 
     Local-only event types (``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES``)
     skip strict validation by design — the set is currently empty but
-    reserved for future internal-only event types.
+    reserved for future internal-only event types. The local
+    :data:`LOCAL_ONLY_LIFECYCLE_EVENT_TYPES` SSOT is also consulted here
+    (#2884): it is the actual enforcement point for the "kept OFF the SaaS
+    strict-validation path" invariant its own docstring claims, since the
+    external set does not yet cover ``MissionReopened`` / ``FollowUpRecorded``
+    even though both are present in ``_EVENT_TYPE_TO_MODEL``.
 
     Unknown event types (event_type not in ``_EVENT_TYPE_TO_MODEL``) pass
     through quietly so unrecognised types don't become sudden hard
@@ -277,7 +282,7 @@ def _validate_lifecycle_payload(event_type: str, payload: Mapping[str, Any]) -> 
     from spec_kitty_events.conformance import validate_event
     from spec_kitty_events.conformance.validators import _EVENT_TYPE_TO_MODEL
 
-    if event_type in LOCAL_ONLY_EVENT_TYPES:
+    if event_type in LOCAL_ONLY_EVENT_TYPES or event_type in LOCAL_ONLY_LIFECYCLE_EVENT_TYPES:
         return
 
     if event_type not in _EVENT_TYPE_TO_MODEL:

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -32,10 +32,21 @@ from specify_cli.sync.history_import.identity import (
     resolve_import_identity,
 )
 from specify_cli.sync.history_import.pipeline import (
+    ApplyResult,
     ImportAuditBlocked,
     ImportPlan,
+    apply_import,
     build_import_plan,
     describe_plan,
+)
+from specify_cli.sync.history_import.upload import (
+    PreflightRejected,
+    ProvenanceEntry,
+    UploadReport,
+    build_provenance_manifest,
+    run_import_upload,
+    run_server_preflight,
+    upload_envelopes,
 )
 from specify_cli.sync.history_import.scan import (
     MissionScan,
@@ -51,19 +62,28 @@ from specify_cli.sync.history_import.synthesize import (
 )
 
 __all__ = [
+    "ApplyResult",
     "ImportAuditBlocked",
     "ImportIdentity",
     "ImportIdentityError",
     "ImportPlan",
     "MissionScan",
     "PrefixSource",
+    "PreflightRejected",
+    "ProvenanceEntry",
     "ScannedWorkPackage",
+    "UploadReport",
+    "apply_import",
     "build_import_plan",
+    "build_provenance_manifest",
     "describe_plan",
     "dry_run_project_uuid",
     "resolve_import_identity",
+    "run_import_upload",
+    "run_server_preflight",
     "scan_mission",
     "scan_missions",
     "synthesize_mission_stream",
     "synthesize_streams",
+    "upload_envelopes",
 ]

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -50,6 +50,7 @@ from specify_cli.sync.history_import.upload import (
 )
 from specify_cli.sync.history_import.scan import (
     MissionScan,
+    MissionScanError,
     PrefixSource,
     ScannedWorkPackage,
     scan_mission,
@@ -68,6 +69,7 @@ __all__ = [
     "ImportIdentityError",
     "ImportPlan",
     "MissionScan",
+    "MissionScanError",
     "PrefixSource",
     "PreflightRejected",
     "ImportProvenanceEntry",

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -41,7 +41,7 @@ from specify_cli.sync.history_import.pipeline import (
 )
 from specify_cli.sync.history_import.upload import (
     PreflightRejected,
-    ProvenanceEntry,
+    ImportProvenanceEntry,
     UploadReport,
     build_provenance_manifest,
     run_import_upload,
@@ -70,7 +70,7 @@ __all__ = [
     "MissionScan",
     "PrefixSource",
     "PreflightRejected",
-    "ProvenanceEntry",
+    "ImportProvenanceEntry",
     "ScannedWorkPackage",
     "UploadReport",
     "apply_import",

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -1,0 +1,35 @@
+"""Historical-import pipeline for ``spec-kitty sync import-history`` (#2262).
+
+A first sync registers a remote project/build but leaves it with zero
+materialized missions — the SaaS materializer refuses to fabricate a
+WorkPackage from a status event with no prior create. This package emits the
+missing ``MissionCreated → WPCreated[] → WPStatusChanged[]`` prefix so
+historical local work populates the projection.
+
+Stages (see issue #2262 §3.3):
+
+* WP-Y2 — :mod:`.scan`: the hybrid SCAN — read the on-disk lifecycle prefix
+  where present, synthesize it from ``meta.json`` + ``tasks/WP*.md`` where
+  absent, and drop local-only lifecycle events.
+
+Later slices add SYNTHESIZE (ordered deterministic envelope stream),
+PROVENANCE, PREFLIGHT, UPLOAD, and REPORT.
+"""
+
+from __future__ import annotations
+
+from specify_cli.sync.history_import.scan import (
+    MissionScan,
+    PrefixSource,
+    ScannedWorkPackage,
+    scan_mission,
+    scan_missions,
+)
+
+__all__ = [
+    "MissionScan",
+    "PrefixSource",
+    "ScannedWorkPackage",
+    "scan_mission",
+    "scan_missions",
+]

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -14,12 +14,20 @@ Stages (see issue #2262 §3.3):
 * WP-Y3 — :mod:`.synthesize`: turn a :class:`MissionScan` into the ordered,
   deterministic ``MissionCreated → WPCreated[] → WPStatusChanged[]`` envelope
   stream (INV-3 / INV-4).
+* WP-Y4 — :mod:`.identity`: resolve the ``(project_uuid, project_slug,
+  repo_slug)`` trio — real persisted UUID on ``--apply`` (INV-5), synthetic
+  offline UUID for dry-run, never persisting on the read path (INV-2).
 
 Later slices add PROVENANCE, PREFLIGHT, UPLOAD, and REPORT.
 """
 
 from __future__ import annotations
 
+from specify_cli.sync.history_import.identity import (
+    ImportIdentity,
+    ImportIdentityError,
+    resolve_import_identity,
+)
 from specify_cli.sync.history_import.scan import (
     MissionScan,
     PrefixSource,
@@ -34,10 +42,13 @@ from specify_cli.sync.history_import.synthesize import (
 )
 
 __all__ = [
+    "ImportIdentity",
+    "ImportIdentityError",
     "MissionScan",
     "PrefixSource",
     "ScannedWorkPackage",
     "dry_run_project_uuid",
+    "resolve_import_identity",
     "scan_mission",
     "scan_missions",
     "synthesize_mission_stream",

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -11,9 +11,11 @@ Stages (see issue #2262 §3.3):
 * WP-Y2 — :mod:`.scan`: the hybrid SCAN — read the on-disk lifecycle prefix
   where present, synthesize it from ``meta.json`` + ``tasks/WP*.md`` where
   absent, and drop local-only lifecycle events.
+* WP-Y3 — :mod:`.synthesize`: turn a :class:`MissionScan` into the ordered,
+  deterministic ``MissionCreated → WPCreated[] → WPStatusChanged[]`` envelope
+  stream (INV-3 / INV-4).
 
-Later slices add SYNTHESIZE (ordered deterministic envelope stream),
-PROVENANCE, PREFLIGHT, UPLOAD, and REPORT.
+Later slices add PROVENANCE, PREFLIGHT, UPLOAD, and REPORT.
 """
 
 from __future__ import annotations
@@ -25,11 +27,19 @@ from specify_cli.sync.history_import.scan import (
     scan_mission,
     scan_missions,
 )
+from specify_cli.sync.history_import.synthesize import (
+    dry_run_project_uuid,
+    synthesize_mission_stream,
+    synthesize_streams,
+)
 
 __all__ = [
     "MissionScan",
     "PrefixSource",
     "ScannedWorkPackage",
+    "dry_run_project_uuid",
     "scan_mission",
     "scan_missions",
+    "synthesize_mission_stream",
+    "synthesize_streams",
 ]

--- a/src/specify_cli/sync/history_import/__init__.py
+++ b/src/specify_cli/sync/history_import/__init__.py
@@ -17,6 +17,9 @@ Stages (see issue #2262 §3.3):
 * WP-Y4 — :mod:`.identity`: resolve the ``(project_uuid, project_slug,
   repo_slug)`` trio — real persisted UUID on ``--apply`` (INV-5), synthetic
   offline UUID for dry-run, never persisting on the read path (INV-2).
+* :mod:`.pipeline`: ``build_import_plan`` runs SELECT → AUDIT → SCAN →
+  IDENTITY → SYNTHESIZE and returns the :class:`ImportPlan` both ``--dry-run``
+  and ``--apply`` consume.
 
 Later slices add PROVENANCE, PREFLIGHT, UPLOAD, and REPORT.
 """
@@ -27,6 +30,12 @@ from specify_cli.sync.history_import.identity import (
     ImportIdentity,
     ImportIdentityError,
     resolve_import_identity,
+)
+from specify_cli.sync.history_import.pipeline import (
+    ImportAuditBlocked,
+    ImportPlan,
+    build_import_plan,
+    describe_plan,
 )
 from specify_cli.sync.history_import.scan import (
     MissionScan,
@@ -42,11 +51,15 @@ from specify_cli.sync.history_import.synthesize import (
 )
 
 __all__ = [
+    "ImportAuditBlocked",
     "ImportIdentity",
     "ImportIdentityError",
+    "ImportPlan",
     "MissionScan",
     "PrefixSource",
     "ScannedWorkPackage",
+    "build_import_plan",
+    "describe_plan",
     "dry_run_project_uuid",
     "resolve_import_identity",
     "scan_mission",

--- a/src/specify_cli/sync/history_import/identity.py
+++ b/src/specify_cli/sync/history_import/identity.py
@@ -1,0 +1,119 @@
+"""IDENTITY resolution for ``sync import-history`` (WP-Y4, #2262).
+
+Resolves the ``(project_uuid, project_slug, repo_slug)`` trio the SYNTHESIZE
+stage stamps onto every envelope, honoring the mint-boundary invariants:
+
+* **INV-2 (single mint boundary):** project identity is *persisted* only at a
+  write-authorized boundary. The dry-run path is read-only
+  (:func:`resolve_identity` never writes ``.kittify/config.yaml``); ``--apply``
+  is the authorized boundary that may mint+persist via :func:`ensure_identity`.
+* **INV-5 (real UUID on apply):** ``--apply`` uploads under the persisted real
+  ``project_uuid``. The synthetic offline ``uuid5`` is dry-run-only and, by
+  construction here, can never be produced on the apply path.
+
+The stale "add ``persist_identity``" note in the issue §4 predates #1916, which
+added :func:`resolve_identity` — the read-only counterpart of
+:func:`ensure_identity`. We reuse that canonical seam rather than add a parallel
+persist path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from collections.abc import Sequence
+
+from specify_cli.identity.project import (
+    ensure_identity,
+    is_writable,
+    load_identity,
+    resolve_identity,
+)
+from specify_cli.sync.history_import.synthesize import dry_run_project_uuid
+
+_CONFIG_RELPATH = Path(".kittify") / "config.yaml"
+
+
+class ImportIdentityError(RuntimeError):
+    """Raised when ``--apply`` cannot obtain a persisted real project UUID.
+
+    Fail-closed (INV-5/INV-6): the import must never upload historical events
+    under an ephemeral or synthetic identity.
+    """
+
+
+@dataclass(frozen=True)
+class ImportIdentity:
+    """The project-identity trio threaded into every synthesized envelope."""
+
+    project_uuid: uuid.UUID
+    project_slug: str
+    repo_slug: str
+    is_synthetic: bool
+
+
+def resolve_import_identity(
+    repo_root: Path,
+    mission_slugs: Sequence[str],
+    *,
+    apply: bool,
+) -> ImportIdentity:
+    """Resolve the identity trio for an import run.
+
+    * ``--apply`` → the persisted real ``project_uuid`` (minting+persisting once
+      at this authorized boundary if the checkout is uninitialized, else failing
+      closed). Never synthetic.
+    * dry-run → the persisted real UUID when the checkout is initialized, else a
+      synthetic offline ``uuid5`` for schema-only preview. Never persists.
+    """
+    persisted = resolve_identity(repo_root)  # read-only; never writes config
+    project_slug = persisted.project_slug or repo_root.resolve().name
+    repo_slug = persisted.repo_slug or project_slug
+
+    if apply:
+        return ImportIdentity(
+            project_uuid=_real_uuid_for_apply(repo_root, persisted.project_uuid),
+            project_slug=project_slug,
+            repo_slug=repo_slug,
+            is_synthetic=False,
+        )
+
+    if persisted.project_uuid is not None:
+        return ImportIdentity(
+            project_uuid=persisted.project_uuid,
+            project_slug=project_slug,
+            repo_slug=repo_slug,
+            is_synthetic=False,
+        )
+
+    return ImportIdentity(
+        project_uuid=dry_run_project_uuid(mission_slugs),
+        project_slug=project_slug,
+        repo_slug=repo_slug,
+        is_synthetic=True,
+    )
+
+
+def _real_uuid_for_apply(repo_root: Path, persisted_uuid: uuid.UUID | None) -> uuid.UUID:
+    """Return the persisted real project UUID for ``--apply``, or fail closed.
+
+    An already-initialized checkout returns its persisted UUID with no mint
+    (INV-2). A truly-uninitialized checkout mints+persists once here (the
+    authorized boundary) and re-reads to confirm the write landed — refusing to
+    proceed under an ephemeral identity that a re-run could not reproduce.
+    """
+    if persisted_uuid is not None:
+        return persisted_uuid
+
+    config_path = repo_root / _CONFIG_RELPATH
+    if not is_writable(config_path):
+        raise ImportIdentityError(
+            "cannot persist a project identity (config.yaml is not writable); run `spec-kitty init` in this checkout before importing history"
+        )
+
+    ensure_identity(repo_root)  # mints + persists at this authorized boundary
+    minted: uuid.UUID | None = load_identity(config_path).project_uuid
+    if minted is None:
+        raise ImportIdentityError("project identity did not persist; refusing to upload under an ephemeral UUID that a re-run could not reproduce")
+    return minted

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -50,6 +50,13 @@ class MissionSummary:
     prefix_source: str
     wp_count: int
     status_count: int
+    # Malformed-frontmatter WP files the scan skipped (fail-loud, B3/#2884):
+    # these MUST render in the report so skips never read as clean success.
+    skipped_wp_files: tuple[str, ...] = ()
+
+    @property
+    def skipped_wp_count(self) -> int:
+        return len(self.skipped_wp_files)
 
 
 @dataclass(frozen=True)
@@ -75,6 +82,11 @@ class ImportPlan:
     def total_events(self) -> int:
         return len(self.envelopes)
 
+    @property
+    def skipped_wp_total(self) -> int:
+        """Total malformed-frontmatter WP files skipped across all scans."""
+        return sum(len(scan.skipped_wp_files) for scan in self.scans)
+
     def event_type_counts(self) -> dict[str, int]:
         return dict(Counter(str(env["event_type"]) for env in self.envelopes))
 
@@ -85,6 +97,7 @@ class ImportPlan:
                 prefix_source=str(scan.prefix_source),
                 wp_count=len(scan.work_packages),
                 status_count=len(scan.lane_transitions),
+                skipped_wp_files=scan.skipped_wp_files,
             )
             for scan in self.scans
         ]
@@ -165,12 +178,18 @@ def describe_plan(plan: ImportPlan) -> list[str]:
         return ["No missions eligible for import."]
 
     identity_note = " (synthetic offline id — dry-run only)" if plan.identity.is_synthetic else ""
+    # Skips must be impossible to read past: they mark the summary line itself,
+    # not just a footnote (fail-loud, B3/#2884).
+    skipped_note = f" · {plan.skipped_wp_total} WP file(s) SKIPPED" if plan.skipped_wp_total else ""
     lines = [
         f"Import plan for project {plan.identity.project_slug} [{plan.identity.project_uuid}]{identity_note}",
-        f"{plan.mission_count} mission(s) → {plan.total_events} event(s):",
+        f"{plan.mission_count} mission(s) → {plan.total_events} event(s){skipped_note}:",
     ]
     for summary in plan.mission_summaries():
-        lines.append(f"  • {summary.mission_slug}  [{summary.prefix_source}]  {summary.wp_count} WP, {summary.status_count} status")
+        row = f"  • {summary.mission_slug}  [{summary.prefix_source}]  {summary.wp_count} WP, {summary.status_count} status"
+        if summary.skipped_wp_count:
+            row += f" · {summary.skipped_wp_count} WPs SKIPPED (malformed frontmatter: {', '.join(summary.skipped_wp_files)})"
+        lines.append(row)
     counts = plan.event_type_counts()
     breakdown = ", ".join(f"{count} {event_type}" for event_type, count in sorted(counts.items()))
     lines.append(f"events to materialize: {breakdown}")

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -18,9 +18,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from specify_cli.delivery.receivers import DeliveryReceiver, HttpPoster, _requests_post
 from specify_cli.sync.history_import.identity import ImportIdentity, resolve_import_identity
 from specify_cli.sync.history_import.scan import MissionScan, scan_missions
 from specify_cli.sync.history_import.synthesize import synthesize_streams
+from specify_cli.sync.history_import.upload import (
+    ProvenanceEntry,
+    UploadReport,
+    build_provenance_manifest,
+    run_import_upload,
+)
 
 
 class ImportAuditBlocked(RuntimeError):
@@ -113,6 +120,43 @@ def build_import_plan(repo_root: Path, *, mission: str | None, apply: bool) -> I
         )
     )
     return ImportPlan(identity=identity, scans=scans, envelopes=envelopes)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """The outcome of an ``--apply`` run: the plan, its provenance, the upload."""
+
+    plan: ImportPlan
+    manifest: list[ProvenanceEntry]
+    report: UploadReport
+
+
+def apply_import(
+    repo_root: Path,
+    *,
+    mission: str | None,
+    receiver: DeliveryReceiver,
+    server_url: str,
+    auth_token: str,
+    poster: HttpPoster = _requests_post,
+    chunk_size: int | None = None,
+) -> ApplyResult:
+    """Materialize: build the plan (real identity), then preflight + upload.
+
+    Raises :class:`ImportAuditBlocked` / ``MissionStateRepairError`` /
+    ``ImportIdentityError`` (from the plan) or ``PreflightRejected`` (from the
+    server preflight) — all fail-closed before or without a partial upload.
+    """
+    plan = build_import_plan(repo_root, mission=mission, apply=True)
+    if plan.is_empty:
+        return ApplyResult(plan=plan, manifest=[], report=UploadReport())
+
+    manifest = build_provenance_manifest(plan.envelopes)
+    upload_kwargs: dict[str, Any] = {"receiver": receiver, "server_url": server_url, "auth_token": auth_token, "poster": poster}
+    if chunk_size is not None:
+        upload_kwargs["chunk_size"] = chunk_size
+    report = run_import_upload(plan.envelopes, **upload_kwargs)
+    return ApplyResult(plan=plan, manifest=manifest, report=report)
 
 
 def describe_plan(plan: ImportPlan) -> list[str]:

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -1,0 +1,133 @@
+"""Import-history orchestration (#2262).
+
+`build_import_plan` runs the read-only half of the pipeline end to end —
+SELECT → AUDIT (fail-closed) → SCAN → IDENTITY → SYNTHESIZE — and returns an
+:class:`ImportPlan`: the resolved identity, the per-mission scans, and the full
+ordered envelope stream that *would* be uploaded.
+
+Both surfaces share this core: ``--dry-run`` builds the plan and reports it
+(no upload); ``--apply`` builds the plan and hands the envelopes to the upload
+stage (WP-Y5). Keeping the orchestration here keeps the CLI command thin and
+lets the whole plan be tested without the CLI.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from specify_cli.sync.history_import.identity import ImportIdentity, resolve_import_identity
+from specify_cli.sync.history_import.scan import MissionScan, scan_missions
+from specify_cli.sync.history_import.synthesize import synthesize_streams
+
+
+class ImportAuditBlocked(RuntimeError):
+    """Raised when the fail-closed TeamSpace audit finds blocking findings.
+
+    Carries the blocker records (each a dict with at least ``mission_slug`` and
+    ``message``) so the caller can name them without re-running the audit.
+    """
+
+    def __init__(self, blockers: list[dict[str, object]]) -> None:
+        self.blockers = blockers
+        super().__init__(f"{len(blockers)} audit finding(s) must be resolved before import")
+
+
+@dataclass(frozen=True)
+class MissionSummary:
+    """One row of the dry-run preview."""
+
+    mission_slug: str
+    prefix_source: str
+    wp_count: int
+    status_count: int
+
+
+@dataclass(frozen=True)
+class ImportPlan:
+    """The read-only import plan: identity, scans, and the envelope stream.
+
+    ``identity`` is ``None`` only for the empty plan (no eligible missions).
+    """
+
+    identity: ImportIdentity | None
+    scans: tuple[MissionScan, ...]
+    envelopes: tuple[dict[str, Any], ...]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.scans
+
+    @property
+    def mission_count(self) -> int:
+        return len(self.scans)
+
+    @property
+    def total_events(self) -> int:
+        return len(self.envelopes)
+
+    def event_type_counts(self) -> dict[str, int]:
+        return dict(Counter(str(env["event_type"]) for env in self.envelopes))
+
+    def mission_summaries(self) -> list[MissionSummary]:
+        return [
+            MissionSummary(
+                mission_slug=scan.mission_slug,
+                prefix_source=str(scan.prefix_source),
+                wp_count=len(scan.work_packages),
+                status_count=len(scan.lane_transitions),
+            )
+            for scan in self.scans
+        ]
+
+
+def build_import_plan(repo_root: Path, *, mission: str | None, apply: bool) -> ImportPlan:
+    """SELECT → AUDIT → SCAN → IDENTITY → SYNTHESIZE for the selected missions.
+
+    Raises :class:`ImportAuditBlocked` when the fail-closed audit finds blockers,
+    and propagates ``MissionStateRepairError`` from selection. Returns an empty
+    plan (no identity resolved) when nothing is eligible.
+    """
+    # Local import: the migration helpers pull a heavy dependency graph, and
+    # keeping the bind lazy lets tests patch the seams on the source module.
+    from specify_cli.migration.mission_state import _select_mission_dirs, _teamspace_audit_blockers
+
+    mission_dirs = _select_mission_dirs(repo_root, scan_root=None, mission=mission)
+    if not mission_dirs:
+        return ImportPlan(identity=None, scans=(), envelopes=())
+
+    blockers = _teamspace_audit_blockers(repo_root, scan_root=None, mission_dirs=mission_dirs)
+    if blockers:
+        raise ImportAuditBlocked(blockers)
+
+    scans = tuple(scan_missions(mission_dirs))
+    identity = resolve_import_identity(repo_root, [scan.mission_slug for scan in scans], apply=apply)
+    envelopes = tuple(
+        synthesize_streams(
+            scans,
+            project_uuid=identity.project_uuid,
+            project_slug=identity.project_slug,
+            repo_slug=identity.repo_slug,
+        )
+    )
+    return ImportPlan(identity=identity, scans=scans, envelopes=envelopes)
+
+
+def describe_plan(plan: ImportPlan) -> list[str]:
+    """Render the dry-run preview as plain lines (no CLI dependency)."""
+    if plan.is_empty or plan.identity is None:
+        return ["No missions eligible for import."]
+
+    identity_note = " (synthetic offline id — dry-run only)" if plan.identity.is_synthetic else ""
+    lines = [
+        f"Import plan for project {plan.identity.project_slug} [{plan.identity.project_uuid}]{identity_note}",
+        f"{plan.mission_count} mission(s) → {plan.total_events} event(s):",
+    ]
+    for summary in plan.mission_summaries():
+        lines.append(f"  • {summary.mission_slug}  [{summary.prefix_source}]  {summary.wp_count} WP, {summary.status_count} status")
+    counts = plan.event_type_counts()
+    breakdown = ", ".join(f"{count} {event_type}" for event_type, count in sorted(counts.items()))
+    lines.append(f"events to materialize: {breakdown}")
+    return lines

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -23,7 +23,7 @@ from specify_cli.sync.history_import.identity import ImportIdentity, resolve_imp
 from specify_cli.sync.history_import.scan import MissionScan, scan_missions
 from specify_cli.sync.history_import.synthesize import synthesize_streams
 from specify_cli.sync.history_import.upload import (
-    ProvenanceEntry,
+    ImportProvenanceEntry,
     UploadReport,
     build_provenance_manifest,
     run_import_upload,
@@ -127,7 +127,7 @@ class ApplyResult:
     """The outcome of an ``--apply`` run: the plan, its provenance, the upload."""
 
     plan: ImportPlan
-    manifest: list[ProvenanceEntry]
+    manifest: list[ImportProvenanceEntry]
     report: UploadReport
 
 

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -111,14 +111,15 @@ def build_import_plan(repo_root: Path, *, mission: str | None, apply: bool) -> I
     plan (no identity resolved) when nothing is eligible.
     """
     # Local import: the migration helpers pull a heavy dependency graph, and
-    # keeping the bind lazy lets tests patch the seams on the source module.
-    from specify_cli.migration.mission_state import _select_mission_dirs, _teamspace_audit_blockers
+    # keeping the bind lazy lets tests patch the seams on envelope_seam (the
+    # deliberate public surface over migration.mission_state's internals).
+    from specify_cli.migration.envelope_seam import select_mission_dirs, teamspace_audit_blockers
 
-    mission_dirs = _select_mission_dirs(repo_root, scan_root=None, mission=mission)
+    mission_dirs = select_mission_dirs(repo_root, scan_root=None, mission=mission)
     if not mission_dirs:
         return ImportPlan(identity=None, scans=(), envelopes=())
 
-    blockers = _teamspace_audit_blockers(repo_root, scan_root=None, mission_dirs=mission_dirs)
+    blockers = teamspace_audit_blockers(repo_root, scan_root=None, mission_dirs=mission_dirs)
     if blockers:
         raise ImportAuditBlocked(blockers)
 

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from specify_cli.delivery.receivers import DeliveryReceiver, HttpPoster, _requests_post
+from specify_cli.delivery.receivers import DeliveryReceiver, HttpPoster, default_http_poster
 from specify_cli.sync.history_import.identity import ImportIdentity, resolve_import_identity
 from specify_cli.sync.history_import.scan import MissionScan, scan_missions
 from specify_cli.sync.history_import.synthesize import synthesize_streams
@@ -27,6 +27,7 @@ from specify_cli.sync.history_import.upload import (
     UploadReport,
     build_provenance_manifest,
     run_import_upload,
+    validate_import_envelopes,
 )
 
 
@@ -152,7 +153,7 @@ def apply_import(
     receiver: DeliveryReceiver,
     server_url: str,
     auth_token: str,
-    poster: HttpPoster = _requests_post,
+    poster: HttpPoster = default_http_poster,
     chunk_size: int | None = None,
 ) -> ApplyResult:
     """Materialize: build the plan (real identity), then preflight + upload.
@@ -165,6 +166,10 @@ def apply_import(
     if plan.is_empty:
         return ApplyResult(plan=plan, manifest=[], report=UploadReport())
 
+    # Offline defense-in-depth: run the outbound-envelope contract gate over the
+    # real synthesized stream before any upload, consistent with every other
+    # producer (#2884). Raises ContractViolationError, fail-closed, offline.
+    validate_import_envelopes(plan.envelopes)
     manifest = build_provenance_manifest(plan.envelopes)
     upload_kwargs: dict[str, Any] = {"receiver": receiver, "server_url": server_url, "auth_token": auth_token, "poster": poster}
     if chunk_size is not None:

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -54,6 +54,10 @@ class MissionSummary:
     # Malformed-frontmatter WP files the scan skipped (fail-loud, B3/#2884):
     # these MUST render in the report so skips never read as clean success.
     skipped_wp_files: tuple[str, ...] = ()
+    # Malformed/unrecoverable on-disk lifecycle-prefix rows the scan dropped
+    # (truncated JSON, missing wp_id, ...) — same fail-loud contract as
+    # ``skipped_wp_files`` but for the on-disk prefix path (#2884 finding A).
+    skipped_event_rows: int = 0
 
     @property
     def skipped_wp_count(self) -> int:
@@ -88,6 +92,11 @@ class ImportPlan:
         """Total malformed-frontmatter WP files skipped across all scans."""
         return sum(len(scan.skipped_wp_files) for scan in self.scans)
 
+    @property
+    def skipped_event_rows_total(self) -> int:
+        """Total malformed on-disk lifecycle-prefix rows skipped across all scans."""
+        return sum(scan.skipped_event_rows for scan in self.scans)
+
     def event_type_counts(self) -> dict[str, int]:
         return dict(Counter(str(env["event_type"]) for env in self.envelopes))
 
@@ -99,6 +108,7 @@ class ImportPlan:
                 wp_count=len(scan.work_packages),
                 status_count=len(scan.lane_transitions),
                 skipped_wp_files=scan.skipped_wp_files,
+                skipped_event_rows=scan.skipped_event_rows,
             )
             for scan in self.scans
         ]
@@ -187,14 +197,21 @@ def describe_plan(plan: ImportPlan) -> list[str]:
     # Skips must be impossible to read past: they mark the summary line itself,
     # not just a footnote (fail-loud, B3/#2884).
     skipped_note = f" · {plan.skipped_wp_total} WP file(s) SKIPPED" if plan.skipped_wp_total else ""
+    # Same fail-loud contract for the on-disk lifecycle-prefix path (finding A):
+    # a dropped WPCreated/MissionCreated row must mark the summary line too.
+    skipped_event_note = (
+        f" · {plan.skipped_event_rows_total} lifecycle row(s) SKIPPED" if plan.skipped_event_rows_total else ""
+    )
     lines = [
         f"Import plan for project {plan.identity.project_slug} [{plan.identity.project_uuid}]{identity_note}",
-        f"{plan.mission_count} mission(s) → {plan.total_events} event(s){skipped_note}:",
+        f"{plan.mission_count} mission(s) → {plan.total_events} event(s){skipped_note}{skipped_event_note}:",
     ]
     for summary in plan.mission_summaries():
         row = f"  • {summary.mission_slug}  [{summary.prefix_source}]  {summary.wp_count} WP, {summary.status_count} status"
         if summary.skipped_wp_count:
             row += f" · {summary.skipped_wp_count} WPs SKIPPED (malformed frontmatter: {', '.join(summary.skipped_wp_files)})"
+        if summary.skipped_event_rows:
+            row += f" · {summary.skipped_event_rows} lifecycle row(s) SKIPPED (malformed on-disk prefix)"
         lines.append(row)
     counts = plan.event_type_counts()
     breakdown = ", ".join(f"{count} {event_type}" for event_type, count in sorted(counts.items()))

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -30,25 +30,28 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.frontmatter import FrontmatterError
-from specify_cli.status import read_events
-from specify_cli.status.lifecycle_events import (
+
+# Access the status subsystem only through its package facade (the
+# status-module-boundary gate forbids new deep submodule imports).
+from specify_cli.status import (
     FOLLOW_UP_RECORDED,
     MISSION_CREATED,
     MISSION_REOPENED,
     WP_CREATED,
+    StatusEvent,
     mission_event_log_path,
+    read_authored_wp_frontmatter,
+    read_events,
     read_lifecycle_events,
 )
-from specify_cli.status.models import StatusEvent
-from specify_cli.status.wp_metadata import read_authored_wp_frontmatter
 
 logger = logging.getLogger(__name__)
 
 _META_FILENAME = "meta.json"
 _TASKS_DIRNAME = "tasks"
 _DEFAULT_MISSION_TYPE = "software-dev"
-_KITTY_SPECS_ANCHOR = "kitty-specs"
 
 # The lifecycle event types that are deliberately local-only and MUST be kept
 # off the SaaS strict-validation path (status/lifecycle.py:165). We mirror that
@@ -267,8 +270,8 @@ def _ensure_wp_coverage(
 def _repo_relative_path(path: Path) -> str | None:
     """Return the POSIX ``kitty-specs/...`` path, matching the on-disk shape."""
     parts = path.parts
-    if _KITTY_SPECS_ANCHOR in parts:
-        return "/".join(parts[parts.index(_KITTY_SPECS_ANCHOR) :])
+    if KITTY_SPECS_DIR in parts:
+        return "/".join(parts[parts.index(KITTY_SPECS_DIR) :])
     return None
 
 

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -114,6 +114,10 @@ class MissionScan:
     prefix_source: PrefixSource
     work_packages: tuple[ScannedWorkPackage, ...]
     lane_transitions: tuple[StatusEvent, ...]
+    # WP files skipped for malformed/unreadable frontmatter (file names).
+    # Fail-loud, not fail-closed: the scan survives, but the skips MUST reach
+    # the operator-facing report so a partial import never reads as clean.
+    skipped_wp_files: tuple[str, ...] = ()
 
 
 # ── public API ───────────────────────────────────────────────────────────────
@@ -130,7 +134,10 @@ def scan_mission(mission_dir: Path) -> MissionScan:
     prefix_source = PrefixSource.ON_DISK if mc_payload is not None else PrefixSource.SYNTHESIZED
     fields = _resolve_mission_fields(mission_dir, meta, mc_payload)
 
-    work_packages = _wps_from_prefix(wp_payloads) if wp_payloads else _wps_from_task_files(mission_dir)
+    if wp_payloads:
+        work_packages, skipped_wp_files = _wps_from_prefix(wp_payloads), ()
+    else:
+        work_packages, skipped_wp_files = _wps_from_task_files(mission_dir)
 
     try:
         lane_transitions = tuple(read_events(mission_dir))
@@ -144,6 +151,7 @@ def scan_mission(mission_dir: Path) -> MissionScan:
         prefix_source=prefix_source,
         work_packages=work_packages,
         lane_transitions=lane_transitions,
+        skipped_wp_files=skipped_wp_files,
         **fields,
     )
 
@@ -216,17 +224,21 @@ def _wps_from_prefix(wp_payloads: Sequence[Mapping[str, Any]]) -> tuple[ScannedW
     return tuple(wps)
 
 
-def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
+def _wps_from_task_files(mission_dir: Path) -> tuple[tuple[ScannedWorkPackage, ...], tuple[str, ...]]:
     """Synthesize WPs from ``tasks/WP*.md`` frontmatter (canonical, §3.4/§6).
 
-    Files with unreadable or invalid frontmatter are skipped here; any WP a
-    lane transition still references is back-filled minimally by
+    Returns ``(work_packages, skipped_wp_files)``. Files with unreadable or
+    invalid frontmatter are skipped — but never silently: the skipped file
+    names are returned so the scan result carries them into the operator-facing
+    report (fail-loud, the #2884 review's chosen design over fail-closed). Any
+    WP a lane transition still references is back-filled minimally by
     :func:`_ensure_wp_coverage`, so INV-3 coverage holds regardless.
     """
     tasks_dir = mission_dir / _TASKS_DIRNAME
     if not tasks_dir.is_dir():
-        return ()
+        return (), ()
     wps: list[ScannedWorkPackage] = []
+    skipped: list[str] = []
     for wp_file in sorted(tasks_dir.glob("WP*.md")):
         try:
             metadata, _ = read_authored_wp_frontmatter(wp_file)
@@ -236,9 +248,11 @@ def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
             # frontmatter/validation errors to the structural ones a malformed
             # doc can raise before validation (e.g. a YAML-list frontmatter →
             # TypeError) — the #2883 items 3/4 concern, applied to this reader.
-            # Skip here; _ensure_wp_coverage back-fills any WP a lane transition
-            # still references, so INV-3 coverage holds.
+            # Skip here (recorded, surfaced in the report); _ensure_wp_coverage
+            # back-fills any WP a lane transition still references, so INV-3
+            # coverage holds.
             logger.warning("import-history: skipping unreadable WP file %s: %s", wp_file, exc)
+            skipped.append(wp_file.name)
             continue
         wps.append(
             ScannedWorkPackage(
@@ -250,7 +264,7 @@ def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
                 source=PrefixSource.SYNTHESIZED,
             )
         )
-    return tuple(wps)
+    return tuple(wps), tuple(skipped)
 
 
 def _ensure_wp_coverage(

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -1,0 +1,307 @@
+"""Hybrid SCAN stage for ``sync import-history`` (WP-Y2, #2262).
+
+Produces a normalized, source-agnostic view of one mission's importable
+history: the mission-creation facts, the work-package definitions, and the
+lane transitions — with local-only lifecycle events dropped so they never
+reach the SaaS strict-validation path.
+
+The stage is *hybrid* (issue #2262 §3.4). Both shapes were adjudicated against
+real event logs:
+
+* **Prefixed missions** carry a ``MissionCreated``/``WPCreated`` prefix in
+  ``status.events.jsonl`` — read it from disk.
+* **Legacy missions** carry only lane transitions — synthesize the prefix from
+  ``meta.json`` + ``tasks/WP*.md`` frontmatter.
+
+This module reads only; it never writes, uploads, or mints envelopes. WP-Y3
+turns a :class:`MissionScan` into the ordered, deterministic envelope stream
+(INV-3 / INV-4).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from specify_cli.frontmatter import FrontmatterError
+from specify_cli.status import read_events
+from specify_cli.status.lifecycle_events import (
+    FOLLOW_UP_RECORDED,
+    MISSION_CREATED,
+    MISSION_REOPENED,
+    WP_CREATED,
+    mission_event_log_path,
+    read_lifecycle_events,
+)
+from specify_cli.status.models import StatusEvent
+from specify_cli.status.wp_metadata import read_authored_wp_frontmatter
+
+logger = logging.getLogger(__name__)
+
+_META_FILENAME = "meta.json"
+_TASKS_DIRNAME = "tasks"
+_DEFAULT_MISSION_TYPE = "software-dev"
+_KITTY_SPECS_ANCHOR = "kitty-specs"
+
+# The lifecycle event types that are deliberately local-only and MUST be kept
+# off the SaaS strict-validation path (status/lifecycle.py:165). We mirror that
+# set from the public constants rather than trusting
+# ``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES``, which is empty in the installed
+# package while both types ARE in its model map — so relying on it would let
+# these hit strict validation and reject the whole batch.
+_LOCAL_ONLY_EVENT_TYPES = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+
+
+class PrefixSource(StrEnum):
+    """Where a mission's (or WP's) creation prefix was resolved from."""
+
+    ON_DISK = "on_disk"
+    SYNTHESIZED = "synthesized"
+
+
+@dataclass(frozen=True)
+class ScannedWorkPackage:
+    """A work package to be created in the projection, source-tagged."""
+
+    wp_id: str
+    wp_title: str
+    depends_on: tuple[str, ...]
+    wp_path: str | None
+    created_at: str | None
+    source: PrefixSource
+
+
+@dataclass(frozen=True)
+class MissionScan:
+    """Normalized importable history for one mission.
+
+    ``work_packages`` is guaranteed to cover every ``wp_id`` referenced by
+    ``lane_transitions`` (a minimal synthesized WP is added for any gap), so a
+    downstream ``WPStatusChanged`` can never precede its ``WPCreated`` (INV-3).
+    """
+
+    mission_slug: str
+    canonical_mission_id: str | None
+    mission_number: int | None
+    name: str
+    mission_type: str
+    purpose_tldr: str | None
+    purpose_context: str | None
+    target_branch: str | None
+    created_at: str | None
+    prefix_source: PrefixSource
+    work_packages: tuple[ScannedWorkPackage, ...]
+    lane_transitions: tuple[StatusEvent, ...]
+
+
+# ── public API ───────────────────────────────────────────────────────────────
+
+
+def scan_mission(mission_dir: Path) -> MissionScan:
+    """Scan one mission directory into a normalized :class:`MissionScan`."""
+    meta = _load_meta(mission_dir)
+    lifecycle = _read_importable_lifecycle(mission_dir)
+
+    mc_payload = _first_payload(lifecycle, MISSION_CREATED)
+    wp_payloads = _payloads(lifecycle, WP_CREATED)
+
+    prefix_source = PrefixSource.ON_DISK if mc_payload is not None else PrefixSource.SYNTHESIZED
+    fields = _resolve_mission_fields(mission_dir, meta, mc_payload)
+
+    work_packages = _wps_from_prefix(wp_payloads) if wp_payloads else _wps_from_task_files(mission_dir)
+
+    lane_transitions = tuple(read_events(mission_dir))
+    work_packages = _ensure_wp_coverage(work_packages, lane_transitions)
+
+    return MissionScan(
+        prefix_source=prefix_source,
+        work_packages=work_packages,
+        lane_transitions=lane_transitions,
+        **fields,
+    )
+
+
+def scan_missions(mission_dirs: Sequence[Path]) -> list[MissionScan]:
+    """Scan several mission directories, preserving input order."""
+    return [scan_mission(mission_dir) for mission_dir in mission_dirs]
+
+
+# ── mission-level resolution ──────────────────────────────────────────────────
+
+
+def _resolve_mission_fields(
+    mission_dir: Path,
+    meta: Mapping[str, Any],
+    mc_payload: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve the ``MissionCreated`` fields, preferring the on-disk payload.
+
+    Falls back to ``meta.json`` per the issue #2262 §3.4 field map; a legacy
+    ``source_description`` back-fills ``purpose_tldr`` when no richer purpose
+    text is present.
+    """
+    mission_slug = _coalesce(mc_payload, meta, "mission_slug") or mission_dir.name
+    name = _coalesce(mc_payload, meta, "friendly_name") or mission_slug
+    mission_type = _coalesce(mc_payload, meta, "mission_type") or _DEFAULT_MISSION_TYPE
+    purpose_tldr = _coalesce(mc_payload, meta, "purpose_tldr") or meta.get("source_description")
+    return {
+        "mission_slug": mission_slug,
+        "canonical_mission_id": _coalesce(mc_payload, meta, "mission_id"),
+        "mission_number": _coalesce(mc_payload, meta, "mission_number"),
+        "name": name,
+        "mission_type": mission_type,
+        "purpose_tldr": purpose_tldr,
+        "purpose_context": _coalesce(mc_payload, meta, "purpose_context"),
+        "target_branch": _coalesce(mc_payload, meta, "target_branch"),
+        "created_at": _coalesce(mc_payload, meta, "created_at"),
+    }
+
+
+def _coalesce(payload: Mapping[str, Any] | None, meta: Mapping[str, Any], key: str) -> Any:
+    """Return ``payload[key]`` if present and non-null, else ``meta[key]``."""
+    if payload is not None:
+        value = payload.get(key)
+        if value is not None:
+            return value
+    return meta.get(key)
+
+
+# ── work-package resolution ───────────────────────────────────────────────────
+
+
+def _wps_from_prefix(wp_payloads: Sequence[Mapping[str, Any]]) -> tuple[ScannedWorkPackage, ...]:
+    """Build WPs from on-disk ``WPCreated`` payloads."""
+    wps: list[ScannedWorkPackage] = []
+    for payload in wp_payloads:
+        wp_id = payload.get("wp_id")
+        if not wp_id:
+            continue
+        wps.append(
+            ScannedWorkPackage(
+                wp_id=str(wp_id),
+                wp_title=str(payload.get("wp_title") or wp_id),
+                depends_on=tuple(payload.get("depends_on") or ()),
+                wp_path=payload.get("wp_path"),
+                created_at=payload.get("created_at"),
+                source=PrefixSource.ON_DISK,
+            )
+        )
+    return tuple(wps)
+
+
+def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
+    """Synthesize WPs from ``tasks/WP*.md`` frontmatter (canonical, §3.4/§6).
+
+    Files with unreadable or invalid frontmatter are skipped here; any WP a
+    lane transition still references is back-filled minimally by
+    :func:`_ensure_wp_coverage`, so INV-3 coverage holds regardless.
+    """
+    tasks_dir = mission_dir / _TASKS_DIRNAME
+    if not tasks_dir.is_dir():
+        return ()
+    wps: list[ScannedWorkPackage] = []
+    for wp_file in sorted(tasks_dir.glob("WP*.md")):
+        try:
+            metadata, _ = read_authored_wp_frontmatter(wp_file)
+        except (FrontmatterError, ValidationError) as exc:
+            # Unreadable / invalid frontmatter: skip here and let
+            # _ensure_wp_coverage back-fill from the lane transitions.
+            logger.warning("import-history: skipping unreadable WP file %s: %s", wp_file, exc)
+            continue
+        wps.append(
+            ScannedWorkPackage(
+                wp_id=metadata.work_package_id,
+                wp_title=metadata.display_title,
+                depends_on=tuple(metadata.dependencies),
+                wp_path=_repo_relative_path(wp_file),
+                created_at=None,
+                source=PrefixSource.SYNTHESIZED,
+            )
+        )
+    return tuple(wps)
+
+
+def _ensure_wp_coverage(
+    work_packages: Sequence[ScannedWorkPackage],
+    lane_transitions: Sequence[StatusEvent],
+) -> tuple[ScannedWorkPackage, ...]:
+    """Guarantee a WP exists for every ``wp_id`` in the lane transitions.
+
+    A legacy task file may have been deleted after the mission ran, leaving a
+    lane transition whose WP has no create source. Synthesize a minimal WP for
+    each such gap so ``WPStatusChanged`` never precedes ``WPCreated`` (the
+    ``wp_status_event_without_create`` anomaly). Result is sorted by ``wp_id``
+    for a deterministic create order.
+    """
+    known = {wp.wp_id for wp in work_packages}
+    backfilled: list[ScannedWorkPackage] = []
+    for event in lane_transitions:
+        wp_id = event.wp_id
+        if wp_id and wp_id not in known:
+            known.add(wp_id)
+            backfilled.append(
+                ScannedWorkPackage(
+                    wp_id=wp_id,
+                    wp_title=wp_id,
+                    depends_on=(),
+                    wp_path=None,
+                    created_at=None,
+                    source=PrefixSource.SYNTHESIZED,
+                )
+            )
+    return tuple(sorted([*work_packages, *backfilled], key=lambda wp: wp.wp_id))
+
+
+def _repo_relative_path(path: Path) -> str | None:
+    """Return the POSIX ``kitty-specs/...`` path, matching the on-disk shape."""
+    parts = path.parts
+    if _KITTY_SPECS_ANCHOR in parts:
+        return "/".join(parts[parts.index(_KITTY_SPECS_ANCHOR) :])
+    return None
+
+
+# ── lifecycle-prefix reading ──────────────────────────────────────────────────
+
+
+def _read_importable_lifecycle(mission_dir: Path) -> list[dict[str, Any]]:
+    """Read on-disk lifecycle-prefix events, dropping local-only types.
+
+    ``read_lifecycle_events`` returns only rows carrying a top-level
+    ``event_type`` (skipping malformed lines); we then strip the local-only
+    types so they never propagate toward the SaaS strict validator.
+    """
+    events = read_lifecycle_events(mission_event_log_path(mission_dir))
+    return [event for event in events if event.get("event_type") not in _LOCAL_ONLY_EVENT_TYPES]
+
+
+def _payloads(lifecycle: Sequence[Mapping[str, Any]], event_type: str) -> list[dict[str, Any]]:
+    return [dict(event.get("payload") or {}) for event in lifecycle if event.get("event_type") == event_type]
+
+
+def _first_payload(lifecycle: Sequence[Mapping[str, Any]], event_type: str) -> dict[str, Any] | None:
+    payloads = _payloads(lifecycle, event_type)
+    return payloads[0] if payloads else None
+
+
+# ── meta.json ─────────────────────────────────────────────────────────────────
+
+
+def _load_meta(mission_dir: Path) -> dict[str, Any]:
+    """Read ``meta.json``; a missing or unreadable file yields ``{}``."""
+    meta_path = mission_dir / _META_FILENAME
+    try:
+        raw = meta_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -210,9 +210,14 @@ def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
     for wp_file in sorted(tasks_dir.glob("WP*.md")):
         try:
             metadata, _ = read_authored_wp_frontmatter(wp_file)
-        except (FrontmatterError, ValidationError) as exc:
-            # Unreadable / invalid frontmatter: skip here and let
-            # _ensure_wp_coverage back-fill from the lane transitions.
+        except (FrontmatterError, ValidationError, ValueError, TypeError, KeyError) as exc:
+            # A malformed WP doc (bad YAML, non-dict frontmatter, invalid schema)
+            # must never abort the whole scan. The catch is broadened past the
+            # frontmatter/validation errors to the structural ones a malformed
+            # doc can raise before validation (e.g. a YAML-list frontmatter →
+            # TypeError) — the #2883 items 3/4 concern, applied to this reader.
+            # Skip here; _ensure_wp_coverage back-fills any WP a lane transition
+            # still references, so INV-3 coverage holds.
             logger.warning("import-history: skipping unreadable WP file %s: %s", wp_file, exc)
             continue
         wps.append(

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -20,7 +20,6 @@ turns a :class:`MissionScan` into the ordered, deterministic envelope stream
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -32,6 +31,7 @@ from pydantic import ValidationError
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.frontmatter import FrontmatterError
+from specify_cli.mission_metadata import load_meta_or_empty
 
 # Access the status subsystem only through its package facade (the
 # status-module-boundary gate forbids new deep submodule imports).
@@ -41,6 +41,7 @@ from specify_cli.status import (
     MISSION_REOPENED,
     WP_CREATED,
     StatusEvent,
+    StoreError,
     mission_event_log_path,
     read_authored_wp_frontmatter,
     read_events,
@@ -49,7 +50,6 @@ from specify_cli.status import (
 
 logger = logging.getLogger(__name__)
 
-_META_FILENAME = "meta.json"
 _TASKS_DIRNAME = "tasks"
 _DEFAULT_MISSION_TYPE = "software-dev"
 
@@ -60,6 +60,18 @@ _DEFAULT_MISSION_TYPE = "software-dev"
 # package while both types ARE in its model map — so relying on it would let
 # these hit strict validation and reject the whole batch.
 _LOCAL_ONLY_EVENT_TYPES = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+
+
+class MissionScanError(RuntimeError):
+    """A mission's on-disk state could not be read (e.g. a corrupt status log).
+
+    Fail-closed: raised so the CLI/pipeline can name the offending mission and
+    abort without uploading, rather than surfacing a raw ``StoreError`` traceback.
+    """
+
+    def __init__(self, mission_slug: str, detail: str) -> None:
+        self.mission_slug = mission_slug
+        super().__init__(f"{mission_slug}: {detail}")
 
 
 class PrefixSource(StrEnum):
@@ -109,7 +121,7 @@ class MissionScan:
 
 def scan_mission(mission_dir: Path) -> MissionScan:
     """Scan one mission directory into a normalized :class:`MissionScan`."""
-    meta = _load_meta(mission_dir)
+    meta = load_meta_or_empty(mission_dir)
     lifecycle = _read_importable_lifecycle(mission_dir)
 
     mc_payload = _first_payload(lifecycle, MISSION_CREATED)
@@ -120,7 +132,12 @@ def scan_mission(mission_dir: Path) -> MissionScan:
 
     work_packages = _wps_from_prefix(wp_payloads) if wp_payloads else _wps_from_task_files(mission_dir)
 
-    lane_transitions = tuple(read_events(mission_dir))
+    try:
+        lane_transitions = tuple(read_events(mission_dir))
+    except StoreError as exc:
+        # A corrupt status.events.jsonl must fail closed with the mission named,
+        # not surface as a raw traceback (matches the graceful WP-frontmatter skip).
+        raise MissionScanError(fields["mission_slug"], f"corrupt status log: {exc}") from exc
     work_packages = _ensure_wp_coverage(work_packages, lane_transitions)
 
     return MissionScan(
@@ -213,7 +230,7 @@ def _wps_from_task_files(mission_dir: Path) -> tuple[ScannedWorkPackage, ...]:
     for wp_file in sorted(tasks_dir.glob("WP*.md")):
         try:
             metadata, _ = read_authored_wp_frontmatter(wp_file)
-        except (FrontmatterError, ValidationError, ValueError, TypeError, KeyError) as exc:
+        except (FrontmatterError, ValidationError, ValueError, TypeError, KeyError, OSError) as exc:
             # A malformed WP doc (bad YAML, non-dict frontmatter, invalid schema)
             # must never abort the whole scan. The catch is broadened past the
             # frontmatter/validation errors to the structural ones a malformed
@@ -296,20 +313,3 @@ def _payloads(lifecycle: Sequence[Mapping[str, Any]], event_type: str) -> list[d
 def _first_payload(lifecycle: Sequence[Mapping[str, Any]], event_type: str) -> dict[str, Any] | None:
     payloads = _payloads(lifecycle, event_type)
     return payloads[0] if payloads else None
-
-
-# ── meta.json ─────────────────────────────────────────────────────────────────
-
-
-def _load_meta(mission_dir: Path) -> dict[str, Any]:
-    """Read ``meta.json``; a missing or unreadable file yields ``{}``."""
-    meta_path = mission_dir / _META_FILENAME
-    try:
-        raw = meta_path.read_text(encoding="utf-8")
-    except OSError:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -134,8 +134,9 @@ def scan_mission(mission_dir: Path) -> MissionScan:
     prefix_source = PrefixSource.ON_DISK if mc_payload is not None else PrefixSource.SYNTHESIZED
     fields = _resolve_mission_fields(mission_dir, meta, mc_payload)
 
+    skipped_wp_files: tuple[str, ...] = ()
     if wp_payloads:
-        work_packages, skipped_wp_files = _wps_from_prefix(wp_payloads), ()
+        work_packages = _wps_from_prefix(wp_payloads)
     else:
         work_packages, skipped_wp_files = _wps_from_task_files(mission_dir)
 

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -36,9 +36,8 @@ from specify_cli.mission_metadata import load_meta_or_empty
 # Access the status subsystem only through its package facade (the
 # status-module-boundary gate forbids new deep submodule imports).
 from specify_cli.status import (
-    FOLLOW_UP_RECORDED,
+    LOCAL_ONLY_LIFECYCLE_EVENT_TYPES,
     MISSION_CREATED,
-    MISSION_REOPENED,
     WP_CREATED,
     StatusEvent,
     StoreError,
@@ -53,13 +52,13 @@ logger = logging.getLogger(__name__)
 _TASKS_DIRNAME = "tasks"
 _DEFAULT_MISSION_TYPE = "software-dev"
 
-# The lifecycle event types that are deliberately local-only and MUST be kept
-# off the SaaS strict-validation path (status/lifecycle.py:165). We mirror that
-# set from the public constants rather than trusting
-# ``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES``, which is empty in the installed
-# package while both types ARE in its model map — so relying on it would let
-# these hit strict validation and reject the whole batch.
-_LOCAL_ONLY_EVENT_TYPES = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+# The lifecycle event types kept OFF the SaaS strict-validation path — bound from
+# the single public owner in the status package (#2884) rather than a
+# hand-mirrored frozenset. (Deliberately NOT the installed
+# ``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES``, which is empty while both types
+# ARE in its model map — trusting it would let these reach strict validation and
+# reject the whole batch; the public owner documents that rationale.)
+_LOCAL_ONLY_EVENT_TYPES = LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
 
 
 class MissionScanError(RuntimeError):

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -20,6 +20,7 @@ turns a :class:`MissionScan` into the ordered, deterministic envelope stream
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -117,6 +118,13 @@ class MissionScan:
     # Fail-loud, not fail-closed: the scan survives, but the skips MUST reach
     # the operator-facing report so a partial import never reads as clean.
     skipped_wp_files: tuple[str, ...] = ()
+    # Malformed/unrecoverable rows dropped from the on-disk lifecycle prefix
+    # (status.events.jsonl): raw lines `read_lifecycle_events` silently skips
+    # (bad JSON, non-dict, or missing `event_type`) plus `WPCreated` payloads
+    # with no `wp_id`. Counted (not just logged) so a truncated prefix line
+    # surfaces here the same way a malformed WP file surfaces in
+    # `skipped_wp_files` — never a silent drop (#2884 finding A).
+    skipped_event_rows: int = 0
 
 
 # ── public API ───────────────────────────────────────────────────────────────
@@ -126,6 +134,7 @@ def scan_mission(mission_dir: Path) -> MissionScan:
     """Scan one mission directory into a normalized :class:`MissionScan`."""
     meta = load_meta_or_empty(mission_dir)
     lifecycle = _read_importable_lifecycle(mission_dir)
+    skipped_event_rows = _count_malformed_lifecycle_rows(mission_event_log_path(mission_dir))
 
     mc_payload = _first_payload(lifecycle, MISSION_CREATED)
     wp_payloads = _payloads(lifecycle, WP_CREATED)
@@ -135,7 +144,8 @@ def scan_mission(mission_dir: Path) -> MissionScan:
 
     skipped_wp_files: tuple[str, ...] = ()
     if wp_payloads:
-        work_packages = _wps_from_prefix(wp_payloads)
+        work_packages, wp_created_skipped = _wps_from_prefix(wp_payloads)
+        skipped_event_rows += wp_created_skipped
     else:
         work_packages, skipped_wp_files = _wps_from_task_files(mission_dir)
 
@@ -152,6 +162,7 @@ def scan_mission(mission_dir: Path) -> MissionScan:
         work_packages=work_packages,
         lane_transitions=lane_transitions,
         skipped_wp_files=skipped_wp_files,
+        skipped_event_rows=skipped_event_rows,
         **fields,
     )
 
@@ -204,12 +215,27 @@ def _coalesce(payload: Mapping[str, Any] | None, meta: Mapping[str, Any], key: s
 # ── work-package resolution ───────────────────────────────────────────────────
 
 
-def _wps_from_prefix(wp_payloads: Sequence[Mapping[str, Any]]) -> tuple[ScannedWorkPackage, ...]:
-    """Build WPs from on-disk ``WPCreated`` payloads."""
+def _wps_from_prefix(
+    wp_payloads: Sequence[Mapping[str, Any]],
+) -> tuple[tuple[ScannedWorkPackage, ...], int]:
+    """Build WPs from on-disk ``WPCreated`` payloads.
+
+    Returns ``(work_packages, skipped_count)``. A payload with no ``wp_id`` is
+    unusable (there is no aggregate to create), but dropping it silently would
+    let one truncated ``WPCreated`` line vanish the WP from the import while
+    the plan still reports clean — the skip is counted here so it reaches
+    ``MissionScan.skipped_event_rows`` (#2884 finding A).
+    """
     wps: list[ScannedWorkPackage] = []
+    skipped = 0
     for payload in wp_payloads:
         wp_id = payload.get("wp_id")
         if not wp_id:
+            logger.warning(
+                "import-history: skipping WPCreated payload with no wp_id: %r",
+                payload,
+            )
+            skipped += 1
             continue
         wps.append(
             ScannedWorkPackage(
@@ -221,7 +247,7 @@ def _wps_from_prefix(wp_payloads: Sequence[Mapping[str, Any]]) -> tuple[ScannedW
                 source=PrefixSource.ON_DISK,
             )
         )
-    return tuple(wps)
+    return tuple(wps), skipped
 
 
 def _wps_from_task_files(mission_dir: Path) -> tuple[tuple[ScannedWorkPackage, ...], tuple[str, ...]]:
@@ -318,6 +344,57 @@ def _read_importable_lifecycle(mission_dir: Path) -> list[dict[str, Any]]:
     """
     events = read_lifecycle_events(mission_event_log_path(mission_dir))
     return [event for event in events if event.get("event_type") not in _LOCAL_ONLY_EVENT_TYPES]
+
+
+def _count_malformed_lifecycle_rows(log_path: Path) -> int:
+    """Count raw JSONL rows ``read_lifecycle_events`` silently drops.
+
+    ``read_lifecycle_events`` (the status package's public accessor) tolerates
+    missing files, blank lines, and corrupted lines — it only returns rows
+    that parse as a JSON object carrying a top-level *string* ``event_type``,
+    logging a debug line for anything else and moving on. That is the right
+    behavior for its other callers, but for import-history a dropped
+    ``WPCreated``/``MissionCreated`` row must not vanish quietly. The sharpest
+    case (#2884 finding A) is genuinely silent: a row with ``event_type: null``
+    is valid JSON, so ``read_events`` (the lane-transition reader sharing this
+    same file) treats it as a skippable non-lane row and does NOT fail the
+    whole scan closed — but ``read_lifecycle_events`` also drops it (its
+    ``event_type`` isn't a ``str``), so the row vanishes from BOTH readers
+    with no signal at all.
+
+    This reads the same file independently (mirroring, not importing, the
+    private skip conditions in ``status.lifecycle_events._read_lifecycle_lines``)
+    so the count can be surfaced at the scan layer without modifying the
+    status package. A row with NO ``event_type`` key at all is the common
+    lane-transition (``StatusEvent``) shape sharing this file — not malformed,
+    just a sibling format read by ``read_events`` instead; only a row that
+    carries ``event_type`` but as a non-string value (or fails to parse as a
+    JSON object at all) counts as malformed here.
+    """
+    if not log_path.exists():
+        return 0
+    try:
+        text = log_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0
+    malformed = 0
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            malformed += 1
+            continue
+        if not isinstance(obj, dict):
+            malformed += 1
+            continue
+        if "event_type" not in obj:
+            continue  # a lane-transition (StatusEvent) row — not malformed, a sibling format
+        if not isinstance(obj["event_type"], str):
+            malformed += 1
+    return malformed
 
 
 def _payloads(lifecycle: Sequence[Mapping[str, Any]], event_type: str) -> list[dict[str, Any]]:

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -1,0 +1,276 @@
+"""SYNTHESIZE stage for ``sync import-history`` (WP-Y3, #2262).
+
+Turns a :class:`~specify_cli.sync.history_import.scan.MissionScan` into the
+ordered TeamSpace envelope stream
+
+    MissionCreated → WPCreated[] → WPStatusChanged[]
+
+that the SaaS materializer accepts (INV-3). Event ids are deterministic
+(INV-4): the synthesized creation prefix is minted from source facts via
+:func:`deterministic_ulid` under a dedicated ``import:`` namespace (so it never
+collides with the migration dry-run's ``teamspace-dry-run:`` ids or across
+re-runs), while replayed ``WPStatusChanged`` envelopes keep their real on-disk
+``event_id`` — both paths dedup cleanly on the server.
+
+Reuse (spec §3.3 stage 5):
+
+* ``WPStatusChanged`` envelopes are built by the existing
+  :func:`_status_event_to_teamspace_envelope`, so the lane back-fill and the
+  historical-evidence synthesis (required by the TeamSpace 5.0.0 contract on
+  ``approved``/``done``) are not re-implemented here.
+* ``MissionCreated`` / ``WPCreated`` payloads are built by the canonical
+  ``build_mission_created_payload`` and ``WPCreatedPayload`` so the wire shapes
+  cannot drift from the producers the rest of the CLI uses.
+
+The synthesizer is pure: it takes the project-identity trio as arguments and
+returns envelope dicts. Dry-run passes a synthetic offline ``project_uuid``;
+WP-Y4 injects the persisted real UUID at the same seam (INV-5). This module
+does not validate, persist, or upload — WP-Y5 owns preflight/upload.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from spec_kitty_events.project_lifecycle import WPCreatedPayload
+
+from specify_cli.core.mission_payload import build_mission_created_payload
+from specify_cli.migration.mission_state import (
+    CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    _status_event_to_teamspace_envelope,
+    deterministic_ulid,
+)
+from specify_cli.status.lifecycle_events import MISSION_CREATED, WP_CREATED
+from specify_cli.sync.history_import.scan import MissionScan, ScannedWorkPackage
+
+# Envelope provenance. build_id/node_id are metadata the SaaS materializer does
+# not route on (it dispatches on event_type and reads project_uuid/slug/repo_slug),
+# so branding the synthesized prefix as "import-history" is honest provenance and
+# harmless alongside the reused status builder's own tag.
+_BUILD_ID = "import-history"
+_NODE_ID = "import-history"
+
+_AGG_MISSION = "Mission"
+_AGG_WORK_PACKAGE = "WorkPackage"
+
+_DEFAULT_TARGET_BRANCH = "main"
+# A historical mission with no recoverable timestamp anywhere: a deterministic
+# epoch sentinel keeps synthesis pure (never `now()`), honest (unknown time),
+# and keeps MissionCreated ordered at or before everything else.
+_UNKNOWN_TIMESTAMP = "1970-01-01T00:00:00+00:00"
+
+_ACTOR = "spec-kitty sync import-history"
+
+
+def synthesize_mission_stream(
+    scan: MissionScan,
+    *,
+    project_uuid: uuid.UUID,
+    project_slug: str,
+    repo_slug: str,
+) -> list[dict[str, Any]]:
+    """Synthesize one mission's ordered, deterministic envelope stream.
+
+    Lamport clocks are per-mission and monotonic: ``MissionCreated`` is ``1``,
+    the ``WPCreated`` events follow (in the scan's deterministic WP order), then
+    the ``WPStatusChanged`` events in ``(at, event_id)`` order — so a status
+    change can never carry a lower clock than its work package's creation.
+    """
+    mission_ts = _earliest_timestamp(scan)
+    correlation_id = deterministic_ulid(f"import:{scan.mission_slug}:correlation")
+    identity = _EnvelopeIdentity(
+        project_uuid=str(project_uuid),
+        project_slug=project_slug,
+        repo_slug=repo_slug,
+        correlation_id=correlation_id,
+    )
+
+    stream: list[dict[str, Any]] = []
+    lamport = 1
+
+    stream.append(_mission_created_envelope(scan, mission_ts, lamport, identity))
+    lamport += 1
+
+    for wp in scan.work_packages:
+        stream.append(_wp_created_envelope(scan, wp, mission_ts, lamport, identity))
+        lamport += 1
+
+    ordered_transitions = sorted(scan.lane_transitions, key=lambda event: (event.at, event.event_id))
+    for status_event in ordered_transitions:
+        status_envelope = _status_event_to_teamspace_envelope(
+            status_event,
+            project_uuid=project_uuid,
+            lamport_clock=lamport,
+            project_slug=project_slug,
+            repo_slug=repo_slug,
+        )
+        stream.append(_rebrand_as_import(status_envelope, identity))
+        lamport += 1
+
+    return stream
+
+
+def synthesize_streams(
+    scans: Sequence[MissionScan],
+    *,
+    project_uuid: uuid.UUID,
+    project_slug: str,
+    repo_slug: str,
+) -> list[dict[str, Any]]:
+    """Concatenate per-mission streams (lamport clocks restart per mission)."""
+    envelopes: list[dict[str, Any]] = []
+    for scan in scans:
+        envelopes.extend(
+            synthesize_mission_stream(
+                scan,
+                project_uuid=project_uuid,
+                project_slug=project_slug,
+                repo_slug=repo_slug,
+            )
+        )
+    return envelopes
+
+
+def dry_run_project_uuid(mission_slugs: Sequence[str]) -> uuid.UUID:
+    """Synthetic offline ``project_uuid`` for dry-run (mirrors ``teamspace_dry_run``).
+
+    WP-Y4 replaces this with the persisted real UUID (INV-5); the synthetic id
+    must never reach the server on ``--apply``.
+    """
+    seed = "spec-kitty:teamspace-dry-run:" + "|".join(mission_slugs)
+    return uuid.uuid5(uuid.NAMESPACE_URL, seed)
+
+
+# ── internals ─────────────────────────────────────────────────────────────────
+
+
+class _EnvelopeIdentity:
+    """The envelope keys shared across every event in one mission's stream."""
+
+    __slots__ = ("project_uuid", "project_slug", "repo_slug", "correlation_id")
+
+    def __init__(self, *, project_uuid: str, project_slug: str, repo_slug: str, correlation_id: str) -> None:
+        self.project_uuid = project_uuid
+        self.project_slug = project_slug
+        self.repo_slug = repo_slug
+        self.correlation_id = correlation_id
+
+
+def _mission_created_envelope(
+    scan: MissionScan,
+    mission_ts: str,
+    lamport: int,
+    identity: _EnvelopeIdentity,
+) -> dict[str, Any]:
+    payload = build_mission_created_payload(
+        mission_slug=scan.mission_slug,
+        target_branch=scan.target_branch or _DEFAULT_TARGET_BRANCH,
+        mission_type=scan.mission_type,
+        wp_count=len(scan.work_packages),
+        mission_id=scan.canonical_mission_id,
+        mission_number=scan.mission_number,
+        friendly_name=scan.name,
+        purpose_tldr=scan.purpose_tldr,
+        purpose_context=scan.purpose_context,
+        created_at=mission_ts,
+    )
+    return _envelope(
+        event_id=deterministic_ulid(f"import:{scan.mission_slug}:MissionCreated"),
+        event_type=MISSION_CREATED,
+        aggregate_id=scan.canonical_mission_id or scan.mission_slug,
+        aggregate_type=_AGG_MISSION,
+        payload=payload,
+        timestamp=mission_ts,
+        lamport=lamport,
+        identity=identity,
+    )
+
+
+def _wp_created_envelope(
+    scan: MissionScan,
+    wp: ScannedWorkPackage,
+    mission_ts: str,
+    lamport: int,
+    identity: _EnvelopeIdentity,
+) -> dict[str, Any]:
+    payload = WPCreatedPayload(
+        mission_slug=scan.mission_slug,
+        mission_number=scan.mission_number,
+        wp_id=wp.wp_id,
+        wp_title=wp.wp_title,
+        wp_path=wp.wp_path,
+        depends_on=list(wp.depends_on),
+        actor=_ACTOR,
+        created_at=wp.created_at,
+    ).model_dump(mode="json", exclude_none=False)
+    return _envelope(
+        event_id=deterministic_ulid(f"import:{scan.mission_slug}:WPCreated:{wp.wp_id}"),
+        event_type=WP_CREATED,
+        aggregate_id=wp.wp_id,
+        aggregate_type=_AGG_WORK_PACKAGE,
+        payload=payload,
+        # Envelope timestamp needs a value for ordering; the payload keeps the
+        # truthful created_at (None when synthesized for a legacy WP).
+        timestamp=wp.created_at or mission_ts,
+        lamport=lamport,
+        identity=identity,
+    )
+
+
+def _envelope(
+    *,
+    event_id: str,
+    event_type: str,
+    aggregate_id: str,
+    aggregate_type: str,
+    payload: dict[str, Any],
+    timestamp: str,
+    lamport: int,
+    identity: _EnvelopeIdentity,
+) -> dict[str, Any]:
+    """Assemble a full TeamSpace envelope, matching the WPStatusChanged shape."""
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "aggregate_id": aggregate_id,
+        "aggregate_type": aggregate_type,
+        "payload": payload,
+        "timestamp": timestamp,
+        "build_id": _BUILD_ID,
+        "node_id": _NODE_ID,
+        "lamport_clock": lamport,
+        "causation_id": None,
+        "project_uuid": identity.project_uuid,
+        "project_slug": identity.project_slug,
+        "repo_slug": identity.repo_slug,
+        "correlation_id": identity.correlation_id,
+        "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    }
+
+
+def _rebrand_as_import(envelope: dict[str, Any], identity: _EnvelopeIdentity) -> dict[str, Any]:
+    """Unify a reused status envelope's operation-identity fields.
+
+    ``_status_event_to_teamspace_envelope`` was written for the migration
+    dry-run, so it stamps its own ``build_id``/``node_id`` and a per-event
+    ``teamspace-dry-run:`` correlation. In the import context the whole stream
+    is one operation, so we re-stamp those three (non-load-bearing) fields to
+    match the synthesized prefix. Everything the builder computed — payload,
+    real ``event_id``, lane back-fill, historical evidence — is left intact.
+    """
+    envelope["build_id"] = _BUILD_ID
+    envelope["node_id"] = _NODE_ID
+    envelope["correlation_id"] = identity.correlation_id
+    return envelope
+
+
+def _earliest_timestamp(scan: MissionScan) -> str:
+    """Earliest known timestamp across mission/WP/lane sources (deterministic)."""
+    candidates: list[str] = []
+    if scan.created_at:
+        candidates.append(scan.created_at)
+    candidates.extend(wp.created_at for wp in scan.work_packages if wp.created_at)
+    candidates.extend(event.at for event in scan.lane_transitions if event.at)
+    return min(candidates) if candidates else _UNKNOWN_TIMESTAMP

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -80,7 +80,7 @@ def synthesize_mission_stream(
     change can never carry a lower clock than its work package's creation.
     """
     mission_ts = _earliest_timestamp(scan)
-    correlation_id = deterministic_ulid(f"import:{scan.mission_slug}:correlation")
+    correlation_id = deterministic_ulid(f"import:{_identity_key(scan)}:correlation")
     identity = _EnvelopeIdentity(
         project_uuid=str(project_uuid),
         project_slug=project_slug,
@@ -178,7 +178,7 @@ def _mission_created_envelope(
         created_at=mission_ts,
     )
     return _envelope(
-        event_id=deterministic_ulid(f"import:{scan.mission_slug}:MissionCreated"),
+        event_id=deterministic_ulid(f"import:{_identity_key(scan)}:MissionCreated"),
         event_type=MISSION_CREATED,
         aggregate_id=scan.canonical_mission_id or scan.mission_slug,
         aggregate_type=_AGG_MISSION,
@@ -207,7 +207,7 @@ def _wp_created_envelope(
         created_at=_parse_timestamp(wp.created_at),
     ).model_dump(mode="json", exclude_none=False)
     return _envelope(
-        event_id=deterministic_ulid(f"import:{scan.mission_slug}:WPCreated:{wp.wp_id}"),
+        event_id=deterministic_ulid(f"import:{_identity_key(scan)}:WPCreated:{wp.wp_id}"),
         event_type=WP_CREATED,
         aggregate_id=wp.wp_id,
         aggregate_type=_AGG_WORK_PACKAGE,
@@ -270,6 +270,19 @@ def _rebrand_as_import(envelope: dict[str, Any], identity: _EnvelopeIdentity) ->
     envelope["node_id"] = _NODE_ID
     envelope["correlation_id"] = identity.correlation_id
     return envelope
+
+
+def _identity_key(scan: MissionScan) -> str:
+    """Seed/dedup key: the canonical mission id when present, else the slug.
+
+    The deterministic import ``event_id``s must key on the same identity the
+    envelopes' ``aggregate_id`` trusts (mission 083 moved identity onto
+    ``mission_id``). Seeding on the slug alone would let a deleted-then-recreated
+    same-slug mission hash an identical creation prefix, so the server dedups the
+    new mission's ``MissionCreated`` as a duplicate and it silently never
+    materializes (its WPs orphan).
+    """
+    return scan.canonical_mission_id or scan.mission_slug
 
 
 def _parse_timestamp(value: str | None) -> datetime | None:

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -31,6 +31,7 @@ does not validate, persist, or upload — WP-Y5 owns preflight/upload.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from collections.abc import Sequence
 from typing import Any
 
@@ -42,7 +43,7 @@ from specify_cli.migration.mission_state import (
     _status_event_to_teamspace_envelope,
     deterministic_ulid,
 )
-from specify_cli.status.lifecycle_events import MISSION_CREATED, WP_CREATED
+from specify_cli.status import MISSION_CREATED, WP_CREATED
 from specify_cli.sync.history_import.scan import MissionScan, ScannedWorkPackage
 
 # Envelope provenance. build_id/node_id are metadata the SaaS materializer does
@@ -203,7 +204,7 @@ def _wp_created_envelope(
         wp_path=wp.wp_path,
         depends_on=list(wp.depends_on),
         actor=_ACTOR,
-        created_at=wp.created_at,
+        created_at=_parse_timestamp(wp.created_at),
     ).model_dump(mode="json", exclude_none=False)
     return _envelope(
         event_id=deterministic_ulid(f"import:{scan.mission_slug}:WPCreated:{wp.wp_id}"),
@@ -229,9 +230,14 @@ def _envelope(
     timestamp: str,
     lamport: int,
     identity: _EnvelopeIdentity,
-) -> dict[str, Any]:
-    """Assemble a full TeamSpace envelope, matching the WPStatusChanged shape."""
-    return {
+) -> dict[str, Any]:  # canonical-producer-exempt: #2262 -- historical import-replay envelope builder
+    """Assemble a full TeamSpace envelope, matching the WPStatusChanged shape.
+
+    Mirrors the migration-replay builder ``_status_event_to_teamspace_envelope``
+    (itself #1198-exempt): a historical replay/synthesis producer, not a
+    live-path event emitter, so it assembles the envelope dict directly.
+    """
+    return {  # canonical-producer-exempt: #2262 -- see function-level comment
         "event_id": event_id,
         "event_type": event_type,
         "aggregate_id": aggregate_id,
@@ -264,6 +270,21 @@ def _rebrand_as_import(envelope: dict[str, Any], identity: _EnvelopeIdentity) ->
     envelope["node_id"] = _NODE_ID
     envelope["correlation_id"] = identity.correlation_id
     return envelope
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 string to ``datetime`` for the ``WPCreated`` payload.
+
+    The scan carries ``created_at`` as a string (on-disk) or ``None``
+    (synthesized), while ``WPCreatedPayload.created_at`` is typed ``datetime``.
+    An unparseable value degrades to ``None`` rather than aborting synthesis.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
 
 
 def _earliest_timestamp(scan: MissionScan) -> str:

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -15,9 +15,10 @@ re-runs), while replayed ``WPStatusChanged`` envelopes keep their real on-disk
 Reuse (spec §3.3 stage 5):
 
 * ``WPStatusChanged`` envelopes are built by the existing
-  :func:`_status_event_to_teamspace_envelope`, so the lane back-fill and the
-  historical-evidence synthesis (required by the TeamSpace 5.0.0 contract on
-  ``approved``/``done``) are not re-implemented here.
+  :func:`~specify_cli.migration.envelope_seam.status_event_to_teamspace_envelope`
+  (via the deliberate ``migration.envelope_seam`` surface), so the lane
+  back-fill and the historical-evidence synthesis (required by the TeamSpace
+  5.0.0 contract on ``approved``/``done``) are not re-implemented here.
 * ``MissionCreated`` / ``WPCreated`` payloads are built by the canonical
   ``build_mission_created_payload`` and ``WPCreatedPayload`` so the wire shapes
   cannot drift from the producers the rest of the CLI uses.
@@ -38,10 +39,10 @@ from typing import Any
 from spec_kitty_events.project_lifecycle import WPCreatedPayload
 
 from specify_cli.core.mission_payload import build_mission_created_payload
-from specify_cli.migration.mission_state import (
+from specify_cli.migration.envelope_seam import (
     CANONICAL_ENVELOPE_SCHEMA_VERSION,
-    _status_event_to_teamspace_envelope,
     deterministic_ulid,
+    status_event_to_teamspace_envelope,
 )
 from specify_cli.status import MISSION_CREATED, WP_CREATED
 from specify_cli.sync.history_import.scan import MissionScan, ScannedWorkPackage
@@ -100,7 +101,7 @@ def synthesize_mission_stream(
 
     ordered_transitions = sorted(scan.lane_transitions, key=lambda event: (event.at, event.event_id))
     for status_event in ordered_transitions:
-        status_envelope = _status_event_to_teamspace_envelope(
+        status_envelope = status_event_to_teamspace_envelope(
             status_event,
             project_uuid=project_uuid,
             lamport_clock=lamport,
@@ -233,7 +234,7 @@ def _envelope(
 ) -> dict[str, Any]:  # canonical-producer-exempt: #2262 -- historical import-replay envelope builder
     """Assemble a full TeamSpace envelope, matching the WPStatusChanged shape.
 
-    Mirrors the migration-replay builder ``_status_event_to_teamspace_envelope``
+    Mirrors the migration-replay builder ``status_event_to_teamspace_envelope``
     (itself #1198-exempt): a historical replay/synthesis producer, not a
     live-path event emitter, so it assembles the envelope dict directly.
     """
@@ -259,7 +260,7 @@ def _envelope(
 def _rebrand_as_import(envelope: dict[str, Any], identity: _EnvelopeIdentity) -> dict[str, Any]:
     """Unify a reused status envelope's operation-identity fields.
 
-    ``_status_event_to_teamspace_envelope`` was written for the migration
+    ``status_event_to_teamspace_envelope`` was written for the migration
     dry-run, so it stamps its own ``build_id``/``node_id`` and a per-event
     ``teamspace-dry-run:`` correlation. In the import context the whole stream
     is one operation, so we re-stamp those three (non-load-bearing) fields to

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -40,7 +40,7 @@ from spec_kitty_events.project_lifecycle import WPCreatedPayload
 
 from specify_cli.core.mission_payload import build_mission_created_payload
 from specify_cli.migration.envelope_seam import (
-    CANONICAL_ENVELOPE_SCHEMA_VERSION,
+    build_teamspace_envelope,
     deterministic_ulid,
     status_event_to_teamspace_envelope,
 )
@@ -238,30 +238,34 @@ def _envelope(
     timestamp: str,
     lamport: int,
     identity: _EnvelopeIdentity,
-) -> dict[str, Any]:  # canonical-producer-exempt: #2262 -- historical import-replay envelope builder
-    """Assemble a full TeamSpace envelope, matching the WPStatusChanged shape.
+) -> dict[str, Any]:
+    """Assemble the creation-prefix TeamSpace envelope via the shared shell.
 
-    Mirrors the migration-replay builder ``status_event_to_teamspace_envelope``
-    (itself #1198-exempt): a historical replay/synthesis producer, not a
-    live-path event emitter, so it assembles the envelope dict directly.
+    The 15-key envelope shell is owned by ``build_teamspace_envelope`` (the same
+    owner the migration ``WPStatusChanged`` builder uses, re-exported through
+    ``envelope_seam``) — #2891, so the two replay producers cannot drift on the
+    envelope-level fields. This builder only supplies the import producer's
+    ``build_id``/``node_id``/``correlation_id`` values.
     """
-    return {  # canonical-producer-exempt: #2262 -- see function-level comment
-        "event_id": event_id,
-        "event_type": event_type,
-        "aggregate_id": aggregate_id,
-        "aggregate_type": aggregate_type,
-        "payload": payload,
-        "timestamp": timestamp,
-        "build_id": _BUILD_ID,
-        "node_id": _NODE_ID,
-        "lamport_clock": lamport,
-        "causation_id": None,
-        "project_uuid": identity.project_uuid,
-        "project_slug": identity.project_slug,
-        "repo_slug": identity.repo_slug,
-        "correlation_id": identity.correlation_id,
-        "schema_version": CANONICAL_ENVELOPE_SCHEMA_VERSION,
-    }
+    # Explicit annotation: under the project's ``follow_imports = "skip"`` mypy
+    # config the cross-module ``build_teamspace_envelope`` return is seen as
+    # ``Any``; re-narrow it (the seam owner IS typed ``-> dict[str, Any]``).
+    envelope: dict[str, Any] = build_teamspace_envelope(
+        event_id=event_id,
+        event_type=event_type,
+        aggregate_id=aggregate_id,
+        aggregate_type=aggregate_type,
+        payload=payload,
+        timestamp=timestamp,
+        build_id=_BUILD_ID,
+        node_id=_NODE_ID,
+        lamport_clock=lamport,
+        project_uuid=identity.project_uuid,
+        project_slug=identity.project_slug,
+        repo_slug=identity.repo_slug,
+        correlation_id=identity.correlation_id,
+    )
+    return envelope
 
 
 def _rebrand_as_import(envelope: dict[str, Any], identity: _EnvelopeIdentity) -> dict[str, Any]:

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -32,7 +32,7 @@ does not validate, persist, or upload — WP-Y5 owns preflight/upload.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from collections.abc import Sequence
 from typing import Any
 
@@ -204,6 +204,7 @@ def _wp_created_envelope(
     lamport: int,
     identity: _EnvelopeIdentity,
 ) -> dict[str, Any]:
+    parsed_created_at = _parse_timestamp(wp.created_at)
     payload = WPCreatedPayload(
         mission_slug=scan.mission_slug,
         mission_number=scan.mission_number,
@@ -212,17 +213,24 @@ def _wp_created_envelope(
         wp_path=wp.wp_path,
         depends_on=list(wp.depends_on),
         actor=_ACTOR,
-        created_at=_parse_timestamp(wp.created_at),
+        created_at=parsed_created_at,
     ).model_dump(mode="json", exclude_none=False)
+    aware_created_at = _as_aware_utc(parsed_created_at)
+    # The envelope timestamp and the payload's created_at must reach the SAME
+    # verdict on wp.created_at. Previously the envelope let the raw string
+    # pass through (`wp.created_at or mission_ts`) while the payload nulled
+    # the exact same unparseable value — one envelope, two verdicts (#2884
+    # finding C). Both now derive from the one `parsed_created_at`, and the
+    # envelope's is the normalized ISO form (aware isoformat) consistent with
+    # what ``_earliest_timestamp`` already emits — never a raw passthrough.
+    timestamp = aware_created_at.isoformat() if aware_created_at is not None else mission_ts
     return _envelope(
         event_id=deterministic_ulid(f"{_IMPORT_ID_NAMESPACE}{_identity_key(scan)}:WPCreated:{wp.wp_id}"),
         event_type=WP_CREATED,
         aggregate_id=wp.wp_id,
         aggregate_type=_AGG_WORK_PACKAGE,
         payload=payload,
-        # Envelope timestamp needs a value for ordering; the payload keeps the
-        # truthful created_at (None when synthesized for a legacy WP).
-        timestamp=wp.created_at or mission_ts,
+        timestamp=timestamp,
         lamport=lamport,
         identity=identity,
     )
@@ -316,11 +324,47 @@ def _parse_timestamp(value: str | None) -> datetime | None:
         return None
 
 
+def _as_aware_utc(value: datetime | None) -> datetime | None:
+    """Normalize a ``datetime`` to an aware, UTC-offset instant.
+
+    The three writers behind ``_earliest_timestamp``'s candidates (mission
+    ``meta.json``, WP ``WPCreated`` payloads, and lane-transition ``at``
+    fields) do not all use the same UTC offset convention. A naive value is
+    assumed to already be UTC (the codebase's own writer, ``now_utc_iso()``,
+    only ever produces offset-aware strings — a naive value would only occur
+    for hand-authored or legacy data). An aware value with a NON-UTC offset
+    is converted to UTC via ``astimezone`` — merely tagging ``tzinfo`` would
+    leave the wall-clock time unconverted (e.g. ``08:00+02:00`` would render
+    as ``08:00+00:00``, two hours off) and defeat the whole comparison
+    (#2884 finding B).
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 def _earliest_timestamp(scan: MissionScan) -> str:
-    """Earliest known timestamp across mission/WP/lane sources (deterministic)."""
+    """Earliest known timestamp across mission/WP/lane sources (deterministic).
+
+    Candidates come from three different writers using different ISO-8601
+    suffix conventions (a literal ``Z``, ``+00:00``, or another UTC offset). A
+    raw string ``min()`` compares candidates lexicographically, which picks
+    the wrong instant across those forms — e.g. ``"...07:00:00Z"`` sorts
+    before ``"...08:00:00+02:00"`` even though the latter (06:00 UTC) is
+    actually earlier (#2884 finding B). Parse every candidate to an aware
+    ``datetime`` first and compare true instants; a candidate that fails to
+    parse is excluded rather than let back in via the raw string.
+    """
     candidates: list[str] = []
     if scan.created_at:
         candidates.append(scan.created_at)
     candidates.extend(wp.created_at for wp in scan.work_packages if wp.created_at)
     candidates.extend(event.at for event in scan.lane_transitions if event.at)
-    return min(candidates) if candidates else _UNKNOWN_TIMESTAMP
+
+    parsed = [_as_aware_utc(_parse_timestamp(value)) for value in candidates]
+    aware = [dt for dt in parsed if dt is not None]
+    if not aware:
+        return _UNKNOWN_TIMESTAMP
+    return min(aware).isoformat()

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -247,9 +247,13 @@ def _envelope(
     envelope-level fields. This builder only supplies the import producer's
     ``build_id``/``node_id``/``correlation_id`` values.
     """
-    # Explicit annotation: under the project's ``follow_imports = "skip"`` mypy
-    # config the cross-module ``build_teamspace_envelope`` return is seen as
-    # ``Any``; re-narrow it (the seam owner IS typed ``-> dict[str, Any]``).
+    # ``build_teamspace_envelope`` returns the canonical ``_TeamspaceEnvelope``
+    # model (CP001/CP002, #2884); ``.model_dump()`` is this function's
+    # serialization boundary back to the wire-format dict the rest of the
+    # import pipeline (mutation in ``_rebrand_as_import``, hashing, upload)
+    # expects. Explicit annotation: under the project's ``follow_imports =
+    # "skip"`` mypy config the cross-module call is seen as ``Any`` regardless;
+    # re-narrow it here.
     envelope: dict[str, Any] = build_teamspace_envelope(
         event_id=event_id,
         event_type=event_type,
@@ -264,7 +268,7 @@ def _envelope(
         project_slug=identity.project_slug,
         repo_slug=identity.repo_slug,
         correlation_id=identity.correlation_id,
-    )
+    ).model_dump()
     return envelope
 
 

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -65,6 +65,13 @@ _UNKNOWN_TIMESTAMP = "1970-01-01T00:00:00+00:00"
 
 _ACTOR = "spec-kitty sync import-history"
 
+# The dedicated deterministic-id namespace for the synthesized creation prefix.
+# Load-bearing: it MUST stay distinct from the migration dry-run's
+# ``teamspace-dry-run:`` seeds (INV-4), so it is a single named constant — a
+# typo in one of its three call sites would silently split the id namespace and
+# break cross-run dedup.
+_IMPORT_ID_NAMESPACE = "import:"
+
 
 def synthesize_mission_stream(
     scan: MissionScan,
@@ -81,7 +88,7 @@ def synthesize_mission_stream(
     change can never carry a lower clock than its work package's creation.
     """
     mission_ts = _earliest_timestamp(scan)
-    correlation_id = deterministic_ulid(f"import:{_identity_key(scan)}:correlation")
+    correlation_id = deterministic_ulid(f"{_IMPORT_ID_NAMESPACE}{_identity_key(scan)}:correlation")
     identity = _EnvelopeIdentity(
         project_uuid=str(project_uuid),
         project_slug=project_slug,
@@ -179,7 +186,7 @@ def _mission_created_envelope(
         created_at=mission_ts,
     )
     return _envelope(
-        event_id=deterministic_ulid(f"import:{_identity_key(scan)}:MissionCreated"),
+        event_id=deterministic_ulid(f"{_IMPORT_ID_NAMESPACE}{_identity_key(scan)}:MissionCreated"),
         event_type=MISSION_CREATED,
         aggregate_id=scan.canonical_mission_id or scan.mission_slug,
         aggregate_type=_AGG_MISSION,
@@ -208,7 +215,7 @@ def _wp_created_envelope(
         created_at=_parse_timestamp(wp.created_at),
     ).model_dump(mode="json", exclude_none=False)
     return _envelope(
-        event_id=deterministic_ulid(f"import:{_identity_key(scan)}:WPCreated:{wp.wp_id}"),
+        event_id=deterministic_ulid(f"{_IMPORT_ID_NAMESPACE}{_identity_key(scan)}:WPCreated:{wp.wp_id}"),
         event_type=WP_CREATED,
         aggregate_id=wp.wp_id,
         aggregate_type=_AGG_WORK_PACKAGE,

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -1,0 +1,201 @@
+"""PROVENANCE + PREFLIGHT + UPLOAD for ``sync import-history`` (WP-Y5, #2262).
+
+Takes the synthesized envelope stream and materializes it into the SaaS
+projection, reusing the WP06 delivery receiver as the transport seam rather
+than hand-rolling HTTP:
+
+* **PROVENANCE (stage 6):** a per-envelope ``envelope_sha256`` manifest, hashed
+  with the same canonical-JSON shape the migration dry-run uses.
+* **PREFLIGHT (stage 7):** POST each chunk to ``/api/v1/events/preflight/`` and
+  gate on ``accepted`` — the server validates shape/ingress without mutating
+  state. Every chunk is preflighted *before* any chunk uploads, so a rejection
+  anywhere leaves the projection untouched (fail-closed, INV-6).
+* **UPLOAD (stage 8):** chunk the stream and hand each chunk to a
+  :class:`DeliveryReceiver` (gzip + POST + response mapping + poison-batch
+  bisection all live there). The server dedups on ``event_id``, so a re-run is
+  idempotent (already-ingested events return ``duplicate``).
+
+The transport is injectable: production passes an authed ``TeamspaceReceiver``
+and the default ``requests`` poster; tests pass a ``StubReceiver`` and a fake
+poster, so the whole stage runs with no network.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from specify_cli.delivery.receivers import (
+    DeliveryOutcome,
+    DeliveryReceiver,
+    DeliveryResult,
+    HttpPoster,
+    OutboundEvent,
+    _requests_post,
+)
+
+_PREFLIGHT_ENDPOINT_PATH = "/api/v1/events/preflight/"
+_PREFLIGHT_TIMEOUT_SECONDS = 60.0
+# Conservative per-request size: well under the server's 1000-event cap and its
+# 512 KiB decompressed byte ceiling. The receiver still auto-bisects on a 413.
+_IMPORT_CHUNK_SIZE = 500
+_MAX_REJECTED_SAMPLES = 5
+
+Envelope = Mapping[str, Any]
+
+
+# ── provenance (stage 6) ──────────────────────────────────────────────────────
+
+
+def envelope_sha256(envelope: Envelope) -> str:
+    """Canonical-JSON SHA-256 of an envelope (matches the dry-run row-mapping)."""
+    canonical = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()  # noqa: TID251 - body checksum for the import provenance manifest
+
+
+@dataclass(frozen=True)
+class ProvenanceEntry:
+    """One provenance record for the import audit manifest."""
+
+    event_id: str
+    event_type: str
+    envelope_sha256: str
+    # Import envelopes are synthesized / replayed, not lifted verbatim from a
+    # single on-disk JSONL row, so there is no row_sha256 to anchor.
+    row_sha256: str | None = None
+
+
+def build_provenance_manifest(envelopes: Sequence[Envelope]) -> list[ProvenanceEntry]:
+    return [
+        ProvenanceEntry(
+            event_id=str(env["event_id"]),
+            event_type=str(env["event_type"]),
+            envelope_sha256=envelope_sha256(env),
+        )
+        for env in envelopes
+    ]
+
+
+# ── preflight (stage 7) ───────────────────────────────────────────────────────
+
+
+class PreflightRejected(RuntimeError):
+    """Raised when the server preflight refuses a chunk (fail-closed)."""
+
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self.payload = dict(payload)
+        reconciliation = self.payload.get("reconciliation") or self.payload.get("error") or self.payload
+        super().__init__(f"server preflight rejected the batch: {reconciliation}")
+
+
+def run_server_preflight(
+    envelopes: Sequence[Envelope],
+    *,
+    server_url: str,
+    auth_token: str,
+    poster: HttpPoster = _requests_post,
+) -> dict[str, Any]:
+    """POST ``{"events": [...]}`` to the preflight endpoint; raise if not accepted."""
+    url = server_url.rstrip("/") + _PREFLIGHT_ENDPOINT_PATH
+    body = gzip.compress(json.dumps({"events": [dict(env) for env in envelopes]}, separators=(",", ":")).encode("utf-8"))
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Encoding": "gzip",
+        "Content-Type": "application/json",
+    }
+    response = poster(url, data=body, headers=headers, timeout=_PREFLIGHT_TIMEOUT_SECONDS)
+    try:
+        payload = response.json()
+    except Exception as exc:  # non-JSON (5xx / proxy error) is a hard, fail-closed stop
+        raise PreflightRejected({"error": f"preflight response was not JSON (HTTP {response.status_code})"}) from exc
+    if response.status_code != 200 or not payload.get("accepted"):
+        raise PreflightRejected(payload)
+    return dict(payload)
+
+
+# ── upload (stage 8) ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class UploadReport:
+    """Tally of per-event delivery outcomes for one import run."""
+
+    success: int = 0
+    duplicate: int = 0
+    pending: int = 0
+    rejected: int = 0
+    rejected_samples: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.success + self.duplicate + self.pending + self.rejected
+
+    @property
+    def ok(self) -> bool:
+        return self.rejected == 0
+
+
+def upload_envelopes(
+    envelopes: Sequence[Envelope],
+    *,
+    receiver: DeliveryReceiver,
+    chunk_size: int = _IMPORT_CHUNK_SIZE,
+) -> UploadReport:
+    """Chunk the stream and deliver each chunk through the receiver, tallying outcomes."""
+    report = UploadReport()
+    for chunk in _chunked(envelopes, chunk_size):
+        outbound = [OutboundEvent(event_id=str(env["event_id"]), payload=env) for env in chunk]
+        for result in receiver.deliver(outbound):
+            _tally(report, result)
+    return report
+
+
+def run_import_upload(
+    envelopes: Sequence[Envelope],
+    *,
+    receiver: DeliveryReceiver,
+    server_url: str,
+    auth_token: str,
+    poster: HttpPoster = _requests_post,
+    chunk_size: int = _IMPORT_CHUNK_SIZE,
+) -> UploadReport:
+    """Preflight every chunk, then (only if all pass) upload every chunk.
+
+    Preflighting the whole stream before delivering anything is the fail-closed
+    ordering: a rejection in any chunk raises :class:`PreflightRejected` and
+    nothing is uploaded (INV-6).
+    """
+    chunks = list(_chunked(envelopes, chunk_size))
+    for chunk in chunks:
+        run_server_preflight(chunk, server_url=server_url, auth_token=auth_token, poster=poster)
+    report = UploadReport()
+    for chunk in chunks:
+        outbound = [OutboundEvent(event_id=str(env["event_id"]), payload=env) for env in chunk]
+        for result in receiver.deliver(outbound):
+            _tally(report, result)
+    return report
+
+
+# ── internals ─────────────────────────────────────────────────────────────────
+
+
+def _tally(report: UploadReport, result: DeliveryResult) -> None:
+    if result.outcome is DeliveryOutcome.SUCCESS:
+        report.success += 1
+    elif result.outcome is DeliveryOutcome.DUPLICATE:
+        report.duplicate += 1
+    elif result.outcome is DeliveryOutcome.PENDING:
+        report.pending += 1
+    else:  # REJECTED / TERMINAL_FAILED / TRANSIENT
+        report.rejected += 1
+        if len(report.rejected_samples) < _MAX_REJECTED_SAMPLES:
+            report.rejected_samples.append(f"{result.event_id}: {result.error or result.outcome.value}")
+
+
+def _chunked(items: Sequence[Envelope], size: int) -> Iterator[Sequence[Envelope]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -58,7 +58,7 @@ def envelope_sha256(envelope: Envelope) -> str:
 
 
 @dataclass(frozen=True)
-class ProvenanceEntry:
+class ImportProvenanceEntry:
     """One provenance record for the import audit manifest."""
 
     event_id: str
@@ -69,9 +69,9 @@ class ProvenanceEntry:
     row_sha256: str | None = None
 
 
-def build_provenance_manifest(envelopes: Sequence[Envelope]) -> list[ProvenanceEntry]:
+def build_provenance_manifest(envelopes: Sequence[Envelope]) -> list[ImportProvenanceEntry]:
     return [
-        ProvenanceEntry(
+        ImportProvenanceEntry(
             event_id=str(env["event_id"]),
             event_type=str(env["event_type"]),
             envelope_sha256=envelope_sha256(env),

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -8,8 +8,10 @@ than hand-rolling HTTP:
   with the same canonical-JSON shape the migration dry-run uses.
 * **PREFLIGHT (stage 7):** POST each chunk to ``/api/v1/events/preflight/`` and
   gate on ``accepted`` — the server validates shape/ingress without mutating
-  state. Every chunk is preflighted *before* any chunk uploads, so a rejection
-  anywhere leaves the projection untouched (fail-closed, INV-6).
+  state. Every chunk is preflighted *before* any chunk uploads, so a *preflight*
+  rejection anywhere leaves the projection untouched (fail-closed, INV-6). A
+  mid-upload delivery failure can leave a partial, but it is a valid Lamport-
+  ordered prefix (never an orphan) and a re-run completes idempotently.
 * **UPLOAD (stage 8):** chunk the stream and hand each chunk to a
   :class:`DeliveryReceiver` (gzip + POST + response mapping + poison-batch
   bisection all live there). The server dedups on ``event_id``, so a re-run is
@@ -166,8 +168,17 @@ def run_import_upload(
     """Preflight every chunk, then (only if all pass) upload every chunk.
 
     Preflighting the whole stream before delivering anything is the fail-closed
-    ordering: a rejection in any chunk raises :class:`PreflightRejected` and
-    nothing is uploaded (INV-6).
+    ordering: a **preflight** rejection in any chunk raises
+    :class:`PreflightRejected` and nothing is uploaded (INV-6).
+
+    A mid-upload *delivery* failure (after preflight passes) can leave a partial
+    upload, but that is still safe: chunks carry monotonic per-mission Lamport
+    clocks, so any delivered prefix is a valid ordered prefix (a WPStatusChanged
+    never lands before its WPCreated), never an orphan — and a re-run completes
+    idempotently (the server dedups on ``event_id``). Note the import-once
+    payload freeze: a fixed deterministic ``event_id`` means re-running after the
+    on-disk facts change re-sends the *same* id, so the updated payload is
+    dropped as a duplicate rather than overwriting.
     """
     chunks = list(_chunked(envelopes, chunk_size))
     for chunk in chunks:

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -9,13 +9,17 @@ than hand-rolling HTTP:
 * **PREFLIGHT (stage 7):** POST each chunk to ``/api/v1/events/preflight/`` and
   gate on ``accepted`` — the server validates shape/ingress without mutating
   state. Every chunk is preflighted *before* any chunk uploads, so a *preflight*
-  rejection anywhere leaves the projection untouched (fail-closed, INV-6). A
-  mid-upload delivery failure can leave a partial, but it is a valid Lamport-
-  ordered prefix (never an orphan) and a re-run completes idempotently.
-* **UPLOAD (stage 8):** chunk the stream and hand each chunk to a
+  rejection anywhere leaves the projection untouched (fail-closed, INV-6).
+* **UPLOAD (stage 8):** chunk the stream mission-atomically (no mission ever
+  straddles a chunk boundary — see :func:`_chunked`) and hand each chunk to a
   :class:`DeliveryReceiver` (gzip + POST + response mapping + poison-batch
-  bisection all live there). The server dedups on ``event_id``, so a re-run is
-  idempotent (already-ingested events return ``duplicate``).
+  bisection all live there). Delivery stops at the first chunk that reports any
+  failure outcome, so a mid-upload delivery failure leaves at most a partial —
+  and because chunks are Lamport-ordered and mission-atomic, any delivered
+  prefix is a valid ordered prefix of whole missions (never an orphan). The
+  report flags that state (``UploadReport.partial``) and a re-run completes
+  idempotently: the server dedups on ``event_id``, so already-ingested events
+  return ``duplicate``.
 
 The transport is injectable: production passes an authed ``TeamspaceReceiver``
 and the default ``requests`` poster; tests pass a ``StubReceiver`` and a fake
@@ -39,12 +43,18 @@ from specify_cli.delivery.receivers import (
     OutboundEvent,
     _requests_post,
 )
+from specify_cli.status import MISSION_CREATED
 
 _PREFLIGHT_ENDPOINT_PATH = "/api/v1/events/preflight/"
 _PREFLIGHT_TIMEOUT_SECONDS = 60.0
 # Conservative per-request size: well under the server's 1000-event cap and its
 # 512 KiB decompressed byte ceiling. The receiver still auto-bisects on a 413.
 _IMPORT_CHUNK_SIZE = 500
+# The server's hard per-batch envelope cap. A single mission larger than
+# _IMPORT_CHUNK_SIZE is deliberately NOT split (mission-atomic chunking, see
+# _chunked) and becomes one oversized chunk — safe because the server accepts
+# up to this many events per batch, double our conservative budget.
+_SERVER_MAX_BATCH_SIZE = 1000
 _MAX_REJECTED_SAMPLES = 5
 
 Envelope = Mapping[str, Any]
@@ -124,13 +134,23 @@ def run_server_preflight(
 
 @dataclass
 class UploadReport:
-    """Tally of per-event delivery outcomes for one import run."""
+    """Tally of per-event delivery outcomes for one import run.
+
+    ``partial`` marks the distinct third state between success and total
+    failure: a chunk failed mid-run, delivery stopped there, and
+    ``undelivered_event_count`` events in later chunks were never attempted.
+    ``delivered_through_chunk`` counts the chunks that were delivered cleanly
+    before the stop.
+    """
 
     success: int = 0
     duplicate: int = 0
     pending: int = 0
     rejected: int = 0
     rejected_samples: list[str] = field(default_factory=list)
+    partial: bool = False
+    delivered_through_chunk: int = 0
+    undelivered_event_count: int = 0
 
     @property
     def total(self) -> int:
@@ -138,7 +158,7 @@ class UploadReport:
 
     @property
     def ok(self) -> bool:
-        return self.rejected == 0
+        return self.rejected == 0 and not self.partial
 
 
 def upload_envelopes(
@@ -147,12 +167,14 @@ def upload_envelopes(
     receiver: DeliveryReceiver,
     chunk_size: int = _IMPORT_CHUNK_SIZE,
 ) -> UploadReport:
-    """Chunk the stream and deliver each chunk through the receiver, tallying outcomes."""
+    """Chunk the stream (mission-atomically) and deliver, stopping on failure.
+
+    Same delivery semantics as :func:`run_import_upload` minus the preflight:
+    the first chunk with a failure outcome halts the run and the report records
+    the partial state.
+    """
     report = UploadReport()
-    for chunk in _chunked(envelopes, chunk_size):
-        outbound = [OutboundEvent(event_id=str(env["event_id"]), payload=env) for env in chunk]
-        for result in receiver.deliver(outbound):
-            _tally(report, result)
+    _deliver_chunks(list(_chunked(envelopes, chunk_size)), receiver, report)
     return report
 
 
@@ -165,33 +187,56 @@ def run_import_upload(
     poster: HttpPoster = _requests_post,
     chunk_size: int = _IMPORT_CHUNK_SIZE,
 ) -> UploadReport:
-    """Preflight every chunk, then (only if all pass) upload every chunk.
+    """Preflight every chunk, then (only if all pass) upload chunks in order.
 
     Preflighting the whole stream before delivering anything is the fail-closed
     ordering: a **preflight** rejection in any chunk raises
     :class:`PreflightRejected` and nothing is uploaded (INV-6).
 
-    A mid-upload *delivery* failure (after preflight passes) can leave a partial
-    upload, but that is still safe: chunks carry monotonic per-mission Lamport
-    clocks, so any delivered prefix is a valid ordered prefix (a WPStatusChanged
-    never lands before its WPCreated), never an orphan — and a re-run completes
-    idempotently (the server dedups on ``event_id``). Note the import-once
-    payload freeze: a fixed deterministic ``event_id`` means re-running after the
-    on-disk facts change re-sends the *same* id, so the updated payload is
-    dropped as a duplicate rather than overwriting.
+    A mid-upload *delivery* failure (after preflight passes) stops the run at
+    the failed chunk — later chunks are never attempted, and the report records
+    the partial state (``partial`` / ``delivered_through_chunk`` /
+    ``undelivered_event_count``). The partial is safe: chunks are
+    mission-atomic and carry monotonic per-mission Lamport clocks, so any
+    delivered prefix is a valid ordered prefix of whole missions (a
+    WPStatusChanged never lands before its WPCreated), never an orphan — and a
+    re-run completes idempotently (the server dedups on ``event_id``). Note the
+    import-once payload freeze: a fixed deterministic ``event_id`` means
+    re-running after the on-disk facts change re-sends the *same* id, so the
+    updated payload is dropped as a duplicate rather than overwriting.
     """
     chunks = list(_chunked(envelopes, chunk_size))
     for chunk in chunks:
         run_server_preflight(chunk, server_url=server_url, auth_token=auth_token, poster=poster)
     report = UploadReport()
-    for chunk in chunks:
-        outbound = [OutboundEvent(event_id=str(env["event_id"]), payload=env) for env in chunk]
-        for result in receiver.deliver(outbound):
-            _tally(report, result)
+    _deliver_chunks(chunks, receiver, report)
     return report
 
 
 # ── internals ─────────────────────────────────────────────────────────────────
+
+
+def _deliver_chunks(chunks: Sequence[Sequence[Envelope]], receiver: DeliveryReceiver, report: UploadReport) -> None:
+    """Deliver chunks in order, stopping at the first chunk with a failure.
+
+    A chunk whose delivery reports any outcome outside {success, duplicate,
+    pending} — i.e. REJECTED / TERMINAL_FAILED / TRANSIENT — halts the run:
+    subsequent chunks are never attempted and the report records the partial
+    state. Everything delivered before the stop is a valid ordered prefix of
+    whole missions (mission-atomic chunks, monotonic Lamport clocks), and a
+    re-run resumes idempotently (the server dedups on ``event_id``).
+    """
+    for index, chunk in enumerate(chunks):
+        outbound = [OutboundEvent(event_id=str(env["event_id"]), payload=env) for env in chunk]
+        failures_before = report.rejected
+        for result in receiver.deliver(outbound):
+            _tally(report, result)
+        if report.rejected > failures_before:
+            report.delivered_through_chunk = index
+            report.undelivered_event_count = sum(len(later) for later in chunks[index + 1 :])
+            report.partial = report.undelivered_event_count > 0
+            return
+        report.delivered_through_chunk = index + 1
 
 
 def _tally(report: UploadReport, result: DeliveryResult) -> None:
@@ -208,5 +253,52 @@ def _tally(report: UploadReport, result: DeliveryResult) -> None:
 
 
 def _chunked(items: Sequence[Envelope], size: int) -> Iterator[Sequence[Envelope]]:
-    for start in range(0, len(items), size):
-        yield items[start : start + size]
+    """Mission-atomic chunking: pack whole missions into chunks of ≤ *size* envelopes.
+
+    The ordered stream is grouped into contiguous mission units — each unit
+    starts at a ``MissionCreated`` and carries that mission's ``WPCreated[]`` +
+    ``WPStatusChanged[]``; envelopes arriving before the first
+    ``MissionCreated`` (synthetic/legacy streams) are singleton units. Units
+    are packed greedily up to the *size* budget and a unit is NEVER split: a
+    single mission larger than *size* becomes its own oversized chunk, which
+    the server still accepts (``_SERVER_MAX_BATCH_SIZE`` = 1000 events/batch
+    vs our conservative 500 budget).
+
+    Recorded assumption, verified server-side: SaaS ``/events/preflight/``
+    (apps/sync/views.py::preflight_sync_events →
+    apps/sync/cutover_contract.py::_validate_event_batch) validates each
+    envelope in isolation — schema/shape only, no cross-event
+    referential-completeness check — so chunk boundaries are not
+    correctness-bearing for preflight; mission-atomic chunking is
+    defense-in-depth for delivery-prefix semantics.
+    """
+    chunk: list[Envelope] = []
+    for unit in _mission_units(items):
+        if chunk and len(chunk) + len(unit) > size:
+            yield chunk
+            chunk = []
+        chunk.extend(unit)
+    if chunk:
+        yield chunk
+
+
+def _mission_units(items: Sequence[Envelope]) -> Iterator[list[Envelope]]:
+    """Group the ordered stream into contiguous per-mission units.
+
+    A unit opens at each ``MissionCreated`` and absorbs every envelope up to
+    the next one. Envelopes before the first ``MissionCreated`` have no mission
+    prefix to stay atomic with, so each is its own singleton unit (this also
+    preserves plain size-based packing for prefix-less synthetic streams).
+    """
+    unit: list[Envelope] = []
+    for env in items:
+        if env.get("event_type") == MISSION_CREATED:
+            if unit:
+                yield unit
+            unit = [env]
+        elif unit:
+            unit.append(env)
+        else:
+            yield [env]
+    if unit:
+        yield unit

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -29,7 +29,6 @@ poster, so the whole stage runs with no network.
 from __future__ import annotations
 
 import gzip
-import hashlib
 import json
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -43,6 +42,7 @@ from specify_cli.delivery.receivers import (
     OutboundEvent,
     _requests_post,
 )
+from specify_cli.migration.envelope_seam import envelope_sha256
 from specify_cli.status import MISSION_CREATED
 
 _PREFLIGHT_ENDPOINT_PATH = "/api/v1/events/preflight/"
@@ -61,12 +61,10 @@ Envelope = Mapping[str, Any]
 
 
 # ── provenance (stage 6) ──────────────────────────────────────────────────────
-
-
-def envelope_sha256(envelope: Envelope) -> str:
-    """Canonical-JSON SHA-256 of an envelope (matches the dry-run row-mapping)."""
-    canonical = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(canonical).hexdigest()  # noqa: TID251 - body checksum for the import provenance manifest
+#
+# The canonical-JSON SHA-256 recipe is shared with the migration dry-run's
+# row mapping — one owner (mission_state.envelope_sha256, re-exported through
+# the envelope_seam), so the two checksums cannot drift (#2884).
 
 
 @dataclass(frozen=True)

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -213,7 +213,7 @@ class UploadReport:
 
     @property
     def ok(self) -> bool:
-        return self.rejected == 0 and not self.partial
+        return self.pending == 0 and self.rejected == 0 and not self.partial
 
 
 def upload_envelopes(

--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -34,28 +34,41 @@ from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
+import requests
+
+from specify_cli.core.contract_gate import validate_outbound_payload
 from specify_cli.delivery.receivers import (
+    BATCH_TIMEOUT_SECONDS,
     DeliveryOutcome,
     DeliveryReceiver,
     DeliveryResult,
     HttpPoster,
     OutboundEvent,
-    _requests_post,
+    default_http_poster,
 )
 from specify_cli.migration.envelope_seam import envelope_sha256
 from specify_cli.status import MISSION_CREATED
 
 _PREFLIGHT_ENDPOINT_PATH = "/api/v1/events/preflight/"
-_PREFLIGHT_TIMEOUT_SECONDS = 60.0
+# One delivery timeout policy for the whole SaaS transport: reuse the receiver's
+# canonical batch timeout rather than re-declaring the same 60s value (#2884).
+_PREFLIGHT_TIMEOUT_SECONDS = BATCH_TIMEOUT_SECONDS
 # Conservative per-request size: well under the server's 1000-event cap and its
 # 512 KiB decompressed byte ceiling. The receiver still auto-bisects on a 413.
 _IMPORT_CHUNK_SIZE = 500
 # The server's hard per-batch envelope cap. A single mission larger than
 # _IMPORT_CHUNK_SIZE is deliberately NOT split (mission-atomic chunking, see
-# _chunked) and becomes one oversized chunk — safe because the server accepts
-# up to this many events per batch, double our conservative budget.
+# _chunked) and becomes one oversized chunk — safe up to this many events per
+# batch. A mission that exceeds even this cap is caught fail-closed before any
+# network round-trip by _assert_batches_within_cap.
 _SERVER_MAX_BATCH_SIZE = 1000
 _MAX_REJECTED_SAMPLES = 5
+
+# The outbound-envelope contract context every producer validates against
+# (sync.emitter/batch/client all pass this to validate_outbound_payload). The
+# import producer runs the same offline gate so its hand-assembled prefix
+# envelopes fail fast locally, consistent with the rest of the fleet (#2884).
+_ENVELOPE_CONTRACT_CONTEXT = "envelope"
 
 Envelope = Mapping[str, Any]
 
@@ -107,7 +120,7 @@ def run_server_preflight(
     *,
     server_url: str,
     auth_token: str,
-    poster: HttpPoster = _requests_post,
+    poster: HttpPoster = default_http_poster,
 ) -> dict[str, Any]:
     """POST ``{"events": [...]}`` to the preflight endpoint; raise if not accepted."""
     url = server_url.rstrip("/") + _PREFLIGHT_ENDPOINT_PATH
@@ -117,7 +130,14 @@ def run_server_preflight(
         "Content-Encoding": "gzip",
         "Content-Type": "application/json",
     }
-    response = poster(url, data=body, headers=headers, timeout=_PREFLIGHT_TIMEOUT_SECONDS)
+    try:
+        response = poster(url, data=body, headers=headers, timeout=_PREFLIGHT_TIMEOUT_SECONDS)
+    except requests.RequestException as exc:
+        # A transport failure (unreachable host, timeout, TLS reset) during
+        # preflight must fail closed as a graceful rejection, not escape as a raw
+        # traceback — the delivery path maps the same error to a batch failure
+        # (receivers.py::_attempt_batch_send); preflight now matches (#2884).
+        raise PreflightRejected({"error": f"preflight transport failed: {exc}"}) from exc
     try:
         payload = response.json()
     except Exception as exc:  # non-JSON (5xx / proxy error) is a hard, fail-closed stop
@@ -125,6 +145,43 @@ def run_server_preflight(
     if response.status_code != 200 or not payload.get("accepted"):
         raise PreflightRejected(payload)
     return dict(payload)
+
+
+def validate_import_envelopes(envelopes: Sequence[Envelope]) -> None:
+    """Run the offline outbound-envelope contract gate over every envelope.
+
+    Every other envelope producer (``sync.emitter``/``batch``/``client``)
+    validates at emit/enqueue time; the import producer runs the same gate so
+    its hand-assembled ``MissionCreated``/``WPCreated`` prefix envelopes fail
+    fast locally instead of only at the server-preflight round-trip — closing
+    the defense-in-depth gap the #2884 review flagged. Raises
+    :class:`~specify_cli.core.contract_gate.ContractViolationError` on the first
+    offending envelope, before any network call.
+    """
+    for env in envelopes:
+        validate_outbound_payload(dict(env), _ENVELOPE_CONTRACT_CONTEXT)
+
+
+def _assert_batches_within_cap(chunks: Sequence[Sequence[Envelope]]) -> None:
+    """Fail closed if any mission-atomic chunk exceeds the server's batch cap.
+
+    Mission-atomic chunking (:func:`_chunked`) never splits a mission, so a
+    single mission larger than ``_SERVER_MAX_BATCH_SIZE`` becomes one oversized
+    chunk that the server would reject at preflight. Catch it here, before the
+    network round-trip, with an actionable message rather than an opaque
+    server-side rejection (#2884).
+    """
+    for chunk in chunks:
+        if len(chunk) > _SERVER_MAX_BATCH_SIZE:
+            raise PreflightRejected(
+                {
+                    "error": (
+                        f"a single mission is {len(chunk)} events, over the server's "
+                        f"{_SERVER_MAX_BATCH_SIZE}-event batch cap; mission-atomic chunking "
+                        "cannot split it. Import this mission on its own or trim its history."
+                    )
+                }
+            )
 
 
 # ── upload (stage 8) ──────────────────────────────────────────────────────────
@@ -171,8 +228,10 @@ def upload_envelopes(
     the first chunk with a failure outcome halts the run and the report records
     the partial state.
     """
+    chunks = list(_chunked(envelopes, chunk_size))
+    _assert_batches_within_cap(chunks)
     report = UploadReport()
-    _deliver_chunks(list(_chunked(envelopes, chunk_size)), receiver, report)
+    _deliver_chunks(chunks, receiver, report)
     return report
 
 
@@ -182,7 +241,7 @@ def run_import_upload(
     receiver: DeliveryReceiver,
     server_url: str,
     auth_token: str,
-    poster: HttpPoster = _requests_post,
+    poster: HttpPoster = default_http_poster,
     chunk_size: int = _IMPORT_CHUNK_SIZE,
 ) -> UploadReport:
     """Preflight every chunk, then (only if all pass) upload chunks in order.
@@ -204,6 +263,7 @@ def run_import_upload(
     updated payload is dropped as a duplicate rather than overwriting.
     """
     chunks = list(_chunked(envelopes, chunk_size))
+    _assert_batches_within_cap(chunks)
     for chunk in chunks:
         run_server_preflight(chunk, server_url=server_url, auth_token=auth_token, poster=poster)
     report = UploadReport()

--- a/tests/architectural/_baselines.yaml
+++ b/tests/architectural/_baselines.yaml
@@ -31,7 +31,7 @@ test_no_dead_modules:
   # wp-lane-state-machine-fsm): upstream #1756 added m_3_3_0_session_presence_all_harnesses
   # and m_3_3_0_session_presence_claude_code; both auto-discovered via
   # pkgutil.iter_modules, never statically imported. Growth here is expected/routine.
-  category_1_auto_discovered_migrations: 94  # justification: 94 after #2804 added m_3_2_6_gate_artifact_merge_drivers (gate-artifact merge-driver seeding, target 3.2.6), registered via @MigrationRegistry.register and discovered through pkgutil rather than a static importer -- same auto-discovery shape as the sibling m_3_2_6_meta_traces_merge_drivers; no runtime caller by design.
+  category_1_auto_discovered_migrations: 95  # justification: 95 after the coord-write-placement-closure mission added m_3_2_6_decisions_event_log_merge_driver (decisions.events.jsonl merge-driver seeding, target 3.2.6), registered via @MigrationRegistry.register and discovered through pkgutil rather than a static importer -- same auto-discovery shape as the sibling m_3_2_6_meta_traces_merge_drivers / m_3_2_6_gate_artifact_merge_drivers; no runtime caller by design.
   # justification: 3 schema generator modules consumed by
   # scripts/generate_schemas.py via importlib.import_module.
   # Shrunk from 4 → 3 when doctrine.missions.models gained a live

--- a/tests/architectural/test_guard_capability_call_sites.py
+++ b/tests/architectural/test_guard_capability_call_sites.py
@@ -42,11 +42,14 @@ _ENUM_HOME = "src/specify_cli/core/commit_guard.py"
 _PROTECTED_FLOW_ALLOWLISTS: dict[str, frozenset[str]] = {
     # Test-fixture-only: no production caller, ever.
     "TEST_MODE": frozenset({_ENUM_HOME}),
-    # The bona-fide merge/close done-transitions bookkeeping flow. Both the merge
-    # executor AND the post-merge retrospective terminus (which also runs from the
-    # `mission close` path) land their bookkeeping commit through the ONE shared
-    # seam `git/bookkeeping_commit.py` (#2280 / PR #2281) — a single sanctioned
-    # protected-flow commit surface, not a second guard-capability call site.
+    # The bona-fide merge/close done-transitions bookkeeping flow. Every caller
+    # (the merge executor's done-transitions commit AND its birth-cutover COORD
+    # seed commit, plus the post-merge retrospective terminus) lands through the
+    # ONE shared seam `git/bookkeeping_commit.py` (#2280 / PR #2281) — its two
+    # named entry points (`commit_merge_bookkeeping` PRIMARY /
+    # `commit_coord_seed_bookkeeping` COORD) both delegate to a single guarded
+    # `_commit_bookkeeping` call site. A single sanctioned protected-flow commit
+    # surface, not a second guard-capability call site outside this module.
     "MERGE_BOOKKEEPING": frozenset({_ENUM_HOME, "src/specify_cli/git/bookkeeping_commit.py"}),
     # The bona-fide upgrade bookkeeping flow. Main checkout AND every sibling
     # worktree (#2385 / epic #2392) land their upgrade commit through the ONE

--- a/tests/architectural/test_inline_meta_read_gate.py
+++ b/tests/architectural/test_inline_meta_read_gate.py
@@ -101,17 +101,18 @@ FLOOR_MARGIN = 2
 
 # WP16 SC-004-equivalent anti-mass-allow-list guard: the number of call sites
 # routed through load_meta/load_meta_strict/load_meta_or_empty has its own
-# floor and can only rise. Live routed census on this tree is 117 (includes
+# floor and can only rise. Live routed census on this tree is 121 (includes
 # mission_metadata.py's own internal call sites — e.g. load_meta_strict/
 # load_meta_or_empty delegating to load_meta, and the module's many other
 # public helpers reading meta.json through the one canonical primitive; those
 # ARE genuine routed-usage evidence, not the read implementation itself, which
 # is why mission_metadata.py is excluded from the INLINE scan but NOT from this
-# routed-usage census). Floor (112) sits one below the live count, inside the
-# MARGIN(4) band. The floor is kept one below live so the anti-vacuity check
-# proves the census is not merely equal to a hand-entered value.
+# routed-usage census — plus the import-history SCAN's own load_meta_or_empty
+# call, #2262). Floor (117) sits MARGIN(4) below the live count and strictly
+# below it, so the anti-vacuity check proves the census is not merely equal to
+# a hand-entered value.
 ROUTED_LOAD_META_FLOOR_MARGIN = 4
-ROUTED_LOAD_META_FLOOR = 116
+ROUTED_LOAD_META_FLOOR = 117
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/architectural/test_inline_meta_read_gate.py
+++ b/tests/architectural/test_inline_meta_read_gate.py
@@ -101,16 +101,16 @@ FLOOR_MARGIN = 2
 
 # WP16 SC-004-equivalent anti-mass-allow-list guard: the number of call sites
 # routed through load_meta/load_meta_strict/load_meta_or_empty has its own
-# floor and can only rise. Live routed census on this tree is 121 (includes
+# floor and can only rise. Live routed census on this tree is 120 (includes
 # mission_metadata.py's own internal call sites — e.g. load_meta_strict/
 # load_meta_or_empty delegating to load_meta, and the module's many other
 # public helpers reading meta.json through the one canonical primitive; those
 # ARE genuine routed-usage evidence, not the read implementation itself, which
 # is why mission_metadata.py is excluded from the INLINE scan but NOT from this
 # routed-usage census — plus the import-history SCAN's own load_meta_or_empty
-# call, #2262). Floor (117) sits MARGIN(4) below the live count and strictly
-# below it, so the anti-vacuity check proves the census is not merely equal to
-# a hand-entered value.
+# call, #2262). Floor (117) sits 3 below the live count (within MARGIN(4)) and
+# strictly below it, so the anti-vacuity check proves the census is not merely
+# equal to a hand-entered value.
 ROUTED_LOAD_META_FLOOR_MARGIN = 4
 ROUTED_LOAD_META_FLOOR = 117
 

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -739,8 +739,8 @@ _CATEGORY_C_EVENT_SYNC_RETENTION_DELIVERY: frozenset[SymbolKey] = frozenset(
         SymbolKey("TERMINAL_STATUSES", "39cfb0bb7ccf29fe7683659c8e5648022bc1fa98b30069fdee81822c103fe7bd"),  # specify_cli.delivery.ledger::TERMINAL_STATUSES
         SymbolKey("init_ledger", "95d75b9f2c0c5692072a02c2145128f9fe47e82e9a47120235d5c77bfae3f4ec"),  # specify_cli.delivery.ledger::init_ledger
         SymbolKey("BATCH_ENDPOINT_PATH", "ca95ace141f4fdf0e9b45beded0c05ad7eacbf89e4d6d3db6035fd7d17fcc644"),  # specify_cli.delivery.receivers::BATCH_ENDPOINT_PATH
-        # specify_cli.delivery.receivers::BATCH_TIMEOUT_SECONDS
-        SymbolKey("BATCH_TIMEOUT_SECONDS", "b369a7d782ba7ef5f063929fda2b130c0a53b2044621b8d19dd3afe495d3d226"),
+        # BATCH_TIMEOUT_SECONDS left the allowlist: sync.history_import.upload now
+        # imports it (reusing the canonical delivery timeout, #2884).
         SymbolKey("GateDecision", "63e6f6d31d87a0baa8128896db70bcd1a281aef33f9cdc64dc7a4fc1f825dd99"),  # specify_cli.delivery.receivers::GateDecision
         SymbolKey("GateKind", "5b6ccac48cf9723e99c997a1f70c7af1f481e819abb62e251d9b3814fd71d05e"),  # specify_cli.delivery.receivers::GateKind
         SymbolKey("HttpResponse", "424e7dd151b9e7abdea1693be40b486e5755f23c7a23fef775d06f3864217935"),  # specify_cli.delivery.receivers::HttpResponse

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -1225,7 +1225,11 @@ def _record_module_attr_edges(
     ``M::NAME``, silently re-blinding the very gate this mission hardens.
     """
     for node in ast.walk(tree):
-        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id in alias_map:
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in alias_map
+        ):
             resolved = alias_map[node.value.id]
             if resolved in known_modules:
                 per_symbol.setdefault(resolved, set()).add(node.attr)
@@ -1246,7 +1250,12 @@ def _record_getattr_str_edges(
     required to avoid re-blinding the gate via a symbol-path collision.
     """
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+        ):
             continue
         obj, attr_arg = node.args[0], node.args[1]
         if not (isinstance(obj, ast.Name) and obj.id in alias_map):
@@ -1271,7 +1280,12 @@ def _find_facade_lazy_dict_name(tree: ast.Module) -> str | None:
             continue
         arg_id = node.args.args[0].arg
         for child in ast.walk(node):
-            if isinstance(child, ast.Subscript) and isinstance(child.value, ast.Name) and isinstance(child.slice, ast.Name) and child.slice.id == arg_id:
+            if (
+                isinstance(child, ast.Subscript)
+                and isinstance(child.value, ast.Name)
+                and isinstance(child.slice, ast.Name)
+                and child.slice.id == arg_id
+            ):
                 return child.value.id
     return None
 
@@ -1467,7 +1481,9 @@ def _record_dynamic_call_accessor_edges(
     for path, tree in path_to_tree.items():
         containing = _package_of(path)
         alias_map, str_consts = _build_alias_map_and_consts(tree, containing)
-        factories = find_module_factory_functions(tree, alias_map, str_consts, containing, known_modules, _resolve_relative_module)
+        factories = find_module_factory_functions(
+            tree, alias_map, str_consts, containing, known_modules, _resolve_relative_module
+        )
         if not factories:
             continue
         merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
@@ -2040,20 +2056,29 @@ def test_no_false_negative_call_accessor_detector_direct_chain() -> None:
     access would. Resolved generally (no name special-case for
     ``runtime_bridge`` anywhere in the resolver).
     """
-    src = "import importlib\ndef _factory():\n    return importlib.import_module('target_mod')\n_factory().Live\n"
+    src = (
+        "import importlib\n"
+        "def _factory():\n"
+        "    return importlib.import_module('target_mod')\n"
+        "_factory().Live\n"
+    )
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
+    factories = find_module_factory_functions(
+        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
+    )
     ps: dict[str, set[str]] = {}
     record_call_chain_attr_edges(tree, factories, ps)
     sub_idx = _submodule_index(ps)
 
     assert _symbol_has_caller("Live", "target_mod", ps, sub_idx), (
-        "target_mod::Live must be rescued by _factory().Live where _factory() dynamically resolves target_mod via importlib.import_module"
+        "target_mod::Live must be rescued by _factory().Live where _factory() "
+        "dynamically resolves target_mod via importlib.import_module"
     )
     assert not _symbol_has_caller("Live", "unrelated_mod", ps, sub_idx), (
-        "unrelated_mod::Live must NOT be rescued -- the resolver must not widen liveness to any attribute access (contract anti-goal)"
+        "unrelated_mod::Live must NOT be rescued -- the resolver must not "
+        "widen liveness to any attribute access (contract anti-goal)"
     )
 
 
@@ -2062,18 +2087,28 @@ def test_no_false_negative_call_accessor_detector_bound_local() -> None:
     actually used by the known ``_runtime_bridge_module()`` call sites in
     ``next_cmd.py`` (``bridge = _runtime_bridge_module(); bridge.attr``).
     """
-    src = "import importlib\ndef _factory():\n    return importlib.import_module('target_mod')\nbridge = _factory()\nbridge.Live\n"
+    src = (
+        "import importlib\n"
+        "def _factory():\n"
+        "    return importlib.import_module('target_mod')\n"
+        "bridge = _factory()\n"
+        "bridge.Live\n"
+    )
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
+    factories = find_module_factory_functions(
+        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
+    )
     merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
     ps: dict[str, set[str]] = {}
     _record_module_attr_edges(tree, merged_alias_map, ps, known_modules)
     sub_idx = _submodule_index(ps)
 
     assert _symbol_has_caller("Live", "target_mod", ps, sub_idx), (
-        "target_mod::Live must be rescued by bridge.Live where bridge = _factory() and _factory() dynamically resolves target_mod via importlib.import_module"
+        "target_mod::Live must be rescued by bridge.Live where bridge = "
+        "_factory() and _factory() dynamically resolves target_mod via "
+        "importlib.import_module"
     )
     assert not _symbol_has_caller("Live", "unrelated_mod", ps, sub_idx)
 
@@ -2095,7 +2130,9 @@ def test_no_false_negative_call_accessor_detector_unreferenced_stays_dead() -> N
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
+    factories = find_module_factory_functions(
+        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
+    )
     merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
     ps: dict[str, set[str]] = {}
     _record_module_attr_edges(tree, merged_alias_map, ps, known_modules)
@@ -2132,10 +2169,13 @@ def test_wp01_runtime_bridge_facade_symbols_recognised_live_without_allowlist() 
         "QueryModeValidationError",
     ):
         assert name in decls.get(mod_dotted, frozenset()), (
-            f"{mod_dotted}::{name} must still be declared in __all__ -- this test targets the real live corpus, not a stale fixture"
+            f"{mod_dotted}::{name} must still be declared in __all__ -- this "
+            "test targets the real live corpus, not a stale fixture"
         )
         assert _symbol_has_caller(name, mod_dotted, per_symbol, submodule_index), (
-            f"{mod_dotted}::{name} must be recognised-live via the _runtime_bridge_module() dynamic accessor WITHOUT its allowlist row (IC-01 / FR-001 / FR-002)"
+            f"{mod_dotted}::{name} must be recognised-live via the "
+            "_runtime_bridge_module() dynamic accessor WITHOUT its allowlist "
+            "row (IC-01 / FR-001 / FR-002)"
         )
 
 

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -371,14 +371,12 @@ _CATEGORY_B_GRANDFATHERED_LEGACY: frozenset[SymbolKey] = frozenset(
         SymbolKey("SCHEMA_VERSION", "8fb29803d3d131301db2bbe72bbaab5314981664272c6a9d57f2a75684ae1811"),  # specify_cli.skills.manifest_store::SCHEMA_VERSION
         SymbolKey("load", "7689780b2e4a040cfc29e5b540406167217369b98795702cc6c496cb1c9a2b7c"),  # specify_cli.skills.manifest_store::load
         SymbolKey("save", "222fabd1e77c7d011d9fc0b583fd27d7c8a044cf0fe17fdce0a59c95583b1172"),  # specify_cli.skills.manifest_store::save
-        SymbolKey("MISSION_CREATED", "cee8959200ec2e6304a1ff8d59dd8eb356bf76108ecdf4ba8210ff4522fbebdc"),  # specify_cli.status.lifecycle_events::MISSION_CREATED
         # specify_cli.status.lifecycle_events::MISSION_EVENTS_FILENAME
         SymbolKey("MISSION_EVENTS_FILENAME", "725b94e955667ce901d7080717a134b4f0b6da5c5efc829f5fc9e98353d9afc9"),
         # specify_cli.status.lifecycle_events::PROJECT_EVENTS_FILENAME
         SymbolKey("PROJECT_EVENTS_FILENAME", "27f95adf27cd2fb348df3cd92afb8f6bd3c015697e237d232da23bfa900f74fe"),
         # specify_cli.status.lifecycle_events::PROJECT_INITIALIZED
         SymbolKey("PROJECT_INITIALIZED", "ee097bd3221c588159762747beceb7db48856f2f323d8551524f02e238770723"),
-        SymbolKey("WP_CREATED", "4f61af61cf1570deb1b34ef633f688e26483b680cc965d27f75415e188289732"),  # specify_cli.status.lifecycle_events::WP_CREATED
         # specify_cli.status.lifecycle_events::append_lifecycle_event
         SymbolKey("append_lifecycle_event", "44bbd8d10caea88cf4765a3952d39b9c790cb33de16111d5110aa3fb2d574659"),
         # specify_cli.status.lifecycle_events::has_lifecycle_event
@@ -1227,11 +1225,7 @@ def _record_module_attr_edges(
     ``M::NAME``, silently re-blinding the very gate this mission hardens.
     """
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Attribute)
-            and isinstance(node.value, ast.Name)
-            and node.value.id in alias_map
-        ):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id in alias_map:
             resolved = alias_map[node.value.id]
             if resolved in known_modules:
                 per_symbol.setdefault(resolved, set()).add(node.attr)
@@ -1252,12 +1246,7 @@ def _record_getattr_str_edges(
     required to avoid re-blinding the gate via a symbol-path collision.
     """
     for node in ast.walk(tree):
-        if not (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "getattr"
-            and len(node.args) >= 2
-        ):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "getattr" and len(node.args) >= 2):
             continue
         obj, attr_arg = node.args[0], node.args[1]
         if not (isinstance(obj, ast.Name) and obj.id in alias_map):
@@ -1282,12 +1271,7 @@ def _find_facade_lazy_dict_name(tree: ast.Module) -> str | None:
             continue
         arg_id = node.args.args[0].arg
         for child in ast.walk(node):
-            if (
-                isinstance(child, ast.Subscript)
-                and isinstance(child.value, ast.Name)
-                and isinstance(child.slice, ast.Name)
-                and child.slice.id == arg_id
-            ):
+            if isinstance(child, ast.Subscript) and isinstance(child.value, ast.Name) and isinstance(child.slice, ast.Name) and child.slice.id == arg_id:
                 return child.value.id
     return None
 
@@ -1483,9 +1467,7 @@ def _record_dynamic_call_accessor_edges(
     for path, tree in path_to_tree.items():
         containing = _package_of(path)
         alias_map, str_consts = _build_alias_map_and_consts(tree, containing)
-        factories = find_module_factory_functions(
-            tree, alias_map, str_consts, containing, known_modules, _resolve_relative_module
-        )
+        factories = find_module_factory_functions(tree, alias_map, str_consts, containing, known_modules, _resolve_relative_module)
         if not factories:
             continue
         merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
@@ -2058,29 +2040,20 @@ def test_no_false_negative_call_accessor_detector_direct_chain() -> None:
     access would. Resolved generally (no name special-case for
     ``runtime_bridge`` anywhere in the resolver).
     """
-    src = (
-        "import importlib\n"
-        "def _factory():\n"
-        "    return importlib.import_module('target_mod')\n"
-        "_factory().Live\n"
-    )
+    src = "import importlib\ndef _factory():\n    return importlib.import_module('target_mod')\n_factory().Live\n"
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(
-        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
-    )
+    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
     ps: dict[str, set[str]] = {}
     record_call_chain_attr_edges(tree, factories, ps)
     sub_idx = _submodule_index(ps)
 
     assert _symbol_has_caller("Live", "target_mod", ps, sub_idx), (
-        "target_mod::Live must be rescued by _factory().Live where _factory() "
-        "dynamically resolves target_mod via importlib.import_module"
+        "target_mod::Live must be rescued by _factory().Live where _factory() dynamically resolves target_mod via importlib.import_module"
     )
     assert not _symbol_has_caller("Live", "unrelated_mod", ps, sub_idx), (
-        "unrelated_mod::Live must NOT be rescued -- the resolver must not "
-        "widen liveness to any attribute access (contract anti-goal)"
+        "unrelated_mod::Live must NOT be rescued -- the resolver must not widen liveness to any attribute access (contract anti-goal)"
     )
 
 
@@ -2089,28 +2062,18 @@ def test_no_false_negative_call_accessor_detector_bound_local() -> None:
     actually used by the known ``_runtime_bridge_module()`` call sites in
     ``next_cmd.py`` (``bridge = _runtime_bridge_module(); bridge.attr``).
     """
-    src = (
-        "import importlib\n"
-        "def _factory():\n"
-        "    return importlib.import_module('target_mod')\n"
-        "bridge = _factory()\n"
-        "bridge.Live\n"
-    )
+    src = "import importlib\ndef _factory():\n    return importlib.import_module('target_mod')\nbridge = _factory()\nbridge.Live\n"
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(
-        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
-    )
+    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
     merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
     ps: dict[str, set[str]] = {}
     _record_module_attr_edges(tree, merged_alias_map, ps, known_modules)
     sub_idx = _submodule_index(ps)
 
     assert _symbol_has_caller("Live", "target_mod", ps, sub_idx), (
-        "target_mod::Live must be rescued by bridge.Live where bridge = "
-        "_factory() and _factory() dynamically resolves target_mod via "
-        "importlib.import_module"
+        "target_mod::Live must be rescued by bridge.Live where bridge = _factory() and _factory() dynamically resolves target_mod via importlib.import_module"
     )
     assert not _symbol_has_caller("Live", "unrelated_mod", ps, sub_idx)
 
@@ -2132,9 +2095,7 @@ def test_no_false_negative_call_accessor_detector_unreferenced_stays_dead() -> N
     tree = ast.parse(src)
     alias_map, str_consts = _build_alias_map_and_consts(tree, "")
     known_modules = frozenset({"target_mod"})
-    factories = find_module_factory_functions(
-        tree, alias_map, str_consts, "", known_modules, _resolve_relative_module
-    )
+    factories = find_module_factory_functions(tree, alias_map, str_consts, "", known_modules, _resolve_relative_module)
     merged_alias_map = {**alias_map, **bind_call_accessor_aliases(tree, factories)}
     ps: dict[str, set[str]] = {}
     _record_module_attr_edges(tree, merged_alias_map, ps, known_modules)
@@ -2171,13 +2132,10 @@ def test_wp01_runtime_bridge_facade_symbols_recognised_live_without_allowlist() 
         "QueryModeValidationError",
     ):
         assert name in decls.get(mod_dotted, frozenset()), (
-            f"{mod_dotted}::{name} must still be declared in __all__ -- this "
-            "test targets the real live corpus, not a stale fixture"
+            f"{mod_dotted}::{name} must still be declared in __all__ -- this test targets the real live corpus, not a stale fixture"
         )
         assert _symbol_has_caller(name, mod_dotted, per_symbol, submodule_index), (
-            f"{mod_dotted}::{name} must be recognised-live via the "
-            "_runtime_bridge_module() dynamic accessor WITHOUT its allowlist "
-            "row (IC-01 / FR-001 / FR-002)"
+            f"{mod_dotted}::{name} must be recognised-live via the _runtime_bridge_module() dynamic accessor WITHOUT its allowlist row (IC-01 / FR-001 / FR-002)"
         )
 
 

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -741,7 +741,8 @@ _CATEGORY_C_EVENT_SYNC_RETENTION_DELIVERY: frozenset[SymbolKey] = frozenset(
         SymbolKey("BATCH_ENDPOINT_PATH", "ca95ace141f4fdf0e9b45beded0c05ad7eacbf89e4d6d3db6035fd7d17fcc644"),  # specify_cli.delivery.receivers::BATCH_ENDPOINT_PATH
         # BATCH_TIMEOUT_SECONDS left the allowlist: sync.history_import.upload now
         # imports it (reusing the canonical delivery timeout, #2884).
-        SymbolKey("GateDecision", "63e6f6d31d87a0baa8128896db70bcd1a281aef33f9cdc64dc7a4fc1f825dd99"),  # specify_cli.delivery.receivers::GateDecision
+        # GateDecision left the allowlist: cli.commands.sync now imports it for the
+        # shared _resolve_gated_receiver seam (#2884 landing fold).
         SymbolKey("GateKind", "5b6ccac48cf9723e99c997a1f70c7af1f481e819abb62e251d9b3814fd71d05e"),  # specify_cli.delivery.receivers::GateKind
         SymbolKey("HttpResponse", "424e7dd151b9e7abdea1693be40b486e5755f23c7a23fef775d06f3864217935"),  # specify_cli.delivery.receivers::HttpResponse
         SymbolKey("ReceiverGate", "222316c26a75df8f8d97c3423fa0d49fdbd2f6326362a53fd1cb8de155f30298"),  # specify_cli.delivery.receivers::ReceiverGate

--- a/tests/architectural/test_no_raw_mission_spec_paths.py
+++ b/tests/architectural/test_no_raw_mission_spec_paths.py
@@ -71,6 +71,13 @@ _SEMANTIC_CONSTRUCTOR_FILES = {
     Path("src/specify_cli/cli/commands/agent/context.py"),
     Path("src/specify_cli/cli/commands/agent/mission.py"),
     Path("src/specify_cli/cli/commands/decision.py"),
+    # `agent mission repair` (coord split-brain repair) constructs the same
+    # `KITTY_SPECS_DIR / <handle>` primary dir as the WP10 entrypoints above, for
+    # the SOLE purpose of bootstrapping the mission's own content location before
+    # the forward-only repair -- a meta-read seed mirroring the sibling
+    # mission_feature_resolution.py pattern (see the in-file rationale at
+    # mission_repair.py), not an independent resolution path.
+    Path("src/specify_cli/cli/commands/agent/mission_repair.py"),
 }
 
 

--- a/tests/architectural/test_write_surface_placement_guard.py
+++ b/tests/architectural/test_write_surface_placement_guard.py
@@ -520,9 +520,13 @@ PARTITION_RATIONALE: dict[MissionArtifactKind, tuple[_Partition, str, str]] = {
         "PRIMARY",
         "FR-003 (coord-commit-integrity) re-home COORD→PRIMARY: record-analysis "
         "output (analysis-report.md) shares the spec/plan/tasks freshness-hash "
-        "siblings, which are PRIMARY-only — a coord write is structurally impossible. "
-        "The writer + freshness gate + SSOT now agree on the primary target_branch; a "
-        "stale primary copy is REAL dirt, never coord residue.",
+        "siblings, which are PRIMARY-only — so partition-membership policy routes a "
+        "write here to PRIMARY (a coord write is policy-forbidden, not physically "
+        "impossible: resolve_placement_only would route any kind forced into the "
+        "COORD partition to the coordination branch — see "
+        "test_rehome_any_load_bearing_kind_flips_resolved_ref). The writer + "
+        "freshness gate + SSOT now agree on the primary target_branch; a stale "
+        "primary copy is REAL dirt, never coord residue.",
         "record-analysis writer + freshness-hash gate (needs PRIMARY spec/plan/tasks)",
     ),
     MissionArtifactKind.DECISION_LOG: (

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -217,6 +217,19 @@ class TestSafeCommitCalledAfterMarkDoneLoop:
         feature_dir.mkdir(parents=True)
         _write_meta(feature_dir, mission_slug, mission_id=None)
         _seed_mission_branch(tmp_path, mission_slug)
+        # Materialize the status pair on disk BEFORE the merge, matching what the
+        # real (unmocked) `_mark_wp_merged_done` durably writes to the target
+        # checkout in production. This test mocks `_mark_wp_merged_done` itself
+        # (it only asserts the `commit_merge_bookkeeping` call args, not the
+        # done-transition mechanics — that E2E path is covered by
+        # `test_done_events_committed_to_git` below), so the on-disk artifact has
+        # to be seeded directly or `_phase_commit_and_assert`'s existence filter
+        # (added for the optional birth-cutover/baseline meta paths) legitimately
+        # drops a path that was never materialized in this fixture.
+        _seed_status_event(feature_dir, mission_slug, "WP01", "done")
+        from specify_cli.status.reducer import materialize
+
+        materialize(feature_dir)
 
         manifest = MagicMock()
         manifest.target_branch = "main"

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -1,0 +1,181 @@
+"""Tests for ``spec-kitty sync import-history`` — WP-Y1 (#2262).
+
+WP-Y1 is the command surface + mission selection + the fail-closed TeamSpace
+audit gate. It reuses ``migration.mission_state`` helpers rather than
+re-deriving them; envelope synthesis and the §3.6b pre-sync log re-drain land
+in later slices, so ``--apply`` is an honest non-zero stub here (it must never
+claim a materialize it cannot perform).
+
+These tests drive the CLI wrapper only. The selection/audit authority stays in
+``migration.mission_state`` and is monkeypatched at its seams, so the suite
+needs no on-disk repo, no dossier, and no TeamSpace credentials.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands import sync as sync_command
+from specify_cli.cli.commands.sync import app
+
+pytestmark = pytest.mark.fast
+
+runner = CliRunner()
+
+
+# ── seam helpers ─────────────────────────────────────────────────────────────
+
+
+def _patch_checkout(monkeypatch: pytest.MonkeyPatch, repo_root: Path) -> None:
+    """Point the command's active-checkout resolver at a fixed repo root."""
+    monkeypatch.setattr(
+        sync_command,
+        "_require_active_checkout",
+        lambda: SimpleNamespace(repo_root=repo_root),
+    )
+
+
+def _patch_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mission_dirs: list[Path],
+    blockers: list[dict[str, object]],
+) -> None:
+    """Stub the two migration seams the command reuses.
+
+    Patched on the source module so the command's local
+    ``from specify_cli.migration.mission_state import ...`` binds to the stubs.
+    """
+    import specify_cli.migration.mission_state as mission_state
+
+    monkeypatch.setattr(
+        mission_state,
+        "_select_mission_dirs",
+        lambda repo_root, *, scan_root, mission: list(mission_dirs),
+    )
+    monkeypatch.setattr(
+        mission_state,
+        "_teamspace_audit_blockers",
+        lambda repo_root, *, scan_root, mission_dirs: list(blockers),
+    )
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+# ── wiring ───────────────────────────────────────────────────────────────────
+
+
+def test_command_is_wired_with_its_flags():
+    """``import-history --help`` renders and advertises its three flags."""
+    result = runner.invoke(app, ["import-history", "--help"])
+    assert result.exit_code == 0
+    plain = _strip_ansi(result.output)
+    assert "--apply" in plain
+    assert "--dry-run" in plain
+    assert "--mission" in plain
+
+
+def test_apply_and_dry_run_are_mutually_exclusive():
+    """Both flags at once is a usage error (exit 2), caught before any I/O."""
+    result = runner.invoke(app, ["import-history", "--apply", "--dry-run"])
+    assert result.exit_code == 2
+    assert "mutually exclusive" in _strip_ansi(result.output)
+
+
+# ── stage 1: selection ───────────────────────────────────────────────────────
+
+
+def test_no_missions_found_exits_zero(tmp_path, monkeypatch):
+    _patch_checkout(monkeypatch, tmp_path)
+    _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
+    result = runner.invoke(app, ["import-history"])
+    assert result.exit_code == 0
+    assert "No missions found" in _strip_ansi(result.output)
+
+
+def test_selection_repair_error_exits_one(tmp_path, monkeypatch):
+    """A ``MissionStateRepairError`` from selection fails closed (exit 1)."""
+    import specify_cli.migration.mission_state as mission_state
+
+    _patch_checkout(monkeypatch, tmp_path)
+
+    def _boom(repo_root, *, scan_root, mission):
+        raise mission_state.MissionStateRepairError("selector could not resolve mission handle")
+
+    monkeypatch.setattr(mission_state, "_select_mission_dirs", _boom)
+    result = runner.invoke(app, ["import-history", "--mission", "does-not-resolve"])
+    assert result.exit_code == 1
+    assert "selector could not resolve mission handle" in _strip_ansi(result.output)
+
+
+# ── stage 2: fail-closed audit gate ──────────────────────────────────────────
+
+
+def test_clean_missions_are_listed_on_dry_run(tmp_path, monkeypatch):
+    dirs = [tmp_path / "demo-mission-01AAAA", tmp_path / "demo-mission-01BBBB"]
+    _patch_checkout(monkeypatch, tmp_path)
+    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=[])
+
+    result = runner.invoke(app, ["import-history"])
+    assert result.exit_code == 0
+    plain = _strip_ansi(result.output)
+    assert "2 mission(s) eligible for import" in plain
+    assert "audit clean" in plain
+    assert "demo-mission-01AAAA" in plain
+    assert "demo-mission-01BBBB" in plain
+
+
+def test_audit_blockers_block_import_and_name_the_finding(tmp_path, monkeypatch):
+    dirs = [tmp_path / "demo-mission-01CCCC"]
+    blockers = [
+        {
+            "mission_slug": "demo-mission-01CCCC",
+            "artifact_path": "spec.md",
+            "message": "spec.md failed dossier schema validation",
+            "finding_code": "SCHEMA_INVALID",
+        }
+    ]
+    _patch_checkout(monkeypatch, tmp_path)
+    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=blockers)
+
+    result = runner.invoke(app, ["import-history"])
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Import blocked" in plain
+    # The blocker is named (mission + message), not dumped as a raw dict.
+    assert "demo-mission-01CCCC" in plain
+    assert "spec.md failed dossier schema validation" in plain
+    assert "{'mission_slug'" not in plain
+
+
+# ── --apply is an honest stub until the synthesizer lands ────────────────────
+
+
+def test_apply_is_an_honest_nonzero_stub(tmp_path, monkeypatch):
+    """``--apply`` on a clean selection must not fake a materialize (exit 3)."""
+    dirs = [tmp_path / "demo-mission-01DDDD"]
+    _patch_checkout(monkeypatch, tmp_path)
+    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=[])
+
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 3
+    assert "not available yet" in _strip_ansi(result.output)
+
+
+def test_apply_is_still_gated_by_the_audit(tmp_path, monkeypatch):
+    """``--apply`` never reaches the stub if the audit blocks (exit 1, not 3)."""
+    dirs = [tmp_path / "demo-mission-01EEEE"]
+    blockers = [{"mission_slug": "demo-mission-01EEEE", "message": "unresolved blocker"}]
+    _patch_checkout(monkeypatch, tmp_path)
+    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=blockers)
+
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    assert "Import blocked" in _strip_ansi(result.output)

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -49,19 +49,20 @@ def _patch_selection(
 ) -> None:
     """Stub the two migration seams the command reuses.
 
-    Patched on the source module so the command's local
-    ``from specify_cli.migration.mission_state import ...`` binds to the stubs.
+    Patched on ``migration.envelope_seam`` (the deliberate public surface) —
+    the pipeline's lazy ``from specify_cli.migration.envelope_seam import ...``
+    binds to the stubs at call time.
     """
-    import specify_cli.migration.mission_state as mission_state
+    import specify_cli.migration.envelope_seam as envelope_seam
 
     monkeypatch.setattr(
-        mission_state,
-        "_select_mission_dirs",
+        envelope_seam,
+        "select_mission_dirs",
         lambda repo_root, *, scan_root, mission: list(mission_dirs),
     )
     monkeypatch.setattr(
-        mission_state,
-        "_teamspace_audit_blockers",
+        envelope_seam,
+        "teamspace_audit_blockers",
         lambda repo_root, *, scan_root, mission_dirs: list(blockers),
     )
 
@@ -103,6 +104,7 @@ def test_no_missions_found_exits_zero(tmp_path, monkeypatch):
 
 def test_selection_repair_error_exits_one(tmp_path, monkeypatch):
     """A ``MissionStateRepairError`` from selection fails closed (exit 1)."""
+    import specify_cli.migration.envelope_seam as envelope_seam
     import specify_cli.migration.mission_state as mission_state
 
     _patch_checkout(monkeypatch, tmp_path)
@@ -110,7 +112,7 @@ def test_selection_repair_error_exits_one(tmp_path, monkeypatch):
     def _boom(repo_root, *, scan_root, mission):
         raise mission_state.MissionStateRepairError("selector could not resolve mission handle")
 
-    monkeypatch.setattr(mission_state, "_select_mission_dirs", _boom)
+    monkeypatch.setattr(envelope_seam, "select_mission_dirs", _boom)
     result = runner.invoke(app, ["import-history", "--mission", "does-not-resolve"])
     assert result.exit_code == 1
     assert "selector could not resolve mission handle" in _strip_ansi(result.output)

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -174,14 +174,8 @@ def test_apply_fails_closed_when_unauthenticated(monkeypatch):
     assert "Not authenticated" in _strip_ansi(result.output)
 
 
-def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
-    """The wired --apply resolves the authed receiver, runs apply_import, and
-    reports the upload tally (exit 0). apply_import is stubbed with a canned
-    result here; its real behavior is covered in the pipeline/upload suites."""
-    import specify_cli.sync.history_import as history_import
-    from specify_cli.sync.history_import import ApplyResult, ImportIdentity, ImportPlan, UploadReport
-    from specify_cli.sync.history_import.scan import MissionScan, PrefixSource
-
+def _wire_apply_seams(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Wire the auth/config/receiver seams so --apply reaches apply_import."""
     monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "tok")
     monkeypatch.setattr(sync_command, "_open_event_sync_runtime", lambda: SimpleNamespace(target=object()))
     monkeypatch.setattr(
@@ -191,6 +185,12 @@ def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(sync_command, "_resolve_active_receiver", lambda *a, **k: SimpleNamespace(endpoint_url="http://x/batch"))
     _patch_checkout(monkeypatch, tmp_path)
+
+
+def _canned_apply_result(report):
+    """A one-mission, one-envelope ApplyResult carrying the given report."""
+    from specify_cli.sync.history_import import ApplyResult, ImportIdentity, ImportPlan
+    from specify_cli.sync.history_import.scan import MissionScan, PrefixSource
 
     scan = MissionScan(
         mission_slug="m-1",
@@ -213,7 +213,18 @@ def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
         is_synthetic=False,
     )
     plan = ImportPlan(identity=ident, scans=(scan,), envelopes=({"event_id": "e0", "event_type": "MissionCreated"},))
-    canned = ApplyResult(plan=plan, manifest=[], report=UploadReport(success=1))
+    return ApplyResult(plan=plan, manifest=[], report=report)
+
+
+def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
+    """The wired --apply resolves the authed receiver, runs apply_import, and
+    reports the upload tally (exit 0). apply_import is stubbed with a canned
+    result here; its real behavior is covered in the pipeline/upload suites."""
+    import specify_cli.sync.history_import as history_import
+    from specify_cli.sync.history_import import UploadReport
+
+    _wire_apply_seams(monkeypatch, tmp_path)
+    canned = _canned_apply_result(UploadReport(success=1))
     monkeypatch.setattr(history_import, "apply_import", lambda *a, **k: canned)
 
     result = runner.invoke(app, ["import-history", "--apply"])
@@ -221,3 +232,129 @@ def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
     plain = _strip_ansi(result.output)
     assert "Imported:" in plain
     assert "1 created" in plain
+
+
+# ── --apply: the five except branches (T3, #2884) ─────────────────────────────
+
+
+def _invoke_apply_raising(tmp_path, monkeypatch, exc: BaseException):
+    """Wire the seams, make apply_import raise *exc*, invoke --apply."""
+    import specify_cli.sync.history_import as history_import
+
+    _wire_apply_seams(monkeypatch, tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(history_import, "apply_import", _boom)
+    return runner.invoke(app, ["import-history", "--apply"])
+
+
+def test_apply_renders_audit_blockers(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import ImportAuditBlocked
+
+    exc = ImportAuditBlocked([{"mission_slug": "m-bad", "message": "spec.md failed schema validation"}])
+    result = _invoke_apply_raising(tmp_path, monkeypatch, exc)
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Import blocked" in plain
+    assert "m-bad" in plain and "spec.md failed schema validation" in plain
+
+
+def test_apply_renders_preflight_rejection(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import PreflightRejected
+
+    result = _invoke_apply_raising(tmp_path, monkeypatch, PreflightRejected({"reconciliation": {"reason": "bad shape"}}))
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Server preflight rejected the import" in plain
+    assert "bad shape" in plain
+
+
+def test_apply_renders_identity_error(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import ImportIdentityError
+
+    result = _invoke_apply_raising(tmp_path, monkeypatch, ImportIdentityError("no persisted project UUID"))
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Identity error" in plain
+    assert "no persisted project UUID" in plain
+
+
+def test_apply_renders_mission_scan_error(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import MissionScanError
+
+    result = _invoke_apply_raising(tmp_path, monkeypatch, MissionScanError("m-corrupt", "corrupt status log: bad row"))
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Error:" in plain
+    assert "m-corrupt" in plain and "corrupt status log" in plain
+
+
+def test_apply_renders_mission_state_repair_error(tmp_path, monkeypatch):
+    from specify_cli.migration.mission_state import MissionStateRepairError
+
+    result = _invoke_apply_raising(tmp_path, monkeypatch, MissionStateRepairError("Mission not found: 'nope'"))
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Error:" in plain
+    assert "Mission not found" in plain
+
+
+# ── --apply: report-state rendering (rejected / pending / partial) ────────────
+
+
+def _invoke_apply_with_report(tmp_path, monkeypatch, report):
+    import specify_cli.sync.history_import as history_import
+
+    _wire_apply_seams(monkeypatch, tmp_path)
+    canned = _canned_apply_result(report)
+    monkeypatch.setattr(history_import, "apply_import", lambda *a, **k: canned)
+    return runner.invoke(app, ["import-history", "--apply"])
+
+
+def test_apply_renders_rejected_tally_and_samples(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=1, rejected=2, rejected_samples=["e1: nope", "e2: bad payload"])
+    result = _invoke_apply_with_report(tmp_path, monkeypatch, report)
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "2 rejected" in plain
+    assert "e1: nope" in plain and "e2: bad payload" in plain
+    assert "not attempted" not in plain  # total failure is NOT the partial state
+
+
+def test_apply_renders_pending_tally_as_non_final(tmp_path, monkeypatch):
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=1, pending=3)
+    result = _invoke_apply_with_report(tmp_path, monkeypatch, report)
+    assert result.exit_code == 0  # pending is non-final, not a failure
+    plain = _strip_ansi(result.output)
+    assert "3 pending" in plain
+    assert "queued (pending)" in plain
+    assert "not yet" in plain  # explicitly distinct from confirmed success
+
+
+def test_apply_renders_partial_upload_as_distinct_state(tmp_path, monkeypatch):
+    """B1: a mid-run delivery failure renders the explicit partial state — a
+    safe ordered prefix was delivered, N events never attempted — distinct
+    from success and from total failure, and exits non-zero."""
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(
+        success=2,
+        rejected=1,
+        rejected_samples=["e2: nope"],
+        partial=True,
+        delivered_through_chunk=1,
+        undelivered_event_count=5,
+    )
+    result = _invoke_apply_with_report(tmp_path, monkeypatch, report)
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Partial upload" in plain
+    assert "safe ordered" in plain and "prefix" in plain
+    assert "5 event(s) not attempted" in plain
+    assert "e2: nope" in plain

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -14,6 +14,7 @@ needs no on-disk repo, no dossier, and no TeamSpace credentials.
 from __future__ import annotations
 
 import re
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -160,29 +161,61 @@ def test_audit_blockers_block_import_and_name_the_finding(tmp_path, monkeypatch)
     assert "{'mission_slug'" not in plain
 
 
-# ── --apply is an honest stub until the synthesizer lands ────────────────────
+# ── --apply: authed upload path (WP-Y5) ──────────────────────────────────────
 
 
-def test_apply_is_an_honest_nonzero_stub(tmp_path, monkeypatch):
-    """``--apply`` on a clean selection must not fake a materialize (exit 3)."""
-    dirs = [tmp_path / "demo-mission-01DDDD"]
+def test_apply_fails_closed_when_unauthenticated(monkeypatch):
+    """--apply refuses to upload without an access token (fail-closed)."""
+    monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "")
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    assert "Not authenticated" in _strip_ansi(result.output)
+
+
+def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
+    """The wired --apply resolves the authed receiver, runs apply_import, and
+    reports the upload tally (exit 0). apply_import is stubbed with a canned
+    result here; its real behavior is covered in the pipeline/upload suites."""
+    import specify_cli.sync.history_import as history_import
+    from specify_cli.sync.history_import import ApplyResult, ImportIdentity, ImportPlan, UploadReport
+    from specify_cli.sync.history_import.scan import MissionScan, PrefixSource
+
+    monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "tok")
+    monkeypatch.setattr(sync_command, "_open_event_sync_runtime", lambda: SimpleNamespace(target=object()))
+    monkeypatch.setattr(
+        sync_command,
+        "_load_event_sync_config",
+        lambda: SimpleNamespace(resolve_runtime_target=lambda: SimpleNamespace(resolved_server_url="http://x")),
+    )
+    monkeypatch.setattr(sync_command, "_resolve_active_receiver", lambda *a, **k: SimpleNamespace(endpoint_url="http://x/batch"))
     _patch_checkout(monkeypatch, tmp_path)
-    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=[])
+
+    scan = MissionScan(
+        mission_slug="m-1",
+        canonical_mission_id=None,
+        mission_number=None,
+        name="M One",
+        mission_type="software-dev",
+        purpose_tldr=None,
+        purpose_context=None,
+        target_branch="main",
+        created_at=None,
+        prefix_source=PrefixSource.SYNTHESIZED,
+        work_packages=(),
+        lane_transitions=(),
+    )
+    ident = ImportIdentity(
+        project_uuid=uuid.UUID("11111111-2222-3333-4444-555555555555"),
+        project_slug="m-1",
+        repo_slug="m-1",
+        is_synthetic=False,
+    )
+    plan = ImportPlan(identity=ident, scans=(scan,), envelopes=({"event_id": "e0", "event_type": "MissionCreated"},))
+    canned = ApplyResult(plan=plan, manifest=[], report=UploadReport(success=1))
+    monkeypatch.setattr(history_import, "apply_import", lambda *a, **k: canned)
 
     result = runner.invoke(app, ["import-history", "--apply"])
-    assert result.exit_code == 3
-    assert "not available yet" in _strip_ansi(result.output)
-
-
-def test_apply_short_circuits_before_any_work(monkeypatch):
-    """Until WP-Y5 wires the upload, ``--apply`` is a pure honest stub: it does
-    no checkout resolution / selection / scan, so it can have no side effects.
-    (The audit-gate-on-apply returns with the real upload path.)"""
-
-    def _forbidden_checkout():
-        raise AssertionError("the --apply stub must not resolve a checkout")
-
-    monkeypatch.setattr(sync_command, "_require_active_checkout", _forbidden_checkout)
-    result = runner.invoke(app, ["import-history", "--apply"])
-    assert result.exit_code == 3
-    assert "not available yet" in _strip_ansi(result.output)
+    assert result.exit_code == 0
+    plain = _strip_ansi(result.output)
+    assert "Imported:" in plain
+    assert "1 created" in plain

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -118,7 +118,7 @@ def test_selection_repair_error_exits_one(tmp_path, monkeypatch):
 # ── stage 2: fail-closed audit gate ──────────────────────────────────────────
 
 
-def test_clean_missions_are_listed_on_dry_run(tmp_path, monkeypatch):
+def test_clean_missions_are_previewed_on_dry_run(tmp_path, monkeypatch):
     dirs = [tmp_path / "demo-mission-01AAAA", tmp_path / "demo-mission-01BBBB"]
     _patch_checkout(monkeypatch, tmp_path)
     _patch_selection(monkeypatch, mission_dirs=dirs, blockers=[])
@@ -126,10 +126,15 @@ def test_clean_missions_are_listed_on_dry_run(tmp_path, monkeypatch):
     result = runner.invoke(app, ["import-history"])
     assert result.exit_code == 0
     plain = _strip_ansi(result.output)
-    assert "2 mission(s) eligible for import" in plain
-    assert "audit clean" in plain
+    # The dry-run now previews the synthesized plan, not just the selection.
+    assert "2 mission(s)" in plain
     assert "demo-mission-01AAAA" in plain
     assert "demo-mission-01BBBB" in plain
+    # A MissionCreated is synthesized per mission even with nothing on disk.
+    assert "MissionCreated" in plain
+    # Dry-run resolves the synthetic offline identity and uploads nothing.
+    assert "synthetic offline id" in plain
+    assert "nothing uploaded" in plain
 
 
 def test_audit_blockers_block_import_and_name_the_finding(tmp_path, monkeypatch):
@@ -169,13 +174,15 @@ def test_apply_is_an_honest_nonzero_stub(tmp_path, monkeypatch):
     assert "not available yet" in _strip_ansi(result.output)
 
 
-def test_apply_is_still_gated_by_the_audit(tmp_path, monkeypatch):
-    """``--apply`` never reaches the stub if the audit blocks (exit 1, not 3)."""
-    dirs = [tmp_path / "demo-mission-01EEEE"]
-    blockers = [{"mission_slug": "demo-mission-01EEEE", "message": "unresolved blocker"}]
-    _patch_checkout(monkeypatch, tmp_path)
-    _patch_selection(monkeypatch, mission_dirs=dirs, blockers=blockers)
+def test_apply_short_circuits_before_any_work(monkeypatch):
+    """Until WP-Y5 wires the upload, ``--apply`` is a pure honest stub: it does
+    no checkout resolution / selection / scan, so it can have no side effects.
+    (The audit-gate-on-apply returns with the real upload path.)"""
 
+    def _forbidden_checkout():
+        raise AssertionError("the --apply stub must not resolve a checkout")
+
+    monkeypatch.setattr(sync_command, "_require_active_checkout", _forbidden_checkout)
     result = runner.invoke(app, ["import-history", "--apply"])
-    assert result.exit_code == 1
-    assert "Import blocked" in _strip_ansi(result.output)
+    assert result.exit_code == 3
+    assert "not available yet" in _strip_ansi(result.output)

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -23,6 +23,8 @@ from typer.testing import CliRunner
 
 from specify_cli.cli.commands import sync as sync_command
 from specify_cli.cli.commands.sync import app
+from specify_cli.delivery.config import EventSyncConfig, Mode
+from specify_cli.delivery.receivers import GateContext, _TEAMSPACE_GATES
 
 pytestmark = pytest.mark.fast
 
@@ -184,9 +186,13 @@ def _wire_apply_seams(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(
         sync_command,
         "_open_event_sync_runtime",
-        lambda: SimpleNamespace(target=target),
+        lambda: SimpleNamespace(target=target, close=lambda: None),
     )
-    monkeypatch.setattr(sync_command, "is_saas_sync_enabled", lambda: True)
+    monkeypatch.setattr(
+        sync_command,
+        "_load_event_sync_config",
+        lambda: EventSyncConfig.from_mode(Mode.TEAMSPACE),
+    )
     monkeypatch.setattr(
         sync_command,
         "_resolve_active_receiver",
@@ -245,6 +251,140 @@ def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
     assert "1 created" in plain
     # The provenance manifest is surfaced, not silently discarded (#2884).
     assert "Provenance: 1 envelope(s) hashed" in plain
+
+
+# ── --apply: mode-authority fail-closed (P1, #2884) ──────────────────────────
+#
+# ``_resolve_history_import_receiver`` used to hardcode
+# ``EventSyncConfig.from_mode(Mode.TEAMSPACE)``, discarding whatever mode the
+# operator persisted via ``spec-kitty sync mode``. An operator on
+# EXTERNAL_RECEIVER / LOCAL_RETENTION / OPT_OUT would still get their full
+# mission history uploaded to the SaaS. These tests drive the real
+# ``_load_event_sync_config`` seam per mode to pin the fix.
+
+
+def _config_for_mode(mode: Mode) -> EventSyncConfig:
+    if mode is Mode.EXTERNAL_RECEIVER:
+        return EventSyncConfig.from_mode(mode, external_endpoint="https://x.example/e")
+    return EventSyncConfig.from_mode(mode)
+
+
+@pytest.mark.parametrize("mode", [Mode.EXTERNAL_RECEIVER, Mode.LOCAL_RETENTION, Mode.OPT_OUT])
+def test_apply_refuses_when_persisted_mode_is_not_teamspace(tmp_path, monkeypatch, mode):
+    """A non-TEAMSPACE persisted mode refuses the upload outright (exit 1),
+    naming both the requirement and the operator's current mode."""
+    _wire_apply_seams(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        sync_command, "_load_event_sync_config", lambda: _config_for_mode(mode)
+    )
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "requires event-sync mode TEAMSPACE" in plain
+    assert mode.name in plain
+
+
+def test_apply_proceeds_when_persisted_mode_is_teamspace(tmp_path, monkeypatch):
+    """The counterpart: a persisted TEAMSPACE mode is honored and --apply proceeds."""
+    import specify_cli.sync.history_import as history_import
+    from specify_cli.sync.history_import import UploadReport
+
+    _wire_apply_seams(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        sync_command, "_load_event_sync_config", lambda: EventSyncConfig.from_mode(Mode.TEAMSPACE)
+    )
+    canned = _canned_apply_result(UploadReport(success=1))
+    monkeypatch.setattr(history_import, "apply_import", lambda *a, **k: canned)
+
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 0
+
+
+# ── --apply: real gate evaluation, not the zero-gate stub (P1, #2884) ────────
+#
+# ``_wire_apply_seams`` stubs the receiver with ``gates=lambda: ()`` — zero
+# gates, so ``evaluate_gates`` can never block and the ``gate_decision.blocked``
+# branch (and the receiver-missing / no-endpoint branch) is untestable by
+# construction. These tests wire the REAL ``_TEAMSPACE_GATES`` tuple (or a
+# missing/unconfigured receiver) so the fail-closed branches are genuinely
+# exercised.
+
+
+def _wire_apply_seams_real_gates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, saas_enabled: bool, team_slug: str
+) -> None:
+    """Like ``_wire_apply_seams`` but the receiver declares the real Teamspace
+    gate tuple, so ``evaluate_gates`` genuinely evaluates saas/private/auth."""
+    monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "tok")
+    target = SimpleNamespace(resolved_server_url="http://x", team_slug=team_slug)
+    monkeypatch.setattr(
+        sync_command,
+        "_open_event_sync_runtime",
+        lambda: SimpleNamespace(target=target, close=lambda: None),
+    )
+    monkeypatch.setattr(
+        sync_command,
+        "_load_event_sync_config",
+        lambda: EventSyncConfig.from_mode(Mode.TEAMSPACE),
+    )
+    monkeypatch.setattr(sync_command, "is_saas_sync_enabled", lambda: saas_enabled)
+    monkeypatch.setattr(
+        sync_command,
+        "_resolve_active_receiver",
+        lambda *a, **k: SimpleNamespace(
+            endpoint_url="http://x/batch", gates=lambda: _TEAMSPACE_GATES
+        ),
+    )
+    _patch_checkout(monkeypatch, tmp_path)
+
+
+def test_apply_fails_closed_when_real_gates_are_unsatisfied(tmp_path, monkeypatch):
+    """A GateContext short on saas_enabled and private_teamspace genuinely blocks
+    through the real Teamspace gate tuple, naming both unsatisfied gates."""
+    _wire_apply_seams_real_gates(monkeypatch, tmp_path, saas_enabled=False, team_slug="")
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "gated" in plain
+    assert "saas_enabled" in plain
+    assert "private_teamspace" in plain
+
+
+def test_apply_proceeds_when_real_gates_are_satisfied(tmp_path, monkeypatch):
+    """The same real gate tuple, fully satisfied, lets --apply proceed (exit 0) —
+    the positive counterpart pinning that the real-gate wiring isn't itself
+    broken in a way that always blocks."""
+    import specify_cli.sync.history_import as history_import
+    from specify_cli.sync.history_import import UploadReport
+
+    _wire_apply_seams_real_gates(monkeypatch, tmp_path, saas_enabled=True, team_slug="team")
+    canned = _canned_apply_result(UploadReport(success=1))
+    monkeypatch.setattr(history_import, "apply_import", lambda *a, **k: canned)
+
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 0
+
+
+def test_apply_fails_closed_when_receiver_is_none(tmp_path, monkeypatch):
+    """No resolvable receiver (e.g. an unrecognized target) refuses to upload."""
+    _wire_apply_seams(monkeypatch, tmp_path)
+    monkeypatch.setattr(sync_command, "_resolve_active_receiver", lambda *a, **k: None)
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    assert "not configured" in _strip_ansi(result.output)
+
+
+def test_apply_fails_closed_when_endpoint_url_missing(tmp_path, monkeypatch):
+    """A receiver resolved but with no ``endpoint_url`` also refuses to upload."""
+    _wire_apply_seams(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        sync_command,
+        "_resolve_active_receiver",
+        lambda *a, **k: SimpleNamespace(endpoint_url="", gates=lambda: ()),
+    )
+    result = runner.invoke(app, ["import-history", "--apply"])
+    assert result.exit_code == 1
+    assert "not configured" in _strip_ansi(result.output)
 
 
 # ── --apply: the except branches (T3, #2884) ─────────────────────────────────

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -212,8 +212,11 @@ def _canned_apply_result(report):
         repo_slug="m-1",
         is_synthetic=False,
     )
+    from specify_cli.sync.history_import.upload import ImportProvenanceEntry
+
     plan = ImportPlan(identity=ident, scans=(scan,), envelopes=({"event_id": "e0", "event_type": "MissionCreated"},))
-    return ApplyResult(plan=plan, manifest=[], report=report)
+    manifest = [ImportProvenanceEntry(event_id="e0", event_type="MissionCreated", envelope_sha256="deadbeef")]
+    return ApplyResult(plan=plan, manifest=manifest, report=report)
 
 
 def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
@@ -232,9 +235,11 @@ def test_apply_uploads_and_reports_on_success(tmp_path, monkeypatch):
     plain = _strip_ansi(result.output)
     assert "Imported:" in plain
     assert "1 created" in plain
+    # The provenance manifest is surfaced, not silently discarded (#2884).
+    assert "Provenance: 1 envelope(s) hashed" in plain
 
 
-# ── --apply: the five except branches (T3, #2884) ─────────────────────────────
+# ── --apply: the except branches (T3, #2884) ─────────────────────────────────
 
 
 def _invoke_apply_raising(tmp_path, monkeypatch, exc: BaseException):
@@ -299,6 +304,19 @@ def test_apply_renders_mission_state_repair_error(tmp_path, monkeypatch):
     plain = _strip_ansi(result.output)
     assert "Error:" in plain
     assert "Mission not found" in plain
+
+
+def test_apply_renders_envelope_contract_violation(tmp_path, monkeypatch):
+    """The offline envelope contract gate (raised from apply_import) fails
+    closed with a clear message and exit 1, not a traceback (#2884)."""
+    from specify_cli.core.contract_gate import ContractViolationError
+
+    exc = ContractViolationError(field="from_lane", context="envelope", reason="forbidden field 'from_lane' present")
+    result = _invoke_apply_raising(tmp_path, monkeypatch, exc)
+    assert result.exit_code == 1
+    plain = _strip_ansi(result.output)
+    assert "Envelope contract violation" in plain
+    assert "from_lane" in plain
 
 
 # ── --apply: report-state rendering (rejected / pending / partial) ────────────

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -491,7 +491,11 @@ def test_apply_renders_rejected_tally_and_samples(tmp_path, monkeypatch):
     assert "not attempted" not in plain  # total failure is NOT the partial state
 
 
-def test_apply_renders_pending_tally_as_non_final(tmp_path, monkeypatch):
+def test_apply_treats_pending_as_a_failure(tmp_path, monkeypatch):
+    """Pending is a final failure (exit 1), and the message is honest about why:
+    import event ids are deterministic, so a re-run reports these events as
+    duplicates and exits 0 whether or not the projection ever materialized
+    them — the dashboard/projection is the authoritative check, not a re-run."""
     from specify_cli.sync.history_import import UploadReport
 
     report = UploadReport(success=1, pending=3)
@@ -501,6 +505,9 @@ def test_apply_renders_pending_tally_as_non_final(tmp_path, monkeypatch):
     assert "3 pending" in plain
     assert "remain pending" in plain
     assert "not confirmed" in plain
+    assert "duplicates" in plain
+    assert "dashboard" in plain
+    assert "receiver issue" not in plain  # dropped: not always an operator-fixable cause
     assert "sync now" not in plain
 
 
@@ -525,3 +532,57 @@ def test_apply_renders_partial_upload_as_distinct_state(tmp_path, monkeypatch):
     assert "safe ordered" in plain and "prefix" in plain
     assert "5 event(s) not attempted" in plain
     assert "e2: nope" in plain
+
+
+# ── _render_upload_report: extracted rendering seam (P2 nit, C901 relief) ────
+#
+# ``_run_import_apply`` delegated its partial/pending/rejected tail to this
+# helper so the branches are directly testable without wiring the whole
+# --apply CLI path. Driven straight with synthetic ``UploadReport`` values.
+
+
+def test_render_upload_report_partial_only(capsys):
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=2, partial=True, delivered_through_chunk=1, undelivered_event_count=5)
+    ok = sync_command._render_upload_report(report)
+    plain = _strip_ansi(capsys.readouterr().out)
+    assert ok is False
+    assert "Partial upload" in plain
+    assert "5 event(s) not attempted" in plain
+
+
+def test_render_upload_report_pending_only_points_at_the_projection(capsys):
+    """No re-run suggestion, no 'receiver issue' framing: the honest message
+    names the dedup-duplicate outcome and points at the dashboard/projection."""
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=1, pending=3)
+    ok = sync_command._render_upload_report(report)
+    plain = _strip_ansi(capsys.readouterr().out)
+    assert ok is False
+    assert "remain pending" in plain
+    assert "duplicates" in plain
+    assert "dashboard" in plain
+    assert "receiver issue" not in plain
+
+
+def test_render_upload_report_rejected_prints_samples(capsys):
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=1, rejected=2, rejected_samples=["e1: nope", "e2: bad payload"])
+    ok = sync_command._render_upload_report(report)
+    plain = _strip_ansi(capsys.readouterr().out)
+    assert ok is False
+    assert "e1: nope" in plain
+    assert "e2: bad payload" in plain
+
+
+def test_render_upload_report_all_clean_returns_true_and_prints_nothing(capsys):
+    from specify_cli.sync.history_import import UploadReport
+
+    report = UploadReport(success=5)
+    ok = sync_command._render_upload_report(report)
+    plain = capsys.readouterr().out
+    assert ok is True
+    assert plain == ""

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -24,7 +24,7 @@ from typer.testing import CliRunner
 from specify_cli.cli.commands import sync as sync_command
 from specify_cli.cli.commands.sync import app
 from specify_cli.delivery.config import EventSyncConfig, Mode
-from specify_cli.delivery.receivers import GateContext, _TEAMSPACE_GATES
+from specify_cli.delivery.receivers import _TEAMSPACE_GATES
 
 pytestmark = pytest.mark.fast
 

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -177,13 +177,21 @@ def test_apply_fails_closed_when_unauthenticated(monkeypatch):
 def _wire_apply_seams(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Wire the auth/config/receiver seams so --apply reaches apply_import."""
     monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "tok")
-    monkeypatch.setattr(sync_command, "_open_event_sync_runtime", lambda: SimpleNamespace(target=object()))
+    target = SimpleNamespace(
+        resolved_server_url="http://x",
+        team_slug="team",
+    )
     monkeypatch.setattr(
         sync_command,
-        "_load_event_sync_config",
-        lambda: SimpleNamespace(resolve_runtime_target=lambda: SimpleNamespace(resolved_server_url="http://x")),
+        "_open_event_sync_runtime",
+        lambda: SimpleNamespace(target=target),
     )
-    monkeypatch.setattr(sync_command, "_resolve_active_receiver", lambda *a, **k: SimpleNamespace(endpoint_url="http://x/batch"))
+    monkeypatch.setattr(sync_command, "is_saas_sync_enabled", lambda: True)
+    monkeypatch.setattr(
+        sync_command,
+        "_resolve_active_receiver",
+        lambda *a, **k: SimpleNamespace(endpoint_url="http://x/batch", gates=lambda: ()),
+    )
     _patch_checkout(monkeypatch, tmp_path)
 
 
@@ -348,11 +356,12 @@ def test_apply_renders_pending_tally_as_non_final(tmp_path, monkeypatch):
 
     report = UploadReport(success=1, pending=3)
     result = _invoke_apply_with_report(tmp_path, monkeypatch, report)
-    assert result.exit_code == 0  # pending is non-final, not a failure
+    assert result.exit_code == 1  # no durable retry record exists for direct delivery
     plain = _strip_ansi(result.output)
     assert "3 pending" in plain
-    assert "queued (pending)" in plain
-    assert "not yet" in plain  # explicitly distinct from confirmed success
+    assert "remain pending" in plain
+    assert "not confirmed" in plain
+    assert "sync now" not in plain
 
 
 def test_apply_renders_partial_upload_as_distinct_state(tmp_path, monkeypatch):

--- a/tests/regression/test_birth_cutover.py
+++ b/tests/regression/test_birth_cutover.py
@@ -735,6 +735,163 @@ def test_coord_seed_commit_targets_coord_branch_no_head_mismatch(tmp_path: Path)
     assert "01JSEEDBIRTHCUTOVER0000000" in tracked
 
 
+def _coord_seed_run_real_meta(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[object, Path, Path, str, Path, str]:
+    """Real-``meta.json`` sibling of :func:`_coord_seed_run` (adversarial-review
+    P1, #2884): builds a genuine COORD-topology mission through the REAL
+    ``create_mission_core`` entry point, so ``meta.json`` carries the exact
+    fields production writes (``mission_id``, ``target_branch``,
+    ``coordination_branch``, ``topology``) at the PRIMARY checkout.
+
+    ``_coord_seed_run`` never writes ``kitty-specs/<slug>/meta.json`` into the
+    main repo, so ``_resolve_bookkeeping_commit_target``'s
+    ``_mission_meta_exists`` gate is always False there and every existing F1/F2/F3
+    test runs the ``branch=coord_ref`` degrade fallback — never
+    ``resolve_placement_only(kind=MissionArtifactKind.STATUS_STATE)``, the
+    placement-port branch this fixture exists to exercise. With a real
+    ``meta.json`` present, ``_mission_meta_exists`` is True and the seam must
+    reach the placement port.
+    """
+    from specify_cli.core.mission_creation import create_mission_core
+    from specify_cli.coordination.workspace import CoordinationWorkspace
+    from specify_cli.merge.executor import _MergeRunState
+    from specify_cli.missions._create import ensure_coordination_branch
+
+    repo = _init_project(tmp_path)
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("SPEC_KITTY_SUPPRESS_MISSION_TYPE_DEPRECATION", "1")
+    # Mirrors _bootstrap_born_mission's churn-ignore setup: the nested
+    # coordination worktree is untracked test-harness scaffolding, orthogonal
+    # to the placement-port behavior under test.
+    (repo / ".gitignore").write_text(".worktrees/\n.kittify/sync-state.json\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "chore: ignore worktrees + sync-state churn")
+
+    result = create_mission_core(
+        repo, "coord-seed-real-meta-demo", topology=MissionTopology.COORD
+    )
+    feature_dir = result.feature_dir
+    slug = feature_dir.name
+    assert result.coordination_branch is not None, "COORD topology must mint a coord branch"
+
+    # The planning scaffold (kitty-specs/<slug>/*, incl. meta.json) must be
+    # committed on "main" BEFORE the coordination branch is (re-)forked below —
+    # otherwise the coord branch/worktree carries no kitty-specs/<slug> dir at
+    # all (the "coord-empty" state _bootstrap_born_mission's own comment
+    # documents) and status.events.jsonl would have nowhere real to seed.
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", f"chore({slug}): finalize planning scaffold")
+
+    mission_id = str(result.meta["mission_id"])
+    # Re-fork from the CURRENT "main" tip (now carrying the mission dir),
+    # the same documented operator escape hatch _bootstrap_born_mission uses.
+    ensure_coordination_branch(
+        repo_root=repo,
+        mission_slug=slug,
+        mission_id=mission_id,
+        target_branch="main",
+        force_recreate=True,
+    )
+    coord_worktree = CoordinationWorkspace.resolve(repo, slug, mission_id[:8])
+    coord_branch = result.coordination_branch
+
+    status_feature_dir = coord_worktree / "kitty-specs" / slug
+    assert status_feature_dir.exists(), "coord worktree must carry the mission dir (not coord-empty)"
+    events_path = status_feature_dir / "status.events.jsonl"
+    events_path.write_text(_SEED_EVENT_LINE, encoding="utf-8")  # dirty, uncommitted
+
+    import types
+    from typing import cast
+
+    run = cast(
+        "_MergeRunState",
+        types.SimpleNamespace(
+            main_repo=repo,
+            mission_slug=slug,
+            pre_target_coord_ref=coord_branch,
+            canonical_events_path=events_path,
+        ),
+    )
+    return run, coord_worktree, status_feature_dir, coord_branch, repo, slug
+
+
+def test_coord_seed_commit_targets_coord_branch_via_real_placement_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """F1 sibling, under a REAL coord-topology ``meta.json`` (adversarial-review
+    P1, #2884): proves ``_commit_coord_seed_events`` actually reaches
+    ``resolve_placement_only(kind=MissionArtifactKind.STATUS_STATE)`` through
+    :func:`commit_coord_seed_bookkeeping` — not merely the ``branch=coord_ref``
+    degrade fallback every ``_coord_seed_run``-driven test exercises (that
+    fixture's main repo never carries a ``meta.json``, so
+    ``_mission_meta_exists`` is always False there and the placement-port call
+    is never reached).
+    """
+    from mission_runtime import MissionArtifactKind, resolve_placement_only
+
+    from specify_cli.git import bookkeeping_commit
+    from specify_cli.merge.executor import _commit_coord_seed_events
+
+    run, coord_worktree, status_feature_dir, coord_branch, main_repo, slug = (
+        _coord_seed_run_real_meta(tmp_path, monkeypatch)
+    )
+
+    # Falsifiability precondition: in THIS fixture, the artifact ``kind`` must
+    # actually change the resolved destination, or assertion (b) below would
+    # pass even with the wrong kind (or no placement-port call at all) wired
+    # in. PRIMARY_METADATA resolves to the mission's PRIMARY target branch
+    # ("main"), which is a different ref than the coord branch.
+    primary_target = resolve_placement_only(
+        main_repo, slug, kind=MissionArtifactKind.PRIMARY_METADATA
+    ).ref
+    assert primary_target != coord_branch, (
+        "fixture is not falsifying: PRIMARY_METADATA must NOT resolve to the coord branch"
+    )
+
+    # Spy on the placement port as bookkeeping_commit imports it, to prove the
+    # seam actually CONSULTED it (with the STATUS_STATE kind) rather than
+    # silently taking the branch=coord_ref degrade path (#2884's own review
+    # finding: the degrade fallback's ``branch`` param is ALSO coord_branch in
+    # this fixture, so the resulting ref alone cannot distinguish "the port
+    # resolved it" from "resolution failed and degrade quietly supplied the
+    # same value").
+    real_resolve_placement_only = bookkeeping_commit.resolve_placement_only
+    calls: list[MissionArtifactKind] = []
+
+    def _spy_resolve_placement_only(*args: object, **kwargs: object) -> object:
+        calls.append(kwargs["kind"])  # type: ignore[arg-type]
+        return real_resolve_placement_only(*args, **kwargs)
+
+    monkeypatch.setattr(
+        bookkeeping_commit, "resolve_placement_only", _spy_resolve_placement_only
+    )
+
+    _commit_coord_seed_events(run, status_feature_dir)
+
+    # The placement port was consulted exactly once, with the COORD-partition
+    # kind — proving the degrade path (which never calls resolve_placement_only
+    # at all when _mission_meta_exists is False) was NOT taken.
+    assert calls == [MissionArtifactKind.STATUS_STATE]
+
+    # (a) Same assertion style as the sibling F1 test: the seed commit lands on
+    # the coord branch via real safe_commit (clean tree, reconcile subject).
+    porcelain = _git(coord_worktree, "status", "--porcelain").stdout
+    assert porcelain.strip() == "", f"seed events not committed: {porcelain!r}"
+    subject = _git(coord_worktree, "log", "-1", "--pretty=%s").stdout.strip()
+    assert "birth-cutover seed events reconciled" in subject
+    tracked = _git(
+        coord_worktree, "show", "HEAD:kitty-specs/" + slug + "/status.events.jsonl"
+    ).stdout
+    assert "01JSEEDBIRTHCUTOVER0000000" in tracked
+
+    # (b) The falsifiable assertion the finding demands: the placement port
+    # itself resolves the COORD-partition STATUS_STATE kind to the coord
+    # branch under this real coord topology.
+    resolved = resolve_placement_only(main_repo, slug, kind=MissionArtifactKind.STATUS_STATE)
+    assert resolved.ref == coord_branch
+
+
 def test_coord_seed_commit_is_resume_safe_noop_when_clean(tmp_path: Path) -> None:
     """F2: a second invocation (events already committed, tree clean) is a no-op
     — gated on dirty-state, not the per-run seeded_count, so resume heals without

--- a/tests/specify_cli/cli/commands/agent/test_mission_cli_golden_contract.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_cli_golden_contract.py
@@ -70,7 +70,11 @@ pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 # ---------------------------------------------------------------------------
 
 
-# The exact 8 subcommands `app` exposes, in alphabetical (Typer help) order.
+# The exact 9 subcommands `app` exposes, in alphabetical (Typer help) order.
+# `repair` was added by WP08 of coord-write-placement-closure-01KYCF83 (the
+# Gap-2 cross-partition content repair cure, FR-005/NFR-005) after the
+# original #2056 characterization; the contract below is amended in place
+# rather than treated as append-only drift, per DIRECTIVE_044.
 _EXPECTED_COMMANDS: frozenset[str] = frozenset(
     {
         "branch-context",
@@ -81,6 +85,7 @@ _EXPECTED_COMMANDS: frozenset[str] = frozenset(
         "accept",
         "merge",
         "finalize-tasks",
+        "repair",
     }
 )
 
@@ -132,6 +137,7 @@ _EXPECTED_FLAGS: dict[str, frozenset[str]] = {
     "finalize-tasks": frozenset(
         {"--mission", "--json", "--validate-only", "--target-branch"}
     ),
+    "repair": frozenset({"--mission"}),
 }
 
 
@@ -171,12 +177,12 @@ def runner() -> CliRunner:
 
 
 # ---------------------------------------------------------------------------
-# T001 — the command set is exactly the 8 frozen commands
+# T001 — the command set is exactly the 9 frozen commands
 # ---------------------------------------------------------------------------
 
 
-def test_app_exposes_exactly_eight_frozen_commands(runner: CliRunner) -> None:
-    """``app --help`` lists exactly the 8 contracted commands — no more, no fewer."""
+def test_app_exposes_exactly_nine_frozen_commands(runner: CliRunner) -> None:
+    """``app --help`` lists exactly the 9 contracted commands — no more, no fewer."""
     result = runner.invoke(mission_app, ["--help"], catch_exceptions=False)
     assert result.exit_code == 0, result.stdout
 

--- a/tests/specify_cli/cli/commands/test_doctrine_regenerate_graph.py
+++ b/tests/specify_cli/cli/commands/test_doctrine_regenerate_graph.py
@@ -80,7 +80,15 @@ def _graph_files(doctrine_dir: Path) -> list[Path]:
 #: join gates on the node's *presence*, not on edges. That raises the ceiling from
 #: the historical 14 baseline to 29 (empirical 29, no slack). Full narrative in
 #: ``drg-orphan-residual.md``.
-DOCUMENTED_ORPHAN_RESIDUAL = 29
+#:
+#: 2026-07-26 (PR #2936 fold): #2936 promoted ``toolguide:powershell-syntax`` from a
+#: dead, unreachable file into a live graph node with no inbound/outbound edge (real
+#: PowerShell-authoring content, consumed at runtime, no doctrinal static referent —
+#: same class as the existing ``toolguide:rtk-search-tooling`` /
+#: ``toolguide:python-review-checks`` residuals). Accepted as an edge-less residual per
+#: D-C2 / C-003 rather than a manufactured edge. Raises the ceiling 29 -> 30. Full
+#: narrative in ``drg-orphan-residual.md``.
+DOCUMENTED_ORPHAN_RESIDUAL = 30
 
 
 def _count_orphans(graph: DRGGraph) -> int:

--- a/tests/specify_cli/cli/commands/test_mission_repair.py
+++ b/tests/specify_cli/cli/commands/test_mission_repair.py
@@ -25,6 +25,7 @@ import typer
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.agent import mission_repair as mr
+from tests._support.ansi import strip_ansi
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
@@ -332,7 +333,7 @@ def test_repair_command_registered_on_mission_app() -> None:
 
     result = _RUNNER.invoke(mission_app, ["repair", "--help"])
     assert result.exit_code == 0
-    assert "--mission" in result.stdout
+    assert "--mission" in strip_ansi(result.stdout)
 
 
 @pytest.mark.non_sandbox
@@ -350,4 +351,5 @@ def test_repair_reachable_end_to_end_via_cli(
     result = _RUNNER.invoke(mission_app, ["repair", "--mission", mission_slug])
 
     assert result.exit_code == 0
-    assert "Clean" in result.stdout or "Nothing to repair" in result.stdout
+    plain = strip_ansi(result.stdout)
+    assert "Clean" in plain or "Nothing to repair" in plain

--- a/tests/specify_cli/coordination/test_residual_writer_routing.py
+++ b/tests/specify_cli/coordination/test_residual_writer_routing.py
@@ -264,8 +264,11 @@ class TestBookkeepingProjectionRoutesThroughPlacementPort:
             pytest.raises(ValueError, match="Refusing untrusted status filename"),
         ):
             bp._assert_status_surface_file_path_is_trusted(
-                repo_root=Path("/tmp/does-not-matter"),
-                status_feature_dir=Path("/tmp/does-not-matter/kitty-specs/x"),
+                # Non-shared-temp absolute sentinels (tmp-literal burndown category B):
+                # the call raises on the (patched-untrusted) filename before either
+                # path is ever read, so the dirs are incidental placeholders.
+                repo_root=Path("/sentinel/does-not-matter"),
+                status_feature_dir=Path("/sentinel/does-not-matter/kitty-specs/x"),
                 filename="status.events.jsonl",
             )
         mock_classify.assert_called_once()

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -904,6 +904,55 @@ def test_validate_lifecycle_payload_falls_through_for_unknown_event_types() -> N
     lifecycle._validate_lifecycle_payload("NotARealEventType", {"foo": "bar"})
 
 
+def test_validate_lifecycle_payload_skips_local_only_lifecycle_types() -> None:
+    """MISSION_REOPENED / FOLLOW_UP_RECORDED must skip strict validation.
+
+    Regression guard for the #2884 review finding: both event types are
+    present in the installed ``spec_kitty_events`` model map (so they are
+    NOT "unknown" and would otherwise fall into ``validate_event(strict=True)``),
+    while ``spec_kitty_events.LOCAL_ONLY_EVENT_TYPES`` is empty and does not
+    yet cover them. Without consulting the local
+    ``LOCAL_ONLY_LIFECYCLE_EVENT_TYPES`` SSOT, a malformed payload for either
+    type would incorrectly raise here, contradicting the module docstring's
+    claim that they are "deliberately kept OFF the SaaS strict-validation
+    delivery path". A payload that is missing required canonical fields and
+    carries extra ones must still pass without raising.
+    """
+    from spec_kitty_events.conformance.validators import _EVENT_TYPE_TO_MODEL
+
+    assert lifecycle.MISSION_REOPENED in _EVENT_TYPE_TO_MODEL
+    assert lifecycle.FOLLOW_UP_RECORDED in _EVENT_TYPE_TO_MODEL
+    malformed_payload = {"unexpected_field": "drift", "mission_slug": "demo"}
+    # Should not raise for either local-only lifecycle event type, despite
+    # the payload being nowhere near canonical shape.
+    lifecycle._validate_lifecycle_payload(lifecycle.MISSION_REOPENED, malformed_payload)
+    lifecycle._validate_lifecycle_payload(lifecycle.FOLLOW_UP_RECORDED, malformed_payload)
+
+
+def test_validate_lifecycle_payload_still_strict_for_delivery_path_types() -> None:
+    """A non-local-only, known event type must still validate strictly.
+
+    Guards against the fix in the sibling test above degrading into a
+    blanket skip: only types in ``LOCAL_ONLY_LIFECYCLE_EVENT_TYPES`` are
+    exempted; MissionCreated (a real delivery-path type) still rejects a
+    payload with extra/missing fields.
+    """
+    assert lifecycle.MISSION_CREATED not in lifecycle.LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
+    bad_payload = {
+        "mission_slug": "demo",
+        "mission_number": None,
+        "target_branch": "main",
+        "mission_id": "01J6XW9KQT7M0YB3N4R5CQZ2EX",
+        "actor": "spec-kitty mission create",  # extra — schema forbids it
+        "created_at": "2026-05-20T00:00:00+00:00",
+        "friendly_name": "Demo",
+        "purpose_tldr": "tldr",
+        "purpose_context": "context",
+    }
+    with pytest.raises(ValueError, match="actor"):
+        lifecycle._validate_lifecycle_payload(lifecycle.MISSION_CREATED, bad_payload)
+
+
 _SAAS_KW = {
     "build_id": "build-1",
     "project_uuid": "proj-uuid",

--- a/tests/sync/test_history_import_identity.py
+++ b/tests/sync/test_history_import_identity.py
@@ -102,6 +102,17 @@ def test_apply_fails_closed_when_config_not_writable(tmp_path, monkeypatch):
         resolve_import_identity(tmp_path, [], apply=True)
 
 
+def test_apply_fails_closed_when_persist_silently_fails(tmp_path, monkeypatch):
+    """If the boundary reports writable but no UUID actually lands (a silent
+    write failure), --apply refuses rather than proceeding under no identity."""
+    (tmp_path / ".kittify").mkdir()
+    monkeypatch.setattr(identity_module, "is_writable", lambda _path: True)
+    # ensure_identity "runs" but persists nothing → the re-read finds no UUID.
+    monkeypatch.setattr(identity_module, "ensure_identity", lambda _root: None)
+    with pytest.raises(ImportIdentityError, match="did not persist"):
+        resolve_import_identity(tmp_path, [], apply=True)
+
+
 def test_apply_fails_closed_on_a_non_checkout(tmp_path):
     """No ``.kittify/`` at all means this isn't an initialized checkout — apply
     must refuse rather than mint an identity outside a real project."""

--- a/tests/sync/test_history_import_identity.py
+++ b/tests/sync/test_history_import_identity.py
@@ -1,0 +1,118 @@
+"""Tests for the IDENTITY stage of ``sync import-history`` — WP-Y4 (#2262).
+
+Pins the mint-boundary invariants:
+
+* INV-2: the dry-run (read) path never writes ``.kittify/config.yaml``.
+* INV-5: ``--apply`` resolves the persisted real UUID (never synthetic), minting
+  once at the authorized boundary when the checkout is uninitialized, and
+  failing closed when it cannot persist.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from specify_cli.identity.project import ProjectIdentity, atomic_write_config
+from specify_cli.sync.history_import import identity as identity_module
+from specify_cli.sync.history_import.identity import (
+    ImportIdentityError,
+    resolve_import_identity,
+)
+from specify_cli.sync.history_import.synthesize import dry_run_project_uuid
+
+pytestmark = pytest.mark.fast
+
+_KNOWN_UUID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def _config_path(repo_root):
+    return repo_root / ".kittify" / "config.yaml"
+
+
+def _seed_identity(repo_root, *, repo_slug="acme/demo-project"):
+    atomic_write_config(
+        _config_path(repo_root),
+        ProjectIdentity(
+            project_uuid=_KNOWN_UUID,
+            project_slug="demo-project",
+            node_id="node-abc",
+            repo_slug=repo_slug,
+            build_id="build-1",
+        ),
+    )
+
+
+# ── dry-run: read-only, synthetic when uninitialized (INV-2) ──────────────────
+
+
+def test_dry_run_uninitialized_is_synthetic_and_writes_nothing(tmp_path):
+    result = resolve_import_identity(tmp_path, ["m-one", "m-two"], apply=False)
+
+    assert result.is_synthetic is True
+    assert result.project_uuid == dry_run_project_uuid(["m-one", "m-two"])
+    # The read path must never mint/persist an identity (INV-2 / no-dirty-tree).
+    assert not _config_path(tmp_path).exists()
+
+
+def test_dry_run_initialized_uses_real_uuid_without_writing(tmp_path):
+    _seed_identity(tmp_path)
+    before = _config_path(tmp_path).read_bytes()
+
+    result = resolve_import_identity(tmp_path, ["ignored"], apply=False)
+
+    assert result.is_synthetic is False
+    assert result.project_uuid == _KNOWN_UUID
+    assert result.repo_slug == "acme/demo-project"
+    # Byte-identical config: resolution did not rewrite it.
+    assert _config_path(tmp_path).read_bytes() == before
+
+
+# ── apply: real UUID, never synthetic (INV-5) ─────────────────────────────────
+
+
+def test_apply_initialized_uses_persisted_uuid_no_remint(tmp_path):
+    _seed_identity(tmp_path)
+    result = resolve_import_identity(tmp_path, ["ignored"], apply=True)
+
+    assert result.is_synthetic is False
+    assert result.project_uuid == _KNOWN_UUID
+
+
+def test_apply_uninitialized_mints_persists_and_is_idempotent(tmp_path):
+    # A real checkout with an uninitialized identity: .kittify/ exists, but no
+    # project UUID is persisted yet. --apply is the authorized boundary to mint.
+    (tmp_path / ".kittify").mkdir()
+
+    first = resolve_import_identity(tmp_path, [], apply=True)
+
+    assert first.is_synthetic is False
+    assert first.project_uuid is not None
+    assert _config_path(tmp_path).exists(), "--apply must persist the minted identity"
+
+    # A second apply reuses the persisted UUID — no re-mint (idempotent).
+    second = resolve_import_identity(tmp_path, [], apply=True)
+    assert second.project_uuid == first.project_uuid
+
+
+def test_apply_fails_closed_when_config_not_writable(tmp_path, monkeypatch):
+    monkeypatch.setattr(identity_module, "is_writable", lambda _path: False)
+    with pytest.raises(ImportIdentityError, match="not writable"):
+        resolve_import_identity(tmp_path, [], apply=True)
+
+
+def test_apply_fails_closed_on_a_non_checkout(tmp_path):
+    """No ``.kittify/`` at all means this isn't an initialized checkout — apply
+    must refuse rather than mint an identity outside a real project."""
+    with pytest.raises(ImportIdentityError, match="spec-kitty init"):
+        resolve_import_identity(tmp_path, [], apply=True)
+
+
+# ── slug / repo_slug derivation ───────────────────────────────────────────────
+
+
+def test_repo_slug_falls_back_to_project_slug_when_absent(tmp_path):
+    _seed_identity(tmp_path, repo_slug=None)
+    result = resolve_import_identity(tmp_path, ["ignored"], apply=False)
+    assert result.repo_slug == result.project_slug == "demo-project"

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-import specify_cli.migration.mission_state as mission_state
+import specify_cli.migration.envelope_seam as envelope_seam
 from specify_cli.delivery.receivers import StubReceiver
 from specify_cli.sync.history_import.pipeline import (
     ImportAuditBlocked,
@@ -32,8 +32,10 @@ _FIXTURES = _LEGACY.is_dir() and _PREFIXED.is_dir()
 
 
 def _patch_selection(monkeypatch, *, mission_dirs, blockers):
-    monkeypatch.setattr(mission_state, "_select_mission_dirs", lambda root, *, scan_root, mission: list(mission_dirs))
-    monkeypatch.setattr(mission_state, "_teamspace_audit_blockers", lambda root, *, scan_root, mission_dirs: list(blockers))
+    # The pipeline binds these lazily from the envelope_seam surface, so the
+    # seam module is where stubs go (not mission_state's underscore internals).
+    monkeypatch.setattr(envelope_seam, "select_mission_dirs", lambda root, *, scan_root, mission: list(mission_dirs))
+    monkeypatch.setattr(envelope_seam, "teamspace_audit_blockers", lambda root, *, scan_root, mission_dirs: list(blockers))
 
 
 # ── happy path over real fixtures ─────────────────────────────────────────────

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -104,6 +104,48 @@ def test_describe_plan_lists_missions_and_breakdown(tmp_path, monkeypatch):
     assert "event(s)" in text
 
 
+def test_describe_plan_makes_skipped_wps_impossible_to_miss():
+    """A scan with malformed-frontmatter skips must mark BOTH the summary line
+    and the mission row — a skip can never read as clean success (B3, #2884)."""
+    import uuid
+
+    from specify_cli.sync.history_import.identity import ImportIdentity
+    from specify_cli.sync.history_import.pipeline import ImportPlan
+    from specify_cli.sync.history_import.scan import MissionScan, PrefixSource
+
+    scan = MissionScan(
+        mission_slug="m-skips",
+        canonical_mission_id=None,
+        mission_number=None,
+        name="M Skips",
+        mission_type="software-dev",
+        purpose_tldr=None,
+        purpose_context=None,
+        target_branch="main",
+        created_at=None,
+        prefix_source=PrefixSource.SYNTHESIZED,
+        work_packages=(),
+        lane_transitions=(),
+        skipped_wp_files=("WP07.md", "WP11.md"),
+    )
+    identity = ImportIdentity(
+        project_uuid=uuid.UUID("11111111-2222-3333-4444-555555555555"),
+        project_slug="p",
+        repo_slug="p",
+        is_synthetic=True,
+    )
+    plan = ImportPlan(
+        identity=identity,
+        scans=(scan,),
+        # canonical-event-exempt(exception-flow): minimal wire-envelope fixture for report rendering
+        envelopes=({"event_id": "e0", "event_type": "MissionCreated"},),
+    )
+
+    text = "\n".join(describe_plan(plan))
+    assert "2 WP file(s) SKIPPED" in text  # the summary line itself is marked
+    assert "2 WPs SKIPPED (malformed frontmatter: WP07.md, WP11.md)" in text  # the mission row names them
+
+
 def test_describe_empty_plan(tmp_path, monkeypatch):
     _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
     plan = build_import_plan(tmp_path, mission=None, apply=False)

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -1,0 +1,108 @@
+"""Tests for the import-history orchestration — ``build_import_plan`` (#2262).
+
+Drives the whole read-only pipeline (SELECT → AUDIT → SCAN → IDENTITY →
+SYNTHESIZE) end to end: real fixtures for the happy path, patched migration
+seams for the empty/blocked branches, and the apply path to prove the real
+project UUID is threaded onto every envelope (INV-5).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import specify_cli.migration.mission_state as mission_state
+from specify_cli.sync.history_import.pipeline import (
+    ImportAuditBlocked,
+    build_import_plan,
+    describe_plan,
+)
+
+pytestmark = pytest.mark.fast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPECS = _REPO_ROOT / "kitty-specs"
+_LEGACY = _SPECS / "032-identity-aware-cli-event-sync"
+_PREFIXED = _SPECS / "single-mission-surface-resolver-01KVGCE8"
+
+_FIXTURES = _LEGACY.is_dir() and _PREFIXED.is_dir()
+
+
+def _patch_selection(monkeypatch, *, mission_dirs, blockers):
+    monkeypatch.setattr(mission_state, "_select_mission_dirs", lambda root, *, scan_root, mission: list(mission_dirs))
+    monkeypatch.setattr(mission_state, "_teamspace_audit_blockers", lambda root, *, scan_root, mission_dirs: list(blockers))
+
+
+# ── happy path over real fixtures ─────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
+def test_build_plan_over_real_fixtures(tmp_path, monkeypatch):
+    _patch_selection(monkeypatch, mission_dirs=[_LEGACY, _PREFIXED], blockers=[])
+
+    plan = build_import_plan(tmp_path, mission=None, apply=False)
+
+    assert not plan.is_empty
+    assert plan.mission_count == 2
+    assert plan.identity is not None and plan.identity.is_synthetic  # uninitialized dry-run
+    counts = plan.event_type_counts()
+    assert counts.get("MissionCreated") == 2
+    assert counts.get("WPCreated", 0) >= 6
+    assert counts.get("WPStatusChanged", 0) >= 1
+    assert plan.total_events == sum(counts.values())
+
+
+# ── empty / blocked branches ──────────────────────────────────────────────────
+
+
+def test_empty_selection_yields_empty_plan(tmp_path, monkeypatch):
+    _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
+    plan = build_import_plan(tmp_path, mission=None, apply=False)
+    assert plan.is_empty
+    assert plan.identity is None
+    assert plan.envelopes == ()
+
+
+def test_audit_blockers_raise_before_synthesis(tmp_path, monkeypatch):
+    blockers = [{"mission_slug": "m-01", "message": "bad row"}]
+    _patch_selection(monkeypatch, mission_dirs=[tmp_path / "m-01"], blockers=blockers)
+    with pytest.raises(ImportAuditBlocked) as excinfo:
+        build_import_plan(tmp_path, mission=None, apply=False)
+    assert excinfo.value.blockers == blockers
+
+
+# ── apply threads the real UUID (INV-5) ───────────────────────────────────────
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
+def test_apply_plan_threads_the_real_uuid(tmp_path, monkeypatch):
+    (tmp_path / ".kittify").mkdir()  # a real (uninitialized) checkout
+    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+
+    plan = build_import_plan(tmp_path, mission=None, apply=True)
+
+    assert plan.identity is not None and plan.identity.is_synthetic is False
+    assert plan.envelopes
+    assert all(env["project_uuid"] == str(plan.identity.project_uuid) for env in plan.envelopes)
+
+
+# ── describe_plan rendering ───────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
+def test_describe_plan_lists_missions_and_breakdown(tmp_path, monkeypatch):
+    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+    plan = build_import_plan(tmp_path, mission=None, apply=False)
+
+    lines = describe_plan(plan)
+    text = "\n".join(lines)
+    assert "032-identity-aware-cli-event-sync" in text
+    assert "MissionCreated" in text
+    assert "event(s)" in text
+
+
+def test_describe_empty_plan(tmp_path, monkeypatch):
+    _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
+    plan = build_import_plan(tmp_path, mission=None, apply=False)
+    assert describe_plan(plan) == ["No missions eligible for import."]

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -13,8 +13,10 @@ from pathlib import Path
 import pytest
 
 import specify_cli.migration.mission_state as mission_state
+from specify_cli.delivery.receivers import StubReceiver
 from specify_cli.sync.history_import.pipeline import (
     ImportAuditBlocked,
+    apply_import,
     build_import_plan,
     describe_plan,
 )
@@ -106,3 +108,39 @@ def test_describe_empty_plan(tmp_path, monkeypatch):
     _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
     plan = build_import_plan(tmp_path, mission=None, apply=False)
     assert describe_plan(plan) == ["No missions eligible for import."]
+
+
+# ── apply_import: plan → provenance → preflight → upload ──────────────────────
+
+
+class _AcceptingResponse:
+    status_code = 200
+
+    def json(self):
+        return {"accepted": True, "event_count": 0, "reconciliation": {}}
+
+
+def _accepting_poster(url, *, data, headers, timeout):
+    return _AcceptingResponse()
+
+
+@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
+def test_apply_import_uploads_every_envelope_under_the_real_uuid(tmp_path, monkeypatch):
+    (tmp_path / ".kittify").mkdir()  # a real (uninitialized) checkout → apply mints the UUID
+    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+    stub = StubReceiver()
+
+    result = apply_import(
+        tmp_path,
+        mission=None,
+        receiver=stub,
+        server_url="http://teamspace.test",
+        auth_token="tok",
+        poster=_accepting_poster,
+    )
+
+    assert result.plan.identity is not None and result.plan.identity.is_synthetic is False  # INV-5
+    assert result.report.ok
+    assert result.report.success == result.plan.total_events
+    assert set(stub.received_event_ids()) == {env["event_id"] for env in result.plan.envelopes}
+    assert len(result.manifest) == result.plan.total_events

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -1,14 +1,23 @@
 """Tests for the import-history orchestration — ``build_import_plan`` (#2262).
 
 Drives the whole read-only pipeline (SELECT → AUDIT → SCAN → IDENTITY →
-SYNTHESIZE) end to end: real fixtures for the happy path, patched migration
-seams for the empty/blocked branches, and the apply path to prove the real
-project UUID is threaded onto every envelope (INV-5).
+SYNTHESIZE) end to end: synthetic dual-shape on-disk fixtures for the happy
+path, patched migration seams for the empty/blocked branches, and the apply
+path to prove the real project UUID is threaded onto every envelope (INV-5).
+
+The happy-path / apply-path fixtures are built under ``tmp_path`` via the
+shared builders in ``test_history_import_scan`` (``_build_legacy_shape_mission``
+/ ``_build_prefixed_shape_mission``) rather than pinned to specific
+``kitty-specs/`` dogfood missions in this repo. Those directories are
+scheduled for archival/relocation by the dogfood-corpus cutover (#2917); a
+mission-keyed ``skipif`` would then silently skip forever instead of failing
+(#2884 adversarial-review finding) — including the end-to-end apply test
+below, which is the ONLY proof that a real synthesized stream survives
+``validate_import_envelopes`` (the real outbound-envelope contract gate) and
+uploads cleanly.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
@@ -20,15 +29,102 @@ from specify_cli.sync.history_import.pipeline import (
     build_import_plan,
     describe_plan,
 )
+from tests.sync.test_history_import_scan import (
+    _build_legacy_shape_mission,
+    _build_prefixed_shape_mission,
+)
 
 pytestmark = pytest.mark.fast
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SPECS = _REPO_ROOT / "kitty-specs"
-_LEGACY = _SPECS / "032-identity-aware-cli-event-sync"
-_PREFIXED = _SPECS / "single-mission-surface-resolver-01KVGCE8"
+# ── fixed ULID-shaped ids (real ``python-ulid`` output, hardcoded for a
+# deterministic, production-realistic ``mission_id`` per test) ───────────────
+_PLAN_LEGACY_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWP"
+_PLAN_PREFIXED_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWQ"
+_APPLY_UUID_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWR"
+_DESCRIBE_PLAN_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWS"
+_E2E_LEGACY_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWT"
+_E2E_PREFIXED_MISSION_ID = "01KYFVD16B6AAJKDMT8SHR6VWV"
 
-_FIXTURES = _LEGACY.is_dir() and _PREFIXED.is_dir()
+# Reused across the happy-path / apply / e2e fixtures below: six legacy WPs
+# (SYNTHESIZED prefix) drives the same WP-count floor the pipeline previously
+# asserted against the real ``032-identity-aware-cli-event-sync`` fixture.
+_LEGACY_WP_SPECS = [
+    ("WP01", "ProjectIdentity Module", []),
+    ("WP02", "Emitter Identity Injection", ["WP01"]),
+    ("WP03", "AuthClient Team Slug", ["WP01"]),
+    ("WP04", "Sync Runtime Lazy Singleton", ["WP02"]),
+    ("WP05", "Fix Duplicate Emissions", ["WP02", "WP03"]),
+    ("WP06", "Integration Tests", ["WP04", "WP05"]),
+]
+_PREFIXED_WP_SPECS = [
+    (
+        "WP01",
+        "Surface-resolution audit (read-only inventory)",
+        [],
+        "kitty-specs/plan-prefixed-mission/tasks/WP01-surface-resolution-audit.md",
+        "2026-06-19T17:11:46.841180Z",
+    ),
+    (
+        "WP02",
+        "Differential equivalence test (the deletion safety gate)",
+        [],
+        "kitty-specs/plan-prefixed-mission/tasks/WP02-differential-equivalence-test.md",
+        "2026-06-19T17:11:46.855890Z",
+    ),
+]
+
+
+def _legacy_lane_rows(mission_id: str, mission_slug: str) -> list[dict]:
+    return [
+        {
+            "actor": "migration",
+            "at": "2026-02-07T00:00:00Z",
+            "event_id": "01KJ5V38V9HRA67BAXKNQDG0H7",
+            "evidence": None,
+            "execution_mode": "direct_repo",
+            "force": True,
+            "from_lane": "planned",
+            "mission_id": mission_id,
+            "mission_slug": mission_slug,
+            "policy_metadata": None,
+            "reason": "historical_frontmatter_to_jsonl:v1",
+            "review_ref": None,
+            "to_lane": "done",
+            "wp_id": "WP01",
+        },
+        {
+            "actor": "migration",
+            "at": "2026-02-07T00:00:00Z",
+            "event_id": "01KJ5V38VBW3NMHJEHCCKB3V7C",
+            "evidence": None,
+            "execution_mode": "direct_repo",
+            "force": True,
+            "from_lane": "planned",
+            "mission_id": mission_id,
+            "mission_slug": mission_slug,
+            "policy_metadata": None,
+            "reason": "historical_frontmatter_to_jsonl:v1",
+            "review_ref": None,
+            "to_lane": "done",
+            "wp_id": "WP02",
+        },
+        {
+            "actor": "migration",
+            "at": "2026-02-07T00:00:00Z",
+            "event_id": "01KJ5V38VD6E2V3WJE9KVG9M82",
+            "evidence": None,
+            "execution_mode": "direct_repo",
+            "force": True,
+            "from_lane": "planned",
+            "mission_id": mission_id,
+            "mission_slug": mission_slug,
+            "policy_metadata": None,
+            "reason": "historical_frontmatter_to_jsonl:v1",
+            "review_ref": None,
+            "to_lane": "in_progress",
+            "wp_id": "WP03",
+        },
+    ]
 
 
 def _patch_selection(monkeypatch, *, mission_dirs, blockers):
@@ -38,12 +134,27 @@ def _patch_selection(monkeypatch, *, mission_dirs, blockers):
     monkeypatch.setattr(envelope_seam, "teamspace_audit_blockers", lambda root, *, scan_root, mission_dirs: list(blockers))
 
 
-# ── happy path over real fixtures ─────────────────────────────────────────────
+# ── happy path over a synthetic dual-shape corpus ─────────────────────────────
 
 
-@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
-def test_build_plan_over_real_fixtures(tmp_path, monkeypatch):
-    _patch_selection(monkeypatch, mission_dirs=[_LEGACY, _PREFIXED], blockers=[])
+def test_build_plan_over_synthetic_dual_shape_corpus(tmp_path, monkeypatch):
+    """SELECT→AUDIT→SCAN→IDENTITY→SYNTHESIZE over BOTH hybrid-SCAN shapes
+    (§3.4) — a legacy (SYNTHESIZED) mission and a prefixed (ON_DISK) mission,
+    same dual-shape guarantee the real dogfood fixtures used to exercise."""
+    legacy_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-plan-legacy-mission",
+        mission_id=_PLAN_LEGACY_MISSION_ID,
+        wp_specs=_LEGACY_WP_SPECS,
+        lane_rows=_legacy_lane_rows(_PLAN_LEGACY_MISSION_ID, "087-plan-legacy-mission"),
+    )
+    prefixed_dir = _build_prefixed_shape_mission(
+        tmp_path,
+        slug="plan-prefixed-mission",
+        mission_id=_PLAN_PREFIXED_MISSION_ID,
+        wp_specs=_PREFIXED_WP_SPECS,
+    )
+    _patch_selection(monkeypatch, mission_dirs=[legacy_dir, prefixed_dir], blockers=[])
 
     plan = build_import_plan(tmp_path, mission=None, apply=False)
 
@@ -79,10 +190,16 @@ def test_audit_blockers_raise_before_synthesis(tmp_path, monkeypatch):
 # ── apply threads the real UUID (INV-5) ───────────────────────────────────────
 
 
-@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
 def test_apply_plan_threads_the_real_uuid(tmp_path, monkeypatch):
     (tmp_path / ".kittify").mkdir()  # a real (uninitialized) checkout
-    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+    mission_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-apply-uuid-mission",
+        mission_id=_APPLY_UUID_MISSION_ID,
+        wp_specs=_LEGACY_WP_SPECS,
+        lane_rows=_legacy_lane_rows(_APPLY_UUID_MISSION_ID, "087-apply-uuid-mission"),
+    )
+    _patch_selection(monkeypatch, mission_dirs=[mission_dir], blockers=[])
 
     plan = build_import_plan(tmp_path, mission=None, apply=True)
 
@@ -94,14 +211,20 @@ def test_apply_plan_threads_the_real_uuid(tmp_path, monkeypatch):
 # ── describe_plan rendering ───────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
 def test_describe_plan_lists_missions_and_breakdown(tmp_path, monkeypatch):
-    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+    mission_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-describe-plan-mission",
+        mission_id=_DESCRIBE_PLAN_MISSION_ID,
+        wp_specs=_LEGACY_WP_SPECS,
+        lane_rows=_legacy_lane_rows(_DESCRIBE_PLAN_MISSION_ID, "087-describe-plan-mission"),
+    )
+    _patch_selection(monkeypatch, mission_dirs=[mission_dir], blockers=[])
     plan = build_import_plan(tmp_path, mission=None, apply=False)
 
     lines = describe_plan(plan)
     text = "\n".join(lines)
-    assert "032-identity-aware-cli-event-sync" in text
+    assert "087-describe-plan-mission" in text
     assert "MissionCreated" in text
     assert "event(s)" in text
 
@@ -211,10 +334,29 @@ def _accepting_poster(url, *, data, headers, timeout):
     return _AcceptingResponse()
 
 
-@pytest.mark.skipif(not _FIXTURES, reason="fixtures not present")
 def test_apply_import_uploads_every_envelope_under_the_real_uuid(tmp_path, monkeypatch):
+    """The end-to-end proof (#2884): synthesize from a synthetic dual-shape
+    corpus → the REAL ``validate_import_envelopes`` contract gate → the REAL
+    ``build_teamspace_envelope`` output → upload against a stub receiver,
+    asserting every envelope lands under the real project UUID. This is the
+    only test that runs a real synthesized stream through the offline
+    contract gate — an envelope-shape drift (e.g. ``schema_version`` off the
+    pinned contract version) would fail here first."""
     (tmp_path / ".kittify").mkdir()  # a real (uninitialized) checkout → apply mints the UUID
-    _patch_selection(monkeypatch, mission_dirs=[_LEGACY], blockers=[])
+    legacy_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-e2e-legacy-mission",
+        mission_id=_E2E_LEGACY_MISSION_ID,
+        wp_specs=_LEGACY_WP_SPECS,
+        lane_rows=_legacy_lane_rows(_E2E_LEGACY_MISSION_ID, "087-e2e-legacy-mission"),
+    )
+    prefixed_dir = _build_prefixed_shape_mission(
+        tmp_path,
+        slug="e2e-prefixed-mission",
+        mission_id=_E2E_PREFIXED_MISSION_ID,
+        wp_specs=_PREFIXED_WP_SPECS,
+    )
+    _patch_selection(monkeypatch, mission_dirs=[legacy_dir, prefixed_dir], blockers=[])
     stub = StubReceiver()
 
     result = apply_import(

--- a/tests/sync/test_history_import_pipeline.py
+++ b/tests/sync/test_history_import_pipeline.py
@@ -148,6 +148,49 @@ def test_describe_plan_makes_skipped_wps_impossible_to_miss():
     assert "2 WPs SKIPPED (malformed frontmatter: WP07.md, WP11.md)" in text  # the mission row names them
 
 
+def test_describe_plan_makes_skipped_event_rows_impossible_to_miss():
+    """Same fail-loud contract as the WP-file skip, for the on-disk lifecycle
+    prefix (#2884 finding A): a dropped WPCreated/MissionCreated row must mark
+    BOTH the summary line and the mission row, never read as clean success."""
+    import uuid
+
+    from specify_cli.sync.history_import.identity import ImportIdentity
+    from specify_cli.sync.history_import.pipeline import ImportPlan
+    from specify_cli.sync.history_import.scan import MissionScan, PrefixSource
+
+    scan = MissionScan(
+        mission_slug="m-event-skips",
+        canonical_mission_id=None,
+        mission_number=None,
+        name="M Event Skips",
+        mission_type="software-dev",
+        purpose_tldr=None,
+        purpose_context=None,
+        target_branch="main",
+        created_at=None,
+        prefix_source=PrefixSource.ON_DISK,
+        work_packages=(),
+        lane_transitions=(),
+        skipped_event_rows=3,
+    )
+    identity = ImportIdentity(
+        project_uuid=uuid.UUID("11111111-2222-3333-4444-555555555555"),
+        project_slug="p",
+        repo_slug="p",
+        is_synthetic=True,
+    )
+    plan = ImportPlan(
+        identity=identity,
+        scans=(scan,),
+        # canonical-event-exempt(exception-flow): minimal wire-envelope fixture for report rendering
+        envelopes=({"event_id": "e0", "event_type": "MissionCreated"},),
+    )
+
+    text = "\n".join(describe_plan(plan))
+    assert "3 lifecycle row(s) SKIPPED" in text  # the summary line itself is marked
+    assert "3 lifecycle row(s) SKIPPED (malformed on-disk prefix)" in text  # the mission row names it
+
+
 def test_describe_empty_plan(tmp_path, monkeypatch):
     _patch_selection(monkeypatch, mission_dirs=[], blockers=[])
     plan = build_import_plan(tmp_path, mission=None, apply=False)

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -204,14 +204,24 @@ def test_corrupt_status_log_raises_named_mission_scan_error(tmp_path):
 def test_malformed_wp_frontmatter_is_skipped_not_fatal(tmp_path):
     """A WP file whose frontmatter parses to a list (not a dict) raises a
     structural TypeError inside the reader. The scan must skip it, not abort —
-    otherwise one bad legacy doc sinks the whole import."""
+    otherwise one bad legacy doc sinks the whole import. The skip is fail-LOUD:
+    the scan result carries the skipped file names so the report can surface
+    them (B3, #2884 review)."""
     mission_dir = tmp_path / "synthetic-malformed-01FFFF"
     tasks = mission_dir / "tasks"
     tasks.mkdir(parents=True)
     (tasks / "WP01-bad.md").write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")
+    (tasks / "WP02-good.md").write_text(
+        "---\nwork_package_id: WP02\ntitle: Good WP\ndependencies: []\n---\nbody\n",
+        encoding="utf-8",
+    )
 
     scan = scan_mission(mission_dir)  # must not raise
-    assert scan.work_packages == ()  # the malformed WP is skipped, scan survives
+
+    # The skip is counted AND named — never silent.
+    assert scan.skipped_wp_files == ("WP01-bad.md",)
+    # The good sibling still scans (skip is per-file, not per-mission).
+    assert [wp.wp_id for wp in scan.work_packages] == ["WP02"]
 
 
 def test_malformed_wp_referenced_by_a_lane_transition_is_backfilled_no_orphan(tmp_path):

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -1,0 +1,179 @@
+"""Tests for the hybrid SCAN stage of ``sync import-history`` — WP-Y2 (#2262).
+
+The SCAN is *hybrid* (§3.4), so the two mission shapes are driven against real
+committed fixtures:
+
+* legacy ``032-identity-aware-cli-event-sync`` — lane transitions only, prefix
+  SYNTHESIZED from ``meta.json`` + ``tasks/WP*.md``;
+* prefixed ``single-mission-surface-resolver-01KVGCE8`` — ``MissionCreated``/
+  ``WPCreated`` read ON_DISK.
+
+The local-only filter and the WPCreated-coverage guard are driven against
+synthetic missions so the assertions don't depend on fixture drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.status.models import StatusEvent
+from specify_cli.sync.history_import.scan import (
+    MissionScan,
+    PrefixSource,
+    _read_importable_lifecycle,
+    scan_mission,
+    scan_missions,
+)
+
+pytestmark = pytest.mark.fast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPECS = _REPO_ROOT / "kitty-specs"
+_LEGACY = _SPECS / "032-identity-aware-cli-event-sync"
+_PREFIXED = _SPECS / "single-mission-surface-resolver-01KVGCE8"
+
+
+# ── legacy shape: prefix SYNTHESIZED from meta.json + tasks/ ──────────────────
+
+
+@pytest.mark.skipif(not _LEGACY.is_dir(), reason="legacy fixture 032 not present")
+def test_legacy_mission_synthesizes_prefix_from_meta_and_tasks():
+    scan = scan_mission(_LEGACY)
+
+    assert scan.prefix_source is PrefixSource.SYNTHESIZED
+    # Identity + display fields resolve from meta.json (verbatim values).
+    assert scan.canonical_mission_id == "01KN2371WRE1E2BH9WR11MAGDG"
+    assert scan.mission_slug == "032-identity-aware-cli-event-sync"
+    assert scan.name == "Identity-Aware CLI Event Sync"
+    assert scan.mission_number == 32
+    assert scan.mission_type == "software-dev"
+    # Legacy has no purpose_tldr; source_description back-fills it.
+    assert scan.purpose_tldr and scan.purpose_tldr.startswith("Make CLI events identity-aware")
+
+    # WPs synthesized from tasks/WP01..WP06.md, each with a non-empty title.
+    wp_ids = {wp.wp_id for wp in scan.work_packages}
+    assert {"WP01", "WP02", "WP03", "WP04", "WP05", "WP06"} <= wp_ids
+    assert all(wp.source is PrefixSource.SYNTHESIZED for wp in scan.work_packages)
+    assert all(wp.wp_title for wp in scan.work_packages)
+
+    # Lane transitions are read (and are real StatusEvents), and every wp_id
+    # they reference has a WPCreated (INV-3 coverage).
+    assert scan.lane_transitions
+    assert all(isinstance(event, StatusEvent) for event in scan.lane_transitions)
+    lane_wp_ids = {event.wp_id for event in scan.lane_transitions if event.wp_id}
+    assert lane_wp_ids <= wp_ids
+
+
+# ── prefixed shape: prefix read ON_DISK ───────────────────────────────────────
+
+
+@pytest.mark.skipif(not _PREFIXED.is_dir(), reason="prefixed fixture not present")
+def test_prefixed_mission_reads_prefix_from_disk():
+    scan = scan_mission(_PREFIXED)
+
+    assert scan.prefix_source is PrefixSource.ON_DISK
+    assert scan.canonical_mission_id == "01KVGCE8GSJE3BPCG6K5WNCH9B"
+    assert scan.name == "Single Mission-Surface Resolver"
+
+    by_id = {wp.wp_id: wp for wp in scan.work_packages}
+    # WP08's on-disk WPCreated payload is read verbatim (title + depends_on).
+    assert "WP08" in by_id
+    wp08 = by_id["WP08"]
+    assert wp08.source is PrefixSource.ON_DISK
+    assert wp08.wp_title == "Load-bearing architectural guard"
+    assert set(wp08.depends_on) == {"WP01", "WP06"}
+
+
+# ── local-only lifecycle events are dropped ───────────────────────────────────
+
+
+def _write_events(mission_dir: Path, rows: list[dict]) -> None:
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "status.events.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def test_local_only_lifecycle_events_are_filtered(tmp_path):
+    mission_dir = tmp_path / "synthetic-filter-01AAAA"
+    _write_events(
+        mission_dir,
+        [
+            {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
+            {"event_type": "MissionReopened", "aggregate_type": "Mission", "payload": {}},
+            {"event_type": "FollowUpRecorded", "aggregate_type": "Mission", "payload": {}},
+            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
+        ],
+    )
+
+    kept = {event["event_type"] for event in _read_importable_lifecycle(mission_dir)}
+    assert kept == {"MissionCreated", "WPCreated"}
+    assert "MissionReopened" not in kept
+    assert "FollowUpRecorded" not in kept
+
+
+# ── WPCreated coverage guard (INV-3) ──────────────────────────────────────────
+
+
+def test_wp_coverage_backfills_a_wp_referenced_only_by_a_lane_transition(tmp_path):
+    """A lane transition for a WP with no task file / no WPCreated still yields
+    a WPCreated, so ``WPStatusChanged`` never precedes ``WPCreated``."""
+    mission_dir = tmp_path / "synthetic-cov-01BBBB"
+    _write_events(
+        mission_dir,
+        [
+            {
+                "actor": "migration",
+                "at": "2026-02-07T00:00:00Z",
+                "event_id": "01KJ5V38V9HRA67BAXKNQDWP99",
+                "evidence": None,
+                "execution_mode": "direct_repo",
+                "force": False,
+                "from_lane": "planned",
+                "mission_id": None,
+                "mission_slug": "synthetic-cov-01BBBB",
+                "policy_metadata": None,
+                "reason": None,
+                "review_ref": None,
+                "to_lane": "in_progress",
+                "wp_id": "WP99",
+            }
+        ],
+    )
+
+    scan = scan_mission(mission_dir)
+
+    assert scan.lane_transitions and scan.lane_transitions[0].wp_id == "WP99"
+    by_id = {wp.wp_id: wp for wp in scan.work_packages}
+    assert "WP99" in by_id, "lane-only WP must be backfilled with a WPCreated"
+    assert by_id["WP99"].wp_title == "WP99"
+    assert by_id["WP99"].source is PrefixSource.SYNTHESIZED
+    assert by_id["WP99"].depends_on == ()
+
+
+def test_work_packages_are_sorted_by_wp_id(tmp_path):
+    mission_dir = tmp_path / "synthetic-sort-01CCCC"
+    _write_events(
+        mission_dir,
+        [
+            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP03"}},
+            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
+            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP02"}},
+        ],
+    )
+    scan = scan_mission(mission_dir)
+    assert [wp.wp_id for wp in scan.work_packages] == ["WP01", "WP02", "WP03"]
+
+
+# ── batch helper ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not (_LEGACY.is_dir() and _PREFIXED.is_dir()), reason="fixtures not present")
+def test_scan_missions_preserves_input_order():
+    scans = scan_missions([_PREFIXED, _LEGACY])
+    assert [scan.mission_slug for scan in scans] == [
+        "single-mission-surface-resolver-01KVGCE8",
+        "032-identity-aware-cli-event-sync",
+    ]
+    assert all(isinstance(scan, MissionScan) for scan in scans)

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -22,6 +22,7 @@ import pytest
 from specify_cli.status.models import StatusEvent
 from specify_cli.sync.history_import.scan import (
     MissionScan,
+    MissionScanError,
     PrefixSource,
     _read_importable_lifecycle,
     scan_mission,
@@ -186,6 +187,20 @@ def test_scan_missions_preserves_input_order():
 # ── malformed WP frontmatter must not abort the scan (#2883 items 3/4) ────────
 
 
+def test_corrupt_status_log_raises_named_mission_scan_error(tmp_path):
+    """A corrupt status.events.jsonl fails closed as MissionScanError naming the
+    mission, not a raw StoreError traceback (Stijn's #2884 review, fix #3)."""
+    mission_dir = tmp_path / "synthetic-corrupt-01GGGG"
+    mission_dir.mkdir(parents=True)
+    # A structurally-broken lane row (not a lifecycle event_type row, so it
+    # reaches the lane reader) that read_events rejects with StoreError.
+    (mission_dir / "status.events.jsonl").write_text("{ this is not valid json\n", encoding="utf-8")
+
+    with pytest.raises(MissionScanError) as excinfo:
+        scan_mission(mission_dir)
+    assert "synthetic-corrupt-01GGGG" in str(excinfo.value)
+
+
 def test_malformed_wp_frontmatter_is_skipped_not_fatal(tmp_path):
     """A WP file whose frontmatter parses to a list (not a dict) raises a
     structural TypeError inside the reader. The scan must skip it, not abort —
@@ -197,3 +212,42 @@ def test_malformed_wp_frontmatter_is_skipped_not_fatal(tmp_path):
 
     scan = scan_mission(mission_dir)  # must not raise
     assert scan.work_packages == ()  # the malformed WP is skipped, scan survives
+
+
+def test_malformed_wp_referenced_by_a_lane_transition_is_backfilled_no_orphan(tmp_path):
+    """A WP whose task file is malformed (skipped) but which a lane transition
+    references must still get a WPCreated via coverage backfill — the exact spot
+    an orphan WPStatusChanged would appear if _ensure_wp_coverage regressed."""
+    mission_dir = tmp_path / "synthetic-orphan-01HHHH"
+    tasks = mission_dir / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "WP01-bad.md").write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")  # malformed → skipped
+    _write_events(
+        mission_dir,
+        [
+            {
+                "actor": "migration",
+                "at": "2026-02-07T00:00:00Z",
+                "event_id": "01KJ5V38V9HRA67BAXKNQDWP01",
+                "evidence": None,
+                "execution_mode": "direct_repo",
+                "force": False,
+                "from_lane": "planned",
+                "mission_id": None,
+                "mission_slug": "synthetic-orphan-01HHHH",
+                "policy_metadata": None,
+                "reason": None,
+                "review_ref": None,
+                "to_lane": "in_progress",
+                "wp_id": "WP01",
+            }
+        ],
+    )
+
+    scan = scan_mission(mission_dir)
+
+    by_id = {wp.wp_id: wp for wp in scan.work_packages}
+    assert "WP01" in by_id, "malformed-but-referenced WP must be backfilled, not orphaned"
+    assert by_id["WP01"].source is PrefixSource.SYNTHESIZED
+    # Every wp_id a lane transition references is covered (INV-3).
+    assert {event.wp_id for event in scan.lane_transitions} <= set(by_id)

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -177,3 +177,19 @@ def test_scan_missions_preserves_input_order():
         "032-identity-aware-cli-event-sync",
     ]
     assert all(isinstance(scan, MissionScan) for scan in scans)
+
+
+# ── malformed WP frontmatter must not abort the scan (#2883 items 3/4) ────────
+
+
+def test_malformed_wp_frontmatter_is_skipped_not_fatal(tmp_path):
+    """A WP file whose frontmatter parses to a list (not a dict) raises a
+    structural TypeError inside the reader. The scan must skip it, not abort —
+    otherwise one bad legacy doc sinks the whole import."""
+    mission_dir = tmp_path / "synthetic-malformed-01FFFF"
+    tasks = mission_dir / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "WP01-bad.md").write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")
+
+    scan = scan_mission(mission_dir)  # must not raise
+    assert scan.work_packages == ()  # the malformed WP is skipped, scan survives

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -100,9 +100,13 @@ def test_local_only_lifecycle_events_are_filtered(tmp_path):
     _write_events(
         mission_dir,
         [
+            # canonical-event-exempt(exception-flow): on-disk lifecycle row fed into the drop-filter under test
             {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
+            # canonical-event-exempt(exception-flow): local-only row the filter must drop
             {"event_type": "MissionReopened", "aggregate_type": "Mission", "payload": {}},
+            # canonical-event-exempt(exception-flow): local-only row the filter must drop
             {"event_type": "FollowUpRecorded", "aggregate_type": "Mission", "payload": {}},
+            # canonical-event-exempt(exception-flow): on-disk lifecycle row fed into the drop-filter under test
             {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
         ],
     )
@@ -153,15 +157,15 @@ def test_wp_coverage_backfills_a_wp_referenced_only_by_a_lane_transition(tmp_pat
 
 
 def test_work_packages_are_sorted_by_wp_id(tmp_path):
+    # Emit WPCreated out of order via the canonical local emitter (not a
+    # hand-rolled event); the scan must return them sorted by wp_id.
+    from specify_cli.status.lifecycle_events import emit_wp_created_local
+
     mission_dir = tmp_path / "synthetic-sort-01CCCC"
-    _write_events(
-        mission_dir,
-        [
-            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP03"}},
-            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
-            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP02"}},
-        ],
-    )
+    mission_dir.mkdir(parents=True)
+    for wp_id in ("WP03", "WP01", "WP02"):
+        emit_wp_created_local(mission_dir, mission_slug="synthetic-sort-01CCCC", wp_id=wp_id, wp_title=wp_id)
+
     scan = scan_mission(mission_dir)
     assert [wp.wp_id for wp in scan.work_packages] == ["WP01", "WP02", "WP03"]
 

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -261,3 +261,20 @@ def test_malformed_wp_referenced_by_a_lane_transition_is_backfilled_no_orphan(tm
     assert by_id["WP01"].source is PrefixSource.SYNTHESIZED
     # Every wp_id a lane transition references is covered (INV-3).
     assert {event.wp_id for event in scan.lane_transitions} <= set(by_id)
+
+
+def test_local_only_event_types_have_one_public_owner() -> None:
+    """SSOT (#2884): scan's local-only filter and lifecycle's post-mission set are
+    the SAME public owner object — no hand-mirrored frozenset copies to drift."""
+    from specify_cli.status import (
+        FOLLOW_UP_RECORDED,
+        LOCAL_ONLY_LIFECYCLE_EVENT_TYPES,
+        MISSION_REOPENED,
+    )
+    from specify_cli.status.lifecycle import _POST_MISSION_EVENT_TYPES
+    from specify_cli.sync.history_import.scan import _LOCAL_ONLY_EVENT_TYPES
+
+    assert LOCAL_ONLY_LIFECYCLE_EVENT_TYPES == frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+    # Identity (``is``), not just equality: both consumers bind the one owner.
+    assert _LOCAL_ONLY_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
+    assert _POST_MISSION_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -274,7 +274,7 @@ def test_local_only_event_types_have_one_public_owner() -> None:
     from specify_cli.status.lifecycle import _POST_MISSION_EVENT_TYPES
     from specify_cli.sync.history_import.scan import _LOCAL_ONLY_EVENT_TYPES
 
-    assert LOCAL_ONLY_LIFECYCLE_EVENT_TYPES == frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+    assert frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED}) == LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
     # Identity (``is``), not just equality: both consumers bind the one owner.
     assert _LOCAL_ONLY_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
     assert _POST_MISSION_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -263,6 +263,73 @@ def test_malformed_wp_referenced_by_a_lane_transition_is_backfilled_no_orphan(tm
     assert {event.wp_id for event in scan.lane_transitions} <= set(by_id)
 
 
+# ── malformed lifecycle rows must be counted, not silently dropped (#2884 A) ──
+
+
+def test_malformed_event_type_row_is_counted_as_a_skipped_event_row(tmp_path):
+    """A row with a null (non-string) ``event_type`` is the genuinely silent
+    failure mode named in the review: valid JSON, so ``read_events`` (the
+    lane-transition reader) treats it as a skippable non-lane row and does
+    NOT fail closed the whole scan — but ``read_lifecycle_events`` also drops
+    it (its ``event_type`` isn't a ``str``), so a ``WPCreated`` row shaped
+    like this vanishes from BOTH readers with no signal at all. The scan must
+    count it (#2884 finding A) so a partial import is loud, not silent."""
+    mission_dir = tmp_path / "synthetic-truncated-01JJJJ"
+    mission_dir.mkdir(parents=True)
+    rows = [
+        {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
+        # canonical-event-exempt(exception-flow): malformed on-disk WPCreated
+        # row under test — null event_type is valid JSON but not a lifecycle
+        # row `read_lifecycle_events` will keep.
+        {"event_type": None, "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
+    ]
+    _write_events(mission_dir, rows)
+
+    scan = scan_mission(mission_dir)
+
+    assert scan.skipped_event_rows == 1
+    # The mission still scans successfully (fail-loud, not fail-closed) and
+    # the malformed WPCreated row truly never reaches work_packages.
+    assert scan.prefix_source is PrefixSource.ON_DISK
+    assert scan.work_packages == ()
+
+
+def test_wp_created_payload_with_no_wp_id_is_counted_not_silently_dropped(tmp_path):
+    """``_wps_from_prefix``'s ``if not wp_id: continue`` used to drop the row
+    with no log and no count. It must now be counted into
+    ``skipped_event_rows`` (#2884 finding A)."""
+    mission_dir = tmp_path / "synthetic-no-wpid-01KKKK"
+    mission_dir.mkdir(parents=True)
+    rows = [
+        {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
+        # canonical-event-exempt(exception-flow): malformed on-disk WPCreated row missing wp_id under test
+        {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_title": "No id here"}},
+        {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01", "wp_title": "Good"}},
+    ]
+    _write_events(mission_dir, rows)
+
+    scan = scan_mission(mission_dir)
+
+    assert scan.skipped_event_rows == 1
+    assert [wp.wp_id for wp in scan.work_packages] == ["WP01"]
+
+
+def test_no_malformed_rows_yields_zero_skipped_event_rows(tmp_path):
+    """The common case: a clean lifecycle prefix counts zero skips."""
+    mission_dir = tmp_path / "synthetic-clean-01LLLL"
+    _write_events(
+        mission_dir,
+        [
+            {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
+            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
+        ],
+    )
+
+    scan = scan_mission(mission_dir)
+
+    assert scan.skipped_event_rows == 0
+
+
 def test_local_only_event_types_have_one_public_owner() -> None:
     """SSOT (#2884): scan's local-only filter and lifecycle's post-mission set are
     the SAME public owner object — no hand-mirrored frozenset copies to drift."""
@@ -274,7 +341,13 @@ def test_local_only_event_types_have_one_public_owner() -> None:
     from specify_cli.status.lifecycle import _POST_MISSION_EVENT_TYPES
     from specify_cli.sync.history_import.scan import _LOCAL_ONLY_EVENT_TYPES
 
-    assert frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED}) == LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
+    # actual == expected (conventional order, #2884 finding D). Bound to local
+    # names first: ruff's SIM300 (Yoda-condition) heuristic treats an ALL_CAPS
+    # name compared directly against a set literal as a constant-on-the-left
+    # false positive, so the operands are named here instead of inlined.
+    actual_local_only_types = LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
+    expected_local_only_types = frozenset({MISSION_REOPENED, FOLLOW_UP_RECORDED})
+    assert actual_local_only_types == expected_local_only_types
     # Identity (``is``), not just equality: both consumers bind the one owner.
     assert _LOCAL_ONLY_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES
     assert _POST_MISSION_EVENT_TYPES is LOCAL_ONLY_LIFECYCLE_EVENT_TYPES

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -90,6 +90,24 @@ def _write_events(mission_dir: Path, rows: list[dict]) -> None:
     (mission_dir / "status.events.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
 
 
+def _append_raw_jsonl_line(mission_dir: Path, raw_json_line: str) -> None:
+    """Append one literal JSON-text line to ``status.events.jsonl``.
+
+    For fixture rows that are deliberately malformed (the shape a canonical
+    ``spec_kitty_events.lifecycle.*Payload`` model cannot represent by
+    definition — that is the point of the test). Writing the line as a
+    Python ``str`` literal rather than a hand-rolled ``dict`` keeps the
+    fixture faithful to "malformed on-disk bytes" as the actual unit under
+    test, and gives the canonical-producer AST lint nothing event-shaped to
+    flag (there is no ``ast.Dict`` literal carrying ``event_type``/``payload``
+    keys — only opaque text).
+    """
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    path = mission_dir / "status.events.jsonl"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(raw_json_line + "\n")
+
+
 def _build_legacy_shape_mission(
     tmp_path: Path,
     *,
@@ -537,16 +555,27 @@ def test_malformed_event_type_row_is_counted_as_a_skipped_event_row(tmp_path):
     it (its ``event_type`` isn't a ``str``), so a ``WPCreated`` row shaped
     like this vanishes from BOTH readers with no signal at all. The scan must
     count it (#2884 finding A) so a partial import is loud, not silent."""
+    from specify_cli.status.lifecycle_events import emit_mission_created_local
+
     mission_dir = tmp_path / "synthetic-truncated-01JJJJ"
     mission_dir.mkdir(parents=True)
-    rows = [
-        {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
-        # canonical-event-exempt(exception-flow): malformed on-disk WPCreated
-        # row under test — null event_type is valid JSON but not a lifecycle
-        # row `read_lifecycle_events` will keep.
-        {"event_type": None, "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
-    ]
-    _write_events(mission_dir, rows)
+    emit_mission_created_local(
+        mission_dir,
+        mission_slug="synthetic-truncated-01JJJJ",
+        mission_id=None,
+        mission_number=None,
+        mission_type="software-dev",
+        target_branch="main",
+        wp_count=0,
+    )
+    # Deliberately malformed on-disk WPCreated row under test — null
+    # event_type is valid JSON but not a lifecycle row `read_lifecycle_events`
+    # will keep. A canonical *Payload model cannot represent this shape (that
+    # is the point), so the raw bytes are appended as a literal JSON-text line.
+    _append_raw_jsonl_line(
+        mission_dir,
+        '{"event_type": null, "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}}',
+    )
 
     scan = scan_mission(mission_dir)
 
@@ -561,15 +590,35 @@ def test_wp_created_payload_with_no_wp_id_is_counted_not_silently_dropped(tmp_pa
     """``_wps_from_prefix``'s ``if not wp_id: continue`` used to drop the row
     with no log and no count. It must now be counted into
     ``skipped_event_rows`` (#2884 finding A)."""
+    from specify_cli.status.lifecycle_events import (
+        emit_mission_created_local,
+        emit_wp_created_local,
+    )
+
     mission_dir = tmp_path / "synthetic-no-wpid-01KKKK"
     mission_dir.mkdir(parents=True)
-    rows = [
-        {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
-        # canonical-event-exempt(exception-flow): malformed on-disk WPCreated row missing wp_id under test
-        {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_title": "No id here"}},
-        {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01", "wp_title": "Good"}},
-    ]
-    _write_events(mission_dir, rows)
+    emit_mission_created_local(
+        mission_dir,
+        mission_slug="synthetic-no-wpid-01KKKK",
+        mission_id=None,
+        mission_number=None,
+        mission_type="software-dev",
+        target_branch="main",
+        wp_count=1,
+    )
+    # Deliberately malformed on-disk WPCreated row missing wp_id under test —
+    # WPCreatedPayload requires wp_id, so a canonical model cannot construct
+    # this shape (that is the point); appended as a literal JSON-text line.
+    _append_raw_jsonl_line(
+        mission_dir,
+        '{"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_title": "No id here"}}',
+    )
+    emit_wp_created_local(
+        mission_dir,
+        mission_slug="synthetic-no-wpid-01KKKK",
+        wp_id="WP01",
+        wp_title="Good",
+    )
 
     scan = scan_mission(mission_dir)
 
@@ -579,13 +628,26 @@ def test_wp_created_payload_with_no_wp_id_is_counted_not_silently_dropped(tmp_pa
 
 def test_no_malformed_rows_yields_zero_skipped_event_rows(tmp_path):
     """The common case: a clean lifecycle prefix counts zero skips."""
+    from specify_cli.status.lifecycle_events import (
+        emit_mission_created_local,
+        emit_wp_created_local,
+    )
+
     mission_dir = tmp_path / "synthetic-clean-01LLLL"
-    _write_events(
+    emit_mission_created_local(
         mission_dir,
-        [
-            {"event_type": "MissionCreated", "aggregate_type": "Mission", "payload": {}},
-            {"event_type": "WPCreated", "aggregate_type": "WorkPackage", "payload": {"wp_id": "WP01"}},
-        ],
+        mission_slug="synthetic-clean-01LLLL",
+        mission_id=None,
+        mission_number=None,
+        mission_type="software-dev",
+        target_branch="main",
+        wp_count=1,
+    )
+    emit_wp_created_local(
+        mission_dir,
+        mission_slug="synthetic-clean-01LLLL",
+        wp_id="WP01",
+        wp_title="WP01",
     )
 
     scan = scan_mission(mission_dir)

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -1,20 +1,31 @@
 """Tests for the hybrid SCAN stage of ``sync import-history`` — WP-Y2 (#2262).
 
-The SCAN is *hybrid* (§3.4), so the two mission shapes are driven against real
-committed fixtures:
+The SCAN is *hybrid* (§3.4): two mission shapes exist on disk and must both
+scan correctly —
 
-* legacy ``032-identity-aware-cli-event-sync`` — lane transitions only, prefix
-  SYNTHESIZED from ``meta.json`` + ``tasks/WP*.md``;
-* prefixed ``single-mission-surface-resolver-01KVGCE8`` — ``MissionCreated``/
-  ``WPCreated`` read ON_DISK.
+* **legacy** — lane transitions only; the creation prefix (mission fields +
+  WPs) is SYNTHESIZED from ``meta.json`` + ``tasks/WP*.md`` frontmatter;
+* **prefixed** — ``MissionCreated``/``WPCreated`` are read verbatim ON_DISK
+  from ``status.events.jsonl``.
+
+Both shapes are built here as synthetic on-disk fixtures under ``tmp_path``
+(``_build_legacy_shape_mission`` / ``_build_prefixed_shape_mission``) rather
+than pinned to specific ``kitty-specs/`` dogfood missions in this repo: the
+dogfood-corpus cutover (#2917) will archive/relocate those directories, and a
+mission-keyed ``skipif`` would then silently skip forever instead of failing
+(#2884 adversarial-review finding). The builders reproduce the two shapes with
+production-realistic data (real ULID-shaped ``mission_id``, realistic WP
+frontmatter / on-disk lifecycle payloads) so each test still exercises the
+exact discriminating shape it is named for.
 
 The local-only filter and the WPCreated-coverage guard are driven against
-synthetic missions so the assertions don't depend on fixture drift.
+smaller synthetic missions so the assertions don't depend on fixture drift.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -31,25 +42,226 @@ from specify_cli.sync.history_import.scan import (
 
 pytestmark = pytest.mark.fast
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SPECS = _REPO_ROOT / "kitty-specs"
-_LEGACY = _SPECS / "032-identity-aware-cli-event-sync"
-_PREFIXED = _SPECS / "single-mission-surface-resolver-01KVGCE8"
+# ── fixed ULID-shaped ids (real ``python-ulid`` output, hardcoded for a
+# deterministic, production-realistic ``mission_id`` per test) ───────────────
+_LEGACY_MISSION_ID = "01KYFV95VETCC5CS96CWFJ9NBF"
+_PREFIXED_MISSION_ID = "01KYFV95VETCC5CS96CWFJ9NBG"
+_ORDER_LEGACY_MISSION_ID = "01KYFV95VETCC5CS96CWFJ9NBH"
+_ORDER_PREFIXED_MISSION_ID = "01KYFV95VETCC5CS96CWFJ9NBJ"
+_LANE_EVENT_WP01 = "01KYFV95VETCC5CS96CWFJ9NBK"
+_LANE_EVENT_WP02 = "01KYFV95VETCC5CS96CWFJ9NBM"
+_LANE_EVENT_WP03 = "01KYFV95VETCC5CS96CWFJ9NBN"
+
+
+# ── synthetic dual-shape fixture builders ─────────────────────────────────────
+
+
+def _lane_transition_row(
+    *,
+    mission_id: str,
+    mission_slug: str,
+    wp_id: str,
+    to_lane: str,
+    event_id: str,
+    from_lane: str = "planned",
+    at: str = "2026-02-07T00:00:00Z",
+) -> dict:
+    """One realistic lane-transition row, matching the on-disk StatusEvent shape."""
+    return {
+        "actor": "migration",
+        "at": at,
+        "event_id": event_id,
+        "evidence": None,
+        "execution_mode": "direct_repo",
+        "force": True,
+        "from_lane": from_lane,
+        "mission_id": mission_id,
+        "mission_slug": mission_slug,
+        "policy_metadata": None,
+        "reason": "historical_frontmatter_to_jsonl:v1",
+        "review_ref": None,
+        "to_lane": to_lane,
+        "wp_id": wp_id,
+    }
+
+
+def _write_events(mission_dir: Path, rows: list[dict]) -> None:
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "status.events.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+
+
+def _build_legacy_shape_mission(
+    tmp_path: Path,
+    *,
+    slug: str,
+    mission_id: str,
+    friendly_name: str = "Legacy Shape Mission",
+    mission_number: int = 87,
+    source_description: str = "Make CLI events identity-aware and auto-syncing so multiple local projects appear in SaaS dashboards.",
+    target_branch: str = "main",
+    wp_specs: Sequence[tuple[str, str, list[str]]] = (),
+    lane_rows: Sequence[dict] = (),
+) -> Path:
+    """Build the LEGACY on-disk shape: ``meta.json`` + ``tasks/WP*.md``
+    frontmatter, a lane-transitions-ONLY ``status.events.jsonl`` (no on-disk
+    ``MissionCreated``/``WPCreated`` prefix) — the SYNTHESIZED half of the
+    hybrid-SCAN dual-shape guarantee (§3.4).
+    """
+    mission_dir = tmp_path / "kitty-specs" / slug
+    tasks_dir = mission_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    meta = {
+        "created_at": "2026-02-07T00:00:00Z",
+        "friendly_name": friendly_name,
+        "mission_id": mission_id,
+        "mission_number": mission_number,
+        "mission_slug": slug,
+        "mission_type": "software-dev",
+        "slug": slug,
+        "source_description": source_description,
+        "status_phase": "1",
+        "target_branch": target_branch,
+        "vcs": "git",
+    }
+    (mission_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    for wp_id, title, deps in wp_specs:
+        frontmatter = "\n".join(
+            [
+                "---",
+                f"work_package_id: {wp_id}",
+                f"title: {title}",
+                f"dependencies: {json.dumps(deps)}",
+                f"base_branch: {target_branch}",
+                "base_commit: fe5dd26eb9160377ee55f83b072f5dc3db322843",
+                "created_at: '2026-02-07T07:23:14.221357+00:00'",
+                "subtasks:",
+                "- T001",
+                "- T002",
+                "phase: Phase 0 - Foundation",
+                "history:",
+                "- timestamp: '2026-02-07T00:00:00Z'",
+                "  lane: planned",
+                "  agent: system",
+                "  shell_pid: ''",
+                "---",
+                "",
+                f"# {title}",
+                "",
+            ]
+        )
+        file_slug = title.lower().replace(" ", "-").replace("/", "-")
+        (tasks_dir / f"{wp_id}-{file_slug}.md").write_text(frontmatter, encoding="utf-8")
+    if lane_rows:
+        _write_events(mission_dir, list(lane_rows))
+    return mission_dir
+
+
+def _build_prefixed_shape_mission(
+    tmp_path: Path,
+    *,
+    slug: str,
+    mission_id: str,
+    friendly_name: str = "Prefixed Shape Mission",
+    purpose_tldr: str = "Collapse the parallel resolvers into one canonical resolver.",
+    purpose_context: str = "Several commands resolve the wrong directory when surfaces diverge.",
+    target_branch: str = "main",
+    created_at: str = "2026-06-19T16:46:47.321621+00:00",
+    wp_specs: Sequence[tuple[str, str, list[str], str, str]] = (),
+) -> Path:
+    """Build the PREFIXED on-disk shape via the canonical local emitters: a
+    real ``MissionCreated`` + ``WPCreated[]`` lifecycle prefix on disk — the
+    ON_DISK half of the hybrid-SCAN dual-shape guarantee (§3.4).
+
+    ``wp_specs`` entries are ``(wp_id, title, depends_on, wp_path, created_at)``.
+    """
+    from specify_cli.status.lifecycle_events import (
+        emit_mission_created_local,
+        emit_wp_created_local,
+    )
+
+    mission_dir = tmp_path / "kitty-specs" / slug
+    mission_dir.mkdir(parents=True)
+    emit_mission_created_local(
+        mission_dir,
+        mission_slug=slug,
+        mission_id=mission_id,
+        mission_number=None,
+        mission_type="software-dev",
+        target_branch=target_branch,
+        wp_count=len(wp_specs),
+        friendly_name=friendly_name,
+        purpose_tldr=purpose_tldr,
+        purpose_context=purpose_context,
+        created_at=created_at,
+    )
+    for wp_id, title, depends_on, wp_path, wp_created_at in wp_specs:
+        emit_wp_created_local(
+            mission_dir,
+            mission_slug=slug,
+            wp_id=wp_id,
+            wp_title=title,
+            wp_path=wp_path,
+            depends_on=depends_on,
+            created_at=wp_created_at,
+        )
+    return mission_dir
 
 
 # ── legacy shape: prefix SYNTHESIZED from meta.json + tasks/ ──────────────────
 
+_LEGACY_WP_SPECS = [
+    ("WP01", "ProjectIdentity Module", []),
+    ("WP02", "Emitter Identity Injection", ["WP01"]),
+    ("WP03", "AuthClient Team Slug", ["WP01"]),
+    ("WP04", "Sync Runtime Lazy Singleton", ["WP02"]),
+    ("WP05", "Fix Duplicate Emissions", ["WP02", "WP03"]),
+    ("WP06", "Integration Tests", ["WP04", "WP05"]),
+]
 
-@pytest.mark.skipif(not _LEGACY.is_dir(), reason="legacy fixture 032 not present")
-def test_legacy_mission_synthesizes_prefix_from_meta_and_tasks():
-    scan = scan_mission(_LEGACY)
+
+def test_legacy_mission_synthesizes_prefix_from_meta_and_tasks(tmp_path):
+    lane_rows = [
+        _lane_transition_row(
+            mission_id=_LEGACY_MISSION_ID,
+            mission_slug="087-legacy-shape-mission",
+            wp_id="WP01",
+            to_lane="done",
+            event_id=_LANE_EVENT_WP01,
+        ),
+        _lane_transition_row(
+            mission_id=_LEGACY_MISSION_ID,
+            mission_slug="087-legacy-shape-mission",
+            wp_id="WP02",
+            to_lane="done",
+            event_id=_LANE_EVENT_WP02,
+        ),
+        _lane_transition_row(
+            mission_id=_LEGACY_MISSION_ID,
+            mission_slug="087-legacy-shape-mission",
+            wp_id="WP03",
+            to_lane="in_progress",
+            event_id=_LANE_EVENT_WP03,
+        ),
+    ]
+    mission_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-legacy-shape-mission",
+        mission_id=_LEGACY_MISSION_ID,
+        friendly_name="Identity-Aware CLI Event Sync",
+        mission_number=87,
+        source_description="Make CLI events identity-aware and auto-syncing so multiple local projects appear in SaaS dashboards.",
+        wp_specs=_LEGACY_WP_SPECS,
+        lane_rows=lane_rows,
+    )
+
+    scan = scan_mission(mission_dir)
 
     assert scan.prefix_source is PrefixSource.SYNTHESIZED
     # Identity + display fields resolve from meta.json (verbatim values).
-    assert scan.canonical_mission_id == "01KN2371WRE1E2BH9WR11MAGDG"
-    assert scan.mission_slug == "032-identity-aware-cli-event-sync"
+    assert scan.canonical_mission_id == _LEGACY_MISSION_ID
+    assert scan.mission_slug == "087-legacy-shape-mission"
     assert scan.name == "Identity-Aware CLI Event Sync"
-    assert scan.mission_number == 32
+    assert scan.mission_number == 87
     assert scan.mission_type == "software-dev"
     # Legacy has no purpose_tldr; source_description back-fills it.
     assert scan.purpose_tldr and scan.purpose_tldr.startswith("Make CLI events identity-aware")
@@ -70,13 +282,55 @@ def test_legacy_mission_synthesizes_prefix_from_meta_and_tasks():
 
 # ── prefixed shape: prefix read ON_DISK ───────────────────────────────────────
 
+_PREFIXED_SLUG = "single-mission-surface-resolver-01KYFV95"
+_PREFIXED_WP_SPECS = [
+    (
+        "WP01",
+        "Surface-resolution audit (read-only inventory)",
+        [],
+        f"kitty-specs/{_PREFIXED_SLUG}/tasks/WP01-surface-resolution-audit.md",
+        "2026-06-19T17:11:46.841180Z",
+    ),
+    (
+        "WP02",
+        "Differential equivalence test (the deletion safety gate)",
+        [],
+        f"kitty-specs/{_PREFIXED_SLUG}/tasks/WP02-differential-equivalence-test.md",
+        "2026-06-19T17:11:46.855890Z",
+    ),
+    (
+        "WP08",
+        "Load-bearing architectural guard",
+        ["WP01", "WP06"],
+        f"kitty-specs/{_PREFIXED_SLUG}/tasks/WP08-load-bearing-guard.md",
+        "2026-06-19T17:11:46.833815Z",
+    ),
+]
 
-@pytest.mark.skipif(not _PREFIXED.is_dir(), reason="prefixed fixture not present")
-def test_prefixed_mission_reads_prefix_from_disk():
-    scan = scan_mission(_PREFIXED)
+
+def test_prefixed_mission_reads_prefix_from_disk(tmp_path):
+    mission_dir = _build_prefixed_shape_mission(
+        tmp_path,
+        slug=_PREFIXED_SLUG,
+        mission_id=_PREFIXED_MISSION_ID,
+        friendly_name="Single Mission-Surface Resolver",
+        purpose_tldr=(
+            "Collapse the 4+ parallel coord/primary mission-surface resolvers into "
+            "one canonical resolver so every command agrees which on-disk surface "
+            "is authoritative."
+        ),
+        purpose_context=(
+            "When a mission's coordination worktree and primary checkout diverge, "
+            "several commands resolve the wrong directory."
+        ),
+        target_branch="feat/single-mission-surface-resolver",
+        wp_specs=_PREFIXED_WP_SPECS,
+    )
+
+    scan = scan_mission(mission_dir)
 
     assert scan.prefix_source is PrefixSource.ON_DISK
-    assert scan.canonical_mission_id == "01KVGCE8GSJE3BPCG6K5WNCH9B"
+    assert scan.canonical_mission_id == _PREFIXED_MISSION_ID
     assert scan.name == "Single Mission-Surface Resolver"
 
     by_id = {wp.wp_id: wp for wp in scan.work_packages}
@@ -89,11 +343,6 @@ def test_prefixed_mission_reads_prefix_from_disk():
 
 
 # ── local-only lifecycle events are dropped ───────────────────────────────────
-
-
-def _write_events(mission_dir: Path, rows: list[dict]) -> None:
-    mission_dir.mkdir(parents=True, exist_ok=True)
-    (mission_dir / "status.events.jsonl").write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
 
 
 def test_local_only_lifecycle_events_are_filtered(tmp_path):
@@ -174,12 +423,26 @@ def test_work_packages_are_sorted_by_wp_id(tmp_path):
 # ── batch helper ──────────────────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(not (_LEGACY.is_dir() and _PREFIXED.is_dir()), reason="fixtures not present")
-def test_scan_missions_preserves_input_order():
-    scans = scan_missions([_PREFIXED, _LEGACY])
+def test_scan_missions_preserves_input_order(tmp_path):
+    """SCAN's batch helper preserves caller-given order across BOTH hybrid
+    shapes (§3.4) — not an accident of alphabetic sort."""
+    legacy_dir = _build_legacy_shape_mission(
+        tmp_path,
+        slug="087-order-legacy-mission",
+        mission_id=_ORDER_LEGACY_MISSION_ID,
+        friendly_name="Order Legacy Mission",
+    )
+    prefixed_dir = _build_prefixed_shape_mission(
+        tmp_path,
+        slug="order-prefixed-mission-01KYFV95",
+        mission_id=_ORDER_PREFIXED_MISSION_ID,
+        friendly_name="Order Prefixed Mission",
+    )
+
+    scans = scan_missions([prefixed_dir, legacy_dir])
     assert [scan.mission_slug for scan in scans] == [
-        "single-mission-surface-resolver-01KVGCE8",
-        "032-identity-aware-cli-event-sync",
+        "order-prefixed-mission-01KYFV95",
+        "087-order-legacy-mission",
     ]
     assert all(isinstance(scan, MissionScan) for scan in scans)
 

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -182,8 +182,10 @@ def test_multi_mission_stream_event_ids_are_unique():
         **kwargs,
     )
 
+    # 2 × (MissionCreated + 2 WPCreated), in order — the content contract.
+    assert [env["event_type"] for env in stream] == ["MissionCreated", "WPCreated", "WPCreated"] * 2
+
     ids = [env["event_id"] for env in stream]
-    assert len(ids) == 6  # 2 × (MissionCreated + 2 WPCreated)
     assert len(set(ids)) == len(ids), f"duplicate event_ids in the synthesized stream: {ids}"
 
 

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -1,0 +1,195 @@
+"""Tests for the SYNTHESIZE stage of ``sync import-history`` — WP-Y3 (#2262).
+
+The load-bearing assertion is *conformance*: every synthesized envelope must
+pass the SAME two-step validation the migration dry-run uses
+(``Event.model_validate`` + ``validate_event`` against the per-type payload
+model), so the SaaS materializer cannot silently reject the batch. The
+ordering (INV-3), determinism (INV-4), and identity threading are pinned on top
+of that.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from spec_kitty_events import Event
+from spec_kitty_events.conformance import validate_event
+
+from specify_cli.status.models import StatusEvent
+from specify_cli.sync.history_import.scan import (
+    MissionScan,
+    PrefixSource,
+    ScannedWorkPackage,
+    scan_mission,
+)
+from specify_cli.sync.history_import.synthesize import (
+    deterministic_ulid,
+    dry_run_project_uuid,
+    synthesize_mission_stream,
+    synthesize_streams,
+)
+
+pytestmark = pytest.mark.fast
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPECS = _REPO_ROOT / "kitty-specs"
+_LEGACY = _SPECS / "032-identity-aware-cli-event-sync"
+_PREFIXED = _SPECS / "single-mission-surface-resolver-01KVGCE8"
+
+_MISSION_ID = "01HZABCDEFGH1234567890JKMN"
+_PROJECT_UUID = uuid.UUID("8a4a7da6-a97c-4bb4-893a-b31664abfee4")
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _status_event(wp_id: str, from_lane: str, to_lane: str, at: str, event_id: str) -> StatusEvent:
+    return StatusEvent.from_dict(
+        {
+            "event_id": event_id,
+            "mission_slug": "demo-mission",
+            "mission_id": _MISSION_ID,
+            "wp_id": wp_id,
+            "from_lane": from_lane,
+            "to_lane": to_lane,
+            "at": at,
+            "actor": "claude",
+            "force": False,
+            "execution_mode": "worktree",
+            "evidence": None,
+            "reason": None,
+            "review_ref": None,
+            "policy_metadata": None,
+        }
+    )
+
+
+def _demo_scan() -> MissionScan:
+    return MissionScan(
+        mission_slug="demo-mission",
+        canonical_mission_id=_MISSION_ID,
+        mission_number=7,
+        name="Demo Mission",
+        mission_type="software-dev",
+        purpose_tldr="Demonstrate import synthesis.",
+        purpose_context="Context for the demo mission.",
+        target_branch="main",
+        created_at="2026-02-01T00:00:00+00:00",
+        prefix_source=PrefixSource.SYNTHESIZED,
+        work_packages=(
+            ScannedWorkPackage("WP01", "First WP", (), None, None, PrefixSource.SYNTHESIZED),
+            ScannedWorkPackage("WP02", "Second WP", ("WP01",), None, None, PrefixSource.SYNTHESIZED),
+        ),
+        lane_transitions=(
+            _status_event("WP01", "planned", "claimed", "2026-02-02T00:00:00Z", "01HZ0000000000000000000001"),
+            _status_event("WP02", "planned", "claimed", "2026-02-03T00:00:00Z", "01HZ0000000000000000000002"),
+        ),
+    )
+
+
+def _assert_all_conform(stream: list[dict]) -> None:
+    """Every envelope passes both validation steps the real pipeline runs."""
+    for env in stream:
+        Event.model_validate(env)  # raises on an invalid envelope
+        result = validate_event(env["payload"], env["event_type"])
+        assert result.valid, f"{env['event_type']} payload invalid: {getattr(result, 'model_violations', result)}"
+
+
+# ── conformance (the non-fakeable proof) ──────────────────────────────────────
+
+
+def test_every_synthesized_envelope_conforms():
+    stream = synthesize_mission_stream(_demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+    _assert_all_conform(stream)
+
+
+# ── ordering + INV-3 ──────────────────────────────────────────────────────────
+
+
+def test_stream_is_ordered_creation_before_status():
+    stream = synthesize_mission_stream(_demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+    types = [env["event_type"] for env in stream]
+    assert types == ["MissionCreated", "WPCreated", "WPCreated", "WPStatusChanged", "WPStatusChanged"]
+
+    # Lamport is per-mission, monotonic 1..N.
+    assert [env["lamport_clock"] for env in stream] == [1, 2, 3, 4, 5]
+
+    # INV-3: each WPStatusChanged's WP has a WPCreated at a strictly lower clock.
+    created_clock = {env["aggregate_id"]: env["lamport_clock"] for env in stream if env["event_type"] == "WPCreated"}
+    for env in stream:
+        if env["event_type"] == "WPStatusChanged":
+            wp_id = env["aggregate_id"]
+            assert wp_id in created_clock, f"{wp_id} has no WPCreated"
+            assert created_clock[wp_id] < env["lamport_clock"]
+
+
+def test_aggregate_conventions():
+    stream = synthesize_mission_stream(_demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+    mission_created = stream[0]
+    assert mission_created["aggregate_type"] == "Mission"
+    assert mission_created["aggregate_id"] == _MISSION_ID
+
+    wp_created = [env for env in stream if env["event_type"] == "WPCreated"]
+    assert {env["aggregate_id"] for env in wp_created} == {"WP01", "WP02"}
+    assert all(env["aggregate_type"] == "WorkPackage" for env in wp_created)
+
+
+# ── determinism (INV-4) + identity threading ──────────────────────────────────
+
+
+def test_event_ids_are_deterministic_and_namespaced():
+    kwargs = {"project_uuid": _PROJECT_UUID, "project_slug": "spec-kitty", "repo_slug": "acme/spec-kitty"}
+    first = synthesize_mission_stream(_demo_scan(), **kwargs)
+    second = synthesize_mission_stream(_demo_scan(), **kwargs)
+
+    assert [env["event_id"] for env in first] == [env["event_id"] for env in second]
+    # Creation-prefix ids live in the `import:` namespace (never the dry-run one).
+    assert first[0]["event_id"] == deterministic_ulid("import:demo-mission:MissionCreated")
+    assert first[1]["event_id"] == deterministic_ulid("import:demo-mission:WPCreated:WP01")
+    # Replayed status events keep their real on-disk event_id.
+    assert first[3]["event_id"] == "01HZ0000000000000000000001"
+
+
+def test_project_identity_is_threaded_into_every_envelope():
+    stream = synthesize_mission_stream(_demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+    assert all(env["project_uuid"] == str(_PROJECT_UUID) for env in stream)
+    assert all(env["project_slug"] == "spec-kitty" for env in stream)
+    assert all(env["repo_slug"] == "acme/spec-kitty" for env in stream)
+    # The whole stream is one coherent import operation: unified correlation id
+    # and build id across the synthesized prefix AND the reused status envelopes.
+    assert len({env["correlation_id"] for env in stream}) == 1
+    assert {env["build_id"] for env in stream} == {"import-history"}
+
+
+def test_dry_run_project_uuid_is_deterministic():
+    a = dry_run_project_uuid(["demo-mission", "other"])
+    b = dry_run_project_uuid(["demo-mission", "other"])
+    assert a == b
+    assert a == uuid.uuid5(uuid.NAMESPACE_URL, "spec-kitty:teamspace-dry-run:demo-mission|other")
+
+
+# ── real fixtures end-to-end ──────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _LEGACY.is_dir(), reason="legacy fixture 032 not present")
+def test_legacy_fixture_synthesizes_a_conforming_stream():
+    scan = scan_mission(_LEGACY)
+    uuid_ = dry_run_project_uuid([scan.mission_slug])
+    stream = synthesize_mission_stream(scan, project_uuid=uuid_, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+
+    _assert_all_conform(stream)
+    assert stream[0]["event_type"] == "MissionCreated"
+    n_wp_created = sum(1 for env in stream if env["event_type"] == "WPCreated")
+    assert n_wp_created >= 6  # WP01..WP06 synthesized from tasks/
+
+
+@pytest.mark.skipif(not _PREFIXED.is_dir(), reason="prefixed fixture not present")
+def test_prefixed_fixture_synthesizes_a_conforming_stream():
+    scan = scan_mission(_PREFIXED)
+    uuid_ = dry_run_project_uuid([scan.mission_slug])
+    stream = synthesize_streams([scan], project_uuid=uuid_, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+
+    _assert_all_conform(stream)
+    assert stream[0]["event_type"] == "MissionCreated"

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -125,6 +125,68 @@ def test_stream_is_ordered_creation_before_status():
             assert created_clock[wp_id] < env["lamport_clock"]
 
 
+def test_status_order_is_sorted_by_at_then_event_id_not_input_order():
+    """Ordering witness (T1, #2884): the transitions arrive deliberately OUT of
+    ``(at, event_id)`` order — including an ``at`` tie that only the
+    ``event_id`` tie-break resolves — so deleting the ``sorted(...)`` in
+    ``synthesize_mission_stream`` makes this test fail."""
+    import dataclasses
+
+    scan = dataclasses.replace(
+        _demo_scan(),
+        lane_transitions=(
+            # input order: 09 (tied at), 01 (earliest), 05 (tied at, lower id)
+            _status_event("WP02", "planned", "claimed", "2026-02-05T00:00:00Z", "01HZ0000000000000000000009"),
+            _status_event("WP01", "planned", "claimed", "2026-02-02T00:00:00Z", "01HZ0000000000000000000001"),
+            _status_event("WP02", "claimed", "in_progress", "2026-02-05T00:00:00Z", "01HZ0000000000000000000005"),
+        ),
+    )
+    stream = synthesize_mission_stream(scan, project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
+
+    status_ids = [env["event_id"] for env in stream if env["event_type"] == "WPStatusChanged"]
+    assert status_ids == [
+        "01HZ0000000000000000000001",  # earliest at
+        "01HZ0000000000000000000005",  # at-tie broken by event_id ...
+        "01HZ0000000000000000000009",  # ... not by input position
+    ]
+
+
+def test_multi_mission_stream_event_ids_are_unique():
+    """Stream-wide id uniqueness (T2, #2884): two missions × two WPs each, with
+    the same wp_ids repeating across missions. A seed regression that dropped
+    ``wp.wp_id`` collides the two WPCreated ids WITHIN a mission; one that
+    dropped the mission identity collides WP01 ACROSS missions."""
+    kwargs = {"project_uuid": _PROJECT_UUID, "project_slug": "p", "repo_slug": "p"}
+
+    def _scan(mission_id: str, slug: str) -> MissionScan:
+        return MissionScan(
+            mission_slug=slug,
+            canonical_mission_id=mission_id,
+            mission_number=None,
+            name=slug,
+            mission_type="software-dev",
+            purpose_tldr=None,
+            purpose_context=None,
+            target_branch="main",
+            created_at="2026-02-01T00:00:00+00:00",
+            prefix_source=PrefixSource.SYNTHESIZED,
+            work_packages=(
+                ScannedWorkPackage("WP01", "First WP", (), None, None, PrefixSource.SYNTHESIZED),
+                ScannedWorkPackage("WP02", "Second WP", (), None, None, PrefixSource.SYNTHESIZED),
+            ),
+            lane_transitions=(),
+        )
+
+    stream = synthesize_streams(
+        [_scan("01AAAAAAAAAAAAAAAAAAAAAAAA", "m-a"), _scan("01BBBBBBBBBBBBBBBBBBBBBBBB", "m-b")],
+        **kwargs,
+    )
+
+    ids = [env["event_id"] for env in stream]
+    assert len(ids) == 6  # 2 × (MissionCreated + 2 WPCreated)
+    assert len(set(ids)) == len(ids), f"duplicate event_ids in the synthesized stream: {ids}"
+
+
 def test_aggregate_conventions():
     stream = synthesize_mission_stream(_demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty")
     mission_created = stream[0]

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -145,11 +145,41 @@ def test_event_ids_are_deterministic_and_namespaced():
     second = synthesize_mission_stream(_demo_scan(), **kwargs)
 
     assert [env["event_id"] for env in first] == [env["event_id"] for env in second]
-    # Creation-prefix ids live in the `import:` namespace (never the dry-run one).
-    assert first[0]["event_id"] == deterministic_ulid("import:demo-mission:MissionCreated")
-    assert first[1]["event_id"] == deterministic_ulid("import:demo-mission:WPCreated:WP01")
+    # Creation-prefix ids live in the `import:` namespace and seed on the
+    # canonical mission id (not the slug — see the collision test below).
+    assert first[0]["event_id"] == deterministic_ulid(f"import:{_MISSION_ID}:MissionCreated")
+    assert first[1]["event_id"] == deterministic_ulid(f"import:{_MISSION_ID}:WPCreated:WP01")
     # Replayed status events keep their real on-disk event_id.
     assert first[3]["event_id"] == "01HZ0000000000000000000001"
+
+
+def test_creation_prefix_ids_seed_on_canonical_id_not_slug():
+    """Two missions sharing a slug but with different canonical ids must NOT
+    produce colliding creation-prefix event_ids — otherwise a deleted-then-
+    recreated same-slug mission would dedup as a duplicate and never
+    materialize (Stijn's #2884 review, fix #2)."""
+    kwargs = {"project_uuid": _PROJECT_UUID, "project_slug": "p", "repo_slug": "p"}
+
+    def _scan(mission_id: str) -> MissionScan:
+        return MissionScan(
+            mission_slug="reused-slug",
+            canonical_mission_id=mission_id,
+            mission_number=None,
+            name="Reused Slug",
+            mission_type="software-dev",
+            purpose_tldr=None,
+            purpose_context=None,
+            target_branch="main",
+            created_at="2026-02-01T00:00:00+00:00",
+            prefix_source=PrefixSource.SYNTHESIZED,
+            work_packages=(),
+            lane_transitions=(),
+        )
+
+    a = synthesize_mission_stream(_scan("01AAAAAAAAAAAAAAAAAAAAAAAA"), **kwargs)
+    b = synthesize_mission_stream(_scan("01BBBBBBBBBBBBBBBBBBBBBBBB"), **kwargs)
+    assert a[0]["event_type"] == b[0]["event_type"] == "MissionCreated"
+    assert a[0]["event_id"] != b[0]["event_id"]
 
 
 def test_project_identity_is_threaded_into_every_envelope():
@@ -159,7 +189,7 @@ def test_project_identity_is_threaded_into_every_envelope():
     assert all(env["repo_slug"] == "acme/spec-kitty" for env in stream)
     # The whole stream is one coherent import operation: unified correlation id
     # and build id across the synthesized prefix AND the reused status envelopes.
-    assert len({env["correlation_id"] for env in stream}) == 1
+    assert len({env["correlation_id"] for env in stream}) == 1  # golden-count: cardinality-is-contract
     assert {env["build_id"] for env in stream} == {"import-history"}
 
 

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -282,6 +282,88 @@ def test_dry_run_project_uuid_is_deterministic():
     assert a == uuid.uuid5(uuid.NAMESPACE_URL, "spec-kitty:teamspace-dry-run:demo-mission|other")
 
 
+# ── timestamp correctness (#2884 findings B/C) ────────────────────────────────
+
+
+def test_earliest_timestamp_compares_true_instants_not_lexicographic_strings():
+    """Mixed ISO-8601 suffix forms (``Z`` / ``+00:00`` / another offset) must
+    compare by true instant, not lexicographically (finding B, #2884): a raw
+    string ``min()`` would pick ``"...07:00:00Z"`` over ``"...08:00:00+02:00"``
+    even though the latter (06:00 UTC) is the actual earlier instant."""
+    import dataclasses
+
+    scan = dataclasses.replace(
+        _demo_scan(),
+        created_at=None,
+        work_packages=(
+            ScannedWorkPackage("WP01", "First WP", (), None, "2026-02-01T07:00:00Z", PrefixSource.SYNTHESIZED),
+            ScannedWorkPackage("WP02", "Second WP", (), None, "2026-02-01T08:00:00+02:00", PrefixSource.SYNTHESIZED),
+        ),
+        lane_transitions=(),
+    )
+    stream = synthesize_mission_stream(
+        scan, project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty"
+    )
+    mission_created = stream[0]
+    # 2026-02-01T08:00:00+02:00 == 06:00 UTC, earlier than 07:00:00Z — a
+    # lexicographic min would have picked the Z candidate instead.
+    assert mission_created["timestamp"] == "2026-02-01T06:00:00+00:00"
+
+
+def test_wp_created_envelope_timestamp_matches_normalized_created_at():
+    """The ``WPCreated`` envelope timestamp and its payload ``created_at``
+    must agree on the same INSTANT (finding C, #2884): a parseable
+    ``created_at`` with a non-UTC offset must produce an envelope timestamp
+    normalized to UTC (consistent with what ``_earliest_timestamp`` emits
+    elsewhere), and it must name the exact same moment the payload's
+    ``created_at`` datetime does — not a raw, un-normalized passthrough."""
+    import dataclasses
+    from datetime import datetime
+
+    scan = dataclasses.replace(
+        _demo_scan(),
+        work_packages=(
+            ScannedWorkPackage("WP01", "First WP", (), None, "2026-02-01T08:00:00+02:00", PrefixSource.ON_DISK),
+        ),
+        lane_transitions=(),
+    )
+    stream = synthesize_mission_stream(
+        scan, project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty"
+    )
+    wp_created = next(env for env in stream if env["event_type"] == "WPCreated")
+    # 08:00+02:00 == 06:00 UTC — the envelope timestamp is the normalized form.
+    assert wp_created["timestamp"] == "2026-02-01T06:00:00+00:00"
+    # The payload keeps its own (pydantic-serialized) datetime, but it must
+    # name the SAME instant as the envelope timestamp — never a differing
+    # verdict on the same underlying created_at.
+    assert datetime.fromisoformat(wp_created["payload"]["created_at"]) == datetime.fromisoformat(
+        wp_created["timestamp"]
+    )
+
+
+def test_wp_created_envelope_falls_back_to_mission_ts_when_created_at_unparseable():
+    """An unparseable ``created_at`` must fall back to ``mission_ts`` for BOTH
+    the envelope timestamp and the payload verdict. Previously the envelope
+    let the raw garbage string pass straight through
+    (``wp.created_at or mission_ts``) while the payload nulled the exact same
+    value — one envelope, two verdicts (finding C, #2884)."""
+    import dataclasses
+
+    scan = dataclasses.replace(
+        _demo_scan(),
+        created_at="2026-02-01T00:00:00+00:00",
+        work_packages=(ScannedWorkPackage("WP01", "First WP", (), None, "not-a-timestamp", PrefixSource.ON_DISK),),
+        lane_transitions=(),
+    )
+    stream = synthesize_mission_stream(
+        scan, project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty"
+    )
+    mission_created = stream[0]
+    wp_created = next(env for env in stream if env["event_type"] == "WPCreated")
+    assert wp_created["payload"]["created_at"] is None
+    assert wp_created["timestamp"] == mission_created["timestamp"]
+
+
 # ── real fixtures end-to-end ──────────────────────────────────────────────────
 
 

--- a/tests/sync/test_history_import_synthesize.py
+++ b/tests/sync/test_history_import_synthesize.py
@@ -105,6 +105,24 @@ def test_every_synthesized_envelope_conforms():
     _assert_all_conform(stream)
 
 
+def test_import_and_status_envelopes_share_one_top_level_key_set():
+    """Guard against envelope-shape drift (Paula's #2884 M1): the hand-built
+    creation-prefix envelope (``_envelope``) and the reused migration status
+    envelope (``status_event_to_teamspace_envelope``) must carry the SAME
+    top-level key set. If they drift, one import stream ships two shapes — the
+    server could accept the WPStatusChanged rows while rejecting the
+    MissionCreated/WPCreated prefix, orphaning every WP. This is the cheap
+    parity guard the full-consolidation follow-up (#2262) can later subsume."""
+    stream = synthesize_mission_stream(
+        _demo_scan(), project_uuid=_PROJECT_UUID, project_slug="spec-kitty", repo_slug="acme/spec-kitty"
+    )
+    mission_created = next(env for env in stream if env["event_type"] == "MissionCreated")
+    wp_created = next(env for env in stream if env["event_type"] == "WPCreated")
+    wp_status = next(env for env in stream if env["event_type"] == "WPStatusChanged")
+    assert set(mission_created) == set(wp_status), "creation-prefix vs status envelope keys drifted"
+    assert set(wp_created) == set(wp_status), "WPCreated vs status envelope keys drifted"
+
+
 # ── ordering + INV-3 ──────────────────────────────────────────────────────────
 
 

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -26,7 +26,12 @@ from specify_cli.sync.history_import.upload import (
 pytestmark = pytest.mark.fast
 
 
-def _env(event_id: str, event_type: str = "WPStatusChanged") -> dict[str, Any]:
+def _env(
+    event_id: str, event_type: str = "WPStatusChanged"
+) -> dict[
+    str, Any
+]:  # canonical-event-exempt(exception-flow): the TeamSpace wire envelope is not a *Payload model; a raw fixture is the transport's unit-under-test input
+    # canonical-event-exempt(exception-flow): minimal wire envelope fed into the upload transport under test
     return {"event_id": event_id, "event_type": event_type, "payload": {"wp_id": "WP01"}}
 
 

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -168,3 +168,20 @@ def test_run_import_upload_uploads_nothing_when_preflight_rejects():
         run_import_upload([_env("e0")], receiver=stub, server_url="http://x", auth_token="t", poster=poster)
     # Fail-closed: preflight ran before any delivery, so nothing was uploaded.
     assert not stub.received_event_ids()
+
+
+def test_run_import_upload_rejects_on_a_later_chunk_uploads_nothing():
+    """A rejection on the SECOND chunk still uploads nothing — every chunk is
+    preflighted before any chunk is delivered (not interleaved)."""
+    stub = StubReceiver()
+    calls = {"n": 0}
+
+    def _poster(url, *, data, headers, timeout):
+        calls["n"] += 1
+        accepted = calls["n"] == 1  # chunk 1 accepts, chunk 2 rejects
+        return _FakeResponse(200 if accepted else 400, {"accepted": accepted, "reconciliation": {}})
+
+    with pytest.raises(PreflightRejected):
+        run_import_upload([_env("e0"), _env("e1")], receiver=stub, server_url="http://x", auth_token="t", poster=_poster, chunk_size=1)
+    assert calls["n"] == 2  # both chunks preflighted...
+    assert not stub.received_event_ids()  # ...before any was delivered

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -15,7 +15,9 @@ import pytest
 
 from specify_cli.delivery.receivers import DeliveryOutcome, DeliveryResult, StubReceiver
 from specify_cli.sync.history_import.upload import (
+    _IMPORT_CHUNK_SIZE,
     PreflightRejected,
+    _chunked,
     build_provenance_manifest,
     envelope_sha256,
     run_import_upload,
@@ -148,6 +150,100 @@ def test_rejected_outcomes_are_tallied():
     assert report.rejected == 1
     assert not report.ok
     assert report.rejected_samples == ["e0: nope"]
+
+
+# ── mission-atomic chunking (B2, #2884) ───────────────────────────────────────
+
+
+def _mission_stream(mission: str, size: int) -> list[dict[str, Any]]:
+    """A contiguous mission unit: MissionCreated + (size-1) trailing events."""
+    # canonical-event-exempt(exception-flow): minimal wire envelopes fed into the chunker under test
+    envs: list[dict[str, Any]] = [{"event_id": f"{mission}-mc", "event_type": "MissionCreated", "payload": {}}]
+    envs += [{"event_id": f"{mission}-e{i}", "event_type": "WPStatusChanged", "payload": {}} for i in range(size - 1)]
+    return envs
+
+
+def test_chunking_never_splits_a_mission():
+    """A mission bigger than the budget becomes ONE oversized chunk (never
+    split), and every chunk of a prefixed stream starts at a MissionCreated."""
+    stream = _mission_stream("a", 4) + _mission_stream("b", 2)
+    chunks = list(_chunked(stream, 3))
+    assert [len(chunk) for chunk in chunks] == [4, 2]
+    assert all(chunk[0]["event_type"] == "MissionCreated" for chunk in chunks)
+
+
+def test_chunking_packs_whole_missions_at_the_real_budget():
+    """At the real _IMPORT_CHUNK_SIZE: missions of 300+200 fill one chunk to
+    exactly 500 and the next mission starts the next chunk (501st event never
+    bleeds into the full chunk)."""
+    stream = _mission_stream("a", 300) + _mission_stream("b", 200) + _mission_stream("c", 1)
+    chunks = list(_chunked(stream, _IMPORT_CHUNK_SIZE))
+    assert [len(chunk) for chunk in chunks] == [_IMPORT_CHUNK_SIZE, 1]
+    assert chunks[1][0]["event_id"] == "c-mc"
+
+
+def test_single_mission_over_the_budget_is_one_oversized_chunk():
+    stream = _mission_stream("big", _IMPORT_CHUNK_SIZE + 1)
+    chunks = list(_chunked(stream, _IMPORT_CHUNK_SIZE))
+    assert [len(chunk) for chunk in chunks] == [_IMPORT_CHUNK_SIZE + 1]
+
+
+# ── stop-on-first-failure delivery (B1, #2884) ────────────────────────────────
+
+
+class _SelectiveReceiver:
+    """Succeeds every event except the ids in *bad* (rejected); records order."""
+
+    def __init__(self, bad: set[str]) -> None:
+        self.bad = bad
+        self.seen: list[str] = []
+
+    def deliver(self, batch):
+        results = []
+        for event in batch:
+            self.seen.append(event.event_id)
+            if event.event_id in self.bad:
+                results.append(DeliveryResult(event_id=event.event_id, outcome=DeliveryOutcome.REJECTED, error="nope"))
+            else:
+                results.append(DeliveryResult(event_id=event.event_id, outcome=DeliveryOutcome.SUCCESS))
+        return results
+
+
+def test_upload_stops_at_the_first_failed_chunk_and_reports_partial():
+    receiver = _SelectiveReceiver(bad={"e1"})
+    report = upload_envelopes([_env(f"e{i}") for i in range(3)], receiver=receiver, chunk_size=1)
+
+    # e2's chunk was never attempted after e1's chunk failed.
+    assert receiver.seen == ["e0", "e1"]
+    assert report.success == 1 and report.rejected == 1
+    assert report.partial
+    assert report.delivered_through_chunk == 1  # only e0's chunk delivered cleanly
+    assert report.undelivered_event_count == 1  # e2
+    assert not report.ok
+
+
+def test_run_import_upload_stops_delivering_after_a_failed_chunk():
+    """The --apply path (preflight passes, delivery fails mid-run) stops at the
+    failed chunk: the remaining chunks are never handed to the receiver."""
+    receiver = _SelectiveReceiver(bad={"e1"})
+    poster = _fake_poster({"accepted": True, "event_count": 1, "reconciliation": {}})
+    report = run_import_upload([_env(f"e{i}") for i in range(4)], receiver=receiver, server_url="http://x", auth_token="t", poster=poster, chunk_size=1)
+
+    assert receiver.seen == ["e0", "e1"]
+    assert report.partial and report.undelivered_event_count == 2  # e2, e3 not attempted
+    assert report.success == 1 and report.rejected == 1
+
+
+def test_a_failure_in_the_final_chunk_is_not_partial():
+    """Total-attempt-with-failures is a distinct state from partial: nothing
+    was left unattempted, so partial stays False (rejected still counts)."""
+    receiver = _SelectiveReceiver(bad={"e2"})
+    report = upload_envelopes([_env(f"e{i}") for i in range(3)], receiver=receiver, chunk_size=1)
+
+    assert receiver.seen == ["e0", "e1", "e2"]
+    assert report.rejected == 1 and not report.partial
+    assert report.undelivered_event_count == 0
+    assert not report.ok
 
 
 # ── run_import_upload: preflight-all-then-upload (fail-closed) ─────────────────

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -1,0 +1,165 @@
+"""Tests for the UPLOAD stage of ``sync import-history`` — WP-Y5 (#2262).
+
+Provenance hashing, server preflight, and chunked delivery, all exercised with
+zero network: a fake ``HttpPoster`` stands in for the preflight endpoint and a
+``StubReceiver`` (records + dedups) stands in for the batch endpoint.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from typing import Any
+
+import pytest
+
+from specify_cli.delivery.receivers import DeliveryOutcome, DeliveryResult, StubReceiver
+from specify_cli.sync.history_import.upload import (
+    PreflightRejected,
+    build_provenance_manifest,
+    envelope_sha256,
+    run_import_upload,
+    run_server_preflight,
+    upload_envelopes,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _env(event_id: str, event_type: str = "WPStatusChanged") -> dict[str, Any]:
+    return {"event_id": event_id, "event_type": event_type, "payload": {"wp_id": "WP01"}}
+
+
+# ── fake poster (preflight transport) ─────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any, *, json_raises: bool = False) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self._json_raises = json_raises
+
+    def json(self) -> Any:
+        if self._json_raises:
+            raise ValueError("not JSON")
+        return self._payload
+
+
+def _fake_poster(payload: Any, *, status: int = 200, json_raises: bool = False):
+    captured: dict[str, Any] = {}
+
+    def _poster(url: str, *, data: bytes, headers: dict[str, str], timeout: float) -> _FakeResponse:
+        captured.update(url=url, data=data, headers=headers, timeout=timeout)
+        return _FakeResponse(status, payload, json_raises=json_raises)
+
+    _poster.captured = captured  # type: ignore[attr-defined]
+    return _poster
+
+
+# ── provenance (stage 6) ──────────────────────────────────────────────────────
+
+
+def test_envelope_sha256_is_canonical_and_deterministic():
+    # Key order does not matter (canonical sort_keys), value changes do.
+    assert envelope_sha256({"event_id": "a", "b": 1}) == envelope_sha256({"b": 1, "event_id": "a"})
+    assert envelope_sha256({"x": 1}) != envelope_sha256({"x": 2})
+
+
+def test_build_provenance_manifest():
+    envelopes = [_env("e1", "MissionCreated"), _env("e2", "WPCreated")]
+    manifest = build_provenance_manifest(envelopes)
+    assert [p.event_id for p in manifest] == ["e1", "e2"]
+    assert [p.event_type for p in manifest] == ["MissionCreated", "WPCreated"]
+    assert all(p.row_sha256 is None for p in manifest)
+    assert manifest[0].envelope_sha256 == envelope_sha256(envelopes[0])
+
+
+# ── preflight (stage 7) ───────────────────────────────────────────────────────
+
+
+def test_preflight_posts_gzipped_events_to_the_endpoint():
+    poster = _fake_poster({"accepted": True, "event_count": 1, "reconciliation": {}})
+    run_server_preflight([_env("e0")], server_url="http://host/", auth_token="tok", poster=poster)
+
+    captured = poster.captured  # type: ignore[attr-defined]
+    assert captured["url"] == "http://host/api/v1/events/preflight/"
+    assert captured["headers"]["Content-Encoding"] == "gzip"
+    assert captured["headers"]["Authorization"] == "Bearer tok"
+    assert json.loads(gzip.decompress(captured["data"])) == {"events": [_env("e0")]}
+
+
+def test_preflight_rejection_raises():
+    poster = _fake_poster({"accepted": False, "reconciliation": {"reason": "bad shape"}}, status=400)
+    with pytest.raises(PreflightRejected, match="bad shape"):
+        run_server_preflight([_env("e0")], server_url="http://x", auth_token="t", poster=poster)
+
+
+def test_preflight_non_json_response_fails_closed():
+    poster = _fake_poster(None, status=502, json_raises=True)
+    with pytest.raises(PreflightRejected, match="not JSON"):
+        run_server_preflight([_env("e0")], server_url="http://x", auth_token="t", poster=poster)
+
+
+# ── upload (stage 8) ──────────────────────────────────────────────────────────
+
+
+def test_upload_delivers_all_then_dedups_on_rerun():
+    stub = StubReceiver()
+    envelopes = [_env(f"e{i}") for i in range(3)]
+
+    first = upload_envelopes(envelopes, receiver=stub)
+    assert first.success == 3
+    assert first.rejected == 0 and first.ok
+    assert set(stub.received_event_ids()) == {"e0", "e1", "e2"}
+
+    # Re-delivering the same event_ids to the same stub maps them to duplicate.
+    second = upload_envelopes(envelopes, receiver=stub)
+    assert second.duplicate == 3
+    assert second.ok
+
+
+def test_upload_chunks_by_chunk_size():
+    class _SpyStub(StubReceiver):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sizes: list[int] = []
+
+        def deliver(self, batch):
+            events = list(batch)
+            self.sizes.append(len(events))
+            return super().deliver(events)
+
+    stub = _SpyStub()
+    upload_envelopes([_env(f"e{i}") for i in range(5)], receiver=stub, chunk_size=2)
+    assert stub.sizes == [2, 2, 1]
+
+
+def test_rejected_outcomes_are_tallied():
+    class _RejectingReceiver:
+        def deliver(self, batch):
+            return [DeliveryResult(event_id=e.event_id, outcome=DeliveryOutcome.REJECTED, error="nope") for e in batch]
+
+    report = upload_envelopes([_env("e0")], receiver=_RejectingReceiver())
+    assert report.rejected == 1
+    assert not report.ok
+    assert report.rejected_samples == ["e0: nope"]
+
+
+# ── run_import_upload: preflight-all-then-upload (fail-closed) ─────────────────
+
+
+def test_run_import_upload_preflights_then_uploads():
+    stub = StubReceiver()
+    poster = _fake_poster({"accepted": True, "event_count": 3, "reconciliation": {}})
+    report = run_import_upload([_env(f"e{i}") for i in range(3)], receiver=stub, server_url="http://x", auth_token="t", poster=poster)
+    assert report.success == 3
+    assert set(stub.received_event_ids()) == {"e0", "e1", "e2"}
+
+
+def test_run_import_upload_uploads_nothing_when_preflight_rejects():
+    stub = StubReceiver()
+    poster = _fake_poster({"accepted": False, "reconciliation": {}}, status=400)
+    with pytest.raises(PreflightRejected):
+        run_import_upload([_env("e0")], receiver=stub, server_url="http://x", auth_token="t", poster=poster)
+    # Fail-closed: preflight ran before any delivery, so nothing was uploaded.
+    assert not stub.received_event_ids()

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -159,6 +159,7 @@ def _mission_stream(mission: str, size: int) -> list[dict[str, Any]]:
     """A contiguous mission unit: MissionCreated + (size-1) trailing events."""
     # canonical-event-exempt(exception-flow): minimal wire envelopes fed into the chunker under test
     envs: list[dict[str, Any]] = [{"event_id": f"{mission}-mc", "event_type": "MissionCreated", "payload": {}}]
+    # canonical-event-exempt(exception-flow): minimal wire envelopes fed into the chunker under test
     envs += [{"event_id": f"{mission}-e{i}", "event_type": "WPStatusChanged", "payload": {}} for i in range(size - 1)]
     return envs
 

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -12,10 +12,13 @@ import json
 from typing import Any
 
 import pytest
+import requests
 
+from specify_cli.core.contract_gate import ContractViolationError
 from specify_cli.delivery.receivers import DeliveryOutcome, DeliveryResult, StubReceiver
 from specify_cli.sync.history_import.upload import (
     _IMPORT_CHUNK_SIZE,
+    _SERVER_MAX_BATCH_SIZE,
     PreflightRejected,
     _chunked,
     build_provenance_manifest,
@@ -23,6 +26,7 @@ from specify_cli.sync.history_import.upload import (
     run_import_upload,
     run_server_preflight,
     upload_envelopes,
+    validate_import_envelopes,
 )
 
 pytestmark = pytest.mark.fast
@@ -107,6 +111,18 @@ def test_preflight_non_json_response_fails_closed():
         run_server_preflight([_env("e0")], server_url="http://x", auth_token="t", poster=poster)
 
 
+def test_preflight_transport_error_fails_closed_not_traceback():
+    """A transport failure (unreachable host / timeout / TLS reset) during
+    preflight maps to a graceful PreflightRejected, not an escaping traceback
+    (#2884). The delivery path already catches this; preflight now matches."""
+
+    def _raising_poster(url: str, *, data: bytes, headers: dict[str, str], timeout: float):
+        raise requests.ConnectionError("host unreachable")
+
+    with pytest.raises(PreflightRejected, match="transport failed"):
+        run_server_preflight([_env("e0")], server_url="http://x", auth_token="t", poster=_raising_poster)
+
+
 # ── upload (stage 8) ──────────────────────────────────────────────────────────
 
 
@@ -187,6 +203,82 @@ def test_single_mission_over_the_budget_is_one_oversized_chunk():
     stream = _mission_stream("big", _IMPORT_CHUNK_SIZE + 1)
     chunks = list(_chunked(stream, _IMPORT_CHUNK_SIZE))
     assert [len(chunk) for chunk in chunks] == [_IMPORT_CHUNK_SIZE + 1]
+
+
+def test_single_mission_over_the_server_cap_fails_closed_before_delivery():
+    """A mission bigger than the server's per-batch cap can't be split
+    (mission-atomic) and would be rejected server-side. Catch it locally,
+    before any delivery, with an actionable message (#2884, Paula n1)."""
+    stub = StubReceiver()
+    stream = _mission_stream("huge", _SERVER_MAX_BATCH_SIZE + 1)
+    with pytest.raises(PreflightRejected, match=f"{_SERVER_MAX_BATCH_SIZE}-event batch cap"):
+        upload_envelopes(stream, receiver=stub)
+    assert not stub.received_event_ids()  # nothing delivered — fail-closed
+
+
+# ── transport-transient partial delivery (B1, #2884) ──────────────────────────
+
+
+class _TransientReceiver:
+    """Succeeds every event except ids in *bad*, which map to TRANSIENT (a
+    network error with no http_status), recording delivery order."""
+
+    def __init__(self, bad: set[str]) -> None:
+        self.bad = bad
+        self.seen: list[str] = []
+
+    def deliver(self, batch):
+        results = []
+        for event in batch:
+            self.seen.append(event.event_id)
+            outcome = DeliveryOutcome.TRANSIENT if event.event_id in self.bad else DeliveryOutcome.SUCCESS
+            error = "network error" if event.event_id in self.bad else None
+            results.append(DeliveryResult(event_id=event.event_id, outcome=outcome, error=error))
+        return results
+
+
+def test_transport_transient_mid_stream_stops_and_reports_partial():
+    """A transport TRANSIENT (network error, not a server rejection) on chunk 2
+    of 3 halts delivery and reports partial — the same stop-on-failure contract
+    as REJECTED, pinned for the transient path the transport actually raises."""
+    receiver = _TransientReceiver(bad={"e1"})
+    report = upload_envelopes([_env(f"e{i}") for i in range(3)], receiver=receiver, chunk_size=1)
+
+    assert receiver.seen == ["e0", "e1"]  # e2's chunk never attempted
+    assert report.success == 1 and report.rejected == 1
+    assert report.partial
+    assert report.delivered_through_chunk == 1
+    assert report.undelivered_event_count == 1
+    assert not report.ok
+
+
+# ── offline envelope contract gate (M2, #2884) ────────────────────────────────
+
+
+def _valid_envelope(event_type: str = "MissionCreated") -> dict[str, Any]:
+    # canonical-event-exempt(exception-flow): a minimal contract-valid wire envelope for the gate under test
+    return {
+        "event_id": "e0",
+        "event_type": event_type,
+        "aggregate_type": "Mission",
+        "build_id": "import-history",
+        "schema_version": "3.0.0",
+        "payload": {},
+    }
+
+
+def test_validate_import_envelopes_passes_a_contract_valid_stream():
+    validate_import_envelopes([_valid_envelope("MissionCreated"), _valid_envelope("WPCreated")])
+
+
+def test_validate_import_envelopes_rejects_a_forbidden_top_level_field():
+    """The offline gate refuses a leaked forbidden top-level field before any
+    network round-trip — the drift a future edit to the hand-built envelope
+    could introduce (#2884)."""
+    leaked = _valid_envelope()
+    leaked["from_lane"] = "planned"  # a retired status field that belongs in payload
+    with pytest.raises(ContractViolationError):
+        validate_import_envelopes([leaked])
 
 
 # ── stop-on-first-failure delivery (B1, #2884) ────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -2338,7 +2338,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygments", specifier = ">=2.20.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3,<9.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "pytest-playwright", marker = "extra == 'test'", specifier = ">=0.7.0" },


### PR DESCRIPTION
Implements `spec-kitty sync import-history` (#2262, epic WPs Y1–Y5). A first sync registers a remote project/build but leaves it with **zero materialized missions** — the SaaS materializer refuses to fabricate a WorkPackage from a `WPStatusChanged` with no prior `WPCreated`. This command emits the missing `MissionCreated → WPCreated[] → WPStatusChanged[]` prefix (INV-3) so historical local work populates the projection.

Draft: opening for approach review before I call it done. The buildable slices (Y1–Y5) are complete; Y6/Y7/Y8 are gated (see below).

## What's here (7 commits, one per slice)

| WP | Stage | Module |
|----|-------|--------|
| Y1 | command + SELECT + fail-closed AUDIT | `cli/commands/sync.py` |
| Y2 | hybrid SCAN (read-or-synthesize prefix, local-only filter, INV-3 coverage) | `sync/history_import/scan.py` |
| Y3 | SYNTHESIZE ordered deterministic stream (INV-3/4) | `.../synthesize.py` |
| Y4 | IDENTITY (real UUID on apply / synthetic dry-run / fail-closed, INV-2/5) | `.../identity.py` |
| — | dry-run vertical wired + `build_import_plan` orchestrator | `.../pipeline.py` |
| Y5 | PROVENANCE + PREFLIGHT + chunked UPLOAD, `--apply` | `.../upload.py` |
| fix | SCAN hardened vs malformed WP frontmatter (#2883 items 3/4, applied here) | `.../scan.py` |

Both modes work:
- **`--dry-run`** (default) runs the whole read-only pipeline and previews the stream.
- **`--apply`** attaches provenance, server-preflights the *entire* stream before uploading *anything* (fail-closed — a reject leaves the projection untouched), then uploads in ~500-event chunks via the existing WP06 delivery receiver. Idempotent: the server dedups on `event_id`, so re-runs map to `duplicate`.

## Design notes worth a reviewer's eye

- **Reuse over reinvention** per §3.3: WPStatusChanged envelopes reuse `_status_event_to_teamspace_envelope` (keeps the lane back-fill + historical-evidence synthesis); payloads use the canonical `build_mission_created_payload` / `WPCreatedPayload`; identity uses `resolve_identity`/`ensure_identity` (the §4 "add persist_identity" note is stale — #1916 already added the read-only seam).
- **Deterministic ids (INV-4):** the synthesized creation prefix is minted under a dedicated `import:` namespace, proven collision-free vs the existing `teamspace-dry-run:` seeds (resolves the §6 seeding open-question). Replayed status events keep their real on-disk `event_id`.
- **Fail-closed everywhere:** audit blockers (INV-6), unauthenticated `--apply`, non-checkout, and preflight rejection all stop before any upload.

## Testing

- **46 feature tests + 35 existing sync tests green; ruff + mypy clean.**
- The load-bearing proof: WP-Y3 validates **every** synthesized envelope through the same `Event.model_validate` + `validate_event` path the migration dry-run uses — passing end-to-end on **synthetic dual-shape fixtures** (legacy `NNN-slug` shape with forced `planned→done` rows; prefixed identity shape written via the canonical local emitters). Originally proven on the two real dogfood missions; converted to synthetic `tmp_path` corpora in the landing pass so the #2917 corpus cutover cannot turn the proof green-by-skip.
- Upload/preflight are fully stub-tested (fake `HttpPoster` + `StubReceiver`), no network.
- Verified live on this checkout: dry-run correctly **blocks** missions with `status.json` drift (audit gate); `--apply` **stops at "Not authenticated"** with no token (auth gate).

## Deferred (gated, not forgotten)

- **Y7 (§3.6b pre-sync re-drain)** — waits on #2874 (the trusted status-transition/commit-path rework), per your steer in DM.
- **Y6 (report → #2264 fields)** — waits on #2264 defining `historical_import_state` / `last_blocker_sample`.
- **Y8 (acceptance suite §5)** — the non-fakeable "row-counts > 0 after real materialize" needs a live SaaS target; the dry-run-inert half is testable now.

## Re #2883

The reconciler review follow-ups are handled separately (see the plan on #2883): most of that code lives on the #2820 branch, not main, so it rides its own follow-up PR. Items 3/4 also describe a pattern this PR's SCAN reuses, so the `scan.py` catch-hardening is included here (the import reader's own concern); the `indexer.py` fix stays with #2883.

## Final landing pass (2026-07-26)

Rebased onto `main` post-#2936 (zero conflicts; semantic coherence adversarially verified). A three-lens review squad (correctness/test-quality, boundaries/seams, rebase-coherence) ran on the aggregate diff; **all** its P1/P2/nit findings were folded as single-commit ops:

- **Consensus P1:** `import-history --apply` now honors the persisted event-sync mode (refuses non-`teamspace` instead of silently uploading past an `opt_out`), via one shared `_resolve_gated_receiver` seam; the fail-closed exits got real-gate tests.
- **P1:** the coord-seed placement-port path (`commit_coord_seed_bookkeeping` → `resolve_placement_only(kind=STATUS_STATE)`) is now proven by a real coord-topology regression test (was only exercised via the degrade fallback); test validated red-first.
- **P1:** the seven import-history tests keyed on dogfood `kitty-specs/` missions were converted to synthetic dual-shape fixtures — zero green-by-skip exposure to #2917.
- CP001/CP002: the TeamSpace envelope is now constructed via a frozen pydantic model (byte-identical wire format, verified by `envelope_sha256`). Plus: loud skipped-event-row accounting in SCAN, instant-order `_earliest_timestamp`, local-only lifecycle types enforced at the validation gate, honest pending-exit guidance, and an extracted `_render_upload_report` seam.

**Why the bookkeeping seam refactor is in this PR:** it heals a red arch gate on the base — PR #2920's direct `safe_commit` in `merge/executor.py` was a second guard-capability call site (the #1850 bypass shape); the kind-parameterized seam restores the two-site invariant without widening any allowlist.

**Unrelated riders, named explicitly (green-PR policy — base reds this branch carries the fold for):**
- `pytest>=9.0.3,<9.1` pin in `pyproject.toml` + `uv.lock`: dodges a CI-only `reorder_items` INTERNALERROR. Note the offending scheduler is **pytest-xdist's**; the durable fix is raising the xdist floor and dropping this cap (follow-up).
- `_baselines.yaml` 94→95 and the `mission_repair.py` `test_no_raw_mission_spec_paths` exemption (both red on base, justifications inline).
- DRG orphan residual 29→30: #2936 promoted `toolguide:powershell-syntax` into `built-in/` with no inbound edge; documented as residual (same class as the two existing standalone toolguides) rather than manufacturing an edge.

No Sonar-UI work is known-outstanding for this branch; if the gate raises hotspots on the new `sync/history_import/` code, they are loopback/stub-poster patterns covered by tests, not transport regressions.

## Issue links

Closes #2262
Closes #2926
Closes #2891

Follow-up work tracked separately (kept open): #2925, #2933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787385179&installation_model_id=427282&pr_number=2884&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2884&signature=a94d3165f98a1c6543caf32290dbc2de1eac66370ab1be724b983c8f0b6cd260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

