### PR TITLE
docs(dev): onboarding-run priming prompt + known-friction-points reference

### DIFF
--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5771,6 +5771,14 @@ pages:
     - {slug: "release-and-ci-policy", text: "Release and CI policy", level: 2}
     - {slug: "non-page-artifacts", text: "Non-page artifacts", level: 2}
     - {slug: "see-also", text: "See also", level: 2}
+  - path: "docs/development/known-friction-points.md"
+    title: "Known Current Friction Points"
+    divio_type: "reference"
+    abstract: "A time-stamped, fast-drifting list of current repo and tooling friction points a maintainer or agent hits mid-mission; re-verify against the tracker before trusting specifics."
+    anchors:
+    - {slug: "the-friction-points", text: "The friction points", level: 2}
+    - {slug: "maintaining-this-page", text: "Maintaining this page", level: 2}
+    - {slug: "see-also", text: "See also", level: 2}
   - path: "docs/development/local-overrides.md"
     title: "Local Overrides for Cross-Package Development"
     divio_type: "how-to"
@@ -5795,6 +5803,14 @@ pages:
     - {slug: "native-type-is-the-kind-carrier", text: "Native type is the kind carrier", level: 3}
     - {slug: "priority-and-what-makes-a-p0", text: "Priority, and what makes a P0", level: 3}
     - {slug: "a-p0-bug-should-carry-a-failing-reproduction-test", text: "A P0 bug should carry a failing reproduction test", level: 3}
+    - {slug: "see-also", text: "See also", level: 2}
+  - path: "docs/development/onboarding-run.md"
+    title: "Onboarding Run: Priming a Co-Maintainer Mission Session"
+    divio_type: "how-to"
+    abstract: "A reusable priming prompt and 12-step cadence for running a full Spec-Driven Development mission the way this team runs them — for onboarding prospective co-maintainers."
+    anchors:
+    - {slug: "how-to-use-it", text: "How to use it", level: 2}
+    - {slug: "the-priming-prompt", text: "The priming prompt", level: 2}
     - {slug: "see-also", text: "See also", level: 2}
   - path: "docs/development/pr-landing.md"
     title: "Landing Contributor PRs: The Maintainer Runbook"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1730,6 +1730,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/development/known-friction-points.md
+  tag: current
+  divio_type: reference
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/development/local-overrides.md
   tag: current
   divio_type: how-to
@@ -1737,6 +1743,12 @@
   current_target: true
   notes: null
 - path: docs/development/manage-issue-tracker.md
+  tag: current
+  divio_type: how-to
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/development/onboarding-run.md
   tag: current
   divio_type: how-to
   owning_workstream: none

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -28,6 +28,8 @@ no contributor-only page is reachable from end-user navigation.
 Runbooks scoped to maintainers (and agents acting in a maintainer capacity), not general contributors.
 
 - [Landing contributor PRs](pr-landing.md) — the claim → isolate → rebase → classify → fold → squad → hand-off maintainer runbook.
+- [Onboarding run](onboarding-run.md) — a reusable priming prompt and 12-step SDD cadence for onboarding a prospective co-maintainer.
+- [Known current friction points](known-friction-points.md) — the fast-drifting list of current repo/tooling gotchas an agent hits mid-mission.
 - [Managing the issue tracker](manage-issue-tracker.md) — epics vs. meta-trackers, native sub-issue parenting, and triage conventions.
 
 ## Testing the Spec Kitty codebase

