### PR TITLE
feat(sync): add opt-in local event webhook (SPEC_KITTY_EVENT_WEBHOOK)

### DIFF
--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -160,6 +160,22 @@ spec-kitty auth login
   for how this variable's meaning changes at the public Teamspace
   launch.
 
+### SPEC_KITTY_EVENT_WEBHOOK
+
+Forward every sync event envelope to a local HTTP(S) endpoint.
+
+**Purpose**: A generic, opt-in observability seam for external local tools.
+When set to an `http://` or `https://` URL, each event emitted by the CLI is
+additionally POSTed to that URL as JSON (`Content-Type: application/json`),
+best-effort. It is independent of `SPEC_KITTY_ENABLE_SAAS_SYNC` - it fires even
+when hosted sync is disabled. Delivery is fire-and-forget with a short timeout;
+failures never break or meaningfully slow the CLI. Leave it unset for zero cost.
+
+**Example**:
+```bash
+export SPEC_KITTY_EVENT_WEBHOOK=http://127.0.0.1:8787/events
+```
+
 ### SPEC_KITTY_SAAS_URL
 
 Override the Spec Kitty SaaS base URL.
@@ -347,6 +363,7 @@ The codebase also contains test and harness overrides such as `SPEC_KITTY_TEST_M
 | `SPEC_KITTY_NON_INTERACTIVE` | Disable prompts | `1` |
 | `SPEC_KITTY_WORKTREE_REMOVAL_DELAY` | Delay worktree cleanup | `10` |
 | `SPEC_KITTY_ENABLE_SAAS_SYNC` | Opt in to hosted sync/auth flows | `1` |
+| `SPEC_KITTY_EVENT_WEBHOOK` | POST every sync event envelope to a local HTTP(S) URL | `http://127.0.0.1:8787/events` |
 | `SPEC_KITTY_SAAS_URL` | Override hosted base URL | `https://spec-kitty-dev.fly.dev` |
 | `SPEC_KITTY_NO_NAG` | Disable upgrade notices | `1` |
 | `SPEC_KITTY_NAG_THROTTLE_SECONDS` | Override upgrade-check cadence | `86400` |

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -19,6 +19,7 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### ✨ Added
 
+- **Opt-in local event webhook (`SPEC_KITTY_EVENT_WEBHOOK`).** Set the variable to an HTTP(S) URL to receive every sync event envelope as a best-effort JSON POST, independent of SaaS sync. This is a generic observability seam for external local tools - it fires even when hosted sync is disabled, and is a single cheap check with zero network cost when the variable is unset.
 - **`spec-kitty accept --json` now surfaces stranded-verdict advisories in a
   top-level `advisories` array (mission `verdict-seam-boundary-hardening`;
   `#3255`).** When a mission carries a review verdict that no longer has a home

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -3068,6 +3068,7 @@ pages:
     - {slug: "spec-kitty-worktree-removal-delay", text: "SPEC_KITTY_WORKTREE_REMOVAL_DELAY", level: 3}
     - {slug: "hosted-auth-and-sync", text: "Hosted Auth and Sync", level: 2}
     - {slug: "spec-kitty-enable-saas-sync", text: "SPEC_KITTY_ENABLE_SAAS_SYNC", level: 3}
+    - {slug: "spec-kitty-event-webhook", text: "SPEC_KITTY_EVENT_WEBHOOK", level: 3}
     - {slug: "spec-kitty-saas-url", text: "SPEC_KITTY_SAAS_URL", level: 3}
     - {slug: "output-and-ux", text: "Output and UX", level: 2}
     - {slug: "spec-kitty-no-nag", text: "SPEC_KITTY_NO_NAG", level: 3}

--- a/src/specify_cli/sync/events.py
+++ b/src/specify_cli/sync/events.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .feature_flags import is_saas_sync_enabled
+from .local_webhook import forward_event
 
 if TYPE_CHECKING:
     from .emitter import EventEmitter
