### PR TITLE
fix(ci): measure mission_runtime coverage in the job that actually runs its tests

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1576,6 +1576,21 @@ jobs:
       # by the ignore-mirror architectural invariant (FR-012 /
       # test_catch_all_ignore_lists_mirror_owned_roots_live): drift between this
       # list and the shard-owned roots fails tests/architectural/.
+      #
+      # --cov=src/mission_runtime (added alongside the pre-existing
+      # integration-tests-core-misc / arch-adversarial instrumentation): the
+      # "core-misc" shard's ``paths: ''`` selection includes tests/mission_runtime,
+      # but several of that package's own tests carry ONLY ``pytest.mark.fast``
+      # (no git_repo/integration/architectural) -- e.g.
+      # tests/mission_runtime/test_write_target_degrade.py, whose
+      # fail-closed-cause-chain assertions are pure-logic/tmp_path-only by
+      # design. Before this line, those files ran here (selected by ``-m
+      # "fast and not windows_ci"``) but their hits were never attributed to
+      # ``src/mission_runtime`` (only integration/architectural-marked
+      # mission_runtime tests were ever instrumented for it), so the
+      # diff-coverage critical-path gate saw them as 0% collected rather than
+      # exercised. Mirrors the sibling jobs' instrumentation instead of
+      # widening this file's own markers away from their correct fast tier.
       - name: "Run fast tests — core misc"
         run: |
           uv run python -m pytest \
@@ -1586,6 +1601,7 @@ jobs:
             --durations=50 \
             --cov=src/specify_cli \
             --cov=src/glossary \
+            --cov=src/mission_runtime \
             --cov-report=xml:out/reports/coverage/coverage-fast-core-misc-${{ matrix.shard }}.xml
       - name: "Upload fast-core-misc coverage"
         if: always()

--- a/tests/mission_runtime/test_write_target_degrade.py
+++ b/tests/mission_runtime/test_write_target_degrade.py
@@ -158,6 +158,64 @@ class TestFailClosedPreservesCause:
         assert raised.__cause__ is concrete_exc
         assert isinstance(raised.__cause__, CoordinationBranchDeleted)
 
+    def test_plain_action_context_error_cause_and_code_survive(
+        self, tmp_path: Path
+    ) -> None:
+        """Companion case: when ``resolve_placement_only`` itself raises a
+        plain ``ActionContextError`` (NOT a ``StatusReadPathNotFound``/
+        ``CoordinationBranchDeleted`` subclass -- e.g. an ambiguous or
+        malformed mission handle caught inside the port), ``_fail_closed_error``
+        takes its OWN first branch (``isinstance(resolution_exc,
+        ActionContextError)``) rather than the ``StatusReadPathNotFound`` arm
+        exercised above. That branch must preserve the caught error's own
+        ``.code`` (not the generic ``FEATURE_CONTEXT_UNRESOLVED`` fallback)
+        and chain it as ``__cause__`` -- the same discipline the
+        ``StatusReadPathNotFound`` arm already gets, just for the sibling
+        exception type.
+        """
+        mission_slug = "023-plain-action-context-error-mission"
+        feature_dir = tmp_path / "kitty-specs" / mission_slug
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "meta.json").write_text(
+            json.dumps(
+                {"mission_id": "01HXYZ0000000000000000000D", "mission_slug": mission_slug}
+            ),
+            encoding="utf-8",
+        )
+        concrete_exc = ActionContextError(
+            "AMBIGUOUS_MISSION_HANDLE", "mission slug resolves to more than one candidate"
+        )
+
+        with (
+            mock.patch(
+                "specify_cli.missions._read_path_resolver.candidate_feature_dir_for_mission",
+                return_value=feature_dir,
+            ),
+            mock.patch(
+                "mission_runtime.write_target_degrade.resolve_placement_only",
+                side_effect=concrete_exc,
+            ),
+            pytest.raises(ActionContextError) as exc_info,
+        ):
+            resolve_write_target_or_degrade(
+                repo_root=tmp_path,
+                mission_slug=mission_slug,
+                kind=MissionArtifactKind.STATUS_STATE,
+                degrade_ref=None,  # fail-closed: no degrade path supplied
+            )
+
+        raised = exc_info.value
+        # The caught error's own code survives -- NOT the generic
+        # FEATURE_CONTEXT_UNRESOLVED fallback (that fallback is reserved for
+        # the "nothing was ever caught" branch, exercised by
+        # ``test_bookkeeping_raises_when_branch_none_and_mission_missing``
+        # below, which never reaches ``resolve_placement_only`` at all).
+        assert raised.code == "AMBIGUOUS_MISSION_HANDLE"
+        assert raised.code != "FEATURE_CONTEXT_UNRESOLVED"
+        # The chain is preserved -- not a fresh, cause-less exception.
+        assert raised.__cause__ is concrete_exc
+        assert isinstance(raised.__cause__, ActionContextError)
+
 
 class TestDecisionLogFailOpen:
     """Test decision_log preserves fail-open behavior through the helper."""