--- a/docs/development/known-friction-points.md
+++ b/docs/development/known-friction-points.md
@@ -1,0 +1,92 @@
+---
+title: 'Known Current Friction Points'
+description: 'A time-stamped, fast-drifting list of current repo and tooling friction points a maintainer or agent hits mid-mission; re-verify against the tracker before trusting specifics.'
+doc_status: active
+updated: '2026-07-24'
+type: reference
+related:
+- docs/development/pr-landing.md
+- docs/development/onboarding-run.md
+- docs/development/testing-flakiness.md
+- docs/development/testing-parallel.md
+- docs/development/red-main-and-release-readiness.md
+- docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
+---
+# Known Current Friction Points
+
+> **This page is deliberately time-sensitive and drifts fast.** It captures
+> repo and tooling friction that a maintainer — or an agent acting in a
+> maintainer capacity — is likely to hit while running a mission *today*. It is
+> **not** durable doctrine: specific issue numbers, version gates, and toggles
+> change as the codebase moves. Always re-verify against the authoritative
+> sources before trusting a specific number:
+> [`CLAUDE.md`](../../CLAUDE.md) (its "Test-run baseline-red gotcha" note),
+> [ADR 2026-07-17-1](../adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md),
+> and the issue tracker.
+
+**Snapshot date: 2026-07-24 · Spec Kitty 3.2.x.** Proof that this list drifts:
+`#2772` was a known-red P0 when this note was first drafted and has since been
+closed — so the "known reds" below are already a different set than a month ago.
+
+## The friction points
+
+- **`main` may be legitimately RED.** Honest P0 reproductions are left red on
+  purpose ([ADR 2026-07-17-1](../adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md));
+  currently open examples: **#2736**, **#1834**. Before "fixing" any red,
+  **attribute** it — reproduce on `upstream/main` / the merge-base. Never
+  green-wash a `@pytest.mark.regression` red; that erases a deliberate
+  release-blocker signal.
+- **CI-environment false reds that pass locally:** auth
+  (`logged_out_on_connected_teamspace`) and the sync toggles
+  (`SPEC_KITTY_SYNC_MINIMAL_IMPORT` / `SPEC_KITTY_SYNC_DISABLE`, which also skip
+  the pre-review gate). Config, not your diff.
+- **Stale-install false reds.** Commands that shell out to `spec-kitty` (e.g.
+  the `merge-driver-*` commands) only reflect your working tree after
+  `pip install -e .` / `uv pip install -e .`. Re-install after every rebase.
+- **Real-port / daemon tests are not HOME-isolated** (ports 9400–9449). Run them
+  serially with `-n0`. Leaked daemons from a prior run squat those ports and fail
+  singleton/reaping tests (`test_issue_1071_*`) with a "got 2 ports" assertion —
+  that is environmental, not your change. Check `ss -ltnp | grep 94` if a daemon
+  test flaps.
+- **In a lane or clone, a bare `python` / `pytest` imports the PRIMARY `src`, not
+  your lane.** Always `uv run <cmd>`.
+- **CI-only gates that pass locally then fail ~40 minutes later:** the
+  terminology guard, the architectural shards
+  (`integration-tests-core-misc (architectural)`, `arch-adversarial`),
+  `canonical-producer-lint` (CP001 fires on a hand-rolled event dict with
+  `event_type`+`payload` keys — build via `spec_kitty_events.lifecycle.*`
+  instead), and `docs-freshness`. Run `tests/architectural/`, the terminology
+  guard, and `PYTHONPATH=. python scripts/docs/check_docs_freshness.py --ci`
+  locally on the **rebased** tip before declaring a branch green.
+- **The status daemon can auto-commit your staged files** with the *previous*
+  mission's commit message. Commit promptly; do not leave a dirty index while it
+  runs.
+- **No `git stash` in lane worktrees** — the stash stack is shared across
+  worktrees, so a `pop` can steal a sibling lane's work-in-progress.
+- **`move-task` can hang on sync-daemon fan-out.** Background it and set
+  `SPEC_KITTY_SYNC_MINIMAL_IMPORT=1`.
+- **After `finalize-tasks`, verify the issue-matrix / coordination state.** 3.2.6
+  made the PRIMARY scaffolder idempotent; the coord/merge reset path is not fully
+  verified.
+- **Docs scripts need `PYTHONPATH=.`**, and `build_cli_reference.py` defaults to
+  the *wrong* output path — pass `--output docs/api/cli-commands.md
+  --agent-output docs/api/agent-subcommands.md` explicitly.
+- **Shared-package boundary:** anchor new runtime code in
+  `src/runtime/next/_internal_runtime/`; `src/specify_cli/next/` is a shim
+  removed in 3.3.0. Consume events / tracker only via `spec_kitty_events.*` /
+  `spec_kitty_tracker.*`.
+
+## Maintaining this page
+
+When you hit a new mid-mission friction point — or when one above stops being
+true (a known-red P0 closes, a toggle is retired, a version gate passes) —
+update this page and bump the snapshot date in the same change. Keep entries
+short and actionable; deep rationale belongs in the linked runbooks, not here.
+
+## See also
+
+- [Landing contributor PRs](pr-landing.md) — the maintainer landing runbook.
+- [Onboarding run](onboarding-run.md) — the mission-run priming prompt that
+  points here.
+- [Test-flakiness handling policy](testing-flakiness.md) — the never-retry-to-green rule.
+- [Red main and release readiness](red-main-and-release-readiness.md).

