### PR TITLE
fix(ci): stop coverage reports silently losing data to Cobertura root collisions

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -3471,19 +3471,39 @@ jobs:
       - name: "[ENFORCED] Normalize coverage XML paths for Sonar multi-package src layout"
         if: steps.sonar_token.outputs.enabled == 'true'
         run: |
-          # Problem: each CI test job runs with --cov=src/<package> which produces a
-          # coverage XML whose <sources> block lists the per-package absolute path, e.g.:
+          # Historical problem (pre-#2975): jobs ran with --cov=src/<package>,
+          # which produced coverage XML whose <sources> block listed multiple
+          # per-package absolute paths, e.g.:
           #   <source>/github/workspace/src/specify_cli</source>
           #   <source>/github/workspace/src/mission_runtime</source>
-          # …and bare filenames like filename="__init__.py".
-          # SonarCloud tries to resolve every bare filename against ALL <source> entries
+          # …with bare filenames like filename="__init__.py". SonarCloud tries
+          # to resolve every bare filename against ALL <source> entries
           # simultaneously, finds __init__.py under multiple sources, and logs:
-          #   ERROR Cannot resolve the file path '__init__.py' of the coverage report,
-          #         ambiguity, the file exists in several 'source'.
-          # Fix: rewrite each XML so there is exactly ONE <source> (the common src/
-          # ancestor) and every filename is prefixed with its package sub-path, e.g.:
-          #   src/specify_cli/__init__.py, src/mission_runtime/__init__.py
-          # SonarCloud can then match each path to exactly one file in sonar.sources=src.
+          #   ERROR Cannot resolve the file path '__init__.py' of the coverage
+          #         report, ambiguity, the file exists in several 'source'.
+          #
+          # #2975 removed the root cause instead of guessing around it here:
+          # every multi-root --cov invocation was converted to dotted module
+          # form (--cov=specify_cli --cov=mission_runtime), which keeps
+          # coverage.py's XmlReporter.source_paths empty and emits full
+          # project-relative filenames with zero or one <source> entries. The
+          # multi-source rewrite branch that used to live in this step
+          # (DIRECTIVE_043: remove the mechanism, not document around it) is
+          # deleted -- it picked the winning root by testing basename
+          # existence in `human_sorted` <source> order while coverage.py's own
+          # dict-overwrite keeps the alphabetically LAST root, so it
+          # systematically relabelled surviving data with the WRONG file's
+          # path (verified by reproduction: a 2-statement package's data was
+          # relabelled as an 8-statement one, and the small package vanished
+          # from the report entirely).
+          #
+          # What remains: (1) relativize a single absolute <source> (still
+          # needed — coverage.py still emits an absolute CWD-rooted path for
+          # single-root/path-form invocations, e.g. --cov=src/kernel), and
+          # (2) drop an empty/blank <sources> block. Dotted module form emits
+          # a bare <source/> (no text) because source_paths never gets
+          # populated; Sonar's handling of an empty <source> element is
+          # unverified, so the block is removed rather than shipped.
           python3 - << 'PYEOF'
           import os, sys, glob, xml.etree.ElementTree as ET
 
@@ -3512,62 +3532,45 @@ jobs:
                   continue
 
               raw_sources = [s.text.strip() for s in sources_el.findall('source') if s.text and s.text.strip()]
-              if len(raw_sources) <= 1:
-                  # Single source — check if it already has unambiguous paths or is an
-                  # absolute path that needs making relative.
-                  if not raw_sources:
-                      continue
-                  src = raw_sources[0]
-                  # If it's already a relative path ending in 'src' or similar, skip.
-                  if not os.path.isabs(src):
-                      continue
-                  # Single absolute source: just make it relative (strip CWD prefix).
-                  cwd = os.getcwd()
-                  rel = os.path.relpath(src, cwd)
-                  sources_el.clear()
-                  new_src = ET.SubElement(sources_el, 'source')
-                  new_src.text = rel
-                  # Filenames already include the package sub-path when there's one source,
-                  # so no filename prefixing is needed.
+
+              if not raw_sources:
+                  # Dotted module form (e.g. --cov=specify_cli) never populates
+                  # XmlReporter.source_paths, so coverage.py emits an empty
+                  # <source/> element. Drop the whole <sources> block rather
+                  # than ship an empty one Sonar has not been verified to
+                  # handle.
+                  root.remove(sources_el)
                   tree.write(xml_path, encoding='unicode', xml_declaration=True)
                   normalized += 1
-                  print(f'  Relativized single source: {xml_path}  ({src} -> {rel})')
+                  print(f'  Dropped empty <sources> block: {xml_path}')
                   continue
 
-              # Multiple sources: find common ancestor (the src/ parent directory).
-              common = os.path.commonpath(raw_sources)
+              if len(raw_sources) > 1:
+                  # #2975 converted every multi-root --cov invocation to
+                  # dotted module form, so no report should carry >=2
+                  # <source> entries any more (the architectural guard
+                  # tests/architectural/test_coverage_root_collisions.py
+                  # fails the workflow statically if one is ever
+                  # reintroduced). Leave an unexpected multi-source report
+                  # untouched rather than resurrecting the misattributing
+                  # rewrite.
+                  print(f'  SKIP (unexpected multi-source report, not normalized): {xml_path}')
+                  continue
+
+              # Single source — relativize if absolute (filenames already
+              # include the package sub-path when there's exactly one source,
+              # so no filename prefixing is needed).
+              src = raw_sources[0]
+              if not os.path.isabs(src):
+                  continue
               cwd = os.getcwd()
-              common_rel = os.path.relpath(common, cwd)  # e.g. 'src'
-
-              # Build prefix map: source_path -> relative_prefix (e.g. 'specify_cli')
-              prefix_map = {}
-              for src in raw_sources:
-                  rel_prefix = os.path.relpath(src, common)
-                  prefix_map[src] = rel_prefix
-
-              # Rewrite <source> block to single canonical entry.
+              rel = os.path.relpath(src, cwd)
               sources_el.clear()
               new_src = ET.SubElement(sources_el, 'source')
