### PR TITLE
docs(triage): define what "good first issue" means in this project

### DIFF
--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5847,6 +5847,7 @@ pages:
     - {slug: "native-type-is-the-kind-carrier", text: "Native type is the kind carrier", level: 3}
     - {slug: "priority-and-what-makes-a-p0", text: "Priority, and what makes a P0", level: 3}
     - {slug: "a-p0-bug-should-carry-a-failing-reproduction-test", text: "A P0 bug should carry a failing reproduction test", level: 3}
+    - {slug: "what-good-first-issue-means-here", text: "What \"good first issue\" means here", level: 3}
     - {slug: "see-also", text: "See also", level: 2}
   - path: "docs/development/onboarding-run.md"
     title: "Onboarding Run: Priming a Co-Maintainer Mission Session"

--- a/docs/development/manage-issue-tracker.md
+++ b/docs/development/manage-issue-tracker.md
@@ -185,6 +185,21 @@ false red corrupts the signal it exists to give. Expensive QA and manual testing
 wait for green; maintainers prioritize red recovery. See the
 [red-main policy](red-main-and-release-readiness.md).
 
+### What "good first issue" means here
+
+`good first issue` is **not** a difficulty or seniority signal — this project's
+contributor base is senior by default. It marks a **good entry point into the
+codebase**: a self-contained issue that teaches a subsystem while carrying **low
+customer and blast-radius impact**, so someone new to the repo can land it
+without first absorbing deep cross-cutting context.
+
+Reach for it when an issue is well-scoped, has a clear deliverable, and touches a
+peripheral or tooling surface rather than a load-bearing one. One guardrail: if a
+`good first issue` could still alter a **blocking or shared gate** (or otherwise
+carry real blast radius despite being a good entry point), require maintainer
+concurrence on the chosen approach **before** implementation — normal PR review
+then covers the rest.
+
 ## See also
 
 - [Contributing to Spec Kitty](contributing.md) — pull-request and maintainer workflow.


### PR DESCRIPTION
## Why

The contributor base here is senior by default, so the `good first issue` label was ambiguous — read literally it implies "junior/easy," which isn't what we mean. We use it for a **good entry point into the codebase**: self-contained, teaches a subsystem, low customer/blast-radius impact. This encodes that meaning in the triage guide so it's documented, not tribal, and matches the label description (just updated to the same wording).

## What

- Adds a `### What "good first issue" means here` subsection to `docs/development/manage-issue-tracker.md`, under the triage section — defines GFI as an entry-point/low-blast-radius signal (explicitly not difficulty/seniority) and states the one guardrail: a GFI whose outcome could alter a blocking/shared gate needs maintainer concurrence before implementation.
- Regenerates `3-2-docs-retrieval-index.yaml` for the new heading anchor (docs-freshness clean).

Context: #2913 (the first issue triaged under this clarified meaning) and its parent #2853 / epic #2071. Not a `Closes` — this is the guide change, not those tickets' work.

Gates: terminology guard, `relative_link_fixer --check`, and `check_docs_freshness --ci` all green (0 errors; the remaining freshness warnings are pre-existing external link-health probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAYG4JHbHudbGAHpRKw5Pr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787551702&installation_model_id=427282&pr_number=2914&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2914&signature=93638feb03b9a71866920dfb9a2fbd922a2c1c68152ddeba3e3c40983f73738d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->