### PR DESCRIPTION
## Why

PR #2963's `diff-coverage` gate failed at **88%** against a 90% threshold, on four lines in `src/mission_runtime/` — **two of which are demonstrably executed by passing tests**. That contradiction is the whole story: this was not a test gap, it was coverage that never got measured.

The investigation downloaded all 25 coverage artifacts from the failing run (`30241287792`, commit `6849b469f`) and replayed the gate's own `diff-cover` invocation locally, reproducing 88% / 4-missing exactly before changing anything.

## What this PR fixes (two of three mechanisms)

**1. Collection gap — the real one.** `tests/mission_runtime/test_write_target_degrade.py` is marked `fast`, which is correct: it is pure logic over `tmp_path`. But the two jobs that instrument `--cov=src/mission_runtime` (`integration-tests-core-misc`, `arch-adversarial`) filter to `git_repo or integration or architectural`, which excludes it — and `fast-tests-core-misc`, the job that *does* select those tests, never carried that `--cov`. The proof is in the artifact itself: `coverage-integration-core-misc-misc.xml` declares `<source>src/mission_runtime</source>` and contains **zero `<class>` entries** under it. Fixed by adding `--cov=src/mission_runtime` to `fast-tests-core-misc`, mirroring its siblings.

**2. A genuine test gap** on the plain-`ActionContextError` arm of `_fail_closed_error`. (The `CoordinationBranchDeleted` arm was already covered by an existing test — it just wasn't being counted.) The new test asserts the caught error's own `.code` survives rather than collapsing into the generic `FEATURE_CONTEXT_UNRESOLVED` fallback, and that `__cause__` is chained.

**Verification:** regenerating the `fast-tests-core-misc` report under the new `--cov` and re-running the gate's exact invocation gives `write_target_degrade.py` **100%** and an aggregate of **94%**, clearing the floor.

## What this PR deliberately does NOT fix

A **third, distinct mechanism** was found and is filed separately: coverage's Cobertura writer keys root-level files as `(package=".", filename)` with no per-source disambiguation, so `mission_runtime/__init__.py` (18 statements) collides with `specify_cli/__init__.py` (218) in **every** job that instruments both packages in one `pytest-cov` invocation. Verified in three sampled real artifacts — the slot always shows 218 lines, never 18.

No test or marker change can fix that, and it plausibly affects other root-level basename collisions in `src/` (`resolution.py`, `context.py`, `versioning.py`, …). It needs the shared multi-package `--cov` invocation restructured, which is more than a CI one-liner. Documented rather than gamed: `__init__.py` remains at 0% in the numbers above, and the gate still clears without it.

## Notes

- No production code changes — a CI workflow line and a test.
- This is the **third** instance this week of the same class (CI measuring something it cannot see), after #2957 and the coverage-history anomaly noted in the quality review. That pattern, not this one gate, is the thing worth fixing structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TF3TAv5kQ3tMg5cKV4aa7F

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787727951&installation_model_id=427282&pr_number=2974&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2974&signature=1d6e30ca3f41f4a37827ebdefbf8f5abfc4ebd332fe019e220538fa3a72221d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->