-              new_src.text = common_rel  # e.g. 'src'
-
-              # Prefix every <class filename=...> with the correct sub-path.
-              # We must determine which source each file belongs to by checking existence.
-              changed = 0
-              for cls in root.findall('packages/package/classes/class'):
-                  fname = cls.get('filename', '')
-                  if not fname or os.path.isabs(fname):
-                      continue
-                  for src_path, prefix in prefix_map.items():
-                      candidate = os.path.join(src_path, fname)
-                      if os.path.exists(candidate):
-                          new_fname = fname if prefix == '.' else os.path.join(prefix, fname)
-                          cls.set('filename', new_fname)
-                          changed += 1
-                          break
-
+              new_src.text = rel
               tree.write(xml_path, encoding='unicode', xml_declaration=True)
               normalized += 1
-              print(f'  Normalized: {xml_path}  ({len(raw_sources)} sources -> {common_rel!r}, {changed} filenames prefixed)')
+              print(f'  Relativized single source: {xml_path}  ({src} -> {rel})')
 
           print(f'Normalization complete: {normalized}/{len(xml_files)} files updated.')
           PYEOF

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1577,8 +1577,9 @@ jobs:
       # test_catch_all_ignore_lists_mirror_owned_roots_live): drift between this
       # list and the shard-owned roots fails tests/architectural/.
       #
-      # --cov=src/mission_runtime (added alongside the pre-existing
-      # integration-tests-core-misc / arch-adversarial instrumentation): the
+      # --cov=mission_runtime (added alongside the pre-existing
+      # integration-tests-core-misc / arch-adversarial instrumentation; dotted
+      # module form since #2975 -- see the coverage-root-collisions guard): the
       # "core-misc" shard's ``paths: ''`` selection includes tests/mission_runtime,
       # but several of that package's own tests carry ONLY ``pytest.mark.fast``
       # (no git_repo/integration/architectural) -- e.g.
@@ -1586,7 +1587,7 @@ jobs:
       # fail-closed-cause-chain assertions are pure-logic/tmp_path-only by
       # design. Before this line, those files ran here (selected by ``-m
       # "fast and not windows_ci"``) but their hits were never attributed to
-      # ``src/mission_runtime`` (only integration/architectural-marked
+      # ``mission_runtime`` (only integration/architectural-marked
       # mission_runtime tests were ever instrumented for it), so the
       # diff-coverage critical-path gate saw them as 0% collected rather than
       # exercised. Mirrors the sibling jobs' instrumentation instead of
@@ -1599,9 +1600,9 @@ jobs:
             -m "fast and not windows_ci" -q --tb=short \
             -n auto --dist loadfile \
             --durations=50 \
-            --cov=src/specify_cli \
-            --cov=src/glossary \
-            --cov=src/mission_runtime \
+            --cov=specify_cli \
+            --cov=glossary \
+            --cov=mission_runtime \
             --cov-report=xml:out/reports/coverage/coverage-fast-core-misc-${{ matrix.shard }}.xml
       - name: "Upload fast-core-misc coverage"
         if: always()
@@ -1801,8 +1802,8 @@ jobs:
             -q --tb=short \
             -n auto --dist loadfile \
             --durations=50 \
-            --cov=src/specify_cli \
-            --cov=src/mission_runtime \
+            --cov=specify_cli \
+            --cov=mission_runtime \
             --cov-report=xml:out/reports/coverage/coverage-integration-core-misc-${{ matrix.shard }}.xml
       - name: "Upload integration-core-misc coverage"
         if: always()
@@ -1933,8 +1934,8 @@ jobs:
               -q --tb=short \
               -n auto --dist loadfile \
               --durations=50 \
-              --cov=src/specify_cli \
-              --cov=src/mission_runtime \
+              --cov=specify_cli \
+              --cov=mission_runtime \
               --cov-report=xml:out/reports/coverage/coverage-arch-adversarial-${{ matrix.shard }}.xml
             ec=$?
             set -e
@@ -1950,8 +1951,8 @@ jobs:
               -q --tb=short \
               -n auto --dist loadfile \
               --durations=50 \
-              --cov=src/specify_cli \
-              --cov=src/mission_runtime \
+              --cov=specify_cli \
+              --cov=mission_runtime \
               --cov-report=xml:out/reports/coverage/coverage-arch-adversarial-${{ matrix.shard }}.xml
           fi
       - name: "Upload arch-adversarial coverage"
@@ -2050,8 +2051,8 @@ jobs:
             -m "fast and not windows_ci" -q --tb=short \
             -n auto --dist loadfile \
             --durations=50 \
-            --cov=src/charter \
-            --cov=src/specify_cli/charter_runtime \
+            --cov=charter \
+            --cov=specify_cli.charter_runtime \
             --cov-fail-under=55 \
             --cov-report=xml:out/reports/coverage/coverage-fast-charter.xml
       - name: "Upload fast-charter coverage"
@@ -2208,8 +2209,8 @@ jobs:
             -m 'not windows_ci and (git_repo or integration)' \
             -q --tb=short \
             -n auto --dist loadfile -p no:cacheprovider \
-            --cov=src/charter \
-            --cov=src/specify_cli/charter_runtime \
+            --cov=charter \
+            --cov=specify_cli.charter_runtime \
             --cov-report=xml:out/reports/coverage/coverage-integration-charter.xml
       - name: "Upload integration-charter coverage"
         if: always()
@@ -2459,16 +2460,17 @@ jobs:
           # specify-cli-rest shard (its sole owner) to remove the same-tier
           # double-run AND cover the arch-marked coordination boundary tests this
           # job's git_repo/integration marker drops (mission ci-topology-shrink
