### PR TITLE
test(regression): red-first P0 reproductions for #2804 and #2876

### DIFF
--- a/tests/regression/test_issue_2804_merge_resets_gate_artifacts.py
+++ b/tests/regression/test_issue_2804_merge_resets_gate_artifacts.py
@@ -1,0 +1,459 @@
+"""Scope: #2804 (P0) -- ``spec-kitty merge`` clobbers filled coordination gate
+artifacts (``acceptance-matrix.json`` / ``issue-matrix.md``) back to their
+empty placeholder scaffold, on the integration branch, AFTER the done-gate has
+already consumed their filled contents.
+
+RED-FIRST P0 reproduction, intentionally FAILING until the product defect is
+fixed. Tracking issue: https://github.com/Priivacy-ai/spec-kitty/issues/2804.
+Do NOT xfail/skip/quarantine to green; fix the product.
+
+Root-cause mechanism (confirmed by replaying the real incident's git history --
+mission ``charter-deadcode-noop-campsite-01KXW0NY``, reflog entries
+``aa9126844`` "Record acceptance commit for ..." -> ``2be339a0c`` "squash merge
+of mission" -> the operator's manual recovery commit "restore terminal
+issue-matrix + acceptance-matrix (merge reset them to placeholders)"):
+
+``acceptance-matrix.json`` / ``issue-matrix.md`` are COORD-partition kinds
+(``mission_runtime.artifacts._PLACEMENT_ARTIFACT_KINDS``). ``finalize-tasks``
+scaffolds their placeholder INSIDE the mission-branch checkout (the
+finalize-tasks / lane-provisioning step runs there), while ``spec-kitty
+accept``'s residual-artifact commit lands them on the PRIMARY checkout
+(target_branch) -- a *different* branch, per the sibling, already-open #2404
+("accept reads/writes acceptance-matrix.json via the primary checkout, not the
+coordination surface"). Because the file is introduced FOR THE FIRST TIME
+independently on each side (an add/add divergence -- the mission branch never
+carries the accept-authored fill, and the target branch never carried the
+placeholder), ``spec-kitty merge``'s mission->target squash step
+(``specify_cli.lanes.merge._merge_branch_into``, ``git merge --squash -X
+theirs <mission_branch>``) resolves the add/add conflict by taking "theirs"
+(the mission branch's stale placeholder) -- silently discarding the target's
+already-filled, already-accepted content. This is orthogonal to the
+``finalize-tasks`` scaffolder itself, which is idempotent and never touches an
+existing file (``scaffold_acceptance_matrix``/``scaffold_issue_matrix``: "if
+path.exists(): return path") -- the reset happens purely through ``-X theirs``
+conflict resolution during the REAL merge branch-integration step, not through
+any scaffold call.
+
+This module reproduces the clobber through the real, pre-existing merge entry
+point (``specify_cli.cli.commands.merge._run_lane_based_merge`` ->
+``specify_cli.merge.executor`` -> ``specify_cli.lanes.merge.
+integrate_mission_into_target`` -> the real ``git merge --squash -X theirs``
+subprocess), never a hand-rolled reimplementation of the merge or of git's
+conflict resolution. The harness mirrors the proven coord-topology
+lane-based-merge fixture in ``tests/regression/
+test_issue_2711_merge_rollback_resume_coherence.py`` (mocking only side
+effects that are irrelevant to git content -- dossier sync, stale-assertion
+scan, merge-gate policy, baseline-commit bookkeeping, done-transition
+recording) while leaving the git plumbing (branch creation, lane merge,
+mission->target squash merge) entirely real.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from contextlib import ExitStack
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the status package before any coordination submodule -- mirrors the
+# production CLI entrypoint's import order (see test_issue_2711's identical
+# guard) so this module stays importable under ``PYTHONPATH=src``.
+import specify_cli.status  # noqa: F401  # import-order guard
+
+from specify_cli.acceptance.matrix import SCAFFOLD_TODO_MARKER
+from specify_cli.cli.commands.merge import _run_lane_based_merge
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.lanes.persistence import write_lanes_json
+from specify_cli.merge.config import MergeStrategy
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo, pytest.mark.non_sandbox]
+
+MID8 = "01KXW0NY"
+MISSION_ID = f"01KXW0NY0000000000000000{MID8[-2:]}"
+MISSION_SLUG = f"charter-deadcode-noop-campsite-{MID8}"
+MISSION_BRANCH = f"kitty/mission-{MISSION_SLUG}"
+LANE_ID = "lane-a"
+LANE_CODE = "src/charter/generator.py"
+WP_ID = "WP01"
+
+# --- Realistic, production-shaped acceptance-matrix.json ------------------
+# Mirrors the real (pre-clobber) evidence recorded for the incident mission
+# that surfaced #2804 -- multiple genuinely-verified FR criteria, real
+# reviewer/evidence text, ``overall_verdict: pass`` -- not a toy placeholder.
+FILLED_ACCEPTANCE_MATRIX: dict[str, object] = {
+    "mission_slug": MISSION_SLUG,
+    "mission_number": "",
+    "mission_type": "software-dev",
+    "overall_verdict": "pass",
+    "criteria": [
+        {
+            "criterion_id": "FR-001",
+            "description": (
+                "Delete charter.generator module (CharterDraft/"
+                "build_charter_draft/write_charter) + its __init__ import "
+                "and __all__ entries."
+            ),
+            "proof_type": "automated_test",
+            "evidence": (
+                "WP01 (commit d5b8324f9): src/charter/generator.py deleted; "
+                "src/charter/__init__.py import (was line 31) + 3 __all__ "
+                "entries removed. git grep finds zero live src refs. "
+                "uv run pytest tests/charter/test_generator.py "
+                "tests/architectural/test_no_dead_modules.py -> 6 passed. "
+                "Net -156 LOC."
+            ),
+            "pass_fail": "pass",
+            "verified_by": "reviewer-renata/opus (per-WP) + orchestrator synthesis",
+            "verified_at": "2026-07-19T03:20:00+00:00",
+            "notes": "LM-4 clear: no charter.md scaffold path dropped.",
+        },
+        {
+            "criterion_id": "FR-003",
+            "description": (
+                "Delete charter.extractor module + its test-only references "
+                "(dedicated tests retired; incidental fixtures reconstructed)."
+            ),
+            "proof_type": "automated_test",
+            "evidence": (
+                "WP02 (commit 8a0a1fcf2): src/charter/extractor.py (577 LOC) "
+                "+ 5 dedicated test files deleted. 2 incidental fixtures "
+                "reconstructed inline so live assertions survive (31 passed)."
+            ),
+            "pass_fail": "pass",
+            "verified_by": "reviewer-renata/opus (per-WP) + orchestrator synthesis",
+            "verified_at": "2026-07-19T03:20:00+00:00",
+            "notes": "Net -1685/+55 LOC.",
+        },
+    ],
+    "negative_invariants": [],
+}
+
+FILLED_ISSUE_MATRIX = (
+    "# Issue matrix -- " + MISSION_SLUG + "\n\n"
+    "Per FR-037 of the spec-kitty-mission-review skill Gate-4. One row per "
+    "issue referenced in spec.md.\n\n"
+    "| Issue | Title | Verdict | Evidence ref |\n"
+    "|-------|-------|---------|--------------|\n"
+    "| #2373 | dead-code baseline noop-stability | verified-already-fixed | "
+    "commit d5b8324f9 (WP01) |\n"
+)
+
+# --- The empty scaffold placeholder produced by ``scaffold_acceptance_matrix``
+# / ``scaffold_issue_matrix`` at finalize-tasks time (byte-identical shape to
+# the real product scaffolder -- this is what the mission branch still
+# carries, since it never sees the later accept-authored fill). ---
+PLACEHOLDER_ACCEPTANCE_MATRIX: dict[str, object] = {
+    "mission_slug": MISSION_SLUG,
+    "criteria": [
+        {
+            "criterion_id": "AC-001",
+            "description": SCAFFOLD_TODO_MARKER,
+            "proof_type": "automated_test",
+            "pass_fail": "pending",
+            "evidence": None,
+            "notes": SCAFFOLD_TODO_MARKER,
+        }
+    ],
+    "negative_invariants": [],
+}
+PLACEHOLDER_ISSUE_MATRIX = (
+    "# Issue Matrix\n\n| Issue | Verdict | Evidence ref |\n| --- | --- | --- |\n"
+)
+
+
+def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(["git", "-C", str(repo), *args], cwd=repo)
+
+
+def _init_git_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-qb", "main", str(repo)], cwd=repo)
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+
+
+def _write_meta(feature_dir: Path) -> None:
+    meta = {
+        "mission_slug": MISSION_SLUG,
+        "mission_id": MISSION_ID,
+        "mid8": MID8,
+        "mission_number": None,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "purpose_tldr": "dead-code burndown + #2373/#1914 no-op-stability",
+        "purpose_context": "regression fixture for #2804",
+    }
+    (feature_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _write_manifest(feature_dir: Path) -> LanesManifest:
+    manifest = LanesManifest(
+        version=1,
+        mission_slug=MISSION_SLUG,
+        mission_id=MISSION_SLUG,
+        mission_branch=MISSION_BRANCH,
+        target_branch="main",
+        lanes=[
+            ExecutionLane(
+                lane_id=LANE_ID,
+                wp_ids=(WP_ID,),
+                write_scope=(LANE_CODE,),
+                predicted_surfaces=("code",),
+                depends_on_lanes=(),
+                parallel_group=0,
+            )
+        ],
+        computed_at=datetime.now(UTC).isoformat(),
+        computed_from="test-fixture",
+    )
+    write_lanes_json(feature_dir, manifest)
+    return manifest
+
+
+def _write_wp_file(feature_dir: Path) -> None:
+    (feature_dir / "tasks" / f"{WP_ID}-work.md").write_text(
+        "---\n"
+        f"work_package_id: {WP_ID}\n"
+        f"title: {WP_ID} retire charter.generator\n"
+        "agent: implementer-bot\n"
+        "review_status: approved\n"
+        "reviewed_by: reviewer-renata\n"
+        "---\n"
+        f"# {WP_ID}\n",
+        encoding="utf-8",
+    )
+
+
+def _approved_event() -> dict[str, object]:
+    return {
+        "actor": "reviewer-renata",
+        "at": datetime.now(UTC).isoformat(),
+        "event_id": "01HXYZAPPR000000000000002804A",
+        "evidence": None,
+        "execution_mode": "worktree",
+        "feature_slug": MISSION_SLUG,
+        "force": False,
+        "from_lane": "in_review",
+        "reason": None,
+        "review_ref": f"review-{WP_ID}",
+        "to_lane": "approved",
+        "wp_id": WP_ID,
+    }
+
+
+def _bootstrap_mission(repo: Path) -> Path:
+    """Build the real #2804 divergence: mission branch and target each
+    introduce ``acceptance-matrix.json`` / ``issue-matrix.md`` INDEPENDENTLY
+    (an add/add divergence), matching the real incident's history:
+
+    1. Shared ancestor WITHOUT either gate artifact (meta/lanes/WP/status only).
+    2. Mission branch (+ lane) fork here, then the mission branch commits its
+       OWN ``finalize-tasks``-style placeholder scaffold (mirrors finalize-
+       tasks running against the mission-branch checkout).
+    3. The PRIMARY checkout (still on target_branch ``main`` -- never switched
+       to the mission branch) commits the FILLED, accept-authored matrix
+       DIRECTLY onto ``main`` -- the first time main ever sees these files at
+       all (mirrors #2404: accept's residual-artifact commit lands on the
+       primary checkout, a branch distinct from the mission integration
+       branch).
+    """
+    feature_dir = repo / "kitty-specs" / MISSION_SLUG
+    (feature_dir / "tasks").mkdir(parents=True)
+    _write_meta(feature_dir)
+    _write_manifest(feature_dir)
+    _write_wp_file(feature_dir)
+    (feature_dir / "status.events.jsonl").write_text(
+        json.dumps(_approved_event(), sort_keys=True) + "\n", encoding="utf-8"
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", f"chore({MISSION_SLUG}): bootstrap (no gate artifacts yet)")
+
+    # --- mission branch + lane fork BEFORE the gate artifacts exist anywhere ---
+    _git(repo, "branch", MISSION_BRANCH)
+    _git(repo, "checkout", MISSION_BRANCH)
+    (feature_dir / "acceptance-matrix.json").write_text(
+        json.dumps(PLACEHOLDER_ACCEPTANCE_MATRIX, indent=2) + "\n", encoding="utf-8"
+    )
+    (feature_dir / "issue-matrix.md").write_text(PLACEHOLDER_ISSUE_MATRIX, encoding="utf-8")
+    _git(repo, "add", "kitty-specs")
+    _git(
+        repo,
+        "commit",
+        "-m",
+        f"tasks({MISSION_SLUG}): finalize -- scaffold acceptance/issue matrix",
+    )
+
+    lane_branch = f"{MISSION_BRANCH}-{LANE_ID}"
+    _git(repo, "branch", lane_branch, MISSION_BRANCH)
+    _git(repo, "checkout", lane_branch)
+    code_path = repo / LANE_CODE
+    code_path.parent.mkdir(parents=True, exist_ok=True)
+    code_path.write_text("# generator module removed by WP01\n", encoding="utf-8")
+    _git(repo, "add", LANE_CODE)
+    _git(repo, "commit", "-m", f"feat({MISSION_SLUG}): {WP_ID} retire charter.generator")
+    _git(repo, "checkout", "main")
+
+    # --- primary checkout (still on target_branch) authors + accepts the
+    # FILLED matrix directly onto main; the mission branch never sees this. ---
+    (feature_dir / "acceptance-matrix.json").write_text(
+        json.dumps(FILLED_ACCEPTANCE_MATRIX, indent=2) + "\n", encoding="utf-8"
+    )
+    (feature_dir / "issue-matrix.md").write_text(FILLED_ISSUE_MATRIX, encoding="utf-8")
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-m", f"Finalize acceptance artifacts for {MISSION_SLUG}")
+
+    return feature_dir
+
+
+def _merge_external_mocks() -> ExitStack:
+    """Mock ONLY side effects that are irrelevant to git tree content: merge
+    gates/policy (no policy config in this minimal fixture), the stale-
+    assertion advisory scan, dossier sync (external SaaS I/O), diff-summary /
+    mission-closed emission (cosmetic), baseline-commit bookkeeping, and
+    done-transition recording (a legacy-topology status-write concern
+    unrelated to the #2804 file-content clobber under test). The git
+    plumbing under test -- lane consolidation and the mission->target squash
+    merge with ``-X theirs`` -- is left completely real.
+    """
+    patches = {
+        "run_check": patch("specify_cli.merge.executor.run_check"),
+        "sparse": patch("specify_cli.merge.executor.require_no_sparse_checkout"),
+        "preflight": patch("specify_cli.cli.commands.merge._enforce_git_preflight"),
+        "review_consistency": patch(
+            "specify_cli.merge.executor._enforce_review_artifact_consistency"
+        ),
+        "status_history": patch(
+            "specify_cli.merge.executor._enforce_canonical_status_history"
+        ),
+        "hollow": patch("specify_cli.merge.executor._warn_or_confirm_hollow_reviews"),
+        "baseline_record": patch(
+            "specify_cli.merge.executor._record_baseline_merge_commit", return_value=None
+        ),
+        "baseline_assert": patch(
+            "specify_cli.merge.executor._assert_baseline_merge_commit_on_target"
+        ),
+        "done_on_target": patch(
+            "specify_cli.merge.executor._assert_merged_wps_done_on_target"
+        ),
+        "record_done": patch(
+            "specify_cli.merge.executor._record_merged_wps_done_for_merge"
+        ),
+        "dossier": patch(
+            "specify_cli.merge.executor.trigger_feature_dossier_sync_if_enabled"
+        ),
+        "mission_closed": patch("specify_cli.merge.executor.emit_mission_closed"),
+        "diff_summary": patch("specify_cli.merge.executor._emit_merge_diff_summary"),
+        "gates": patch("specify_cli.policy.merge_gates.evaluate_merge_gates"),
+        "policy": patch("specify_cli.policy.config.load_policy_config"),
+        "remote": patch("specify_cli.merge.executor.has_remote", return_value=False),
+    }
+    stack = ExitStack()
+    mocks = {name: stack.enter_context(p) for name, p in patches.items()}
+    gate_eval = MagicMock()
+    gate_eval.overall_pass = True
+    gate_eval.gates = []
+    mocks["gates"].return_value = gate_eval
+    policy = MagicMock()
+    policy.merge_gates = []
+    policy.risk = MagicMock()
+    mocks["policy"].return_value = policy
+    stale_report = MagicMock()
+    stale_report.findings = []
+    mocks["run_check"].return_value = stale_report
+    return stack
+
+
+def test_merge_resets_filled_gate_artifacts_to_placeholder(tmp_path: Path) -> None:
+    """RED-FIRST P0 reproduction of #2804.
+
+    Intentionally FAILS until the product bug is fixed: ``spec-kitty merge``
+    must NEVER clobber an already-filled, already-accepted ``acceptance-
+    matrix.json`` / ``issue-matrix.md`` back to the empty scaffold placeholder.
+    Do NOT xfail/skip/quarantine to green -- fix the product (preserve the
+    filled coord gate artifacts through the mission->target squash merge,
+    e.g. by projecting them like ``_project_status_bookkeeping_to_target``
+    already does for ``status.events.jsonl``/``status.json``, or by excluding
+    them from the ``-X theirs`` add/add resolution). Tracking issue: #2804.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    feature_dir = _bootstrap_mission(repo)
+
+    # --- Precondition witnesses (BEFORE the act): the primary checkout
+    # genuinely carries the FILLED, non-placeholder artifacts pre-merge --
+    # so any post-merge placeholder can only be the merge's own doing, never
+    # a fixture that started out empty. ---
+    pre_matrix = json.loads((feature_dir / "acceptance-matrix.json").read_text(encoding="utf-8"))
+    assert pre_matrix["overall_verdict"] == "pass", "precondition: fixture must start FILLED"
+    assert SCAFFOLD_TODO_MARKER not in json.dumps(pre_matrix), (
+        "precondition: fixture must start FILLED, not the scaffold placeholder"
+    )
+    pre_issue_matrix = (feature_dir / "issue-matrix.md").read_text(encoding="utf-8")
+    assert "verified-already-fixed" in pre_issue_matrix, (
+        "precondition: fixture must start with a real terminal verdict row"
+    )
+
+    with _merge_external_mocks():
+        _run_lane_based_merge(
+            repo_root=repo,
+            mission_slug=MISSION_SLUG,
+            push=False,
+            delete_branch=False,
+            remove_worktree=True,
+            strategy=MergeStrategy.SQUASH,
+            allow_sparse_checkout=True,
+        )
+
+    # --- Non-vacuity witness: the merge genuinely ran to completion and
+    # advanced main with a real squash-merge commit (mission_number assigned,
+    # the code file landed) -- so a placeholder result below is the merge's
+    # own reset, not a merge that silently no-op'd or failed. ---
+    code_landed = (repo / LANE_CODE).exists()
+    assert code_landed, (
+        "precondition: the merge must have genuinely integrated the mission "
+        "branch into main (lane code file missing -- merge did not run)"
+    )
+    meta_after = json.loads((feature_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta_after.get("mission_number") == 1, (
+        "precondition: merge must have assigned a mission_number on target "
+        f"(merge did not complete the mission->target integration); got {meta_after.get('mission_number')!r}"
+    )
+
+    # --- CONTRACT (RED on base): the permanent record left on the
+    # integration branch must still be the FILLED content, not the reset
+    # scaffold placeholder. On buggy main, the ``-X theirs`` squash-merge
+    # conflict resolution takes the mission branch's stale placeholder over
+    # target's already-accepted fill. ---
+    post_matrix = json.loads((feature_dir / "acceptance-matrix.json").read_text(encoding="utf-8"))
+    assert post_matrix.get("overall_verdict") == "pass", (
+        "#2804: spec-kitty merge reset acceptance-matrix.json's overall_verdict "
+        f"to {post_matrix.get('overall_verdict')!r} -- the filled, accepted "
+        "evidence was clobbered by the mission->target squash merge's "
+        "'-X theirs' conflict resolution (mission branch's stale placeholder "
+        "won over target's already-accepted fill)."
+    )
+    assert SCAFFOLD_TODO_MARKER not in json.dumps(post_matrix), (
+        "#2804: spec-kitty merge reset acceptance-matrix.json's criteria back "
+        f"to the scaffold placeholder ({SCAFFOLD_TODO_MARKER!r}), discarding "
+        f"the real accepted evidence. Post-merge content: {post_matrix!r}"
+    )
+
+    post_issue_matrix = (feature_dir / "issue-matrix.md").read_text(encoding="utf-8")
+    assert "verified-already-fixed" in post_issue_matrix, (
+        "#2804: spec-kitty merge reset issue-matrix.md back to the bare "
+        f"scaffold, dropping the terminal verdict row. Post-merge content:\n{post_issue_matrix}"
+    )

--- a/tests/regression/test_issue_2876_plan_non_interactive_hang.py
+++ b/tests/regression/test_issue_2876_plan_non_interactive_hang.py
@@ -1,0 +1,194 @@
+"""RED-FIRST P0 reproduction of #2876 — ``spec-kitty plan`` still emits an
+interactive prompt (and, in a real agent/CI harness with an open, un-closed
+stdin pipe, blocks forever on it) under ``SPEC_KITTY_NON_INTERACTIVE=1``.
+
+Intentional red-first P0 reproduction. Tracking issue: #2876. Do NOT
+xfail/skip/quarantine this to green — fix the product (gate the widen
+interview's ``typer.prompt`` calls on the non-interactive contract so the
+command takes defaults or fails fast instead of prompting) and this test
+will turn green on its own.
+
+Defect (per the P0 report): under ``SPEC_KITTY_NON_INTERACTIVE=1`` — the
+primary way agents/CI drive this tool, where stdin is closed or not a TTY —
+``spec-kitty plan`` still reaches ``run_plan_interview``
+(``specify_cli.missions.plan.plan_interview.run_plan_interview``), which
+unconditionally prints a ``[enter]=accept default | ...`` hint line and calls
+``typer.prompt(question_text, ...)`` for every question in
+``PLAN_WIDEN_QUESTIONS`` — there is no ``SPEC_KITTY_NON_INTERACTIVE`` (or any
+other non-interactive) gate anywhere in that call graph. Confirmed by
+grepping the codebase: ``SPEC_KITTY_NON_INTERACTIVE`` is checked only in
+``cli/commands/init.py`` and ``cli/commands/_auth_recovery.py`` — never in
+``cli/commands/lifecycle.py`` or ``missions/plan/plan_interview.py``. In a
+real non-interactive invocation with an open-but-silent stdin pipe (the
+common agent-harness shape), ``typer.prompt``'s underlying ``input()`` call
+blocks forever waiting for a line that will never arrive — the reported hang.
+
+This test drives the exact, unmodified, pre-existing production entry point:
+``specify_cli.cli.commands.lifecycle.plan`` (the same function object
+``specify_cli/cli/commands/__init__.py`` registers as the real
+``spec-kitty plan`` command), wrapped in a throwaway ``typer.Typer()`` the
+same way ``tests/specify_cli/cli/commands/test_plan_widen.py`` already does
+for this exact widen-interview surface. Only ``agent_feature.setup_plan``
+(plan-scaffolding side effects — file/branch/commit mechanics, orthogonal to
+the interview-prompt defect under test) and ``locate_project_root`` are
+patched, mirroring that established harness.
+
+Bounding the hang: CliRunner's ``input=""`` feeds an already-exhausted stdin
+buffer, so ``input()`` raises ``EOFError`` on first read rather than
+blocking forever in-process (a real closed/non-TTY stdin, not an open silent
+pipe) — this reproduces the "still emits a prompt" half of the defect
+without ever blocking the test runner. As an additional guard against any
+unexpected in-process blocking (e.g. a stray network call in the widen
+prereq check), the whole invocation also runs under a hard wall-clock bound
+via a worker thread; a real hang surfaces as a ``TimeoutError`` failure
+rather than a stuck test run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+from click.testing import Result
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.lifecycle import PLAN_WIDEN_QUESTIONS, plan
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo]
+
+_app = typer.Typer()
+_app.command()(plan)
+
+runner = CliRunner()
+
+MISSION_SLUG = "regression-2876-plan-hang"
+MISSION_ID = "01K2876NONINTERACTIVEHANG0"
+
+# Production-shaped, substantive spec.md: real FR-001/FR-002 rows describing
+# the very contract the plan command violates, committed to a real git repo
+# (mirrors tests/agent/test_agent_feature.py's `_write_committed_substantive_spec`).
+SUBSTANTIVE_SPEC = """# Non-Interactive Plan Invocation
+
+## Functional Requirements
+
+| ID | Requirement | Acceptance Criteria | Status |
+| --- | --- | --- | --- |
+| FR-001 | `plan` never blocks on stdin under non-interactive mode. | Closed stdin + env var set -> returns within a bounded time. | proposed |
+| FR-002 | `plan` never emits an interactive prompt under non-interactive mode. | No hint line / prompt text on stdout; defaults or fail-fast. | proposed |
+"""
+
+_TIMEOUT_SECONDS = 10.0
+
+
+def _setup_repo(tmp_path: Path) -> None:
+    """Real git repo + minimal init markers + a committed, substantive spec.md.
+
+    Mirrors ``tests/specify_cli/cli/commands/test_plan_widen.py``'s
+    ``_setup_repo`` (the canonical harness for this exact widen-interview
+    surface), enriched with a real committed ``spec.md`` carrying FR rows so
+    the fixture is production-shaped rather than a bare meta.json stub.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, capture_output=True)
+
+    kittify = tmp_path / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "config.yaml").write_text("agents:\n  available: [claude]\n", encoding="utf-8")
+
+    mission_dir = tmp_path / "kitty-specs" / MISSION_SLUG
+    mission_dir.mkdir(parents=True, exist_ok=True)
+    (mission_dir / "meta.json").write_text(
+        json.dumps({"mission_id": MISSION_ID, "mission_slug": MISSION_SLUG}),
+        encoding="utf-8",
+    )
+    (mission_dir / "spec.md").write_text(SUBSTANTIVE_SPEC, encoding="utf-8")
+
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Spec Kitty Tests",
+            "-c",
+            "user.email=spec-kitty-tests@example.invalid",
+            "commit",
+            "-m",
+            "Add regression-2876 mission scaffold",
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _invoke_plan_non_interactive(tmp_path: Path) -> Result:
+    """Drive the real ``plan`` command with a closed stdin, cwd'd into the fixture repo."""
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with (
+            patch(
+                "specify_cli.cli.commands.lifecycle.agent_feature.setup_plan",
+                return_value=None,
+            ),
+            patch(
+                "specify_cli.cli.commands.lifecycle.locate_project_root",
+                return_value=tmp_path,
+            ),
+        ):
+            return runner.invoke(
+                _app,
+                ["--mission", MISSION_SLUG],
+                input="",  # closed/non-TTY stdin: the agent/CI invocation shape from #2876
+                catch_exceptions=True,
+            )
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_plan_non_interactive_never_prompts_or_hangs_2876(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NOTE:
+    RED-FIRST P0 reproduction of #2876. Intentionally FAILS until the product
+    bug is fixed: ``spec-kitty plan`` must never emit an interactive prompt
+    (and must never block on stdin) when ``SPEC_KITTY_NON_INTERACTIVE=1`` is
+    set — it should take defaults or fail fast instead. Do NOT xfail/skip/
+    quarantine to green; fix the product (gate ``run_plan_interview``'s
+    ``typer.prompt`` calls on the non-interactive contract). Tracking issue:
+    #2876.
+    """
+    monkeypatch.setenv("SPEC_KITTY_NON_INTERACTIVE", "1")
+    _setup_repo(tmp_path)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(_invoke_plan_non_interactive, tmp_path)
+        try:
+            result = future.result(timeout=_TIMEOUT_SECONDS)
+        except FutureTimeoutError:
+            pytest.fail(
+                "spec-kitty plan HUNG waiting on stdin under "
+                "SPEC_KITTY_NON_INTERACTIVE=1 (#2876): the widen-interview "
+                f"prompt loop blocked past the {_TIMEOUT_SECONDS}s bound "
+                "instead of taking defaults or failing fast."
+            )
+
+    # Defect #1 (the P0): the command must never print an interactive prompt
+    # under the non-interactive contract. On buggy main, `run_plan_interview`
+    # prints the question hint line and the first question's text via
+    # `typer.prompt` regardless of SPEC_KITTY_NON_INTERACTIVE.
+    first_question_text = PLAN_WIDEN_QUESTIONS[0][1]
+    forbidden_markers = ["[enter]=accept default", first_question_text]
+    leaked = [marker for marker in forbidden_markers if marker in result.output]
+    assert not leaked, (
+        "spec-kitty plan emitted an interactive prompt under "
+        f"SPEC_KITTY_NON_INTERACTIVE=1 (#2876): {leaked!r} found in captured "
+        f"output:\n{result.output}"
+    )


### PR DESCRIPTION
## What

Two issue-pinned, **intentionally red** reproduction tests for the two P0 bugs
surfaced in the latest tracker triage pass. These tests **reproduce** the
defects — they do **not** fix them, so the tracking issues stay open.

- **#2804** (P0, data/state loss) — `spec-kitty merge` clobbers a filled
  `acceptance-matrix.json` / `issue-matrix.md` back to the empty scaffold on the
  integration branch.
  Test: `tests/regression/test_issue_2804_merge_resets_gate_artifacts.py::test_merge_resets_filled_gate_artifacts_to_placeholder`
  Runs the real `_run_lane_based_merge` entry point to completion, then reds on
  the content-preservation assertion. Root cause: the mission→target squash
  merge hits an add/add conflict on the gate artifacts and `-X theirs` resolves
  toward the mission branch's stale placeholder, discarding target's
  already-accepted fill.

- **#2876** (P0, core-workflow hang) — `spec-kitty plan` emits the widen-interview
  prompt (and in a real agent/CI harness blocks on stdin) under
  `SPEC_KITTY_NON_INTERACTIVE=1`.
  Test: `tests/regression/test_issue_2876_plan_non_interactive_hang.py::test_plan_non_interactive_never_prompts_or_hangs_2876`
  Driven in-process through the real registered `plan` command with an exhausted
  stdin + hard timeout; reds when the prompt leaks to stdout. Root cause:
  `missions/plan/plan_interview.py::run_plan_interview` prints the hint line and
  calls `typer.prompt(...)` unconditionally — no non-interactive gate in that
  call graph.

## Why red-first

Per [ADR 2026-07-17-1](docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md)
and the [issue-tracker triage runbook](docs/development/manage-issue-tracker.md),
an open P0 bug should carry a failing, issue-pinned reproduction so mainline
honestly reflects the blocker. Both tests are marked `@pytest.mark.regression`
(the exact-reproduction marker — not `quarantine`), and both were verified to
fail because of the **product** defect, not a test/setup error (each asserts its
fixture preconditions and that the command ran to completion before the failing
assertion).

## Expected CI

**These tests are expected to RED on mainline** until the underlying P0s are
fixed. That is the intended honest signal, not a regression in this PR.

## Scope

- No product code touched — reproduction tests only.
- Draft: opened for visibility / review; not for merge until the fixes land (or
  per maintainer decision on how to carry the red).

Tracking issues: #2804, #2876 (kept open — this PR does not close them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYG4JHbHudbGAHpRKw5Pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787463774&installation_model_id=427282&pr_number=2902&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2902&signature=f65ec08ffc41d4ecca67bc5c071fb58428a9794cd48c644282174f7f2e625347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->