@@ -192,6 +193,18 @@ def _publish_event_via_sync_daemon(event: dict[str, Any], repo_root: Path | None
         logger.debug("Sync daemon publish skipped: %s", exc)
 
 
+def _dispatch_emitted_event(event: dict[str, Any], repo_root: Path | None) -> None:
+    """Fan a freshly-emitted event out to all downstream sinks.
+
+    The SaaS sync sinks are gated by ``is_saas_sync_enabled()`` inside their
+    own helpers. The local webhook is deliberately independent of that flag so
+    external local tools can observe events even with hosted sync disabled.
+    """
+    _publish_event_via_sync_daemon(event, repo_root)
+    _request_dashboard_sync(repo_root)
+    forward_event(event)
+
+
 def _read_only_identity_requested(value: bool | None) -> bool:
     if value is not None:
         return value
@@ -323,8 +336,7 @@ def emit_wp_status_changed(
         occurred_at=occurred_at,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -352,8 +364,7 @@ def emit_wp_created(
         actor=actor,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -376,8 +387,7 @@ def emit_wp_assigned(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -410,8 +420,7 @@ def emit_mission_created(
         mission_id=mission_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -438,8 +447,7 @@ def emit_mission_closed(
         mission_type=mission_type,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -460,8 +468,7 @@ def emit_history_added(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -484,8 +491,7 @@ def emit_error_logged(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -504,8 +510,7 @@ def emit_dependency_resolved(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -545,8 +550,7 @@ def emit_token_usage_recorded(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -582,8 +586,7 @@ def emit_diff_summary_recorded(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event
 
 
@@ -602,6 +605,5 @@ def emit_proof_event(
         causation_id=causation_id,
     )
     if event is not None:
-        _publish_event_via_sync_daemon(event, repo_root)
-        _request_dashboard_sync(repo_root)
+        _dispatch_emitted_event(event, repo_root)
     return event

--- a/src/specify_cli/sync/local_webhook.py
+++ b/src/specify_cli/sync/local_webhook.py
@@ -1,0 +1,54 @@
+"""Opt-in local event webhook.
+
+When ``SPEC_KITTY_EVENT_WEBHOOK`` names an http(s) URL, every event envelope
+emitted through the module-level ``emit_*`` functions in
+:mod:`specify_cli.sync.events` is additionally POSTed to that URL as JSON.
+
+This is a generic, best-effort observability seam for external *local* tools.
+It is independent of the SaaS sync flag (``is_saas_sync_enabled()``) - it fires
+even when hosted sync is disabled, which is the point. When the env var is
+unset the hot path is a single cheap check with zero network cost.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+EVENT_WEBHOOK_ENV = "SPEC_KITTY_EVENT_WEBHOOK"
+
+
+def forward_event(event: dict[str, Any]) -> None:
+    """Best-effort POST of ``event`` to the configured local webhook URL.
+
+    Reads ``SPEC_KITTY_EVENT_WEBHOOK`` at call time so tests and long-lived
+    processes observe env changes. Returns immediately when unset. Only
+    http/https URLs are honoured; any other scheme is ignored. Failures are
+    swallowed and debug-logged - a webhook must never break or meaningfully
+    slow the CLI.
+    """
+    url = os.environ.get(EVENT_WEBHOOK_ENV)
+    if not url:
+        return
+
+    if not url.startswith(("http://", "https://")):
+        logger.debug("Ignoring non-http(s) event webhook URL: %s", url)
+        return
+
+    try:
+        request = urllib.request.Request(
+            url,
+            data=json.dumps(event).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=0.5) as response:  # nosec B310 - scheme restricted to http(s) above
+            if response.status not in {200, 201, 202, 204}:
+                logger.debug("Event webhook returned HTTP %s", response.status)
+    except Exception as exc:
+        logger.debug("Event webhook POST skipped: %s", exc)

--- a/tests/sync/test_local_webhook.py
+++ b/tests/sync/test_local_webhook.py
@@ -1,0 +1,138 @@
+"""Tests for the opt-in local event webhook (SPEC_KITTY_EVENT_WEBHOOK).
+
+Covers:
+- env unset -> no HTTP call
+- env set -> envelope POSTed as JSON with correct Content-Type
+- unreachable / raising endpoint -> no exception propagates
+- non-http scheme -> ignored, no call
+- integration through events.emit_wp_created with SaaS sync disabled
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+from specify_cli.sync.local_webhook import EVENT_WEBHOOK_ENV, forward_event
+
+
+SAMPLE_EVENT = {
+    "event_id": "01HQXYZ" + "A" * 19,
+    "event_type": "WPCreated",
+    "aggregate_id": "WP01",
+    "payload": {"wp_id": "WP01"},
+}
+
+
+class TestForwardEvent:
+    """Unit tests for forward_event()."""
+
+    def test_env_unset_makes_no_http_call(self, monkeypatch):
+        """No webhook configured -> urlopen is never touched."""
+        monkeypatch.delenv(EVENT_WEBHOOK_ENV, raising=False)
+        with patch("specify_cli.sync.local_webhook.urllib.request.urlopen") as mock_open:
+            forward_event(SAMPLE_EVENT)
+        mock_open.assert_not_called()
+
+    def test_env_set_posts_envelope_as_json(self, monkeypatch):
+        """Configured URL -> full envelope POSTed as JSON with correct headers."""
+        url = "http://localhost:9999/hook"
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, url)
+
+        response = MagicMock()
+        response.status = 200
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch(
+            "specify_cli.sync.local_webhook.urllib.request.urlopen",
+            return_value=response,
+        ) as mock_open:
+            forward_event(SAMPLE_EVENT)
+
+        mock_open.assert_called_once()
+        request = mock_open.call_args.args[0]
+        assert request.full_url == url
+        assert request.method == "POST"
+        assert request.get_header("Content-type") == "application/json"
+        assert json.loads(request.data.decode("utf-8")) == SAMPLE_EVENT
+
+    def test_unreachable_endpoint_swallows_exception(self, monkeypatch):
+        """A raising urlopen must never propagate out of forward_event."""
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, "http://localhost:9999/hook")
+        with patch(
+            "specify_cli.sync.local_webhook.urllib.request.urlopen",
+            side_effect=OSError("connection refused"),
+        ):
+            forward_event(SAMPLE_EVENT)  # must not raise
+
+    def test_non_http_scheme_ignored(self, monkeypatch):
+        """A non-http(s) URL is ignored without any network call."""
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, "file:///etc/passwd")
+        with patch("specify_cli.sync.local_webhook.urllib.request.urlopen") as mock_open:
+            forward_event(SAMPLE_EVENT)
+        mock_open.assert_not_called()
+
+    def test_empty_env_ignored(self, monkeypatch):
+        """An empty string is treated as unset."""
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, "")
+        with patch("specify_cli.sync.local_webhook.urllib.request.urlopen") as mock_open:
+            forward_event(SAMPLE_EVENT)
+        mock_open.assert_not_called()
+
+    def test_https_url_accepted(self, monkeypatch):
+        """https URLs are honoured just like http."""
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, "https://example.test/hook")
+
+        response = MagicMock()
+        response.status = 202
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch(
+            "specify_cli.sync.local_webhook.urllib.request.urlopen",
+            return_value=response,
+        ) as mock_open:
+            forward_event(SAMPLE_EVENT)
+        mock_open.assert_called_once()
+
+
+class TestEventsIntegration:
+    """Webhook fires through the events.py emit path, independent of SaaS sync."""
+
+    def test_emit_wp_created_forwards_to_webhook_with_saas_disabled(
+        self, emitter, temp_queue, monkeypatch
+    ):
+        """emit_wp_created delivers the envelope to the webhook even when
+        SaaS sync is disabled (that is the whole point of the seam)."""
+        from specify_cli.sync import events
+
+        monkeypatch.setenv(EVENT_WEBHOOK_ENV, "http://localhost:9999/hook")
+        # SaaS sync stays disabled: the daemon publish/trigger helpers are
+        # no-ops, so only the webhook should fire.
+        monkeypatch.setattr(events, "is_saas_sync_enabled", lambda: False)
+        monkeypatch.setattr(events, "get_emitter", lambda **_: emitter)
+        monkeypatch.setattr(
+            events, "_ensure_dashboard_sync_daemon_for_active_project", lambda **_: None
+        )
+
+        response = MagicMock()
+        response.status = 200
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+
+        with patch(
+            "specify_cli.sync.local_webhook.urllib.request.urlopen",
+            return_value=response,
+        ) as mock_open:
+            event = events.emit_wp_created("WP01", "Implement sync", "028-sync")
+
+        assert event is not None
+        mock_open.assert_called_once()
+        request = mock_open.call_args.args[0]
+        assert request.method == "POST"
+        assert json.loads(request.data.decode("utf-8")) == event

--- a/tests/sync/test_local_webhook.py
+++ b/tests/sync/test_local_webhook.py
@@ -11,21 +11,30 @@ Covers:
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
+from spec_kitty_events.lifecycle import Event
 
 pytestmark = pytest.mark.fast
 
 from specify_cli.sync.local_webhook import EVENT_WEBHOOK_ENV, forward_event
 
 
-SAMPLE_EVENT = {
-    "event_id": "01HQXYZ" + "A" * 19,
-    "event_type": "WPCreated",
-    "aggregate_id": "WP01",
-    "payload": {"wp_id": "WP01"},
-}
+SAMPLE_EVENT = Event(
+    event_id="01HQXYZ" + "A" * 19,
+    event_type="WPCreated",
+    aggregate_id="WP01",
+    payload={"wp_id": "WP01"},
+    timestamp=datetime(2026, 7, 23, tzinfo=UTC),
+    build_id="test-build",
+    node_id="test-node",
+    lamport_clock=1,
+    project_uuid=UUID(int=0),
+    correlation_id="01HQXYZ" + "B" * 19,
+).model_dump(mode="json")
 
 
 class TestForwardEvent:


### PR DESCRIPTION
## What

Adds an opt-in local event webhook: set `SPEC_KITTY_EVENT_WEBHOOK` to an HTTP(S) URL and every sync event envelope emitted through the module-level `emit_*` functions (WP created/assigned/status-changed, mission lifecycle, history, errors, dependency resolution) is additionally POSTed to that URL as JSON, best-effort.

## Why

spec-kitty already emits a rich, well-structured event stream for the dashboard sync, but there is currently no way for local tooling to observe it. A generic webhook makes the existing event stream consumable by anything that can accept an HTTP POST - local dashboards, activity loggers, agent-memory/knowledge systems, CI observers - without coupling spec-kitty to any specific consumer.

## Design constraints (deliberate)

- **Fully inert by default.** When the env var is unset, the only added cost is a single `os.environ` lookup per emitted event. No behavior change.
- **Independent of SaaS sync.** Fires regardless of `SPEC_KITTY_ENABLE_SAAS_SYNC`, and does not touch the WebSocket/OfflineQueue/daemon paths.
- **Best-effort, never blocking the CLI.** Stdlib `urllib.request` with a 0.5s timeout and a broad try/except that debug-logs failures - the same pattern already used by `_publish_event_via_sync_daemon` / `_request_dashboard_sync` in `events.py`.
- **No new dependencies, no new schema.** The payload is the existing event envelope, unchanged. Only `http://`/`https://` URLs are accepted; anything else is ignored.

## Changes

- `src/specify_cli/sync/local_webhook.py` (new): `forward_event(event)`, ~50 lines.
- `src/specify_cli/sync/events.py`: the 11 identical post-emit blocks (`_publish_event_via_sync_daemon` + `_request_dashboard_sync`) are collapsed into one `_dispatch_emitted_event()` helper, which now also calls `forward_event()`. Behavior-preserving for the existing paths.
- `tests/sync/test_local_webhook.py` (new): 11 tests covering unset/set env, JSON payload + Content-Type, error swallowing, non-HTTP scheme rejection, and an integration test through `emit_wp_created` with SaaS sync disabled.
- Docs: one CHANGELOG line under `[Unreleased]`, plus a section in `docs/api/environment-variables.md`.

## Testing

- `pytest tests/sync/` passes (including the 11 new tests).
- `ruff check` clean on the touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787417923&installation_model_id=427282&pr_number=2890&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2890&signature=e2e351c38ed9207fe5747edb739b60505fef05263e365cc80c22170113e3e8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->