-          # NFR-003 / SC-004). --cov=src/specify_cli/coordination is retained so
-          # a sync/status change still reports coordination coverage from the
+          # NFR-003 / SC-004). --cov=specify_cli.coordination (dotted module
+          # form since #2975) is retained so a sync/status change still
+          # reports coordination coverage from the
           # union with specify-cli-rest.
           uv run python -m pytest \
             -v \
             tests/status/ tests/specify_cli/status/ \
             -m "not windows_ci and (git_repo or integration)" \
             -n auto --dist loadfile -p no:cacheprovider \
-            --cov=src/specify_cli/status \
-            --cov=src/specify_cli/coordination \
+            --cov=specify_cli.status \
+            --cov=specify_cli.coordination \
             --cov-report=xml:out/reports/coverage/coverage-integration-status.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-integration-status-${{ github.run_id }}.xml
 
@@ -2827,7 +2829,7 @@ jobs:
             --ignore=tests/sync/test_issue_1071_singleton_reconfirmation.py \
             -n auto --dist loadfile \
             --durations=50 \
-            --cov=src/specify_cli --cov=src/charter --cov=src/doctrine \
+            --cov=specify_cli --cov=charter --cov=doctrine \
             --cov-report=xml:out/reports/coverage/coverage-slow.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-slow-${{ github.run_id }}.xml \
             || test $? -eq 5
@@ -3012,7 +3014,7 @@ jobs:
             tests/e2e/ tests/cross_cutting/ \
             -m "not distribution and not windows_ci" \
             --durations=50 \
-            --cov=src/specify_cli --cov=src/charter --cov=src/doctrine \
+            --cov=specify_cli --cov=charter --cov=doctrine \
             --cov-report=xml:out/reports/coverage/coverage-e2e.xml \
             --junitxml=out/reports/xunit-reports/xunit-result-e2e-${{ github.run_id }}.xml
 

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -1134,9 +1134,9 @@ jobs:
       - name: "Run fast tests — missions"
         run: |
           uv run python -m pytest tests/missions/ tests/specify_cli/missions/ -m "fast and not windows_ci" -q --tb=short \
-            --cov=src/specify_cli/mission \
-            --cov=src/specify_cli/mission_metadata \
-            --cov=src/doctrine/missions \
+            --cov=specify_cli.mission \
+            --cov=specify_cli.mission_metadata \
+            --cov=doctrine.missions \
             --cov-report=xml:out/reports/coverage/coverage-fast-missions.xml
       - name: "Upload fast-missions coverage"
         if: always()
@@ -2354,9 +2354,9 @@ jobs:
             -m 'not windows_ci and (git_repo or integration)' \
             -q --tb=short \
             -n auto --dist loadfile -p no:cacheprovider \
-            --cov=src/specify_cli/mission \
-            --cov=src/specify_cli/mission_metadata \
-            --cov=src/doctrine/missions \
+            --cov=specify_cli.mission \
+            --cov=specify_cli.mission_metadata \
+            --cov=doctrine.missions \
             --cov-report=xml:out/reports/coverage/coverage-integration-missions.xml
       - name: "Upload integration-missions coverage"
         if: always()

--- a/tests/architectural/_gate_coverage.py
+++ b/tests/architectural/_gate_coverage.py
@@ -358,6 +358,31 @@ _NEEDS_RESULT_RE = re.compile(r"needs\.([A-Za-z0-9_-]+)\.result")
 _FILTER_OUTPUT_RE = re.compile(r"needs\.[A-Za-z0-9_-]+\.outputs\.([A-Za-z0-9_]+)")
 # ``--cov=<target>`` emitters inside run scripts (FR-005).
 _COV_TARGET_RE = re.compile(r"--cov=([^\s\\'\"]+)")
+# Jobs that *consume* coverage XML rather than emit real pytest --cov data.
+# ``sonarcloud`` in particular carries prose ``--cov=...`` examples inside its
+# own step comments and heredoc documentation (see the "Normalize coverage
+# XML..." step) -- ``_COV_TARGET_RE`` has no way to distinguish a documentation
+# mention from a real flag, so the job is excluded wholesale rather than
+# taught to parse comments. Any consumer of ``cov_targets`` that means "jobs
+# that actually run pytest --cov" (not "jobs whose script mentions --cov")
+# must exclude this set.
+NON_EMITTER_JOBS: frozenset[str] = frozenset(
+    {"sonarcloud", "diff-coverage", "mutation-testing"}
+)
+# Top-level packages declared in [build-system].packages (pyproject.toml) --
+# the only names a bare/dotted (no "/") --cov target can legitimately resolve
+# to under src/ (#2975's cov_target_repo_path normalizer).
+_TOP_LEVEL_SRC_PACKAGES: frozenset[str] = frozenset(
+    {
+        "kernel",
+        "glossary",
+        "mission_runtime",
+        "runtime",
+        "specify_cli",
+        "doctrine",
+        "charter",
+    }
+)
 # The diff-coverage job's ``critical_paths=( ... )`` shell array (FR-005).
 _CRITICAL_PATHS_RE = re.compile(r"critical_paths=\((.*?)\)", re.DOTALL)
 _SHELL_QUOTED_RE = re.compile(r"'([^']*)'|\"([^\"]*)\"")
@@ -569,6 +594,39 @@ def load_workflow_model(path: Path) -> WorkflowModel:
         pull_request_paths=_trigger_tuple(on_section, "pull_request", "paths"),
         push_paths=_trigger_tuple(on_section, "push", "paths"),
     )