--- a/docs/development/onboarding-run.md
+++ b/docs/development/onboarding-run.md
@@ -1,0 +1,170 @@
+---
+title: 'Onboarding Run: Priming a Co-Maintainer Mission Session'
+description: 'A reusable priming prompt and 12-step cadence for running a full Spec-Driven Development mission the way this team runs them — for onboarding prospective co-maintainers.'
+doc_status: active
+updated: '2026-07-24'
+type: how-to
+related:
+- docs/development/known-friction-points.md
+- docs/development/pr-landing.md
+- docs/development/contributing.md
+- docs/development/testing-parallel.md
+- docs/development/testing-flakiness.md
+- docs/development/quality-and-tech-debt-standing-orders.md
+---
+# Onboarding Run: Priming a Co-Maintainer Mission Session
+
+This page is a **reusable priming prompt** for a prospective co-maintainer's AI
+session (Claude Code + Spec Kitty). It encodes the team's standard Spec-Driven
+Development (SDD) cadence — spec → plan → tasks → draft PR — with the adversarial
+squad checkpoints and operator-led architecture gates baked in, so an onboarding
+run teaches the *why*, not just the sequence.
+
+## How to use it
+
+1. Copy the prompt block below into the co-maintainer's session.
+2. Fill in the **`## The mission`** block with the specific work (problem,
+   starting design intent, where the evidence lives, hard constraints). Leave the
+   architecture *unlocked* — it is decided with the operator at step 2.
+3. Point them at [Known current friction points](known-friction-points.md) as
+   required pre-reading — that page is the fast-drifting companion to this durable
+   cadence, and the prompt below references it by path rather than inlining it (so
+   the gotchas stay current without re-issuing the prompt).
+
+The cadence itself is stable; the friction list is not. Keeping them in separate
+pages is deliberate.
+
+## The priming prompt
+
+````text
+# Onboarding mission — Spec Kitty co-maintainer run
+
+You are running a full Spec-Driven Development (SDD) mission end-to-end, the way
+this team runs them. This is an ONBOARDING run: work deliberately, explain your
+reasoning at each gate, and PAUSE for operator review at the checkpoints marked 🛑.
+The operator leads architecture decisions and is the ONLY one who merges to
+origin/main — you never do.
+
+## 0. Orient before you touch anything (non-negotiable)
+- Read the project charter FIRST: `.kittify/charter/charter.md`, then load
+  action-scoped doctrine as you go via `spec-kitty charter context --action <name>`.
+- Read `CLAUDE.md`, `docs/development/pr-landing.md` (maintainer runbook),
+  `docs/development/known-friction-points.md` (REQUIRED — the current gotchas),
+  `CONTRIBUTING.md`, `docs/development/testing-parallel.md`, and
+  `docs/development/testing-flakiness.md`.
+- Terminology canon: it's a **Mission**, never a "feature". Run the terminology
+  guard before pushing any prose/doctrine:
+  `pytest tests/architectural/test_no_legacy_terminology.py`.
+- Git law: `origin` = your fork, `upstream` = Priivacy-ai. NEVER `git push origin
+  main`. All shared changes go through a draft PR. `spec-kitty merge` is LOCAL only;
+  the operator merges to origin/main.
+
+## Known current friction points
+Read `docs/development/known-friction-points.md` BEFORE you start — it is the
+fast-drifting list of current repo/tooling gotchas you WILL hit: red-main
+attribution, CI-environment false reds, stale-install reds, real-port/daemon
+leakage (`-n0`), `uv run` in lanes, the CI-only gates that fail ~40 min late, the
+status-daemon auto-commit, no `git stash` in lane worktrees, and more. Treat it as
+required pre-reading and re-verify anything version- or issue-specific against the
+tracker.
+
+## The mission
+<REPLACE THIS BLOCK for the specific run. One or two paragraphs: state the problem,
+the STARTING design intent if any, WHERE the evidence/context lives (issue #, PR #,
+prior squad review, design doc), and any hard constraints. Leave the architecture
+UNLOCKED — it is decided WITH the operator in step 2, not asserted here.>
+
+## The cadence — follow in order, pause at 🛑
+
+1. **Branch off main.** Reuse one mission clone; create a fresh branch off
+   `upstream/main`: `git fetch upstream main && git checkout -b kitty/<mission-slug>
+   upstream/main`. One mission per checkout — never race two missions on one tree.
+
+2. **Pre-spec research squad → operator-led architecture run.** Deploy a bounded,
+   PROFILE-LOADED adversarial squad (load the actual profile YAML for each lens, not
+   a persona name; give any agent that touches a branch/PR `isolation: worktree`).
+   Cover four lenses: (a) alignment to planned architecture, (b) risks, (c)
+   integration points, (d) related/foldable issues. Synthesize their findings into a
+   short options memo. 🛑 Then convene the ARCHITECTURE run WITH the operator —
+   present the options, do NOT unilaterally lock the design. Wait for the operator's
+   architectural call before speccing.
+
+3. **Ensure latest-HEAD Spec Kitty is installed and active.** From the repo,
+   editable-install your working tree so the `spec-kitty` CLI reflects HEAD:
+   `uv pip install -e .` (or `pip install -e .`), then `spec-kitty upgrade` to
+   regenerate agent commands/skills, and verify: `spec-kitty --version` +
+   `spec-kitty doctor`. Re-run this after ANY rebase — a stale install produces false
+   reds on commands that shell out to `spec-kitty`.
+
+4. **Spec the mission.** Run `/spec-kitty.specify`. Answer the discovery interview
+   honestly (it refuses to proceed until the question set is answered). The spec lands
+   in `kitty-specs/<mission>/`. Encode the operator's architecture decision as
+   constraints/FRs. Seed the 3 mission tracer files.
+
+5. **Post-spec squad.** Bounded profile-loaded adversarial pass: anti-laziness,
+   scope-vs-intent, ambiguity/underspecification, testability of acceptance criteria.
+   Fold MAJORs into the spec. 🛑 Operator review of the spec.
+
+6. **Plan.** Run `/spec-kitty.plan`. Architecture, data flow, risks, integration
+   points — consistent with the locked design.
+
+7. **Post-plan squad (brownfield checks).** Foldable-issue check, split-brain / LOC /
+   duplication check, deprecation & canonical-source check, undersizing check. The
+   pre-flight squad cadence catches undersizing 4–5×. Fold findings into the plan.
+
+8. **Commit and push to fork.** Commit the planning artifacts; push the branch to
+   `origin` (your fork). The draft PR comes at step 12, but pushing early keeps a
+   backup and a visible trail. Never to origin/main.
+
+9. **Rebase onto latest upstream/main + drift check.** `git fetch upstream main &&
+   git rebase upstream/main`. Re-install editable (step 3). Then CHECK whether recent
+   upstream changes impact the planned approach — new seams, moved canonical sources,
+   changed contracts. If they do, revise the plan (and flag the operator) before
+   tasking. Don't rebase/switch a tree while a background test run is using it.
+
+10. **Tasks.** Run `/spec-kitty.tasks` (outline → packages), then `spec-kitty agent
+    mission finalize-tasks` (validates deps, writes lane metadata). Post-tasks
+    adversarial squad: verify WP-decomposition claims against the code, census Sonar
+    attack-vectors in touched files, per-WP campsite scope. Verify the issue-matrix
+    after finalize (see the friction-points page).
+
+11. **Full e2e run.** Full suite green on the rebased tip — this is where CI-only
+    arch gates surface locally. Run `PWHEADLESS=1 pytest tests/ -n auto --dist
+    loadfile` (daemon/real-port tests separately with `-n0`), plus
+    `tests/architectural/`, `ruff check .`, `mypy`, the terminology guard, and
+    docs-freshness. Any UI claim needs Playwright proof, never API-response
+    inference. Classify every red into PR-defect / contract-crossed /
+    pre-existing-main / flake — never retry-to-green.
+
+12. **Draft PR + self-review.** Open a DRAFT PR from the mission branch
+    (`gh pr create --draft`). Write a readable PR per DIRECTIVE_046 (what / why /
+    verification; call out any remaining Sonar or UI work). Run the
+    mission-wrap-up-sequence procedure. Then SELF-REVIEW with a fresh squad lens
+    (architect + reviewer) over the aggregate diff and synthesize a LAND/HOLD verdict
+    for the operator. 🛑 Hand off — the operator merges. You never run `gh pr merge`.
+
+## Discipline that applies at every step
+- Squads are BOUNDED and PROFILE-LOADED (load the YAML; delegations LOAD the profile,
+  never a persona name). implement=sonnet, review=opus; match the Agent model to the
+  profile identity.
+- Any agent touching the PR/branch runs in `isolation: worktree`.
+- In a lane/clone, always `uv run <cmd>` — bare `python`/`pytest` imports the PRIMARY
+  src, not your lane.
+- Red-first for any bugfix element: prove the test reds through the real entry point
+  BEFORE the fix. Live evidence over "looks fixed".
+- Realistic, production-shaped test data. Every new branch/helper gets a focused test
+  in the same PR. Campsite-clean surfaces you touch before you change them.
+- When a canonical command/template/surface looks missing or broken, trace the source
+  and file an upstream gap — never improvise a workaround.
+
+Start with step 0, then step 1. At each 🛑 checkpoint, stop and summarize for the
+operator before proceeding.
+````
+
+## See also
+
+- [Known current friction points](known-friction-points.md) — the fast-drifting
+  companion this prompt references.
+- [Landing contributor PRs](pr-landing.md) — the maintainer landing runbook the
+  cadence hands off into.
+- [Quality & tech-debt standing orders](quality-and-tech-debt-standing-orders.md).


