### PR TITLE
ci(#2927): label pytest INTERNALERROR (exit 3) instead of reading it as a regression-test failure

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -2913,7 +2913,9 @@ jobs:
   # It is EXPECTED to be red while open P0s exist — that red is the honest,
   # tracked, release-gating signal, never retried to green; maintainers clear it
   # by fixing the product defect. Tolerates pytest exit code 5 (no regression
-  # tests currently registered) as green.
+  # tests currently registered) as green, and labels exit code 3 (pytest
+  # INTERNALERROR — crashed, nothing ran) as the distinct condition it is
+  # rather than letting it read as a failing reproduction (#2927).
   # ---------------------------------------------------------------------------
   regression-tests:
     name: regression tests (blocking)
@@ -2942,6 +2944,21 @@ jobs:
           if [ "$ec" -eq 5 ]; then
             echo "::notice::No regression red-first reproductions are currently registered (-m regression collected nothing)."
             exit 0
+          fi
+          if [ "$ec" -eq 3 ]; then
+            # Exit 3 is pytest's INTERNALERROR: it crashed (typically during
+            # collection) and NO test ran. Left unlabeled this is indistinguishable
+            # from exit 1 (a real red-first reproduction failing), which sends the
+            # reader hunting for a product defect in whatever subsystem their branch
+            # touched — see #2927, where that cost a full triage pass. Still fails
+            # the job (honest red); it just says what kind of red it is, and leaves
+            # the evidence attached so the next occurrence is diagnosable.
+            echo "::error::pytest INTERNALERROR (exit 3) — the suite CRASHED and no test ran. This is NOT a regression-test failure and says nothing about correctness either way. See #2927."
+            echo "--- resolved pytest/plugin versions ---"
+            python -m pip freeze | grep -Ei "^(pytest|pluggy|iniconfig)" || true
+            echo "--- plugin registration + collection attempt (diagnostic only) ---"
+            python -m pytest tests/ -m regression -p no:cacheprovider --collect-only -q 2>&1 | tail -40 || true
+            exit "$ec"
           fi
           exit "$ec"
 


### PR DESCRIPTION
Item 1 of #2927.

## The problem this fixes

`regression-tests` already special-cases pytest exit **5** (nothing collected). It treats exit **3** identically to exit **1**. Those are very different things:

| exit | meaning | what the reader should do |
|---|---|---|
| 1 | a red-first reproduction failed | fix the product defect |
| 3 | pytest **INTERNALERROR** — crashed, usually in collection, **no test ran** | this says nothing about correctness; diagnose the crash |

Presenting a crash as a failing reproduction points people at a product defect in whatever subsystem their branch happens to touch. On #2884 that is exactly what happened: the shard read as "import-history broke a blocking regression test," and it took a full triage pass — including building a throwaway 3.12 venv with CI's resolved pytest to attempt local reproduction — to establish that **nothing had executed**. A rerun of the unchanged commit went green.

## What changes

An exit-3 branch that:

- fails the job (unchanged — honest red, no tolerance added, no retry-to-green),
- emits an explicit `::error::` saying the suite crashed and no test ran, pointing at #2927,
- dumps the resolved `pytest`/`pluggy`/`iniconfig` versions and a `--collect-only` attempt.

So the next occurrence arrives with its own evidence instead of costing someone else the same triage.

## What this deliberately does NOT do

- It does not make exit 3 green. A crashed blocking shard is still a failure.
- It does not retry, and it does not touch the flakiness policy.
- It does not claim to fix the underlying crash. That is unreproducible so far (green locally on Python 3.11 and on 3.12.3 with CI's own pytest 9.1.1) and is tracked in #2927 with the traceback, the attribution timeline, and the leading hypothesis.

Verified the workflow still parses (`yaml.safe_load`, `regression-tests` job intact at 4 steps).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606901&installation_model_id=427282&pr_number=2928&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2928&signature=3dff5c8f374943eb2f845be75a6a4bad663926c359b70330a5b0b808dac7b60c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->