+
+
+def cov_target_repo_path(target: str) -> str:
+    """Normalize a ``--cov`` target to its ``src/``-relative repo path.
+
+    ``--cov`` targets come in two shapes (#2975): a ``src/``-relative path
+    (single-root invocations, e.g. ``src/kernel``) or a dotted importable
+    module (multi-root invocations, converted to dotted form so
+    coverage.py's ``XmlReporter.source_paths`` stays empty and same-basename
+    files across roots cannot collide, e.g. ``specify_cli.charter_runtime``).
+    Both name the same on-disk location; every consumer of ``cov_targets``
+    that compares against a filesystem path (FR-005's critical-path backing,
+    the src-coverage-emitter set) must go through this normalizer instead of
+    assuming one shape, or a dotted target silently stops matching.
+    """
+    if "/" in target:
+        return target.rstrip("/")
+    return "/".join(("src", *target.split(".")))
+
+
+def is_src_cov_target(target: str) -> bool:
+    """Whether a ``--cov`` target measures a ``src/`` package (dotted or path).
+
+    True for both shapes as long as the top-level segment is one of the
+    packages declared in ``[build-system].packages`` (pyproject.toml) -- the
+    only names coverage.py can resolve a bare/dotted target against. False
+    for non-src targets like ``scripts/docs``.
+    """
+    path = cov_target_repo_path(target)
+    if not path.startswith("src/"):
+        return False
+    top_level = path.split("/", 2)[1]
+    return top_level in _TOP_LEVEL_SRC_PACKAGES
 
 
 def discover_pytest_workflows(workflows_dir: Path | None = None) -> frozenset[str]:

--- a/tests/architectural/test_coverage_consumer_needs.py
+++ b/tests/architectural/test_coverage_consumer_needs.py
@@ -38,11 +38,11 @@ from tests.architectural import _gate_coverage as gc
 pytestmark = [pytest.mark.architectural]
 
 _CI_QUALITY = "ci-quality.yml"
-_SRC_PREFIX = "src/"
 # Jobs that *consume* coverage rather than emit it; excluded from the emitter set
-# (a consumer need not list itself). ``sonarcloud`` also carries a documentation
-# ``--cov=src/<package>`` placeholder in its script that is not a real emitter.
-_CONSUMER_JOBS = frozenset({"sonarcloud", "diff-coverage", "mutation-testing"})
+# (a consumer need not list itself). Canonical set lives on ``_gate_coverage``
+# (``NON_EMITTER_JOBS``) since #2975's coverage-root-collisions guard needs the
+# same exclusion for the same reason (sonarcloud's documentation placeholder).
+_CONSUMER_JOBS = gc.NON_EMITTER_JOBS
 # Graph-ordering / non-test needs that legitimately emit no coverage XML.
 _ORDERING_NEEDS = frozenset({"changes", "lint"})
 
@@ -54,12 +54,18 @@ def ci_model() -> gc.WorkflowModel:
 
 
 def _src_cov_emitters(model: gc.WorkflowModel) -> set[str]:
-    """Jobs emitting a ``--cov`` target under ``src/`` (excluding consumer jobs)."""
+    """Jobs emitting a ``--cov`` target under ``src/`` (excluding consumer jobs).
+
+    ``--cov`` targets come in two shapes since #2975 (a ``src/``-relative path
+    or a dotted module, e.g. ``specify_cli.charter_runtime``) -- both route
+    through ``gc.is_src_cov_target`` so a job that only emits dotted-form
+    targets is not silently dropped from the emitter set.
+    """
     emitters: set[str] = set()
     for job, targets in model.cov_targets.items():
         if job in _CONSUMER_JOBS:
             continue
-        if any(target.startswith(_SRC_PREFIX) for target in targets):
+        if any(gc.is_src_cov_target(target) for target in targets):
             emitters.add(job)
     return emitters
 