### PR DESCRIPTION
## What

Adds two maintainer-zone docs under `docs/development/`:

- **`onboarding-run.md`** — a reusable priming prompt and 12-step SDD cadence (branch → pre-spec research squad + operator-led architecture run → install latest-HEAD SK → spec → post-spec squad → plan → post-plan squad → push → rebase + drift-check → tasks → full e2e → draft PR + self-review), with the adversarial-squad checkpoints and 🛑 operator gates baked in. For onboarding prospective co-maintainers.
- **`known-friction-points.md`** — the fast-drifting, time-stamped list of current repo/tooling gotchas an agent hits mid-mission (red-main attribution, CI-env false reds, stale-install reds, real-port/daemon leakage, lane `uv run`, the CI-only gates that fail ~40 min late, status-daemon auto-commit, no `git stash` in lanes, etc.).

## Why

The mission cadence is durable; the friction list rots fast. Keeping them in **separate** pages — the prompt referencing the friction doc by path rather than inlining it — means the transient gotchas stay current without re-issuing the prompt. The friction page carries an explicit snapshot date and a "re-verify against the tracker" banner (and already demonstrates the drift: `#2772` was a known-red P0 when first drafted and has since closed).

## Verification

- `check_docs_freshness.py --ci`: errors=0 (only pre-existing offline link-probe warnings).
- `related_validator` (0 dangling), `relative_link_fixer --check` (0 dead links), `description_length_check` (0 violations), terminology guard (4 passed), `tests/docs/` (573 passed).
- Both docs registered in the development index, the page inventory, and the retrieval index (regenerated).

Docs-only; no `__init__.py` / version change. Operator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787480522&installation_model_id=427282&pr_number=2903&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2903&signature=506b4c7c0980d5af704630d708b874494e4c7b418fde9e752a07541a59cefc0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->