### PR TITLE
fix(migration): preserve kind:annotation rows in mission-state repair

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -47,7 +47,11 @@ from specify_cli.migration.canonicalization import (
 )
 from specify_cli.status import ULID_PATTERN, Lane, StatusEvent
 from specify_cli.status import materialize_snapshot, materialize_to_json
-from specify_cli.status import LIFECYCLE_EVENT_TYPES, is_retrospective_lifecycle_event
+from specify_cli.status import (
+    ANNOTATION_KIND,
+    LIFECYCLE_EVENT_TYPES,
+    is_retrospective_lifecycle_event,
+)
 
 MIGRATION_SCHEMA_VERSION = "1.0.0"
 CANONICAL_ENVELOPE_SCHEMA_VERSION = "3.0.0"
@@ -1395,8 +1399,8 @@ def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
 
     ``status.events.jsonl`` is a *shared* append log. Lane-transition rows are
     flat (``wp_id`` / ``from_lane`` / ``to_lane``); other subsystems co-locate
-    ``event_type`` / ``type`` rows. Two of those classes have **no other
-    per-mission home**, so quarantining them is real data loss (issue #2376):
+    ``event_type`` / ``type`` / ``kind`` rows. Three of those classes have **no
+    other per-mission home**, so quarantining them is real data loss (#2376):
 
     - **Retrospective lifecycle rows** (``type`` envelope) — contracted
       provenance read back by retrospective consumers.
@@ -1405,6 +1409,11 @@ def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
       ``WPCreated``, …). :mod:`specify_cli.status.lifecycle_events` is their
       sole durable per-mission writer and declares this stream "a safe target
       for repair / replay tooling".
+    - **``InnerStateChanged`` annotations** (``kind: "annotation"`` envelope) —
+      load-bearing runtime state the reducer folds into the per-WP slots. They
+      carry no lane fields by construction, so omitting them here does not just
+      drop data: the row reaches ``_rule_require_to_lane`` and hard-errors the
+      entire mission repair.
 
     Other ``event_type`` rows (e.g. Decision-Moment ``DecisionPoint*``) are NOT
     preserved here: their canonical store is elsewhere
@@ -1424,6 +1433,17 @@ def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
     deliberately NOT mirrored here: the repair's ``LIFECYCLE_EVENT_TYPES``
     narrowing is the intentional pruning divergence for Decision-Moment mirrors.
     """
+    # ``InnerStateChanged`` annotations are preserved FIRST, mirroring the
+    # placement of the durable reader's own leading branch
+    # (:func:`specify_cli.status.store.is_non_lane_event`). They carry no
+    # ``from_lane``/``to_lane`` by construction, so without this branch they
+    # fall through to ``_rule_require_to_lane`` and hard-error the whole
+    # mission repair. Quarantining them is NOT an option: the reducer folds
+    # their typed ``WPInnerStateDelta`` into the per-WP runtime slots, so
+    # dropping them is the #2376 data-loss class in a fourth event format.
+    if row.get("kind") == ANNOTATION_KIND:
+        return True
+
     event_name = row.get("event_name")
     if isinstance(event_name, str) and event_name.startswith("retrospective."):
         return True

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -41,6 +41,7 @@ from .reducer import (
 )
 from .store import (
     is_retrospective_lifecycle_event,
+    ANNOTATION_KIND,
     EVENTS_FILENAME,
     EventPersistenceError,
     StoreError,
@@ -298,6 +299,7 @@ __all__ = [
     "IdentityState",
     "InvalidMissionSlug",
     "MissionMetadataUnavailable",
+    "ANNOTATION_KIND",
     "LIFECYCLE_EVENT_TYPES",
     "LOCAL_ONLY_LIFECYCLE_EVENT_TYPES",
     "FOLLOW_UP_RECORDED",

--- a/tests/integration/migration/test_lifecycle_events_preserved.py
+++ b/tests/integration/migration/test_lifecycle_events_preserved.py
@@ -34,6 +34,8 @@ from specify_cli.decisions.models import DecisionStatus, IndexEntry, OriginFlow
 from specify_cli.migration.mission_state import _repair_mission
 from specify_cli.retrospective.events import CompletedPayload, emit_retrospective_event
 from specify_cli.retrospective.schema import ActorRef
+from specify_cli.status.models import InnerStateChanged, WPInnerStateDelta
+from specify_cli.status.store import append_annotations_atomic_verified
 from specify_cli.status.lifecycle_events import (
     SPECIFY_STARTED,
     emit_artifact_phase,
@@ -255,6 +257,89 @@ def test_retrospective_row_preserved_decision_mirror_pruned(tmp_path: Path) -> N
     assert result.quarantined_rows == 1
     surviving = _event_ids(log.read_text(encoding="utf-8"))
     assert retro_id in surviving
+    for event_id in lifecycle_ids:
+        assert event_id in surviving
+    assert decision_id not in surviving
+
+
+def _emit_inner_state_annotation(mission_dir: Path) -> str:
+    """Emit a canonical ``InnerStateChanged`` annotation; return its ``event_id``.
+
+    Annotations use the ``kind: "annotation"`` envelope — a FOURTH
+    reader-preserved non-lane class (see
+    :func:`specify_cli.status.store.is_non_lane_event`, whose explicit
+    ``kind == ANNOTATION_KIND`` branch is deliberately placed FIRST). They carry
+    no ``from_lane``/``to_lane`` by construction and their only per-mission home
+    is ``status.events.jsonl``; the reducer folds their typed
+    :class:`WPInnerStateDelta` into the per-WP runtime slots.
+
+    Written through the durability-verified producer
+    :func:`append_annotations_atomic_verified` (C-007 / #1248) rather than a
+    hand-assembled dict, matching the rows ``migration:backfill_runtime_state``
+    put in the dogfood corpus.
+    """
+    annotation = InnerStateChanged(
+        event_id="01KWNA4XQF7T3M0GZC1B8VD2WR",
+        wp_id="WP01",
+        at="2026-07-04T00:48:00+00:00",
+        actor="migration:backfill_runtime_state",
+        delta=WPInnerStateDelta(subtasks={"T001": "done", "T002": "done"}),
+    )
+    append_annotations_atomic_verified(mission_dir, [annotation])
+    return annotation.event_id
+
+
+def test_annotation_row_is_preserved(tmp_path: Path) -> None:
+    """#2376 residual: a ``kind: "annotation"`` row shares the log with lifecycle
+    rows and MUST survive repair with zero quarantines.
+
+    This is the same #2376 data-loss class in a FOURTH event format. The repair's
+    ``_is_preserved_non_lane_row`` predicate routes only on ``event_name`` /
+    ``event_type`` / retrospective, so an annotation row matches none of them,
+    falls through ``_rule_reject_non_status_event``'s passthrough, and reaches
+    ``_rule_require_to_lane`` — which hard-errors with "missing required to_lane"
+    on a row that carries no lane fields by construction. The whole mission
+    repair then aborts, so the TeamSpace gate can never clear.
+
+    Preserve is the only correct disposition: annotations are load-bearing
+    (the reducer folds them into runtime slots), so quarantining them would
+    reopen #2376 rather than fix it.
+    """
+    mission_dir, log, lifecycle_ids, _ = _write_mission(tmp_path, with_decision=False)
+    annotation_id = _emit_inner_state_annotation(mission_dir)
+    before_ids = _event_ids(log.read_text(encoding="utf-8"))
+    assert annotation_id in before_ids
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="annotation")
+
+    assert result.status != "error", result.validation_errors
+    assert not any(
+        "missing required to_lane" in err for err in result.validation_errors
+    ), "an annotation row must never be asked for a to_lane it cannot have"
+    assert result.quarantined_rows == 0
+    surviving = _event_ids(log.read_text(encoding="utf-8"))
+    assert annotation_id in surviving, "the annotation row must survive repair"
+    for event_id in lifecycle_ids:
+        assert event_id in surviving
+
+
+def test_annotation_preserved_decision_mirror_pruned(tmp_path: Path) -> None:
+    """Mixed log with all four preserved classes + a prunable Decision mirror:
+    lifecycle + retrospective + annotation survive; only the mirror is pruned."""
+    mission_dir, log, lifecycle_ids, decision_id = _write_mission(
+        tmp_path, with_decision=True
+    )
+    assert decision_id is not None
+    retro_id = _emit_retrospective_completed(mission_dir)
+    annotation_id = _emit_inner_state_annotation(mission_dir)
+
+    result = _repair_mission(tmp_path, mission_dir, run_id="mixed-annotation")
+
+    assert result.status != "error", result.validation_errors
+    assert result.quarantined_rows == 1
+    surviving = _event_ids(log.read_text(encoding="utf-8"))
+    assert retro_id in surviving
+    assert annotation_id in surviving
     for event_id in lifecycle_ids:
         assert event_id in surviving
     assert decision_id not in surviving


### PR DESCRIPTION
## What

`spec-kitty doctor mission-state --fix` hard-errors on every `kind: "annotation"` row in `status.events.jsonl`, aborting repair for the entire mission. This adds the missing preserved-class branch and pins it with regression tests.

Fixes #2995.

## Why it matters

Annotation rows carry no `from_lane`/`to_lane` **by construction** (`InnerStateChanged` is documented as carrying "**no** `from_lane`/`to_lane`"). The repair classifier didn't recognise them, so they fell through to `_rule_require_to_lane` and short-circuited with `missing required to_lane`.

Measured on a 324-mission dogfood corpus: 2,523 such errors across 266 missions, `updated=46, unchanged=12, errors=266`. Because `sync now` refuses to connect until the TeamSpace mission-state migration completes, this closed the hosted-sync drain entirely — a 13,297-event local backlog sat at `Delivered 0/0`.

## Root cause

A documented lock-step invariant had drifted. The durable reader `status/store.py::is_non_lane_event` has an explicit **first** branch for `kind == ANNOTATION_KIND`, commented as placed first so annotations "can never be silently re-skipped (FR-001)". The repair-side `migration/mission_state.py::_is_preserved_non_lane_row` routed only on `event_name` / `event_type` / retrospective — while its own docstring claimed it was *"Kept in lock-step with the durable reader."*

This is the #2376 data-loss class in a fourth event format. #2376 covered the `event_type` lifecycle envelope; a residual covered the `event_name` retrospective envelope; `kind: "annotation"` was never added.

## Approach

**Preserve, not quarantine.** Annotations are load-bearing — the reducer folds their typed `WPInnerStateDelta` into per-WP runtime slots. Quarantining them would reopen #2376 rather than fix it. The new branch is placed first in the predicate, mirroring the reader's own ordering, so a future annotation envelope that grows an `event_type` key cannot be silently re-routed.

## Changes

- `migration/mission_state.py` — annotation branch in `_is_preserved_non_lane_row`, placed first; docstring updated (it enumerated two preserved classes, then three; now three named classes covering four envelopes)
- `status/__init__.py` — export `ANNOTATION_KIND` on the package surface, consistent with `LIFECYCLE_EVENT_TYPES`; `migration/` consumes `status` via the package, not submodules
- `tests/integration/migration/test_lifecycle_events_preserved.py` — two tests: an annotation row survives repair with zero quarantines, and a mixed log where all preserved classes survive while the `DecisionPoint*` mirror is still pruned. Built through the canonical producer `append_annotations_atomic_verified` (C-007 / #1248), not hand-assembled dicts.

## Verification

- New tests fail red before the fix with the exact production error (`missing required to_lane`), through the pre-existing `_repair_mission` entry point
- `tests/integration/migration/test_lifecycle_events_preserved.py` — 7 passed (2 new + 5 pre-existing, no regression)
- `tests/unit/migration/ tests/integration/migration/` — 98 passed
- `tests/architectural/` — see PR checks
- `ruff` and `mypy` clean on all touched files, no suppressions added

**Corpus effect** on the 324-mission dogfood corpus:

| | before | after |
|---|---|---|
| `--fix` | `updated=46, unchanged=12, errors=266` | `updated=266, unchanged=58, **errors=0**` |
| `--teamspace-dry-run` blockers | 305 | 93 |
| synthesized envelopes | 0 | 14,589 |

With the gate open, `sync now` connected and delivered **9,250 events** (0 transient, 0 terminal failures) from a backlog that had been stuck at `Delivered 0/0`.

Zero annotation rows were quarantined by the repaired run — the 25 quarantines are all `DecisionPoint*` mirrors, which is the intended #980 behaviour.

## Out of scope (separate follow-ups)

The remaining 93 dry-run errors are a different class — `PAYLOAD_INVALID` / `transition_rule` on historical events (`… requires review_ref`, `… requires force=True`). Local `status/validate.py:131` enforces the same rule, so these are genuinely legacy rows rather than validator drift, and they reject server-side rather than blocking the connection (4,141 rejections during the drain). Two further envelope-level rejection classes also surfaced — `build_id is required on the event envelope` (687) and `UUID input should be a string, bytes or UUID object` (63). None are addressed here.

## Not a corruption issue

Repair is transactional per mission — the 266 errored missions were verified byte-identical to HEAD. Quarantining `DecisionPoint*` rows remains correct and unchanged (canonical store is `decisions/index.json` + `DM-*.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KoFAHLL66hhCJ1GAPTQ9G

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/2998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787758619&installation_model_id=427282&pr_number=2998&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F2998&signature=c292cc1b238b8ec6cadc303ce37b30461864dc50a1ed780d08931e8245ed12e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->