--- a/tests/architectural/test_coverage_root_collisions.py
+++ b/tests/architectural/test_coverage_root_collisions.py
@@ -1,0 +1,305 @@
+"""Coverage-root reality + collision guard (#2975).
+
+Two independent defect classes were found in ``ci-quality.yml``'s ``--cov``
+invocations, both traced to the same upstream mechanism
+(``coverage.py``'s ``XmlReporter.source_paths``, populated only from
+``--cov`` targets that are *existing directories* -- ``xmlreport.py`` L67-74):
+
+* **Collision.** Once >=2 such directories are co-instrumented in one pytest
+  invocation, coverage.py's dict-overwrite (``report_core.py:96``, iterating
+  ``sorted(fr_morfs)``) keeps only the alphabetically-last root's data for
+  every relative path both roots contain (e.g. ``__init__.py``) and silently
+  drops the rest. Measured on a real invocation of this repo's
+  ``specify_cli + charter + doctrine`` job: header ``lines-valid=108519`` vs
+  summed ``<class>`` statements ``108349`` -- 170 statements / 6 files
+  silently absent, with no error anywhere in the pipeline.
+* **Dead root.** A ``--cov`` target that names a directory that does not
+  exist (e.g. ``src/specify_cli/mission`` when the real surface is
+  ``src/specify_cli/mission.py``) never reaches ``source_paths`` either, so
+  it produces ZERO collisions -- but also measures NOTHING. A collision-only
+  guard would have passed those jobs while they silently measured zero
+  coverage for their primary target.
+
+The fix (this PR) converts every multi-root invocation's ``--cov`` targets to
+dotted importable-module form (``--cov=specify_cli`` instead of
+``--cov=src/specify_cli``), which keeps ``source_paths`` empty and makes the
+collision structurally impossible. This module guards BOTH defect classes
+against regression, over the SAME canonical parser the rest of the CI
+architectural suite uses (DIRECTIVE_044): ``_gate_coverage.load_workflow_models``
+/ ``WorkflowModel.cov_targets`` -- no second workflow parser is written here.
+
+Both invariants are asserted as SET equality (never ``len(x) == N`` --
+``test_golden_count_ban.py``), and both carry a red-negative fault-injection
+proof (``_workflow_fixtures.write_workflow``) showing the guard can actually
+fail, not just pass vacuously.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.architectural import _gate_coverage as gc
+from tests.architectural._workflow_fixtures import write_workflow
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+pytestmark = [pytest.mark.architectural]
+
+
+# ---------------------------------------------------------------------------
+# Pure relation primitives (fault-injection substrate).
+# ---------------------------------------------------------------------------
+
+
+def _flat_cov_targets_by_job(
+    models: Mapping[str, gc.WorkflowModel],
+) -> dict[str, frozenset[str]]:
+    """``"<workflow>:<job>" -> cov targets`` across every parsed workflow.
+
+    Jobs with no ``--cov`` targets (lint/build/consumer jobs) are dropped --
+    they carry nothing for either invariant to check. ``gc.NON_EMITTER_JOBS``
+    (``sonarcloud`` et al.) is also dropped: those jobs' scripts carry prose
+    ``--cov=...`` *examples* in comments/heredoc documentation, which
+    ``_COV_TARGET_RE`` cannot distinguish from a real flag -- the same reason
+    ``test_coverage_consumer_needs.py`` excludes them from its emitter set.
+    """
+    flat: dict[str, frozenset[str]] = {}
+    for wf_name, model in models.items():
+        for job, targets in model.cov_targets.items():
+            if targets and job not in gc.NON_EMITTER_JOBS:
+                flat[f"{wf_name}:{job}"] = targets
+    return flat
+
+
+def _target_resolves(target: str, repo_root: Path) -> bool:
+    """Whether a single ``--cov`` target names something coverage.py can measure.
+
+    Path-form (contains ``/``): must be an existing directory relative to
+    ``repo_root`` -- the same existence check ``XmlReporter.source_paths``
+    performs.
+
+    Dotted/bare module form (no ``/``): must resolve under ``src/`` to either
+    a subpackage directory (``specify_cli.charter_runtime`` ->
+    ``src/specify_cli/charter_runtime/``) or a bare ``.py`` module
+    (``specify_cli.mission`` -> ``src/specify_cli/mission.py``). Both shapes
+    are empirically proven measurable (#2975 research); the ``.py``-module
+    case specifically was NOT proven before this PR (only the subpackage case
+    was) and was verified directly before this guard was written.
+    """
+    if "/" in target:
+        return (repo_root / target).is_dir()
+    rel = target.replace(".", "/")
+    return (repo_root / "src" / rel).is_dir() or (repo_root / "src" / f"{rel}.py").is_file()
+
+
+def unresolvable_cov_targets(
+    cov_targets_by_job: Mapping[str, frozenset[str]], repo_root: Path
+) -> frozenset[str]:
+    """Every ``--cov`` target, across all jobs, that resolves to nothing real.
+
+    Deliberately broader than a collision check: a dead root (e.g.
+    ``--cov=src/specify_cli/mission`` before this PR) produces ZERO
+    collisions -- coverage.py drops it before ``source_paths`` is even built
+    -- while measuring NOTHING for its job. A collision-only guard would have
+    reported those jobs clean.
+    """
+    return frozenset(
+        target
+        for targets in cov_targets_by_job.values()
+        for target in targets
+        if not _target_resolves(target, repo_root)
+    )
+
+
+def _path_form_existing_roots(targets: frozenset[str], repo_root: Path) -> list[str]:
+    """A job's ``--cov`` targets that are path-form AND resolve to a real dir.
+
+    This is exactly the set coverage.py's ``XmlReporter.source_paths`` would
+    populate for the invocation -- the collision precondition.
+    """
+    return sorted(t for t in targets if "/" in t and (repo_root / t).is_dir())
+
+
+def real_tree_collisions(
+    cov_targets_by_job: Mapping[str, frozenset[str]], repo_root: Path
+) -> dict[tuple[str, str], tuple[str, str]]:
+    """Emulate coverage.py's cross-root basename collision over the real tree.
+
+    For every job with >=2 path-form existing-directory roots, walk each
+    root's ``*.py`` files and record the FIRST root claiming each relative
+    path; a second root claiming the same relative path is a collision --
+    exactly the condition under which coverage.py's dict-overwrite
+    (``report_core.py:96``) silently keeps one root's data and drops the
+    other's.
+
+    Returns ``(job, relpath) -> (root_a, root_b)`` (both sides named, per the
+    task) for every colliding relative path found.
+    """
+    collisions: dict[tuple[str, str], tuple[str, str]] = {}
+    for job, targets in cov_targets_by_job.items():
+        roots = _path_form_existing_roots(targets, repo_root)
+        if len(roots) < 2:
+            continue
+        seen: dict[str, str] = {}
+        for root in roots:
+            root_path = repo_root / root
+            for f in root_path.rglob("*.py"):
+                rel = str(f.relative_to(root_path))
+                owner = seen.get(rel)
+                if owner is not None and owner != root:
+                    collisions[(job, rel)] = (owner, root)
+                else:
+                    seen.setdefault(rel, root)
+    return collisions
+
+
+# ---------------------------------------------------------------------------
+# Live invariants over the real workflow files.
+# ---------------------------------------------------------------------------
+
+
+def test_every_cov_target_resolves_to_something_real() -> None:
+    """Every ``--cov`` root, across all 5 modeled workflows, measures something.
+
+    Catches the dead-root defect class (#2975 commit 2:
+    ``--cov=src/specify_cli/mission`` / ``mission_metadata`` pointed at
+    directories that never existed) that a collision-only check would miss
+    entirely -- a dead root never reaches ``source_paths``, so it never
+    collides, it just silently measures zero.
+    """
+    cov_targets_by_job = _flat_cov_targets_by_job(gc.load_workflow_models())
+    unresolvable = unresolvable_cov_targets(cov_targets_by_job, gc.REPO_ROOT)
+    assert unresolvable == set(), (
+        "--cov targets that resolve to no real directory or importable "
+        f"module: {sorted(unresolvable)}"
+    )
+
+
+def test_no_multi_root_invocation_collides_on_the_real_tree() -> None:
+    """No job's path-form ``--cov`` roots share a same-relative-path file.
+
+    Emulates coverage.py's prefix-strip collision directly against the
+    filesystem: for every job with >=2 existing path-form roots, walk both
+    trees and check whether any relative path (e.g. ``__init__.py``) exists
+    under more than one root. A real hit is silent data loss -- only one
+    root's version of that file ever reaches Sonar / diff-cover. #2975
+    commit 1 converted every such invocation to dotted module form, which
+    keeps ``source_paths`` empty and makes this structurally impossible; this
+    is the regression guard against a future job reintroducing >=2 path-form
+    roots.
+    """
+    cov_targets_by_job = _flat_cov_targets_by_job(gc.load_workflow_models())
+    collisions = real_tree_collisions(cov_targets_by_job, gc.REPO_ROOT)
+    assert collisions == {}, (
+        "path-form --cov roots collide on a real relative path -- "
+        f"(job, relpath) -> (root_a, root_b): {collisions}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Red-negatives: prove both guards can actually fail (fault injection).
+# ---------------------------------------------------------------------------
+
+
+def test_reality_guard_reds_on_a_synthetic_dead_root(tmp_path: Path) -> None:
+    """A --cov target with no real directory/module must be caught.
+
+    Mirrors the exact pre-fix defect (``--cov=src/specify_cli/mission``): a
+    guard that only checked for collisions would pass this workflow, because
+    a dead root never collides. Proves the reality invariant, not just the
+    collision invariant, is load-bearing.
+    """
+    path = write_workflow(
+        tmp_path,
+        """\
+        name: fixture
+        on: push
+        jobs:
+          fixture-job:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  uv run pytest tests/ \\
+                    --cov=src/this_package_does_not_exist \\
+                    --cov-report=xml
+        """,
+    )
+    model = gc.load_workflow_model(path)
+    unresolvable = unresolvable_cov_targets(
+        {"fixture.yml:fixture-job": model.cov_targets["fixture-job"]},
+        gc.REPO_ROOT,
+    )
+    assert unresolvable == {"src/this_package_does_not_exist"}, (
+        "the reality guard failed to flag an injected dead --cov root -- "
+        "a guard that cannot fail is worthless"
+    )
+
+
+def test_collision_guard_reds_on_a_synthetic_colliding_invocation(
+    tmp_path: Path,
+) -> None:
+    """A two-existing-root invocation that shares a relative path must be caught.
+
+    Uses two REAL existing directories (``src/charter``, ``src/doctrine``)
+    that both contain ``__init__.py``, so the emulated prefix-strip walk hits
+    a genuine same-relative-path collision on the real tree -- the exact
+    defect class commit 1 removed from the live workflow (that job now uses
+    ``--cov=charter --cov=doctrine``, the dotted form asserted safe below).
+    """
+    path = write_workflow(
+        tmp_path,
+        """\
+        name: fixture
+        on: push
+        jobs:
+          fixture-job:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  uv run pytest tests/ \\
+                    --cov=src/charter --cov=src/doctrine \\
+                    --cov-report=xml
+        """,
+    )
+    model = gc.load_workflow_model(path)
+    collisions = real_tree_collisions(
+        {"fixture.yml:fixture-job": model.cov_targets["fixture-job"]},
+        gc.REPO_ROOT,
+    )
+    assert ("fixture.yml:fixture-job", "__init__.py") in collisions, (
+        "the collision guard failed to flag an injected src/charter + "
+        "src/doctrine collision -- a guard that cannot fail is worthless"
+    )
+
+
+def test_collision_guard_is_clean_on_the_dotted_remediation(tmp_path: Path) -> None:
+    """Benign twin: the same job converted to dotted form has zero collisions.
+
+    Proves the collision check is not a false-positive trap that would red
+    the exact remediation #2975 applied to the live workflow.
+    """
+    path = write_workflow(
+        tmp_path,
+        """\
+        name: fixture
+        on: push
+        jobs:
+          fixture-job:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  uv run pytest tests/ \\
+                    --cov=charter --cov=doctrine \\
+                    --cov-report=xml
+        """,
+    )
+    model = gc.load_workflow_model(path)
+    collisions = real_tree_collisions(
+        {"fixture.yml:fixture-job": model.cov_targets["fixture-job"]},
+        gc.REPO_ROOT,
+    )
+    assert collisions == {}

--- a/tests/architectural/test_gate_coverage_parse_model.py
+++ b/tests/architectural/test_gate_coverage_parse_model.py
@@ -213,6 +213,50 @@ def test_workflow_model_parses_cov_targets_and_critical_paths(tmp_path: Path) ->
 
 
 # ---------------------------------------------------------------------------
+# cov_target_repo_path / is_src_cov_target (#2975: dotted vs path-form --cov)
+# ---------------------------------------------------------------------------
+
+
+def test_cov_target_repo_path_passes_through_path_form() -> None:
+    """A ``src/``-relative path target is returned unchanged (trailing slash stripped)."""
+    assert gc.cov_target_repo_path("src/specify_cli/lanes") == "src/specify_cli/lanes"
+    assert gc.cov_target_repo_path("src/kernel/") == "src/kernel"
+    assert gc.cov_target_repo_path("scripts/docs") == "scripts/docs"
+
+
+def test_cov_target_repo_path_expands_dotted_form() -> None:
+    """A dotted module target expands to its ``src/``-relative path form.
+
+    Both a bare top-level name (single segment) and a dotted subpackage/module
+    (multiple segments) must expand — #2975 converted single-root AND
+    multi-root invocations alike (``--cov=charter``,
+    ``--cov=specify_cli.charter_runtime``, ``--cov=specify_cli.mission``).
+    """
+    assert gc.cov_target_repo_path("charter") == "src/charter"
+    assert (
+        gc.cov_target_repo_path("specify_cli.charter_runtime")
+        == "src/specify_cli/charter_runtime"
+    )
+    assert gc.cov_target_repo_path("specify_cli.mission") == "src/specify_cli/mission"
+
+
+def test_is_src_cov_target_recognizes_both_shapes() -> None:
+    """A src-package target is recognized whether path-form or dotted."""
+    assert gc.is_src_cov_target("src/specify_cli")
+    assert gc.is_src_cov_target("specify_cli")
+    assert gc.is_src_cov_target("specify_cli.charter_runtime")
+    assert gc.is_src_cov_target("mission_runtime")
+
+
+def test_is_src_cov_target_rejects_non_src_targets() -> None:
+    """``scripts/docs`` (not importable, not under src/) is never a src target."""
+    assert not gc.is_src_cov_target("scripts/docs")
+    # A dotted top-level name that isn't a declared src package (typo/rogue
+    # addition) must not be silently accepted as src-backed either.
+    assert not gc.is_src_cov_target("not_a_real_package")
+
+
+# ---------------------------------------------------------------------------
 # WorkflowModel: on: triggers — pull_request types + outer paths (FR-012 / FR-013)
 # ---------------------------------------------------------------------------
 

--- a/tests/architectural/test_workflow_coherence.py
+++ b/tests/architectural/test_workflow_coherence.py
@@ -87,11 +87,18 @@ def glob_is_live(glob: str, tracked: set[str]) -> bool:
 
 
 def critical_path_backed_by(entry: str, cov_targets: set[str]) -> str | None:
-    """FR-005: a ``--cov`` target that is an ancestor-or-equal of ``entry``, if any."""
+    """FR-005: a ``--cov`` target that is an ancestor-or-equal of ``entry``, if any.
+
+    ``cov_targets`` may hold either shape a ``--cov`` flag takes since #2975
+    (a ``src/``-relative path or a dotted module, e.g.
+    ``specify_cli.charter_runtime``); both are normalized to the same
+    ``src/``-relative form via ``gc.cov_target_repo_path`` before comparing,
+    so a dotted emitter still backs its critical-path entry.
+    """
     package = entry[:-2] if entry.endswith("/*") else entry
     package = package.rstrip("/")
     for cov in cov_targets:
-        target = cov.rstrip("/")
+        target = gc.cov_target_repo_path(cov)
         if package == target or package.startswith(target + "/"):
             return cov
     return None


### PR DESCRIPTION
Closes #2975

## Why

Coverage reports have been silently losing data. When one `pytest-cov` invocation instruments two source roots, `coverage.py`'s Cobertura writer keys root-level files by `(package=".", filename)` with no disambiguation (`xmlreport.py:254` — a bare dict assignment, no collision detection), so same-named files across roots overwrite each other.

This is upstream **[coveragepy#1508](https://github.com/coveragepy/coveragepy/issues/1508)**, open since 2022 with zero maintainer replies and unchanged on `master`. It will not be fixed upstream; we work around it.

**Measured on this repo before the fix**, running the real `slow-tests` invocation (`--cov=src/specify_cli --cov=src/charter --cov=src/doctrine`):

```
<sources> = ['src/charter', 'src/doctrine', 'src/specify_cli']
header lines-valid = 108519      summed <class> statements = 108349
                                 → 170 statements lost, 6 files absent
```

It is silent because the XML is internally inconsistent: package aggregates count *both* sides of a collision while only one `<class>` survives, so a consumer reading the header and one summing the classes disagree, and neither errors.

**Three consumers, three different failure modes:**
- **Sonar** — `CoberturaParser.resolve()` finds the bare filename under several `<source>` roots, logs *"ambiguity, the file exists in several 'source'"*, and **drops the file entirely**. So coverage.py loses one file and Sonar discards the survivor.
- **The normalize step** — assigns each `<class>` the *first* source root under which the basename exists, while the dict-overwrite winner is the alphabetically *last* path. Opposite orderings, so it **relabels surviving data with the wrong file's path**, turning a visible Sonar error into silent wrong data.
- **`diff-cover`** — indexes the survivor under *every* source prefix with no existence check, returning one file's line data under another's path. This is the complete, deterministic mechanism behind PR #2963's diff-coverage gate failure.

## The fix

**`--cov=<dotted.module>` instead of `--cov=src/<path>`** on the multi-root invocations.

The causal rule was isolated empirically: the collision occurs **iff** `XmlReporter.source_paths` is non-empty, and that set is populated only from `config.source` entries that are *existing directories*. A module-form value is not a directory at repo root, so `source_paths` stays empty, `rel_name` becomes the full project-relative path, and the collision is structurally impossible.

Why this over the alternatives — all four were sandbox-tested, and all four fix the collision:

| Option | Keeps per-job scope? | Note |
|---|---|---|
| **`--cov=<module>`** ✅ | **Yes — identical measured set** | ~10 workflow lines, no config change |
| `source_pkgs` + bare `--cov` | No — every job measures all of `src` | shifts every denominator |
| `include=` globs + bare `--cov` | No | same |
| one root per job, separate reports | Yes | ~6 new jobs / 10 extra pytest passes |

**A config-only fix is impossible**, which settled this: `source_pkgs` in `pyproject.toml` is *fully overridden* by an explicit `--cov=<path>`, reproducing the broken output byte-identically. The flags themselves had to change.

Verified against the three risks that could have sunk the module form: dotted subpackages work; never-imported files still appear at 0%, so **the denominator does not shrink**; and a package unimported by the selected tests still enumerates fully.

Migration is **all-or-nothing per invocation** — a mixed invocation still emits two `<source>` entries and preserves the Sonar-ambiguity precondition. Single-root invocations are deliberately left as paths (smallest blast radius; the new guard covers future additions), and `--cov=scripts/docs` stays a path because it is not importable.

## Also in this PR

**Two dead `--cov` roots.** `--cov=src/specify_cli/mission` and `--cov=src/specify_cli/mission_metadata` point at paths that do not exist — the real surfaces are `mission.py` and `mission_metadata.py`. Coverage emits `CoverageWarning: Module ... was never imported` and exits 0, so `fast-tests-missions` and `integration-tests-missions` have been measuring **zero** for their two primary targets. That is also *why* those jobs showed no collisions: the roots were dropped before `source_paths` was built, so a clean result there was a symptom rather than health.

**The normalizer's multi-source branch is deleted**, not documented around (DIRECTIVE_043). Once no report carries ≥2 sources it is dead code, and while it lives it is an active misattribution hazard. The step also now drops an empty/blank `<sources>` block, since module form emits `<source/>`.

**A regression guard** (`tests/architectural/test_coverage_root_collisions.py`) reusing the canonical `_gate_coverage.load_workflow_models()` parser rather than writing a second one (DIRECTIVE_044). Two invariants, both as set equalities:
1. every `--cov` target resolves to a real directory or an importable module (`unresolvable == set()`);
2. no invocation's root-set produces a prefix-strip collision (`collisions == {}`).

Invariant 1 is the one that matters most — a collision-only check would have passed the two dead-root jobs while they measured nothing. Ships with a red-negative proving the guard can actually fail.

**Would it have caught this?** Yes, and the sharpest case is our own recent work: PR #2974 added `--cov=src/mission_runtime` to `fast-tests-core-misc`, escalating that job's `__init__.py` collision from 2-way to 3-way and newly introducing the `resolution.py` one. The guard would have gone red in that PR at the moment the root was added. It runs statically against the workflow plus the filesystem — no CI run, no coverage artifact needed.

## Scope — deliberately excluded

- **No Sonar threshold or quality-gate retuning.** This fix changes measured coverage *in both directions* (restoring discarded files, correcting misattributed numbers). Land it, observe one scheduled Sonar run, then adjust separately — retuning here would make the delta unattributable.
- **#2957** (test-*selection* blindness) — same family, different mechanism.
- **The 17.3pp historical coverage drop** — explicitly tested against this mechanism and **falsified**: the collision bounds at 0.23pp (1.3%), and the timeline excludes it. Separate defect, separate investigation.
- **No `src/` restructuring.**

## Evidence

**The fix, measured on the real 3-root `slow-tests` invocation:**

```
BEFORE  --cov=src/specify_cli --cov=src/charter --cov=src/doctrine
        lines-valid=108519   summed=108349   gap=170   files=1077
AFTER   --cov=specify_cli    --cov=charter    --cov=doctrine
        lines-valid=108519   summed=108519   gap=0     files=1083
```

Header and classes now agree, and the 6 previously-absent files are back.

**The guard genuinely reds** — run against fault-injected fixtures, not merely asserted:

```
FAULT (src/charter + src/doctrine, path-form):
  GUARD RAISED: path-form --cov roots collide on a real relative path:
  {('fixture.yml:fixture-job', '__init__.py'): ('src/charter', 'src/doctrine'), ...}
FAULT (dead root src/this_package_does_not_exist):
  GUARD RAISED: unresolvable --cov targets: ['src/this_package_does_not_exist']
REAL ci-quality.yml (post-fix):
  collisions: {}   unresolvable: []
```

**Dotted `.py` modules work** (this was unproven going in, so it was tested rather than assumed): `--cov=specify_cli.mission --cov=specify_cli.mission_metadata --cov=doctrine.missions` yields `mission.py: 317 statements`, `mission_metadata.py: 270 statements`, header `lines-valid=1280` == summed `1280`.

**Local runs:** the new guard plus the four modified architectural tests plus `tests/release/test_coverage_topology_ownership.py` — 49/49 passed; independently re-run at 42/42 on the final tip. `ruff check` clean on all five Python files; `ci-quality.yml` parses as valid YAML.

### Why four existing test files changed — both are re-pins the fix *requires*, not relaxations

This is the part worth a reviewer's attention, since a guard PR that quietly loosens neighbouring guards would be worse than no guard. Both were proven empirically by reverting them against the fixed workflow:

- **`test_workflow_coherence.py`** — with the old un-normalized `critical_path_backed_by`, `test_diff_cover_critical_paths_are_cov_backed_live` goes genuinely **RED** (`UNBACKED: ['src/charter/*', 'src/mission_runtime/*']`). Dot-ification broke backing detection; the fix restores it without touching the assertion.
- **`test_coverage_consumer_needs.py`** — the dangerous one. With the old bare `target.startswith("src/")` predicate, the emitter count drops **29 vs 39** and the test **stays green while silently checking 10 fewer jobs**. That is precisely the "quietly relaxed guard" failure mode — except here it is the *absence* of the change that causes it. The fix restores the original scope.
- **`_gate_coverage.py`** (the canonical parser) — extended, not weakened: a verbatim hoist of the pre-existing non-emitter set plus two normalization helpers. They live here because two *pre-existing* consumers need the same normalization; duplicating it in three places would violate DIRECTIVE_044.
- **`test_gate_coverage_parse_model.py`** — pure addition: unit tests for the two new helpers, no existing assertion touched.

## Reviewer note — one thing CI must confirm

Module-form `--cov` resolves through the installed package. This assumes CI's `uv sync --frozen --all-extras` installs the root project **editably**, so filenames resolve to `<repo>/src/...` rather than site-packages. Very likely (uv installs the root project editable by default), but a non-editable install would put filenames outside the repo and break Sonar's path matching. **The first CI run on this PR settles it** — check that coverage XML filenames start with `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TF3TAv5kQ3tMg5cKV4aa7F

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787739560&installation_model_id=427282&pr_number=2982&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2982&signature=21f6c889126d8623cb2bafada761e413bba09bd7ef2175b5adf0bb0d3549d697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->