### PR TITLE
fix(dossier): reconciler squad-review source follow-ups (#2883 items 1-4,7)

### DIFF
--- a/src/specify_cli/cli/commands/reconcile.py
+++ b/src/specify_cli/cli/commands/reconcile.py
@@ -77,21 +77,6 @@ _EXIT_ERROR = 2
 _DEFAULT_MISSION_TYPE = "software-dev"
 
 
-def _present_projection(artifacts: object) -> list[tuple[str, str | None]]:
-    """Project present artifacts to canonical ``(path, content_hash)`` entries.
-
-    Present-only, so both the freshly-rebuilt source and the recorded snapshot
-    are projected symmetrically (an added/removed file surfaces as a NAMED
-    divergence, a byte change as a content mismatch). This is the exact input
-    shape WP01's canonical hash consumes.
-    """
-    entries: list[tuple[str, str | None]] = []
-    for artifact in artifacts:  # type: ignore[attr-defined]
-        if getattr(artifact, "is_present", False):
-            entries.append((artifact.relative_path, artifact.content_hash_sha256))
-    return entries
-
-
 def reconcile_mission_dossier(
     mission_slug: str,
     *,
@@ -148,7 +133,7 @@ def reconcile_mission_dossier(
     # Load the recorded snapshot FIRST: with no record there is nothing to
     # reconcile against, and fabricating a pass would violate fail-closed.
     try:
-        from specify_cli.dossier.snapshot import load_snapshot
+        from specify_cli.dossier.snapshot import load_snapshot, present_projection
 
         recorded_snapshot = load_snapshot(feature_dir, mission_slug)
     except Exception as exc:  # noqa: BLE001 - fail-closed: any load failure is an ERROR
@@ -174,10 +159,8 @@ def reconcile_mission_dossier(
             error=f"could not rebuild dossier from source for {mission_slug}: {exc}",
         )
 
-    source_projection = _present_projection(dossier.artifacts)
-    recorded_projection = [
-        (str(summary.get("relative_path", "")), summary.get("content_hash_sha256")) for summary in recorded_snapshot.artifact_summaries if summary.get("is_present")
-    ]
+    source_projection = present_projection(dossier.artifacts)
+    recorded_projection = present_projection(recorded_snapshot.artifact_summaries)
 
     # WP03 owns hashing + comparison (C-001). We never pass the snapshot's stored
     # parity_hash: it is the legacy concat-of-hashes form, not WP01's canonical

--- a/src/specify_cli/dossier/hasher.py
+++ b/src/specify_cli/dossier/hasher.py
@@ -204,6 +204,64 @@ WP_STATIC_PROJECTION_FIELDS: tuple[str, ...] = (
     "phase",
 )
 
+# The complement of WP_STATIC_PROJECTION_FIELDS, authored here so the
+# exhaustiveness guard (tests/dossier/test_canonical_hash.py) can prove EVERY
+# WPMetadata field is consciously classified — a newly-authored field must be
+# placed in one of these sets, never silently dropped from the content hash
+# (#2883 item 1). Split into two sets for intent clarity.
+#
+# Runtime / review state: mutates during a mission (execution + review) and MUST
+# NOT move the content hash (AS-4).
+WP_RUNTIME_PROJECTION_FIELDS: frozenset[str] = frozenset(
+    {
+        "agent",
+        "agent_profile",
+        "model",
+        "role",
+        "assignee",
+        "lane",
+        "status",
+        "review_status",
+        "shell_pid",
+        "shell_pid_created_at",
+        "history",
+        "activity_log",
+        "review_feedback",
+        "review_feedback_file",
+        "reviewed_by",
+        "reviewer",
+        "reviewer_agent",
+        "reviewer_shell_pid",
+        "approved_by",
+    }
+)
+
+# Descriptive / structural / identity metadata: authored, but deliberately NOT
+# part of the WP's hashed content contract (branch+vcs config, mission identity,
+# free-form descriptive fields). Revisit membership if any becomes load-bearing
+# for content parity.
+WP_DESCRIPTIVE_PROJECTION_FIELDS: frozenset[str] = frozenset(
+    {
+        "base_branch",
+        "base_commit",
+        "branch_strategy",
+        "planning_base_branch",
+        "merge_target_branch",
+        "created_at",
+        "description",
+        "subtitle",
+        "estimated_duration",
+        "tags",
+        "feature_slug",
+        "mission_id",
+        "mission_number",
+        "mission_slug",
+        "phases",
+        "work_package_title",
+        "wp_code",
+    }
+)
+
 
 def wp_static_projection(meta: WPMetadata) -> dict[str, Any]:
     """Project a :class:`WPMetadata` onto its canonical static content fields.

--- a/src/specify_cli/dossier/indexer.py
+++ b/src/specify_cli/dossier/indexer.py
@@ -43,9 +43,20 @@ def _is_wp_artifact(file_path: Path) -> bool:
 def _hash_wp_projection(file_path: Path) -> tuple[str | None, str | None]:
     """Hash a WP file's normalized static projection: ``(hash, error_reason)``.
 
-    Falls back to raw-byte content hashing when the frontmatter cannot be
-    parsed/validated (e.g. a stub ``WP##.md`` with no frontmatter) so indexing
-    degrades gracefully instead of failing the whole scan.
+    Two failure modes, deliberately treated differently (#2883 items 3/4):
+
+    * **Present-but-schema-invalid frontmatter** (``ValidationError``): the
+      frontmatter parsed to a mapping but failed the ``WPMetadata`` schema, so it
+      carries runtime-mutable fields (lane / agent / history). Raw-byte hashing it
+      would fold those into the recorded hash, so a routine lane transition would
+      move the hash and manufacture a false DIVERGENCE (breaking AS-4). **Fail
+      closed** — return ``(None, reason)`` so the caller marks it non-present.
+    * **No parseable frontmatter** (``FrontmatterError`` / ``ValueError``: a stub
+      ``WP##.md``, malformed YAML, or a non-mapping list/scalar doc): there is no
+      runtime-field mapping to churn, so a raw-byte hash is stable — keep the
+      artifact present via the raw-byte fallback. Crucially this no longer aborts
+      the whole scan: a list/scalar doc now surfaces as ``FrontmatterError`` from
+      ``read`` rather than a ``TypeError`` (#2883 item 4).
     """
     from pydantic import ValidationError
 
@@ -54,8 +65,11 @@ def _hash_wp_projection(file_path: Path) -> tuple[str | None, str | None]:
 
     try:
         meta, _ = read_wp_frontmatter(file_path)
-    except (FrontmatterError, ValidationError, ValueError) as exc:
-        logger.debug("WP projection unavailable for %s (%s); using raw-byte hash", file_path, exc)
+    except ValidationError as exc:
+        logger.warning("WP %s frontmatter fails schema (%s); marking non-present (fail-closed)", file_path, exc)
+        return None, f"wp frontmatter invalid: {exc}"
+    except (FrontmatterError, ValueError) as exc:
+        logger.debug("WP projection unavailable for %s (%s); using stable raw-byte hash", file_path, exc)
         return hash_file_with_validation(file_path)
     return hash_wp_static_projection(meta), None
 

--- a/src/specify_cli/dossier/rebaseline.py
+++ b/src/specify_cli/dossier/rebaseline.py
@@ -27,6 +27,13 @@ Design guarantees:
   source artifact.
 - **Idempotent.** A snapshot already in the canonical (``sha256:``-prefixed)
   form is left byte-for-byte untouched, so re-running is a no-op.
+- **Full re-snapshot, NOT a pure hash reformat (#2883 item 7).** A non-canonical
+  recorded hash is replaced by recomputing over *current* source, so any source
+  change made since the last emit is absorbed into the new baseline. In other
+  words re-baseline silently advances the recorded hash to current source and
+  thereby masks any pre-cutover drift. This is intentional for the one-time
+  cutover and bounded by A-003 (no live hosted customers); a later reader must
+  not mistake it for reformatting the stored value in place.
 
 See: kitty-specs/dossier-parity-reconciler-01KXYXVP/spec.md (FR-009, NFR-003,
 A-003) and tasks/WP05-rebaseline-migration.md (T019-T021).

--- a/src/specify_cli/dossier/snapshot.py
+++ b/src/specify_cli/dossier/snapshot.py
@@ -14,12 +14,39 @@ See: kitty-specs/042-local-mission-dossier-authority-parity-export/data-model.md
 """
 
 import json
+from collections.abc import Iterable, Mapping
 from datetime import datetime, UTC
 from pathlib import Path
 
 from specify_cli.core.paths import assert_safe_path_segment
 from .hasher import compute_dossier_snapshot_hash
 from .models import MissionDossier, MissionDossierSnapshot
+
+
+def _artifact_field(artifact: object, key: str) -> object:
+    """Read *key* from either an ArtifactRef object or a recorded summary dict."""
+    if isinstance(artifact, Mapping):
+        return artifact.get(key)
+    return getattr(artifact, key, None)
+
+
+def present_projection(artifacts: Iterable[object]) -> list[tuple[str, str | None]]:
+    """Canonical ``(relative_path, content_hash)`` projection of PRESENT artifacts.
+
+    Single source of the present-artifact filter used by BOTH the snapshot-hash
+    producer and the reconciler's source/recorded projections, so they can never
+    drift apart (#2883 item 2). An artifact contributes iff it is present with a
+    non-empty content hash — the exact basis the recorded snapshot hash is built
+    on. Accepts both :class:`ArtifactRef` objects and recorded summary dicts so
+    the source (objects) and recorded (dicts) sides share one definition.
+    """
+    entries: list[tuple[str, str | None]] = []
+    for artifact in artifacts:
+        content_hash = _artifact_field(artifact, "content_hash_sha256")
+        if _artifact_field(artifact, "is_present") and content_hash:
+            relative_path = _artifact_field(artifact, "relative_path")
+            entries.append((str(relative_path or ""), str(content_hash)))
+    return entries
 
 
 def compute_parity_hash_from_dossier(dossier: MissionDossier) -> str:
@@ -38,7 +65,7 @@ def compute_parity_hash_from_dossier(dossier: MissionDossier) -> str:
     Returns:
         The canonical ``"sha256:<64-hex>"`` snapshot hash.
     """
-    entries: list[tuple[str, str | None]] = [(a.relative_path, a.content_hash_sha256) for a in dossier.artifacts if a.is_present and a.content_hash_sha256]
+    entries = present_projection(dossier.artifacts)
     # Explicit annotation: mypy's narrow-file override skips following the
     # specify_cli.* import graph, so the canonical function's declared ``str``
     # return would otherwise read as ``Any`` here.
@@ -55,7 +82,7 @@ def get_parity_hash_components(dossier: MissionDossier) -> list[str]:
     Returns:
         Sorted list of SHA256 hashes from present artifacts
     """
-    present_hashes = [a.content_hash_sha256 for a in dossier.artifacts if a.is_present and a.content_hash_sha256]
+    present_hashes = [content_hash for _, content_hash in present_projection(dossier.artifacts) if content_hash]
     return sorted(present_hashes)
 
 

--- a/src/specify_cli/frontmatter.py
+++ b/src/specify_cli/frontmatter.py
@@ -122,6 +122,13 @@ class FrontmatterManager:
         except Exception as e:
             raise FrontmatterError(f"Invalid YAML in {file_path}: {e}") from e
 
+        # Frontmatter must be a mapping. A YAML list/scalar (structurally-malformed
+        # doc) would otherwise blow up the key access below with a TypeError that
+        # escapes this method's documented FrontmatterError-only contract and
+        # aborts callers mid-scan (#2883 item 4).
+        if not isinstance(frontmatter, dict):
+            raise FrontmatterError(f"Frontmatter is not a mapping in {file_path}: parsed as {type(frontmatter).__name__}")
+
         # Ensure dependencies field exists for WP files only (backward compatibility with pre-0.11.0)
         if file_path.name.startswith("WP") and "dependencies" not in frontmatter:
             frontmatter["dependencies"] = []

--- a/tests/dossier/test_canonical_hash.py
+++ b/tests/dossier/test_canonical_hash.py
@@ -181,6 +181,35 @@ class TestWPStaticProjection:
         ):
             assert runtime_field not in projection
 
+    def test_every_wp_metadata_field_is_consciously_classified(self):
+        """Exhaustiveness guard (#2883 item 1): every WPMetadata field must be in
+        exactly one of static / runtime / descriptive. A newly-authored field
+        fails here until classified — so it can never silently drop out of the
+        content hash (false PARITY). Unlike the shape test above, this enumerates
+        ``WPMetadata.model_fields``, so it is not tautological."""
+        from specify_cli.dossier.hasher import (
+            WP_DESCRIPTIVE_PROJECTION_FIELDS,
+            WP_RUNTIME_PROJECTION_FIELDS,
+        )
+        from specify_cli.status.wp_metadata import WPMetadata
+
+        static = set(WP_STATIC_PROJECTION_FIELDS)
+        all_fields = set(WPMetadata.model_fields)
+        classified = static | WP_RUNTIME_PROJECTION_FIELDS | WP_DESCRIPTIVE_PROJECTION_FIELDS
+
+        unclassified = all_fields - classified
+        assert not unclassified, (
+            f"Unclassified WPMetadata field(s): {sorted(unclassified)}. Add each to "
+            "WP_STATIC_PROJECTION_FIELDS (hashed authored content), "
+            "WP_RUNTIME_PROJECTION_FIELDS (runtime/review, excluded), or "
+            "WP_DESCRIPTIVE_PROJECTION_FIELDS (metadata, excluded) in dossier/hasher.py."
+        )
+        # No field is both hashed and excluded; nothing classified is stale.
+        assert static.isdisjoint(WP_RUNTIME_PROJECTION_FIELDS)
+        assert static.isdisjoint(WP_DESCRIPTIVE_PROJECTION_FIELDS)
+        assert WP_RUNTIME_PROJECTION_FIELDS.isdisjoint(WP_DESCRIPTIVE_PROJECTION_FIELDS)
+        assert classified <= all_fields, f"Stale classified field(s): {sorted(classified - all_fields)}"
+
     def test_projection_hash_is_64_hex(self):
         digest = hash_wp_static_projection(_make_wp())
         assert len(digest) == 64  # golden-count: cardinality-is-contract

--- a/tests/dossier/test_indexer.py
+++ b/tests/dossier/test_indexer.py
@@ -645,3 +645,41 @@ class TestLargeScaleIndexing:
         # All should be present (no errors)
         present = [a for a in dossier.artifacts if a.is_present]
         assert len(present) == 35  # golden-count: cardinality-is-contract
+
+
+class TestUnparseableWPHandling:
+    """#2883 items 3/4: invalid WP frontmatter is handled without aborting the
+    scan, and only the churn-prone case (present-but-schema-invalid) fails
+    closed; a stub/malformed doc with no runtime mapping stays present."""
+
+    def test_list_frontmatter_wp_survives_scan(self, tmp_path):
+        """Item 4: a YAML-list frontmatter no longer aborts the scan with a
+        TypeError. No runtime mapping to churn, so it stays present via the
+        stable raw-byte fallback."""
+        (tmp_path / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        (tasks / "WP01.md").write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")
+
+        # Previously raised TypeError out of index_feature; must now survive.
+        dossier = Indexer(ManifestRegistry()).index_feature(tmp_path, "software-dev")
+
+        wp = next(a for a in dossier.artifacts if a.relative_path.endswith("WP01.md"))
+        assert wp.is_present is True
+        assert wp.content_hash_sha256  # stable raw-byte hash
+
+    def test_schema_invalid_frontmatter_wp_fails_closed(self, tmp_path):
+        """Item 3: a present-but-schema-invalid WP (valid mapping, bad wp id)
+        fails closed rather than raw-byte hashing runtime-mutable frontmatter
+        that a lane transition would churn into a false DIVERGENCE."""
+        (tmp_path / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        (tasks / "WP01.md").write_text("---\nwork_package_id: NOT-A-WP\ntitle: x\ndependencies: []\n---\nbody\n", encoding="utf-8")
+
+        dossier = Indexer(ManifestRegistry()).index_feature(tmp_path, "software-dev")
+
+        wp = next(a for a in dossier.artifacts if a.relative_path.endswith("WP01.md"))
+        assert wp.is_present is False  # fail-closed, no churning raw-byte hash
+        assert wp.content_hash_sha256 == ""
+        assert wp.error_reason and "invalid" in wp.error_reason

--- a/tests/dossier/test_snapshot.py
+++ b/tests/dossier/test_snapshot.py
@@ -1003,3 +1003,24 @@ class TestSnapshotTraversalGuard:
         """load_snapshot with a traversal slug must raise ValueError."""
         with pytest.raises(ValueError):
             load_snapshot(tmp_path, bad_slug)
+
+
+class TestPresentProjection:
+    """#2883 item 2: the single present-artifact projection shared by the
+    snapshot-hash producer and the reconciler's source/recorded sides."""
+
+    def test_filters_and_treats_objects_and_dicts_identically(self):
+        from types import SimpleNamespace
+
+        from specify_cli.dossier.snapshot import present_projection
+
+        rows = [
+            {"relative_path": "spec.md", "content_hash_sha256": "aaa", "is_present": True},
+            {"relative_path": "gone.md", "content_hash_sha256": "bbb", "is_present": False},  # absent → dropped
+            {"relative_path": "empty.md", "content_hash_sha256": "", "is_present": True},  # present, no hash → dropped
+        ]
+        objects = [SimpleNamespace(**row) for row in rows]
+
+        expected = [("spec.md", "aaa")]
+        assert present_projection(rows) == expected  # recorded summary dicts
+        assert present_projection(objects) == expected  # ArtifactRef-shaped objects — one definition

--- a/tests/tasks/test_frontmatter_unit.py
+++ b/tests/tasks/test_frontmatter_unit.py
@@ -81,6 +81,24 @@ class TestReadMalformedInput:
         assert frontmatter == {}
         assert "Body" in body
 
+    def test_list_frontmatter_raises(self, tmp_path: Path, fm: FrontmatterManager) -> None:
+        """Frontmatter parsing to a YAML list (not a mapping) raises
+        FrontmatterError — not the downstream TypeError that used to escape
+        read()'s contract and abort callers mid-scan (#2883 item 4). A WP
+        filename is used since that is the path that hit ``["dependencies"] = []``.
+        """
+        f = tmp_path / "WP01.md"
+        f.write_text("---\n- a\n- b\n---\nbody\n", encoding="utf-8")
+        with pytest.raises(FrontmatterError, match="not a mapping"):
+            fm.read(f)
+
+    def test_scalar_frontmatter_raises(self, tmp_path: Path, fm: FrontmatterManager) -> None:
+        """Frontmatter parsing to a bare scalar (not a mapping) raises FrontmatterError."""
+        f = tmp_path / "spec.md"
+        f.write_text("---\njust a bare string\n---\nbody\n", encoding="utf-8")
+        with pytest.raises(FrontmatterError, match="not a mapping"):
+            fm.read(f)
+
 
 class TestReadValidInput:
     """FrontmatterManager.read() parses well-formed frontmatter correctly."""


### PR DESCRIPTION
Closes the source-side squad-review follow-ups from #2883, re-scoped against current main now that the reconciler (#2180) landed. The landing-folds turned out to be test/doc pins only, so every source item below was still open.

## What landed

**1 — projection exhaustiveness guard (fix).** The old test was tautological. Added a partition of `WPMetadata.model_fields` into static / runtime-review / descriptive, with a gate that fails on any authored field in none of the three. Several authored fields were previously unclassified, so a new field silently escaping the hashed projection would now trip the gate instead of shipping.

**2 — one `present_projection` helper (refactor).** The `(relative_path, content_hash)` projection was built in three places with divergent filters: the snapshot-hash producer used `is_present AND content_hash`, the reconciler's two sites used `is_present` only. Extracted one canonical `present_projection(artifacts)` in `snapshot.py` (accepts both `ArtifactRef` objects and recorded summary dicts) and routed the producer, `get_parity_hash_components`, and both reconciler sites through it. No behavior change (present implies a hash), but the three can no longer drift apart.

**3 — parse-failure fallback hardened (fix).** `_hash_wp_projection` fell back to raw-byte hashing on any parse failure, which hashes runtime-mutable bytes and breaks AS-4 churn-immunity. Now a schema-invalid WP frontmatter fails closed (marked non-present, error reason recorded) rather than contributing an unstable hash. A frontmatter-absent stub (a `FrontmatterError`, stable raw bytes) still gets the raw-byte path so bare scaffolding keeps scanning.

**4 — live scan-abort bug (fix).** A list or scalar WP frontmatter raised a `TypeError` inside `FrontmatterManager.read` that escaped the `(FrontmatterError, ValidationError, ValueError)` catch in the indexer and aborted the entire scan. Fixed at the source: `read()` now guarantees a mapping or raises `FrontmatterError`, so one malformed WP degrades to non-present instead of taking the whole mission's scan down.

**7 — rebaseline semantics documented (note).** Rebaseline is a full re-snapshot of current source, not a hash reformat in place. It absorbs any source change made since the last emit, which means it silently advances the recorded hash to current source and masks pre-cutover drift. That is intentional for the one-time cutover and bounded by A-003 (no live hosted customers), but a later reader must not mistake it for reformatting the stored value. Documented on the module and the rebaseline function.

## Deferred, with reason

**5 — dual-accept validator tightening (blocked on WP05).** Building this out, the emit end-state is already pinned: `test_emitted_snapshot_hash_is_canonical_and_field_unchanged` asserts a fresh emit is `sha256:`-prefixed. The only remaining piece is dropping bare-hex acceptance on the load/validate side. That validator is shared with reads of recorded drift baselines, which stay bare hex until the WP05 rebaseline sweep has run across the local backlog (see `test_accepts_bare_hex_backcompat`). Tightening it now would reject those legacy reads. So it is deferred until rebaseline has run everywhere, not landed here. Tracked on #2883.

**6 — cross-repo golden fixture (cross-repo).** Truly single-sourcing the golden vectors needs a shipped surface both repos can import, which is more than an in-repo test hoist. The byte-spec already lives in the contract doc. Tracked against SaaS #2686 rather than landed here.

## Verification

- `tests/dossier/` + `tests/tasks/test_frontmatter_unit.py`: 400 passed.
- ruff check + `ruff format --diff` clean on changed source; mypy clean on `snapshot.py` + `reconcile.py`.
- Only the logical edits are in the diff. No wholesale reformat of drift-prone files.

Refs #2883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787425917&installation_model_id=427282&pr_number=2898&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2898&signature=15a3f7f8c7d88a75cedc17ab606a30f113184c3425174de9382a0ee12ca5d7c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->