### PR TITLE
test: pin six live P0 defects with main-redding regression tests

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -294,6 +294,13 @@ jobs:
               - 'tests/contract/**'
               - 'tests/init/**'
               - 'tests/integration/**'
+              # The `misc` shard owns tests/regression + tests/regressions (see
+              # its run list below), but neither directory was claimed by this
+              # filter — so a PR touching only an issue-pinned reproduction did
+              # not activate `core_misc`, the shard never ran, and the pin was
+              # structurally uncollectable on that PR.
+              - 'tests/regression/**'
+              - 'tests/regressions/**'
               - 'tests/dossier/**'
               - 'tests/git_ops/**'
               - 'tests/tasks/**'

--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -488,3 +488,47 @@ def test_help_output() -> None:
     assert "context" in result.stdout
     assert "sync" in result.stdout
     assert "status" in result.stdout
+
+
+def test_sync_command_human_and_json_surfaces_do_not_contradict_3045(mock_repo: Path) -> None:
+    """#3045: ``charter sync`` always reports success on the human surface,
+    even when the JSON surface (same invocation, same repo state) reports
+    ``stale_before: true``.
+
+    ``mock_repo`` writes only ``charter.md`` -- no ``metadata.yaml`` -- so
+    ``sync()`` computes ``stale_before=True`` (there is nothing yet to compare
+    a hash against). ``_emit_sync_human_result``
+    (``src/specify_cli/cli/commands/charter/sync.py:36-49``) unconditionally
+    prints "Charter already in sync (use --force to re-extract)" whenever
+    ``result.error`` is falsy -- it never branches on ``stale_before``. The
+    JSON payload built two lines earlier by ``_sync_json_payload``
+    (``src/specify_cli/cli/commands/charter/sync.py:23-33``) reports
+    ``stale_before: true`` for the exact same ``SyncResult``. The two surfaces
+    of the SAME command, over the SAME repo state, contradict each other: one
+    says "already in sync", the other says "was stale before this call".
+
+    This directly CONTRADICTS ``test_sync_command_success``
+    (``tests/agent/cli/commands/test_charter_cli.py:83-99``), which pins
+    ``"Charter already in sync" in result.stdout`` as "current, intentional
+    contract" and explicitly rationalizes it in its docstring as the retired
+    IC-04 extraction contract. That assertion must be deleted in the same
+    commit that fixes #3045 -- this test and that one cannot both stay green
+    once the human surface is made to agree with the JSON surface.
+    """
+    with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
+        mock_find_root.return_value = mock_repo
+
+        json_result = runner.invoke(app, ["sync", "--json"])
+        human_result = runner.invoke(app, ["sync"])
+
+        assert json_result.exit_code == 0
+        assert human_result.exit_code == 0
+
+        payload = json.loads(json_result.stdout)
+        assert payload["stale_before"] is True
+
+        assert "already in sync" not in human_result.stdout, (
+            "#3045: human surface claims the charter is already in sync while "
+            "the JSON surface (same repo state) reports stale_before=True -- "
+            f"human stdout: {human_result.stdout!r}, json payload: {payload!r}"
+        )

--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -490,6 +490,7 @@ def test_help_output() -> None:
     assert "status" in result.stdout
 
 
+@pytest.mark.regression
 def test_sync_command_human_and_json_surfaces_do_not_contradict_3045(mock_repo: Path) -> None:
     """#3045: ``charter sync`` always reports success on the human surface,
     even when the JSON surface (same invocation, same repo state) reports

--- a/tests/agent/cli/commands/test_charter_cli.py
+++ b/tests/agent/cli/commands/test_charter_cli.py
@@ -6,6 +6,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.charter import app
@@ -81,20 +82,33 @@ def _write_charter_yaml_bundle(charter_dir: Path) -> None:
 
 
 def test_sync_command_success(mock_repo: Path) -> None:
-    """IC-04 (#2773): ``charter.sync.sync`` extraction is retired -- it is a
-    pure staleness reporter now (``SyncResult.synced`` is hardcoded
-    ``False``; there is no derived triad left to write). ``charter sync``
-    therefore always renders the noop branch, even on a "fresh" charter that
-    has never been synced before -- pin that current, intentional contract
-    (see the module docstring in ``charter.sync``) rather than the retired
-    extraction-success message."""
+    """#3045: the assertion that used to live here --
+    ``"Charter already in sync" in result.stdout``, defended by this test's
+    prior docstring as the "current, intentional contract" -- was a STALE
+    PIN. Issue #3045 identifies it as the P0 escalator for the underlying
+    defect (``charter sync`` reports success unconditionally, even for a
+    charter that was never synced): a test asserting the misleading message
+    is *intended* means no gate could ever catch the regression. Per the
+    failing-test remediation framework a stale pin is deleted/rewritten, not
+    annotated -- removed here in the same commit that adds
+    ``test_sync_command_human_and_json_surfaces_do_not_contradict_3045``
+    below, which is the red-first replacement (see that test's docstring).
+    The two must not be re-separated later: this test defends only the
+    coverage that is still valid under EITHER sanctioned #3045 remedy
+    (repair or honest-reporter) -- it never re-materializes the retired
+    derived triad (``governance.yaml`` / ``directives.yaml`` /
+    ``metadata.yaml``, retired by IC-04 / #2773). No exit-code assertion is
+    kept either: ``mock_repo`` is exactly the "charter.md present,
+    charter.yaml absent, never synced" state the honest-reporter remedy is
+    expected to make exit non-zero for (per #3045's suggested shape) -- a
+    hard ``exit_code == 0`` pin here would forbid that remedy through a
+    second assertion in this file, recreating the same problem this
+    remediation exists to close."""
     with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
         mock_find_root.return_value = mock_repo
 
-        result = runner.invoke(app, ["sync"])
+        runner.invoke(app, ["sync"])
 
-        assert result.exit_code == 0
-        assert "Charter already in sync" in result.stdout
         for retired_file in ("governance.yaml", "directives.yaml", "metadata.yaml"):
             assert not (mock_repo / ".kittify" / "charter" / retired_file).exists()
 
@@ -491,45 +505,98 @@ def test_help_output() -> None:
 
 
 @pytest.mark.regression
-def test_sync_command_human_and_json_surfaces_do_not_contradict_3045(mock_repo: Path) -> None:
+def test_sync_command_human_and_json_surfaces_do_not_contradict_3045(tmp_path: Path) -> None:
     """#3045: ``charter sync`` always reports success on the human surface,
-    even when the JSON surface (same invocation, same repo state) reports
-    ``stale_before: true``.
+    even when the JSON surface (same repo state) reports
+    ``stale_before: true`` / ``success: false``.
 
-    ``mock_repo`` writes only ``charter.md`` -- no ``metadata.yaml`` -- so
-    ``sync()`` computes ``stale_before=True`` (there is nothing yet to compare
-    a hash against). ``_emit_sync_human_result``
+    ``_emit_sync_human_result``
     (``src/specify_cli/cli/commands/charter/sync.py:36-49``) unconditionally
     prints "Charter already in sync (use --force to re-extract)" whenever
-    ``result.error`` is falsy -- it never branches on ``stale_before``. The
-    JSON payload built two lines earlier by ``_sync_json_payload``
+    ``result.error`` is falsy -- it never branches on ``stale_before`` or
+    ``synced``. ``_sync_json_payload``
     (``src/specify_cli/cli/commands/charter/sync.py:23-33``) reports
-    ``stale_before: true`` for the exact same ``SyncResult``. The two surfaces
-    of the SAME command, over the SAME repo state, contradict each other: one
-    says "already in sync", the other says "was stale before this call".
+    ``success: False`` / ``stale_before: True`` for the exact same
+    ``SyncResult``. The two surfaces of the SAME command, over the SAME
+    result, contradict each other: one says "already in sync", the other
+    says "did not sync, was stale before this call".
 
-    This directly CONTRADICTS ``test_sync_command_success``
-    (``tests/agent/cli/commands/test_charter_cli.py:83-99``), which pins
-    ``"Charter already in sync" in result.stdout`` as "current, intentional
-    contract" and explicitly rationalizes it in its docstring as the retired
-    IC-04 extraction contract. That assertion must be deleted in the same
-    commit that fixes #3045 -- this test and that one cannot both stay green
-    once the human surface is made to agree with the JSON surface.
+    The stale pin that used to defend the human-surface message as
+    intentional -- ``test_sync_command_success``'s
+    ``"Charter already in sync" in result.stdout`` assertion, previously
+    rationalized in its own docstring as the "current, intentional
+    contract" -- was REMOVED in this same commit (see that test's updated
+    docstring). This test is the red-first replacement, not an addition
+    alongside the old pin; the two must not be re-separated later.
+
+    Test design, addressing three problems in an earlier draft of this test:
+
+    1. **Single invocation, two rendered surfaces.** ``charter.sync.sync()``
+       is called exactly ONCE to obtain one real ``SyncResult``; both
+       ``_sync_json_payload`` and ``_emit_sync_human_result`` render from
+       that SAME object. An earlier draft invoked the ``sync`` CLI command
+       twice against one shared ``mock_repo`` -- under a *repair*-mode fix,
+       the first (``--json``) invocation would actually repair the charter,
+       so the second (human) invocation would then correctly report
+       "already in sync", falsely reding a fix that fully resolves #3045.
+       Rendering both surfaces from one result sidesteps that ordering
+       hazard entirely.
+    2. **No exit-code pin.** Honest-reporter mode (the operator's stated
+       preference is "loud failures with clear instructions") is expected to
+       fail loudly -- non-zero exit -- when nothing was actually synced.
+       Repair mode may legitimately return ``synced=True`` (and thus exit 0)
+       because restoring the pre-#2773 ``sync()`` contract means a plain
+       (non-``--force``) call auto-extracts whenever the charter IS stale.
+       This test does not hardcode which remedy is chosen; see the
+       ``payload["success"]`` branch below.
+    3. **``stale_before`` is read off the payload, not hard-asserted
+       ``True``.** It is a permanent constant today only because the
+       staleness check targets the retired ``metadata.yaml`` (#3045 remedy
+       3) -- a corrected staleness check may compute it differently.
+
+    The substantive assertion is positive, not a bare negative substring: if
+    the JSON surface reports the sync did NOT actually happen
+    (``success is False``), the human surface must not exit 0 silently --
+    it must fail loudly. A cosmetic reword of the "already in sync" string
+    alone (keeping exit 0) does not satisfy this, because the check does not
+    inspect the human surface's text at all -- only whether it raises a
+    non-zero exit given a ``SyncResult`` that itself reports nothing was
+    synced.
     """
-    with patch("specify_cli.cli.commands.charter.find_repo_root") as mock_find_root:
-        mock_find_root.return_value = mock_repo
+    charter_dir = tmp_path / ".kittify" / "charter"
+    charter_dir.mkdir(parents=True)
+    (charter_dir / "charter.md").write_text(SAMPLE_CHARTER, encoding="utf-8")
 
-        json_result = runner.invoke(app, ["sync", "--json"])
-        human_result = runner.invoke(app, ["sync"])
+    from specify_cli.cli.commands.charter._app import console as charter_console
+    from specify_cli.cli.commands.charter.sync import (
+        _emit_sync_human_result,
+        _sync_json_payload,
+    )
+    from charter.sync import sync as sync_charter
 
-        assert json_result.exit_code == 0
-        assert human_result.exit_code == 0
+    result = sync_charter(charter_dir / "charter.md", charter_dir)
+    payload = _sync_json_payload(result)
 
-        payload = json.loads(json_result.stdout)
-        assert payload["stale_before"] is True
+    human_exit_code: int | None = None
+    with charter_console.capture() as capture:
+        try:
+            _emit_sync_human_result(result)
+        except typer.Exit as exc:
+            human_exit_code = exc.exit_code
+    human_text = capture.get()
 
-        assert "already in sync" not in human_result.stdout, (
-            "#3045: human surface claims the charter is already in sync while "
-            "the JSON surface (same repo state) reports stale_before=True -- "
-            f"human stdout: {human_result.stdout!r}, json payload: {payload!r}"
-        )
+    if payload["success"]:
+        # This single sync() call already resolved the staleness (the
+        # sanctioned *repair* remedy) -- both surfaces legitimately agree
+        # the charter is now in sync, so there is nothing to contradict.
+        return
+
+    assert human_exit_code not in (None, 0), (
+        "#3045: the JSON surface reports success=False (charter was not "
+        f"actually synced by this call; stale_before={payload['stale_before']!r}) "
+        "but the human surface exited 0 without raising -- a silent "
+        "'everything is fine' when nothing was synced. The operator's "
+        "stated preference is a loud failure naming the recovery path "
+        "('charter generate' / 'charter synthesize'), not a quiet success. "
+        f"human output: {human_text!r}, json payload: {payload!r}"
+    )

--- a/tests/delivery/test_dispatch_honours_drain_blocked_3030.py
+++ b/tests/delivery/test_dispatch_honours_drain_blocked_3030.py
@@ -60,7 +60,7 @@ from specify_cli.event_journal.models import DRAIN_BLOCKED_SAAS_DISABLED, Event
 if TYPE_CHECKING:
     from specify_cli.delivery.interfaces import DeliveryTarget
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.regression, pytest.mark.fast]
 
 _TARGET_URL = "https://hosted.example.com"
 _TARGET_TEAM_SLUG = "team"

--- a/tests/delivery/test_dispatch_honours_drain_blocked_3030.py
+++ b/tests/delivery/test_dispatch_honours_drain_blocked_3030.py
@@ -1,0 +1,210 @@
+"""RED pins: the drain must honour the capture-time consent classification (#3030).
+
+Background (see ``docs/development/read-side-seam-classification.md`` sibling
+investigation and issue #3030). ``event_journal/models.py:113-129`` — the
+``Event`` dataclass has no project field. ``SELECT_ALL_SQL``
+(``event_journal/models.py:78``) has no WHERE clause; ``EventJournal.read_all()``
+(``event_journal/journal.py:258``) takes no predicate; ``_select_undelivered``
+(``delivery/dispatcher.py:192-223``) sets ``universe = journal.read_all()`` and
+never inspects ``Event.drain_blocked_reason`` at all. The column exists — it is
+populated at capture time by ``capture_teamspace_bound`` via
+``classify_drain_blocked_reason`` — but nothing on the drain side reads it back.
+``sync/batch.py:357`` (``_prepare_events_for_ingress``) actively *strips*
+``drain_blocked_reason`` from the legacy queue payload before POSTing, which
+confirms the field is understood elsewhere as "must not leave the machine
+un-vetted" — the WP07 journal/dispatcher path (the one under test here) has no
+equivalent guard at all.
+
+Two tests:
+
+* :func:`test_dispatch_excludes_events_with_recorded_drain_blocked_reason` —
+  the direct pin: one blocked event, one unblocked event, single dispatch call.
+  Also closes the #3031 "Defect 5, per-event drain filtering" gap (the sibling
+  ``tests/sync/test_sync_consent_default_deny.py`` docstring flags this as
+  uncovered): both events are drained in the SAME call (one process tick), so
+  a fix that filters per-*process* rather than per-*event* cannot pass this.
+
+* :func:`test_consent_predicate_must_apply_before_limit_not_after` — a guard
+  against the shallow fix: filtering blocked rows out of the *already
+  limit-truncated* selection. With a 10-event blocked backlog older than the
+  one consenting event and ``limit=5``, a post-selection filter starves the
+  queue (the whole window is blocked, so the batch goes to zero and the drain
+  loop looks "done" while the consenting event never gets a turn). The
+  predicate must live inside the filtered read, before ``LIMIT`` truncates —
+  mirrors the legacy ``OfflineQueue.drain_queue`` shape
+  (``sync/queue.py:1570-1593``: ``SELECT event_id, data FROM queue ORDER BY
+  timestamp ASC, id ASC LIMIT ?`` — no predicate at all), which is the sibling
+  code path this journal/dispatcher pair is meant to replace.
+
+Both tests are additive: they do not alter any assertion in
+``tests/delivery/test_dispatcher.py``, whose own fixtures never populate
+``drain_blocked_reason`` (its ``_make_event`` helper leaves the default
+``None`` on every row), so this file's premise cannot collide with any
+existing green there.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from specify_cli.delivery.dispatcher import dispatch
+from specify_cli.delivery.ledger import SqliteDeliveryLedger
+from specify_cli.delivery.receivers import StubReceiver
+from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
+from specify_cli.event_journal.journal import EventJournal
+from specify_cli.event_journal.models import DRAIN_BLOCKED_SAAS_DISABLED, Event
+
+if TYPE_CHECKING:
+    from specify_cli.delivery.interfaces import DeliveryTarget
+
+pytestmark = pytest.mark.fast
+
+_TARGET_URL = "https://hosted.example.com"
+_TARGET_TEAM_SLUG = "team"
+_TARGET_USER_EMAIL = "operator@example.com"
+
+
+def _make_event(
+    event_id: str,
+    *,
+    project_slug: str,
+    drain_blocked_reason: str | None,
+    created_at: str,
+) -> Event:
+    """Build a realistic, production-shaped journal event.
+
+    The payload mirrors the wire envelope's project correlation field
+    (``project_slug`` — see ``sync/emitter.py:2038``), even though today's
+    dispatcher never looks inside the payload to make a delivery decision;
+    that is the point of the wider #3030 defect.
+    """
+    payload = json.dumps(
+        {
+            "event_id": event_id,
+            "event_type": "WorkPackageApproved",
+            "project_slug": project_slug,
+            "drain_blocked_reason": drain_blocked_reason,
+        }
+    ).encode("utf-8")
+    return Event(
+        event_id=event_id,
+        event_type="WorkPackageApproved",
+        payload=payload,
+        occurred_at=created_at,
+        created_at=created_at,
+        drain_blocked_reason=drain_blocked_reason,
+    )
+
+
+def _register_target(registry: SqliteDeliveryTargetRegistry) -> DeliveryTarget:
+    return registry.register(
+        url=_TARGET_URL, team_slug=_TARGET_TEAM_SLUG, user_email=_TARGET_USER_EMAIL
+    )
+
+
+def test_dispatch_excludes_events_with_recorded_drain_blocked_reason(
+    tmp_path: Path,
+) -> None:
+    """A journal row captured as ``drain_blocked_reason=saas_disabled`` must not ship.
+
+    Reds today: the dispatcher delivers BOTH events. ``_select_undelivered``
+    only excludes rows with a terminal-success or terminal-failed *ledger*
+    row for the target (``ledger.select_undelivered``); it applies no
+    predicate over ``Event.drain_blocked_reason`` at all, so a row the capture
+    layer explicitly classified as not-ready-to-ship is drained exactly like
+    any other row.
+    """
+    journal = EventJournal(tmp_path / "journal.db")
+    unblocked = _make_event(
+        "evt-engagement-assistant-0",
+        project_slug="engagement-assistant",
+        drain_blocked_reason=None,
+        created_at="2026-06-29T00:00:00+00:00",
+    )
+    blocked = _make_event(
+        "evt-client-confidential-0",
+        project_slug="client-confidential",
+        drain_blocked_reason=DRAIN_BLOCKED_SAAS_DISABLED,
+        created_at="2026-06-29T00:00:01+00:00",
+    )
+    journal.append(unblocked)
+    journal.append(blocked)
+
+    ledger = SqliteDeliveryLedger(":memory:")
+    registry = SqliteDeliveryTargetRegistry(":memory:")
+    target = _register_target(registry)
+    receiver = StubReceiver()
+
+    dispatch(journal=journal, ledger=ledger, receiver=receiver, target=target)
+
+    received_ids = set(receiver.received_event_ids())
+    assert unblocked.event_id in received_ids, (
+        "the unblocked event must still ship — this test is not about "
+        "breaking healthy drains"
+    )
+    assert blocked.event_id not in received_ids, (
+        f"a journal row captured with drain_blocked_reason={DRAIN_BLOCKED_SAAS_DISABLED!r} "
+        "must never reach the receiver; the drain has no predicate over "
+        "Event.drain_blocked_reason at all (dispatcher.py:_select_undelivered), "
+        "so capture-time consent classification is silently discarded at drain time"
+    )
+
+    blocked_row = ledger.get(blocked.event_id, target.target_id)
+    assert blocked_row is None, (
+        "a blocked event must not be recorded delivered to the ledger either — "
+        "today it is, because dispatch() posted it and _record() wrote a "
+        "terminal-success row for it"
+    )
+
+
+def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> None:
+    """A large blocked backlog must not starve a newer consenting event.
+
+    Seeds 10 non-consenting (blocked) events older than 1 consenting
+    (unblocked) event, then drains with ``limit=5``. ``ledger.select_undelivered``
+    preserves ``event_universe`` order (created_at ASC, from
+    ``journal.read_all()``) and slices ``[:limit]`` — so today's unfiltered
+    selection returns the 5 OLDEST rows, which are all blocked, and the
+    consenting event (created last) is never even selected, let alone
+    delivered. This reds for the same root cause as the test above (no
+    predicate at all) but demonstrates why the eventual fix must apply the
+    consent predicate *inside* the filtered read, before ``LIMIT`` truncates —
+    a fix that instead filters the alreadyselected 5-row batch would leave an
+    empty batch and make the drain loop look "done" while the consenting event
+    is permanently stranded behind the backlog.
+    """
+    journal = EventJournal(tmp_path / "journal.db")
+    for index in range(10):
+        journal.append(
+            _make_event(
+                f"evt-client-confidential-{index}",
+                project_slug="client-confidential",
+                drain_blocked_reason=DRAIN_BLOCKED_SAAS_DISABLED,
+                created_at=f"2026-06-29T00:00:{index:02d}+00:00",
+            )
+        )
+    consenting = _make_event(
+        "evt-engagement-assistant-0",
+        project_slug="engagement-assistant",
+        drain_blocked_reason=None,
+        created_at="2026-06-29T00:01:00+00:00",
+    )
+    journal.append(consenting)
+
+    ledger = SqliteDeliveryLedger(":memory:")
+    registry = SqliteDeliveryTargetRegistry(":memory:")
+    target = _register_target(registry)
+    receiver = StubReceiver()
+
+    dispatch(journal=journal, ledger=ledger, receiver=receiver, target=target, limit=5)
+
+    received_ids = set(receiver.received_event_ids())
+    assert consenting.event_id in received_ids, (
+        "the one consenting event must be delivered even behind a 10-event "
+        "blocked backlog; today the drain has no consent predicate at all, "
+        "so it ships the 5 OLDEST rows (all blocked) and never reaches the "
+        "consenting event within the requested limit"
+    )

--- a/tests/delivery/test_dispatch_honours_drain_blocked_3031.py
+++ b/tests/delivery/test_dispatch_honours_drain_blocked_3031.py
@@ -43,15 +43,27 @@ Two tests:
 
 * :func:`test_consent_predicate_must_apply_before_limit_not_after` — a guard
   against the shallow fix: filtering blocked rows out of the *already
-  limit-truncated* selection. With a 10-event blocked backlog older than the
-  one unblocked event and ``limit=5``, a post-selection filter starves the
-  queue (the whole window is blocked, so the batch goes to zero and the drain
-  loop looks "done" while the unblocked event never gets a turn). The
-  predicate must live inside the filtered read, before ``LIMIT`` truncates —
-  mirrors the legacy ``OfflineQueue.drain_queue`` shape
-  (``sync/queue.py:1570-1593``: ``SELECT event_id, data FROM queue ORDER BY
-  timestamp ASC, id ASC LIMIT ?`` — no predicate at all), which is the sibling
-  code path this journal/dispatcher pair is meant to replace. This test also
+  limit-truncated* selection. This is expressed through
+  ``specify_cli.cli.commands.sync._run_dispatch_batches`` — the actual
+  multi-batch drain loop ``sync now`` runs (``sync.py:807-828``), not a single
+  ``dispatch(..., limit=...)`` call — because a single call cannot
+  distinguish "the predicate lives inside the filtered read" from "the
+  predicate runs after ``LIMIT`` but a later loop iteration reaches the
+  unblocked event anyway"; the multi-batch loop's own termination condition
+  (``batch.selected == 0 or not advanced: break``, ``sync.py:857``) is what a
+  post-selection filter actually breaks: a batch of all-blocked rows that get
+  filtered out post-``LIMIT`` never posts (no ``delivered``), so
+  ``terminal_progress`` is ``False``; since a transparently-filtered row is
+  never added to ``retryable_event_ids`` either, ``skip`` never grows, so
+  ``advanced`` is ``False`` and the loop exits on that very first batch,
+  stranding the unblocked event exactly as the legacy
+  ``OfflineQueue.drain_queue`` shape would (``sync/queue.py:1570-1593``:
+  ``SELECT event_id, data FROM queue ORDER BY timestamp ASC, id ASC LIMIT ?``
+  — no predicate at all), which is the sibling code path this
+  journal/dispatcher pair is meant to replace. The per-batch limit
+  (``sync.py:459``, normally 1000) is monkeypatched down to 5 purely so a
+  10-event blocked backlog is enough to force truncation within one batch —
+  the property under test is unchanged by the smaller number. This test also
   asserts the negative: none of the 10 blocked rows may ship either — a fix
   that merely reorders selection (e.g. newest-first) to surface the unblocked
   event while still shipping the blocked backlog must not pass.
@@ -70,12 +82,19 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from specify_cli.cli.commands import sync as sync_commands
+from specify_cli.cli.commands.sync import _EventSyncRuntime, _run_dispatch_batches
 from specify_cli.delivery.dispatcher import dispatch
 from specify_cli.delivery.ledger import SqliteDeliveryLedger
 from specify_cli.delivery.receivers import StubReceiver
 from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
 from specify_cli.event_journal.journal import EventJournal
 from specify_cli.event_journal.models import DRAIN_BLOCKED_SAAS_DISABLED, Event
+from specify_cli.sync.target_authority import (
+    OverrideMode,
+    QueueScopeStatus,
+    ResolvedSyncTarget,
+)
 
 if TYPE_CHECKING:
     from specify_cli.delivery.interfaces import DeliveryTarget
@@ -124,6 +143,26 @@ def _make_event(
 def _register_target(registry: SqliteDeliveryTargetRegistry) -> DeliveryTarget:
     return registry.register(
         url=_TARGET_URL, team_slug=_TARGET_TEAM_SLUG, user_email=_TARGET_USER_EMAIL
+    )
+
+
+def _resolved_sync_target(tmp_path: Path) -> ResolvedSyncTarget:
+    """Build a plain, no-I/O ``ResolvedSyncTarget`` to satisfy ``_EventSyncRuntime``.
+
+    ``_run_dispatch_batches`` never reads ``runtime.target`` — it only touches
+    ``runtime.journal`` and ``runtime.ledger`` — but the dataclass requires it,
+    so this is inert fixture data, not a behavioural input to the test.
+    """
+    return ResolvedSyncTarget(
+        configured_server_url=_TARGET_URL,
+        env_server_url=None,
+        override_mode=OverrideMode.NONE,
+        resolved_server_url=_TARGET_URL,
+        user_id=None,
+        team_slug=_TARGET_TEAM_SLUG,
+        derived_queue_scope=f"team:{_TARGET_TEAM_SLUG}",
+        queue_db_path=tmp_path / "queue.db",
+        active_queue_scope_status=QueueScopeStatus.MATCHES,
     )
 
 
@@ -187,7 +226,9 @@ def test_dispatch_excludes_events_with_recorded_drain_blocked_reason(
     )
 
 
-def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> None:
+def test_consent_predicate_must_apply_before_limit_not_after(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A large blocked backlog must not starve a newer unblocked event.
 
     #3031 Defect 5 (per-event drain filtering) — NOT a #3030 consent pin. The
@@ -196,18 +237,34 @@ def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> 
     ``Event.drain_blocked_reason`` (machine-global), never per-project
     consent, so it is renamed to blocked/unblocked in this docstring.
 
-    Seeds 10 blocked events older than 1 unblocked event, then drains with
-    ``limit=5``. ``ledger.select_undelivered`` preserves ``event_universe``
-    order (created_at ASC, from ``journal.read_all()``) and slices
-    ``[:limit]`` — so today's unfiltered selection returns the 5 OLDEST rows,
-    which are all blocked, and the unblocked event (created last) is never
-    even selected, let alone delivered. This reds for the same root cause as
-    the test above (no predicate at all) but demonstrates why the eventual
-    fix must apply the drain_blocked_reason predicate *inside* the filtered
-    read, before ``LIMIT`` truncates — a fix that instead filters the
-    already-selected 5-row batch would leave an empty batch and make the
-    drain loop look "done" while the unblocked event is permanently stranded
-    behind the backlog.
+    Driven through ``_run_dispatch_batches`` — the loop
+    ``specify_cli.cli.commands.sync`` runs for every ``sync now`` invocation
+    (``sync.py:807-828``), not a single ``dispatch(..., limit=...)`` call.
+    A single call cannot separate "the predicate is missing" from "the
+    predicate runs after ``LIMIT`` truncates, but a later loop iteration
+    reaches the unblocked event anyway" — both look identical through one
+    call. The multi-batch loop's own stop condition
+    (``batch.selected == 0 or not advanced: break``, ``sync.py:857``) is what
+    actually distinguishes them: a post-``LIMIT`` filter drops the batch to
+    zero *delivered* without producing any *retryable* ids either (the rows
+    were filtered transparently, not rejected), so neither ``terminal_progress``
+    nor ``skip`` growth fires, ``advanced`` is ``False``, and the loop exits
+    on the very first batch — stranding the unblocked event exactly like the
+    legacy ``OfflineQueue.drain_queue`` shape this journal/dispatcher pair
+    replaces (``sync/queue.py:1570-1593``: ``SELECT event_id, data FROM queue
+    ORDER BY timestamp ASC, id ASC LIMIT ?`` — no predicate at all).
+
+    Seeds 10 blocked events older than 1 unblocked event. The per-batch limit
+    (``sync.py:459``, normally 1000) is monkeypatched down to 5 so the same
+    10-event backlog forces truncation within a single batch instead of
+    requiring a 1000+-event fixture — the property under test (predicate
+    placement relative to ``LIMIT``) is unaffected by the constant's value.
+    With today's code (no predicate over ``drain_blocked_reason`` at all,
+    inside or outside the filtered read), the loop simply keeps calling
+    ``dispatch`` with a growing limit until the whole backlog — blocked and
+    unblocked alike — is delivered, so this test currently reds on the
+    negative assertion below: all 10 blocked ids ship alongside the unblocked
+    one.
 
     The negative assertion below (none of the 10 blocked ids ship) closes the
     cheap-green this test previously left open: reversing
@@ -216,6 +273,8 @@ def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> 
     still shipping all 10 blocked rows once the batch/limit allowed it — that
     is not a correct fix and must not pass this test.
     """
+    monkeypatch.setattr(sync_commands, "_EVENT_SYNC_DISPATCH_BATCH_LIMIT", 5)
+
     journal = EventJournal(tmp_path / "journal.db")
     blocked_ids = [f"evt-client-confidential-{index}" for index in range(10)]
     for index, event_id in enumerate(blocked_ids):
@@ -239,15 +298,23 @@ def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> 
     registry = SqliteDeliveryTargetRegistry(":memory:")
     target = _register_target(registry)
     receiver = StubReceiver()
+    runtime = _EventSyncRuntime(
+        target=_resolved_sync_target(tmp_path),
+        journal=journal,
+        ledger=ledger,
+        registry=registry,
+    )
 
-    dispatch(journal=journal, ledger=ledger, receiver=receiver, target=target, limit=5)
+    _run_dispatch_batches(runtime, receiver, target)
 
     received_ids = set(receiver.received_event_ids())
     assert unblocked.event_id in received_ids, (
         "the one unblocked event must be delivered even behind a 10-event "
         "blocked backlog; today the drain has no drain_blocked_reason "
-        "predicate at all, so it ships the 5 OLDEST rows (all blocked) and "
-        "never reaches the unblocked event within the requested limit"
+        "predicate at all, so the batch loop ships the 5 OLDEST rows (all "
+        "blocked) in its first pass and only reaches the unblocked event "
+        "because it keeps looping — a correct fix must not depend on that "
+        "looping behaviour to avoid starving it"
     )
     shipped_blocked_ids = received_ids.intersection(blocked_ids)
     assert not shipped_blocked_ids, (

--- a/tests/delivery/test_dispatch_honours_drain_blocked_3031.py
+++ b/tests/delivery/test_dispatch_honours_drain_blocked_3031.py
@@ -1,14 +1,32 @@
-"""RED pins: the drain must honour the capture-time consent classification (#3030).
+"""RED pins: the drain must filter *per event*, not per process (#3031 Defect 5).
 
-Background (see ``docs/development/read-side-seam-classification.md`` sibling
-investigation and issue #3030). ``event_journal/models.py:113-129`` — the
-``Event`` dataclass has no project field. ``SELECT_ALL_SQL``
-(``event_journal/models.py:78``) has no WHERE clause; ``EventJournal.read_all()``
-(``event_journal/journal.py:258``) takes no predicate; ``_select_undelivered``
-(``delivery/dispatcher.py:192-223``) sets ``universe = journal.read_all()`` and
-never inspects ``Event.drain_blocked_reason`` at all. The column exists — it is
-populated at capture time by ``capture_teamspace_bound`` via
-``classify_drain_blocked_reason`` — but nothing on the drain side reads it back.
+Rescoped from an earlier #3030 framing (see git history / PR #3050 landing
+notes): this file's original docstring claimed a ``drain_blocked_reason``
+predicate implemented per-project consent. It does not. ``drain_blocked_reason``
+is a **capture-time snapshot of machine-global gates**
+(``classify_drain_blocked_reason``, ``event_journal/journal.py:338-351`` —
+SaaS-enabled flag, checkout-enabled flag, auth state, team resolution). Every
+project on the machine that emits at the same moment gets the *same*
+classification, because none of those gates are project-scoped. A predicate
+that filters on this column therefore implements **no per-project consent
+whatsoever** — it can only ever answer "was the whole process/checkout
+blocked at capture time", never "did *this* project consent". Per-project
+consent (repo-slug-keyed, resolvable per event) is a distinct defect, pinned
+separately in ``tests/delivery/test_dispatch_project_consent_3030.py``
+(#3030). Do not read a green here as #3030 coverage.
+
+What #3031 Defect 5 actually is (see
+``docs/development/read-side-seam-classification.md`` and the sibling
+``tests/sync/test_sync_consent_default_deny.py`` docstring, which flags this
+exact gap as uncovered): ``event_journal/models.py:113-129`` — the ``Event``
+dataclass has no project field. ``SELECT_ALL_SQL`` (``event_journal/models.py:78``)
+has no WHERE clause; ``EventJournal.read_all()`` (``event_journal/journal.py:258``)
+takes no predicate; ``_select_undelivered`` (``delivery/dispatcher.py:192-223``)
+sets ``universe = journal.read_all()`` and never inspects
+``Event.drain_blocked_reason`` at all. The column exists — it is populated at
+capture time by ``capture_teamspace_bound`` via ``classify_drain_blocked_reason``
+— but nothing on the drain side reads it back, so even the coarse, machine-global
+signal that DOES exist on the row is silently discarded at drain time.
 ``sync/batch.py:357`` (``_prepare_events_for_ingress``) actively *strips*
 ``drain_blocked_reason`` from the legacy queue payload before POSTing, which
 confirms the field is understood elsewhere as "must not leave the machine
@@ -19,22 +37,24 @@ Two tests:
 
 * :func:`test_dispatch_excludes_events_with_recorded_drain_blocked_reason` —
   the direct pin: one blocked event, one unblocked event, single dispatch call.
-  Also closes the #3031 "Defect 5, per-event drain filtering" gap (the sibling
-  ``tests/sync/test_sync_consent_default_deny.py`` docstring flags this as
-  uncovered): both events are drained in the SAME call (one process tick), so
-  a fix that filters per-*process* rather than per-*event* cannot pass this.
+  Both events are drained in the SAME call (one process tick), so a fix that
+  filters per-*process* rather than per-*event* cannot pass this — the
+  predicate must inspect ``Event.drain_blocked_reason`` on each row.
 
 * :func:`test_consent_predicate_must_apply_before_limit_not_after` — a guard
   against the shallow fix: filtering blocked rows out of the *already
   limit-truncated* selection. With a 10-event blocked backlog older than the
-  one consenting event and ``limit=5``, a post-selection filter starves the
+  one unblocked event and ``limit=5``, a post-selection filter starves the
   queue (the whole window is blocked, so the batch goes to zero and the drain
-  loop looks "done" while the consenting event never gets a turn). The
+  loop looks "done" while the unblocked event never gets a turn). The
   predicate must live inside the filtered read, before ``LIMIT`` truncates —
   mirrors the legacy ``OfflineQueue.drain_queue`` shape
   (``sync/queue.py:1570-1593``: ``SELECT event_id, data FROM queue ORDER BY
   timestamp ASC, id ASC LIMIT ?`` — no predicate at all), which is the sibling
-  code path this journal/dispatcher pair is meant to replace.
+  code path this journal/dispatcher pair is meant to replace. This test also
+  asserts the negative: none of the 10 blocked rows may ship either — a fix
+  that merely reorders selection (e.g. newest-first) to surface the unblocked
+  event while still shipping the blocked backlog must not pass.
 
 Both tests are additive: they do not alter any assertion in
 ``tests/delivery/test_dispatcher.py``, whose own fixtures never populate
@@ -76,10 +96,12 @@ def _make_event(
 ) -> Event:
     """Build a realistic, production-shaped journal event.
 
-    The payload mirrors the wire envelope's project correlation field
-    (``project_slug`` — see ``sync/emitter.py:2038``), even though today's
-    dispatcher never looks inside the payload to make a delivery decision;
-    that is the point of the wider #3030 defect.
+    The payload carries the wire envelope's project correlation field
+    (``project_slug`` — see ``sync/emitter.py:2038``) for payload-shape
+    realism only; this file's pin is about ``Event.drain_blocked_reason``
+    (a machine-global, capture-time column), never about ``project_slug`` or
+    per-project consent — that's #3030, pinned in the sibling
+    ``test_dispatch_project_consent_3030.py``.
     """
     payload = json.dumps(
         {
@@ -109,6 +131,11 @@ def test_dispatch_excludes_events_with_recorded_drain_blocked_reason(
     tmp_path: Path,
 ) -> None:
     """A journal row captured as ``drain_blocked_reason=saas_disabled`` must not ship.
+
+    #3031 Defect 5 (per-event drain filtering) — NOT a #3030 consent pin.
+    ``drain_blocked_reason`` is a machine-global gate snapshot (SaaS-enabled /
+    checkout-enabled / auth / team resolution), not a per-project decision;
+    a fix satisfying this test alone implements no project-scoped consent.
 
     Reds today: the dispatcher delivers BOTH events. ``_select_undelivered``
     only excludes rows with a terminal-success or terminal-failed *ledger*
@@ -161,38 +188,52 @@ def test_dispatch_excludes_events_with_recorded_drain_blocked_reason(
 
 
 def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> None:
-    """A large blocked backlog must not starve a newer consenting event.
+    """A large blocked backlog must not starve a newer unblocked event.
 
-    Seeds 10 non-consenting (blocked) events older than 1 consenting
-    (unblocked) event, then drains with ``limit=5``. ``ledger.select_undelivered``
-    preserves ``event_universe`` order (created_at ASC, from
-    ``journal.read_all()``) and slices ``[:limit]`` — so today's unfiltered
-    selection returns the 5 OLDEST rows, which are all blocked, and the
-    consenting event (created last) is never even selected, let alone
-    delivered. This reds for the same root cause as the test above (no
-    predicate at all) but demonstrates why the eventual fix must apply the
-    consent predicate *inside* the filtered read, before ``LIMIT`` truncates —
-    a fix that instead filters the alreadyselected 5-row batch would leave an
-    empty batch and make the drain loop look "done" while the consenting event
-    is permanently stranded behind the backlog.
+    #3031 Defect 5 (per-event drain filtering) — NOT a #3030 consent pin. The
+    "consenting"/"non-consenting" naming below is legacy from this file's
+    original #3030 framing; the only property under test is
+    ``Event.drain_blocked_reason`` (machine-global), never per-project
+    consent, so it is renamed to blocked/unblocked in this docstring.
+
+    Seeds 10 blocked events older than 1 unblocked event, then drains with
+    ``limit=5``. ``ledger.select_undelivered`` preserves ``event_universe``
+    order (created_at ASC, from ``journal.read_all()``) and slices
+    ``[:limit]`` — so today's unfiltered selection returns the 5 OLDEST rows,
+    which are all blocked, and the unblocked event (created last) is never
+    even selected, let alone delivered. This reds for the same root cause as
+    the test above (no predicate at all) but demonstrates why the eventual
+    fix must apply the drain_blocked_reason predicate *inside* the filtered
+    read, before ``LIMIT`` truncates — a fix that instead filters the
+    already-selected 5-row batch would leave an empty batch and make the
+    drain loop look "done" while the unblocked event is permanently stranded
+    behind the backlog.
+
+    The negative assertion below (none of the 10 blocked ids ship) closes the
+    cheap-green this test previously left open: reversing
+    ``_select_undelivered``'s ordering to newest-first would deliver the
+    unblocked event first and satisfy the old positive-only assertion while
+    still shipping all 10 blocked rows once the batch/limit allowed it — that
+    is not a correct fix and must not pass this test.
     """
     journal = EventJournal(tmp_path / "journal.db")
-    for index in range(10):
+    blocked_ids = [f"evt-client-confidential-{index}" for index in range(10)]
+    for index, event_id in enumerate(blocked_ids):
         journal.append(
             _make_event(
-                f"evt-client-confidential-{index}",
+                event_id,
                 project_slug="client-confidential",
                 drain_blocked_reason=DRAIN_BLOCKED_SAAS_DISABLED,
                 created_at=f"2026-06-29T00:00:{index:02d}+00:00",
             )
         )
-    consenting = _make_event(
+    unblocked = _make_event(
         "evt-engagement-assistant-0",
         project_slug="engagement-assistant",
         drain_blocked_reason=None,
         created_at="2026-06-29T00:01:00+00:00",
     )
-    journal.append(consenting)
+    journal.append(unblocked)
 
     ledger = SqliteDeliveryLedger(":memory:")
     registry = SqliteDeliveryTargetRegistry(":memory:")
@@ -202,9 +243,18 @@ def test_consent_predicate_must_apply_before_limit_not_after(tmp_path: Path) -> 
     dispatch(journal=journal, ledger=ledger, receiver=receiver, target=target, limit=5)
 
     received_ids = set(receiver.received_event_ids())
-    assert consenting.event_id in received_ids, (
-        "the one consenting event must be delivered even behind a 10-event "
-        "blocked backlog; today the drain has no consent predicate at all, "
-        "so it ships the 5 OLDEST rows (all blocked) and never reaches the "
-        "consenting event within the requested limit"
+    assert unblocked.event_id in received_ids, (
+        "the one unblocked event must be delivered even behind a 10-event "
+        "blocked backlog; today the drain has no drain_blocked_reason "
+        "predicate at all, so it ships the 5 OLDEST rows (all blocked) and "
+        "never reaches the unblocked event within the requested limit"
+    )
+    shipped_blocked_ids = received_ids.intersection(blocked_ids)
+    assert not shipped_blocked_ids, (
+        "none of the 10 blocked backlog rows may ship, regardless of how the "
+        f"unblocked event is surfaced — got {sorted(shipped_blocked_ids)!r} "
+        "shipped; a fix that reorders selection (e.g. newest-first) to reach "
+        "the unblocked event while still shipping blocked rows once the "
+        "batch/limit allows is not a correct per-event drain_blocked_reason "
+        "filter and must not pass this test"
     )

--- a/tests/delivery/test_dispatch_project_consent_3030.py
+++ b/tests/delivery/test_dispatch_project_consent_3030.py
@@ -25,6 +25,26 @@ entry at all — not an explicit opt-out — because a predicate that reads
 absence-of-a-decision as consent is the actual defect this incident turned on
 (#3031); an explicit opt-out fixture would pass today's code while the real
 leak (silence, not refusal) sailed through.
+
+Distinct from, and orthogonal to, the sibling
+``tests/delivery/test_dispatch_honours_drain_blocked_3031.py`` (#3031 Defect
+5, per-event drain filtering). That file pins that a drain-blocked-reason
+predicate must inspect each ``Event`` row rather than gating a whole
+process/checkout; it says nothing about *who* consented, because
+``drain_blocked_reason`` is a machine-global gate snapshot, not a per-project
+decision (see that file's docstring). THIS file pins the orthogonal, genuine
+per-project defect: two projects sharing one machine-global journal, where
+only ONE of them ever recorded consent. To keep the two files mutually
+satisfiable (an earlier revision pinned both against fixtures that stamped
+BOTH events with the same ``drain_blocked_reason=saas_disabled``, which made
+this file's "must ship" demand and the sibling's "any such row must never
+ship" demand directly contradictory — no implementation could satisfy both),
+the consenting checkout's capture gate is forced open below so its journal
+row is genuinely unblocked (``drain_blocked_reason=None``); only the
+non-consenting checkout's row is left machine-gate-blocked. The two files now
+key on different, non-overlapping columns: 3031 on
+``Event.drain_blocked_reason`` values it constructs directly; this file on
+``repo_slug``-keyed consent-record resolution via a real emitter round-trip.
 """
 from __future__ import annotations
 
@@ -41,6 +61,7 @@ from specify_cli.delivery.ledger import SqliteDeliveryLedger
 from specify_cli.delivery.receivers import StubReceiver
 from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
 from specify_cli.event_journal import (
+    CaptureGateState,
     get_journal,
     reset_coalesce_strategy,
     reset_journal_cache,
@@ -89,7 +110,9 @@ def _write_consent_for_first_project_only(spec_kitty_home: Path) -> None:
     )
 
 
-def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
+def _stub_emitter(
+    *, project_slug: str, build_id: str, repo_slug: str | None = None
+) -> EventEmitter:
     """A real ``EventEmitter`` with a stubbed identity/git resolver.
 
     Mirrors ``tests/delivery/test_envelope.py:65-74``'s ``_stub_emitter`` but
@@ -98,6 +121,15 @@ def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
     test's ``None`` placeholders — the point being that two checkouts for two
     different projects on the same machine still resolve to the SAME journal
     file (``team_slug=None``) once SaaS sync is globally disabled.
+
+    ``repo_slug`` is the ONLY field a per-project consent lookup can key on
+    (``sync/config.py:get_repository_sync_enabled`` does
+    ``repo_defaults.get(repo_slug)``) — a resolver that instead tried to
+    match on ``project_slug`` would be the fragile fuzzy correspondence
+    #3031 Defect 2 exists to eliminate, so this fixture never invents one.
+    Passing ``repo_slug=None`` (the default) reproduces an unresolvable git
+    identity — genuinely absent from the consent record, not an explicit
+    opt-out.
     """
     from specify_cli.sync.emitter import EventEmitter
     from specify_cli.sync.git_metadata import GitMetadata
@@ -106,8 +138,36 @@ def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
     em._identity = SimpleNamespace(
         build_id=build_id, project_uuid=uuid4(), project_slug=project_slug
     )
-    em._get_git_metadata = lambda: GitMetadata()
+    em._get_git_metadata = lambda: GitMetadata(repo_slug=repo_slug)
     return em
+
+
+def _open_capture_gate(_team_slug: str | None) -> CaptureGateState:
+    """Force one emitter instance's journal-capture gate fully open.
+
+    Real-world equivalent: a checkout that IS SaaS-enabled, authenticated,
+    and team-resolved — i.e. genuinely ready to ship, unlike its sibling
+    checkout on the same machine. This is an instance-level override
+    (mirrors the ``_get_git_metadata`` override above) rather than a further
+    ``is_saas_sync_enabled`` patch, because every real capture gate
+    (``EventEmitter._capture_gate_state``) is machine-global in the current
+    implementation — see ``test_dispatch_honours_drain_blocked_3031.py`` — so
+    there is no real per-process knob that would open the gate for one
+    project's checkout and not the other's. Overriding it per-instance here
+    keeps both events on the SAME producer-scoped journal (``get_journal`` is
+    still keyed on ``team_slug=None`` for both, since ``is_saas_sync_enabled``
+    stays patched ``False`` at module scope) while giving the two rows
+    different ``drain_blocked_reason`` values, so the sibling #3031 file's
+    "any drain_blocked_reason row must never ship" rule and this file's
+    "the consenting event must ship" rule no longer collide (Defect (a) in
+    the fold that produced this fixture).
+    """
+    return CaptureGateState(
+        saas_enabled=True,
+        checkout_enabled=True,
+        authenticated=True,
+        team_slug="team",
+    )
 
 
 def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
@@ -115,13 +175,26 @@ def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
 ) -> None:
     """A consenting checkout's drain must not also ship a non-consenting sibling's event.
 
+    #3030 (per-project consent) — orthogonal to the rescoped
+    ``test_dispatch_honours_drain_blocked_3031.py`` (#3031 Defect 5,
+    machine-global drain-blocked-reason filtering). The consenting emitter's
+    capture gate is forced open below (``_open_capture_gate``) so its journal
+    row carries ``drain_blocked_reason=None``, while the non-consenting
+    emitter's row stays machine-gate-blocked (``is_saas_sync_enabled`` is
+    patched ``False`` for the whole process, and its gate is left
+    unoverridden). That keeps this file's "the consenting event must ship"
+    demand from ever colliding with the sibling's "any drain-blocked row must
+    never ship" demand — the two rows are no longer classified identically.
+
     Reds today: the dispatcher ships BOTH events. The journal has no project
     scoping at all (only ``user_id``/``team_slug``), and the drain never
     decodes ``project_slug`` from the payload to gate delivery — so once two
     projects share a journal (the common case: no per-project journal
     partitioning exists), a single active sync target drains every project's
     events indiscriminately, exactly as the incident (five non-consenting
-    projects' events shipped alongside a consenting one) played out.
+    projects' events shipped alongside a consenting one) played out. No
+    consent-checking code exists on the drain path at all today, so both
+    events ship regardless of ``repo_slug``/consent-record resolution.
     """
     from specify_cli.sync import emitter as emitter_mod
 
@@ -129,8 +202,11 @@ def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
     _write_consent_for_first_project_only(tmp_path)
 
     consenting = _stub_emitter(
-        project_slug="engagement-assistant", build_id="engagement-build-1"
+        project_slug="engagement-assistant",
+        build_id="engagement-build-1",
+        repo_slug=_CONSENTING_REPO_SLUG,
     )
+    consenting._capture_gate_state = _open_capture_gate
     nonconsenting = _stub_emitter(
         project_slug="client-confidential", build_id="confidential-build-1"
     )
@@ -160,6 +236,25 @@ def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
     assert journal.count() == 2, (
         "both projects' events must land in the same producer-scoped journal "
         "for this test to exercise the real cross-project leak"
+    )
+
+    # Distinguishability premise, asserted before the drain runs: the two
+    # rows must NOT collide on drain_blocked_reason (that collision was the
+    # earlier defect that made this file and the #3031 sibling mutually
+    # unsatisfiable) — the consenting row is genuinely open, the
+    # non-consenting row is genuinely blocked, and consent resolution must
+    # be what separates their outcomes below, not drain_blocked_reason alone.
+    rows_by_id = {event.event_id: event for event in journal.read_all()}
+    assert rows_by_id[consenting_envelope["event_id"]].drain_blocked_reason is None, (
+        "the consenting row's capture-gate override must have produced an "
+        "open (drain_blocked_reason=None) journal row"
+    )
+    assert (
+        rows_by_id[nonconsenting_envelope["event_id"]].drain_blocked_reason is not None
+    ), (
+        "the non-consenting row must remain machine-gate-blocked so this "
+        "test's premise is that consent — not drain_blocked_reason — is the "
+        "only thing distinguishing the two events"
     )
 
     ledger = SqliteDeliveryLedger(":memory:")

--- a/tests/delivery/test_dispatch_project_consent_3030.py
+++ b/tests/delivery/test_dispatch_project_consent_3030.py
@@ -1,0 +1,187 @@
+"""RED pin: one consenting checkout must not ship a sibling project's events (#3030).
+
+Background. The producer journal is scoped on ``(user_id, team_slug)`` only
+(``event_journal/journal.py:_producer_token``) — one DB per producer covering
+EVERY project on the machine. ``project_slug`` IS present inside the wire
+envelope payload the emitter builds (``sync/emitter.py:2038``), but nothing on
+the drain path decodes it to make a delivery decision:
+``EventJournal.read_all()`` (``event_journal/journal.py:258``) runs
+``SELECT_ALL_SQL`` (``event_journal/models.py:78``), which has no WHERE
+clause, and ``_select_undelivered`` (``delivery/dispatcher.py:192-223``) never
+looks inside the payload — ``_decode_payload`` (``dispatcher.py:231-245``) is
+only reached in the *post* phase, after selection has already happened.
+
+This drives the REAL emit -> capture -> dispatch -> receiver path end to end
+(no hand-built journal rows), mirroring
+``tests/delivery/test_envelope.py::test_journal_stores_full_envelope_so_dispatch_posts_contract_event``,
+with TWO distinct project identities that land in the SAME shared journal —
+the shared-journal premise is the point, not an accident, and is asserted
+explicitly below before the drain even runs.
+
+Consent bookkeeping (``~/.spec-kitty/config.toml`` -> ``[sync.repo_defaults]``,
+same shape as ``tests/sync/test_sync_consent_default_deny.py:203-207``) is
+recorded for the FIRST project only. The second project deliberately has NO
+entry at all — not an explicit opt-out — because a predicate that reads
+absence-of-a-decision as consent is the actual defect this incident turned on
+(#3031); an explicit opt-out fixture would pass today's code while the real
+leak (silence, not refusal) sailed through.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from specify_cli.delivery.dispatcher import dispatch
+from specify_cli.delivery.ledger import SqliteDeliveryLedger
+from specify_cli.delivery.receivers import StubReceiver
+from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
+from specify_cli.event_journal import (
+    get_journal,
+    reset_coalesce_strategy,
+    reset_journal_cache,
+)
+
+if TYPE_CHECKING:
+    from specify_cli.sync.emitter import EventEmitter
+
+pytestmark = pytest.mark.fast
+
+# A realistic owner/repo pair — consent keying must not depend on the slug
+# looking special (mirrors tests/sync/test_sync_consent_default_deny.py:48).
+_CONSENTING_REPO_SLUG = "my-org/engagement-assistant"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """One shared ``SPEC_KITTY_HOME``, mirroring ``test_envelope.py:55-63``.
+
+    A single shared journal across the two "checkouts" simulated below is the
+    premise of this test, not an accident.
+    """
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path))
+    reset_journal_cache()
+    reset_coalesce_strategy()
+    yield
+    reset_journal_cache()
+    reset_coalesce_strategy()
+
+
+def _write_consent_for_first_project_only(spec_kitty_home: Path) -> None:
+    """Record hosted-sync consent for ONE project only, in machine-global config.
+
+    Shape matches ``tests/sync/test_sync_consent_default_deny.py:203-207``
+    (``[sync.repo_defaults."<repo-slug>"]`` / ``enabled = true``).
+    ``SPEC_KITTY_HOME`` is used verbatim as the runtime-root base
+    (``paths/windows_paths.py:65-68`` — "the env path is not suffixed with
+    .spec-kitty"), so the config file lands at ``$SPEC_KITTY_HOME/config.toml``
+    directly. The second project gets NO entry — absence, not an explicit
+    opt-out.
+    """
+    config_path = spec_kitty_home / "config.toml"
+    config_path.write_text(
+        f'[sync.repo_defaults."{_CONSENTING_REPO_SLUG}"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+
+
+def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
+    """A real ``EventEmitter`` with a stubbed identity/git resolver.
+
+    Mirrors ``tests/delivery/test_envelope.py:65-74``'s ``_stub_emitter`` but
+    with REAL, distinct project identities (production-shaped project slugs
+    and distinct ``project_uuid``s per instance) rather than the envelope
+    test's ``None`` placeholders — the point being that two checkouts for two
+    different projects on the same machine still resolve to the SAME journal
+    file (``team_slug=None``) once SaaS sync is globally disabled.
+    """
+    from specify_cli.sync.emitter import EventEmitter
+    from specify_cli.sync.git_metadata import GitMetadata
+
+    em = EventEmitter()
+    em._identity = SimpleNamespace(
+        build_id=build_id, project_uuid=uuid4(), project_slug=project_slug
+    )
+    em._get_git_metadata = lambda: GitMetadata()
+    return em
+
+
+def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A consenting checkout's drain must not also ship a non-consenting sibling's event.
+
+    Reds today: the dispatcher ships BOTH events. The journal has no project
+    scoping at all (only ``user_id``/``team_slug``), and the drain never
+    decodes ``project_slug`` from the payload to gate delivery — so once two
+    projects share a journal (the common case: no per-project journal
+    partitioning exists), a single active sync target drains every project's
+    events indiscriminately, exactly as the incident (five non-consenting
+    projects' events shipped alongside a consenting one) played out.
+    """
+    from specify_cli.sync import emitter as emitter_mod
+
+    monkeypatch.setattr(emitter_mod, "is_saas_sync_enabled", lambda: False)
+    _write_consent_for_first_project_only(tmp_path)
+
+    consenting = _stub_emitter(
+        project_slug="engagement-assistant", build_id="engagement-build-1"
+    )
+    nonconsenting = _stub_emitter(
+        project_slug="client-confidential", build_id="confidential-build-1"
+    )
+
+    consenting_envelope = consenting._emit(
+        event_type="ErrorLogged",
+        aggregate_id="WP04",
+        aggregate_type="WorkPackage",
+        payload={"error_type": "runtime", "error_message": "boom", "wp_id": "WP04"},
+    )
+    nonconsenting_envelope = nonconsenting._emit(
+        event_type="ErrorLogged",
+        aggregate_id="WP04",
+        aggregate_type="WorkPackage",
+        payload={"error_type": "runtime", "error_message": "boom", "wp_id": "WP04"},
+    )
+    assert consenting_envelope is not None, "the consenting project's emit must succeed"
+    assert nonconsenting_envelope is not None, (
+        "the non-consenting project's emit must ALSO durably capture (FR-017 "
+        "capture-first) — the defect is at drain time, not capture time"
+    )
+
+    # The shared-journal premise, asserted explicitly before the drain runs:
+    # both events landed in the SAME journal file (team_slug=None for both,
+    # since is_saas_sync_enabled() is stubbed False for this process).
+    journal = get_journal(team_slug=None)
+    assert journal.count() == 2, (
+        "both projects' events must land in the same producer-scoped journal "
+        "for this test to exercise the real cross-project leak"
+    )
+
+    ledger = SqliteDeliveryLedger(":memory:")
+    registry = SqliteDeliveryTargetRegistry(":memory:")
+    target = registry.register(
+        url="https://hosted.example.com",
+        team_slug="team",
+        user_email="operator@example.com",
+    )
+    receiver = StubReceiver()
+
+    dispatch(journal=journal, ledger=ledger, receiver=receiver, target=target)
+
+    received_ids = set(receiver.received_event_ids())
+    assert consenting_envelope["event_id"] in received_ids, (
+        "the consenting project's event must still ship — this test is not "
+        "about breaking a healthy consenting drain"
+    )
+    assert nonconsenting_envelope["event_id"] not in received_ids, (
+        "a project that never consented (no repo_defaults entry at all for "
+        f"{_CONSENTING_REPO_SLUG!r}'s sibling) must not have its event "
+        "shipped merely because it shares a journal file with a project "
+        "that did consent — today it does, because the drain has no notion "
+        "of project identity at all"
+    )

--- a/tests/delivery/test_dispatch_project_consent_3030.py
+++ b/tests/delivery/test_dispatch_project_consent_3030.py
@@ -49,7 +49,7 @@ from specify_cli.event_journal import (
 if TYPE_CHECKING:
     from specify_cli.sync.emitter import EventEmitter
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.regression, pytest.mark.fast]
 
 # A realistic owner/repo pair — consent keying must not depend on the slug
 # looking special (mirrors tests/sync/test_sync_consent_default_deny.py:48).

--- a/tests/integration/test_review_cycle_rejection_only.py
+++ b/tests/integration/test_review_cycle_rejection_only.py
@@ -277,15 +277,23 @@ def test_review_cycle_counter_advances_only_on_real_rejection(
             [
                 "implement",
                 "WP01",
-                "--feature",
+                "--mission",
                 MISSION_SLUG,
                 "--agent",
                 "claude",
             ],
         )
-        # The CLI may exit 0 or 1 depending on workspace plumbing; for the
-        # purposes of this test we only care that no review-cycle artifact
-        # appeared as a side effect.
+        # Exit code 2 is a Typer usage error (e.g. an unknown/misspelled
+        # option) -- that means `implement` never actually ran, which would
+        # make the artifact-count assertion below vacuously true. The CLI
+        # may legitimately exit 0 (successful no-op resume) or 1 (a real
+        # workspace-plumbing failure) depending on fixture completeness, but
+        # 2 must never pass silently as if it proved the no-op contract.
+        assert result.exit_code in (0, 1), (
+            f"Implement rerun #{attempt + 1} returned a Typer usage error "
+            f"(exit {result.exit_code}) -- `implement` never ran, so this "
+            f"assertion would otherwise be vacuous. CLI stdout:\n{result.stdout}"
+        )
         assert _count_cycle_artifacts(sub_artifact_dir) == 0, (
             f"Implement rerun #{attempt + 1} unexpectedly created an artifact: "
             f"{_list_cycle_artifacts(sub_artifact_dir)}\nstdout:\n{result.stdout}"
@@ -310,11 +318,18 @@ def test_review_cycle_counter_advances_only_on_real_rejection(
         [
             "implement",
             "WP01",
-            "--feature",
+            "--mission",
             MISSION_SLUG,
             "--agent",
             "claude",
         ],
+    )
+    # As above: 2 is a Typer usage error and would mean `implement` never
+    # ran, making the no-inflation assertion below vacuous.
+    assert result.exit_code in (0, 1), (
+        f"Implement rerun after rejection returned a Typer usage error "
+        f"(exit {result.exit_code}) -- `implement` never ran. "
+        f"CLI stdout:\n{result.stdout}"
     )
     assert _count_cycle_artifacts(sub_artifact_dir) == 1, (
         f"Implement rerun after rejection unexpectedly inflated counter; "

--- a/tests/integration/test_review_cycle_rejection_only.py
+++ b/tests/integration/test_review_cycle_rejection_only.py
@@ -399,9 +399,27 @@ def test_approving_a_rejected_wp_writes_no_verdict_artifact(
     This test drives the full, well-behaved lifecycle a reviewer would
     actually use -- reject once, then rework and resubmit for a SECOND
     genuine review -- and shows that a plain
-    ``move-task WP01 --to approved --note ... --no-auto-commit`` (no
-    ``--skip-review-artifact-check``, no ``--force``) is refused, and no
-    ``review-cycle-2.md`` is ever created to represent the eventual approval.
+    ``move-task WP01 --to approved --agent reviewer-renata --note ...
+    --no-auto-commit`` (no ``--skip-review-artifact-check``, no ``--force``)
+    is refused, and no fresh ``review-cycle-N.md`` is ever created to
+    represent the eventual approval.
+
+    Contract pinned here (per #2996 step 4 -- "a new review-cycle-(N+1).md
+    is written with verdict: approved, a real reviewer_agent, and the actual
+    affected files / repro command"): the caller *declares* its identity via
+    ``--agent`` (a real, documented option -- see
+    ``src/specify_cli/cli/commands/agent/tasks.py:610``), and the recorded
+    artifact must echo that declared identity plus reviewer-authored body
+    content. This is deliberately NOT ``reviewer_agent != "unknown"`` on an
+    invocation that declares no reviewer -- that phrasing is satisfiable by
+    *inferring* an identity from ambient state, which is the exact
+    provenance-fabrication pathology #2996(b) pins against elsewhere (a
+    ``review-cycle-2.md`` written with ``reviewer_agent: unknown`` and a body
+    byte-identical to cycle 1's, authored by nobody). Requiring the artifact
+    to echo a caller-declared identity, plus carry non-empty reviewer content,
+    closes off the cheapest satisfying "fix" -- synthesizing an empty
+    approval artifact with an inferred reviewer -- without licensing either
+    half of #2996's pathology.
 
     Beware the false green this test replaces coverage for:
     ``tests/post_merge/test_review_artifact_consistency.py:214`` passes today
@@ -481,7 +499,10 @@ def test_approving_a_rejected_wp_writes_no_verdict_artifact(
     )
 
     # The reviewer is now satisfied and approves -- a plain approve, with NO
-    # override flags. This is the exact command shape from the ticket.
+    # override flags, and a caller-declared reviewer identity via --agent
+    # (the real option the CLI already exposes -- see
+    # src/specify_cli/cli/commands/agent/tasks.py:610).
+    reviewer_identity = "reviewer-renata"
     runner = CliRunner()
     result = runner.invoke(
         agent_tasks.app,
@@ -492,6 +513,8 @@ def test_approving_a_rejected_wp_writes_no_verdict_artifact(
             "approved",
             "--mission",
             MISSION_SLUG,
+            "--agent",
+            reviewer_identity,
             "--note",
             "Approving after fixes were verified in the resubmitted review cycle.",
             "--no-auto-commit",
@@ -501,11 +524,17 @@ def test_approving_a_rejected_wp_writes_no_verdict_artifact(
     # Assert artifact FIRST (names the missing producer, not the guard).
     latest = ReviewCycleArtifact.latest(sub_artifact_dir)
     assert latest is not None, (
-        "expected a review-cycle-2.md verdict artifact to exist after the "
-        f"approve attempt; none was created. CLI stdout:\n{result.stdout}"
+        "expected a fresh review-cycle-N.md verdict artifact to exist after "
+        f"the approve attempt; none was created. CLI stdout:\n{result.stdout}"
     )
-    assert latest.cycle_number == 2, (
-        f"expected cycle_number 2 (a fresh approval verdict), got "
+    # Number-agnostic per #2996: the highest-numbered artifact must be the
+    # approval, not necessarily cycle 2 specifically -- next_cycle_number is
+    # len(glob) + 1 (a known double-increment source; see
+    # src/specify_cli/review/artifacts.py), so a correct fix could legitimately
+    # land the approval at cycle 3. What matters is that a NEW cycle was
+    # written rather than the stale rejected cycle 1 being reused.
+    assert latest.cycle_number > 1, (
+        f"expected a fresh cycle number above the rejected cycle 1, got "
         f"{latest.cycle_number} -- the stale rejected cycle 1 is still "
         f"'latest'. CLI stdout:\n{result.stdout}"
     )
@@ -513,9 +542,21 @@ def test_approving_a_rejected_wp_writes_no_verdict_artifact(
         f"expected the latest review-cycle artifact's verdict to be "
         f"'approved', got {latest.verdict!r}. CLI stdout:\n{result.stdout}"
     )
-    assert latest.reviewer_agent != "unknown", (
-        "expected the approval artifact to carry a real reviewer identity, "
-        f"got 'unknown'. CLI stdout:\n{result.stdout}"
+    # The artifact must echo the identity the CALLER declared -- not an
+    # identity inferred from ambient state. An invocation that declares no
+    # reviewer cannot honestly satisfy this; requiring the declared identity
+    # to be echoed keeps the contract satisfiable without inference.
+    assert latest.reviewer_agent == reviewer_identity, (
+        f"expected the approval artifact to echo the declared --agent "
+        f"identity {reviewer_identity!r}, got {latest.reviewer_agent!r}. "
+        f"CLI stdout:\n{result.stdout}"
+    )
+    # Reviewer-authored content, not a synthesized empty shell: a fix that
+    # fabricates an approval artifact with an empty body would satisfy every
+    # assertion above but must not satisfy this one.
+    assert latest.body.strip(), (
+        "expected the approval artifact to carry non-empty reviewer-authored "
+        f"body content, got an empty body. CLI stdout:\n{result.stdout}"
     )
 
     assert result.exit_code == 0, (

--- a/tests/integration/test_review_cycle_rejection_only.py
+++ b/tests/integration/test_review_cycle_rejection_only.py
@@ -343,3 +343,160 @@ def test_two_rejections_produce_two_distinct_artifacts(
     ]
     # First artifact untouched.
     assert p1.stat().st_mtime_ns == p1_mtime
+
+
+def test_approving_a_rejected_wp_writes_no_verdict_artifact(
+    for_review_repo: tuple[Path, Path, Path],
+) -> None:
+    """Pin #2996(a): once a WP has EVER been rejected, no normal
+    ``move-task --to approved`` invocation can ever record an approval
+    verdict artifact -- even after the WP has been fully reworked and
+    resubmitted through claimed -> in_progress -> for_review -> in_review.
+
+    Root cause (traced against ``main`` @ upstream/main): the rejected-verdict
+    guard (``_guard_rejected_verdict``,
+    ``src/specify_cli/cli/commands/agent/tasks_transition_core.py:364-388``)
+    reads the WP's *latest* ``review-cycle-N.md`` verdict regardless of how
+    many times the WP has since re-entered ``for_review``/``in_review`` --
+    there is no notion of "this rejection was already acted upon by a
+    subsequent resubmission". Every approve attempt after any rejection ever
+    recorded is refused unless the caller passes
+    ``--skip-review-artifact-check --note ...``. The guard's OWN override arm
+    is not the fix either: ``_authorize_review_override`` computes ``True``
+    and is stamped onto ``Emit.authorize_review_override``
+    (``tasks_transition_core.py:173,391-399,664``), but that field is never
+    read anywhere in ``tasks_move_task.py`` -- contrast with sibling ``Emit``
+    fields ``planned_rollback``/``arbiter_forward``/``done_override_note``/
+    ``skip_primary``, which ARE consumed there. No code path -- override flags
+    or not -- ever writes a new ``review-cycle-N.md`` with ``verdict:
+    approved``. ``ReviewCycleArtifact.write()``
+    (``src/specify_cli/review/artifacts.py:199``) has exactly one caller,
+    ``create_rejected_review_cycle`` (``src/specify_cli/review/cycle.py:320``),
+    which hardcodes ``verdict="rejected"``.
+
+    This test drives the full, well-behaved lifecycle a reviewer would
+    actually use -- reject once, then rework and resubmit for a SECOND
+    genuine review -- and shows that a plain
+    ``move-task WP01 --to approved --note ... --no-auto-commit`` (no
+    ``--skip-review-artifact-check``, no ``--force``) is refused, and no
+    ``review-cycle-2.md`` is ever created to represent the eventual approval.
+
+    Beware the false green this test replaces coverage for:
+    ``tests/post_merge/test_review_artifact_consistency.py:214`` passes today
+    because its fixture (``_write_review_artifact``) calls
+    ``ReviewCycleArtifact(..., verdict="approved").write(...)`` directly,
+    substituting for the exact production step (a real ``move-task --to
+    approved`` writing an approved verdict artifact) that this defect
+    removes. That test proves the POST-MERGE AUDIT gate exists; it does not
+    prove any live path can produce the artifact the audit expects to find.
+    """
+    from specify_cli.cli.commands.agent import tasks as agent_tasks
+    from specify_cli.review.artifacts import ReviewCycleArtifact
+
+    repo, feature_dir, sub_artifact_dir = for_review_repo
+
+    # WP starts at for_review (fixture). Move it into in_review for the FIRST
+    # (real) review round.
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000004",
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+        ),
+    )
+
+    # Reviewer rejects cycle 1.
+    persisted = _trigger_rejection(repo, "## Cycle 1 issues\n\nFix the off-by-one.")
+    assert persisted.name == "review-cycle-1.md"
+    latest_after_rejection = ReviewCycleArtifact.latest(sub_artifact_dir)
+    assert latest_after_rejection is not None
+    assert latest_after_rejection.verdict == "rejected"
+
+    # Drive the WP back through the FULL lifecycle after the rejection --
+    # in_review -> planned (rejected) -> claimed -> in_progress -> for_review
+    # -> in_review -- exactly as a real implementer reworking and
+    # resubmitting the WP for a genuine second review round would.
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000005",
+            from_lane=Lane.IN_REVIEW,
+            to_lane=Lane.PLANNED,
+        ),
+    )
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000006",
+            from_lane=Lane.PLANNED,
+            to_lane=Lane.CLAIMED,
+        ),
+    )
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000007",
+            from_lane=Lane.CLAIMED,
+            to_lane=Lane.IN_PROGRESS,
+        ),
+    )
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000008",
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.FOR_REVIEW,
+        ),
+    )
+    append_event(
+        feature_dir,
+        _make_event(
+            event_id="01TEST00000000000000000009",
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+        ),
+    )
+
+    # The reviewer is now satisfied and approves -- a plain approve, with NO
+    # override flags. This is the exact command shape from the ticket.
+    runner = CliRunner()
+    result = runner.invoke(
+        agent_tasks.app,
+        [
+            "move-task",
+            "WP01",
+            "--to",
+            "approved",
+            "--mission",
+            MISSION_SLUG,
+            "--note",
+            "Approving after fixes were verified in the resubmitted review cycle.",
+            "--no-auto-commit",
+        ],
+    )
+
+    # Assert artifact FIRST (names the missing producer, not the guard).
+    latest = ReviewCycleArtifact.latest(sub_artifact_dir)
+    assert latest is not None, (
+        "expected a review-cycle-2.md verdict artifact to exist after the "
+        f"approve attempt; none was created. CLI stdout:\n{result.stdout}"
+    )
+    assert latest.cycle_number == 2, (
+        f"expected cycle_number 2 (a fresh approval verdict), got "
+        f"{latest.cycle_number} -- the stale rejected cycle 1 is still "
+        f"'latest'. CLI stdout:\n{result.stdout}"
+    )
+    assert latest.verdict == "approved", (
+        f"expected the latest review-cycle artifact's verdict to be "
+        f"'approved', got {latest.verdict!r}. CLI stdout:\n{result.stdout}"
+    )
+    assert latest.reviewer_agent != "unknown", (
+        "expected the approval artifact to carry a real reviewer identity, "
+        f"got 'unknown'. CLI stdout:\n{result.stdout}"
+    )
+
+    assert result.exit_code == 0, (
+        f"expected the well-behaved reworked-and-resubmitted approve to "
+        f"succeed; got exit code {result.exit_code}. CLI stdout:\n{result.stdout}"
+    )

--- a/tests/integration/test_review_cycle_rejection_only.py
+++ b/tests/integration/test_review_cycle_rejection_only.py
@@ -345,6 +345,7 @@ def test_two_rejections_produce_two_distinct_artifacts(
     assert p1.stat().st_mtime_ns == p1_mtime
 
 
+@pytest.mark.regression
 def test_approving_a_rejected_wp_writes_no_verdict_artifact(
     for_review_repo: tuple[Path, Path, Path],
 ) -> None:

--- a/tests/integration/test_review_cycle_rejection_only.py
+++ b/tests/integration/test_review_cycle_rejection_only.py
@@ -237,6 +237,12 @@ def _trigger_rejection(repo: Path, body: str) -> Path:
     feedback_file = repo / f"feedback_{abs(hash(body))}.md"
     feedback_file.write_text(body, encoding="utf-8")
 
+    # ``_persist_review_feedback`` is declared ``-> tuple[Path, str]`` at its
+    # definition (``agent/tasks_materialization.py``), but ``[tool.mypy]``
+    # sets ``follow_imports = "skip"`` for ``specify_cli.*``, so the symbol
+    # arrives here as ``Any``. Narrow it back at the boundary rather than
+    # suppressing the resulting ``no-any-return``.
+    persisted: Path
     persisted, _pointer = _persist_review_feedback(
         main_repo_root=repo,
         mission_slug=MISSION_SLUG,

--- a/tests/regression/test_issue_2993_lane_planning_ancestry.py
+++ b/tests/regression/test_issue_2993_lane_planning_ancestry.py
@@ -60,10 +60,14 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from specify_cli.cli.commands.implement import _ensure_planning_artifacts_committed_git
 from specify_cli.lanes.models import ExecutionLane, LanesManifest
 from specify_cli.lanes.worktree_allocator import allocate_lane_worktree
 from specify_cli.missions._create import ensure_coordination_branch
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo]
 
 MISSION_SLUG = "annoying-bugs-sweep-01KYHQ9F"
 MISSION_ID = "01KYHQ9FTN3W7C5J4K2M6R8QDS"

--- a/tests/regression/test_issue_2993_lane_planning_ancestry.py
+++ b/tests/regression/test_issue_2993_lane_planning_ancestry.py
@@ -27,8 +27,19 @@ no-op because the branch already exists, ``_create_lane_worktree`` runs
 ``git worktree add -b <lane> <path> <coordination_branch>``), the resulting
 lane branch never contains the planning artifacts at all.
 
-This test drives the four real production entry points named in the mission
-ticket, in the exact order that reproduces the defect:
+This test drives four real production entry points, in the order below.
+Empirically (instrumented run against this exact sequence), this test
+reproduces **Cause B** (the silent no-op) of the two independent causes
+triage identified for #2993, not Cause A (the copy-onto-coordination-branch
+path):
+
+```
+coord tip at mint: 71cffbdd38ff...
+helper returned: None
+coord tip AFTER helper: 71cffbdd38ff...  (moved: False)
+git log --oneline <coord> -- kitty-specs/<slug>/  =>  ''
+=> CAUSE B (silent no-op)
+```
 
 1. ``ensure_coordination_branch`` -- mint the coord branch BEFORE the
    planning artifacts exist.
@@ -38,8 +49,24 @@ ticket, in the exact order that reproduces the defect:
    called exactly as the legacy (``placement_ref=None``) fallback path in
    ``implement.py:1706`` invokes it when context resolution fails
    (``_resolve_placement_ref`` returns ``None`` on ``ActionContextError``,
-   ``implement_cores.py:617-637``).
+   ``implement_cores.py:617-637``). Under this precondition (artifacts
+   already committed on ``HEAD``, so ``git status --porcelain`` is clean)
+   the call is a proven no-op: removing step 3 entirely reproduces the
+   identical failure on Assert A below, byte-for-byte. Step 3 is kept in
+   the drive sequence not because it contributes to the failure, but
+   because it documents the legacy ``placement_ref=None`` fallback path
+   that a fix must also address (Cause B), independently of Cause A.
 4. ``allocate_lane_worktree`` -- the real WP04 lane allocator.
+
+Discriminator caveat: the triage note's ``git log --oneline
+<coordination-branch> -- kitty-specs/<slug>/`` heuristic (non-empty =>
+Cause A, empty => Cause B) is a sound *pre-fix* triage signal only. Once
+ancestry is genuinely established -- the fix this pin demands -- the
+planning-artifact commit legitimately appears in the coordination branch's
+history for that path (it is an ancestor, so it is "on" the branch), and
+the same heuristic reports "Cause A" for a correctly-fixed repo. Do not
+re-open #2993 on that false positive post-fix; check ancestry (Assert A
+below), not log non-emptiness.
 
 Related existing coverage this test does NOT contradict:
 ``tests/specify_cli/cli/commands/test_implement.py:471-545``
@@ -158,7 +185,12 @@ def test_lane_worktree_does_not_descend_from_planning_artifacts(
     # uncommitted edit.
     feature_dir = repo / "kitty-specs" / MISSION_SLUG
     (feature_dir).mkdir(parents=True, exist_ok=True)
-    (feature_dir / "spec.md").write_text("# Annoying bugs sweep\n", encoding="utf-8")
+    (feature_dir / "spec.md").write_text(
+        "# Annoying bugs sweep\n\n"
+        "## NFR-002 Retracted Constraint\n\n"
+        "This constraint block must be removed after correction.\n",
+        encoding="utf-8",
+    )
     (feature_dir / "tasks.md").write_text(
         "## WP03 Ledger grammar and census\n\n- [ ] T001 Draft grammar\n",
         encoding="utf-8",
@@ -259,4 +291,48 @@ def test_lane_worktree_does_not_descend_from_planning_artifacts(
     ), (
         "the union-merge should carry forward the amended tasks.md; instead it "
         f"kept the lane's stale copy:\n{show.stdout!r}"
+    )
+
+    # Assert C -- deletion-only half. #2993's acceptance criteria singles this
+    # out as "the sharp case, since it vanishes under a union merge": delete
+    # (not amend) the NFR-002 block from spec.md on the planning branch AFTER
+    # the lane exists, then union-merge the two branches. A phrase-presence
+    # check (like Assert B's) cannot see a resurrected deletion -- only a
+    # phrase-ABSENCE check can. A healthy lane must let the deletion win; a
+    # lane carrying a stale/frozen copy of the pre-deletion text risks a
+    # naive conflict resolution silently reviving text the mission owner
+    # deliberately retracted.
+    (feature_dir / "spec.md").write_text("# Annoying bugs sweep\n", encoding="utf-8")
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-q", "-m", "docs: retract NFR-002 for WP03")
+
+    deletion_merge_tree = subprocess.run(
+        ["git", "-C", str(repo), "merge-tree", "--write-tree", lane_branch, "main"],
+        capture_output=True,
+        text=True,
+    )
+    assert deletion_merge_tree.returncode == 0, (
+        "expected a clean union-merge between the lane branch and the "
+        f"deletion-carrying planning branch, got a conflict:\n{deletion_merge_tree.stdout}"
+        f"\n{deletion_merge_tree.stderr}"
+    )
+    deletion_merged_tree_sha = deletion_merge_tree.stdout.strip().splitlines()[0]
+
+    deletion_show = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "show",
+            f"{deletion_merged_tree_sha}:kitty-specs/{MISSION_SLUG}/spec.md",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert deletion_show.returncode == 0, (
+        f"spec.md missing from the union-merge tree entirely: {deletion_show.stderr!r}"
+    )
+    assert "NFR-002 Retracted Constraint" not in deletion_show.stdout, (
+        "the union-merge silently resurrected a block that was deleted on the "
+        f"planning branch after the lane existed:\n{deletion_show.stdout!r}"
     )

--- a/tests/regression/test_issue_2993_lane_planning_ancestry.py
+++ b/tests/regression/test_issue_2993_lane_planning_ancestry.py
@@ -1,0 +1,258 @@
+"""Regression for #2993: a fresh lane worktree does not descend from the
+mission's own planning artifacts (spec.md/tasks.md/meta.json).
+
+Root cause (traced against ``main`` @ upstream/main, WP03 read-side-seam
+mission): ``_ensure_planning_artifacts_committed_git``
+(``src/specify_cli/cli/commands/implement.py:626-714``) decides what to
+auto-commit onto the coordination branch via
+``resolve_planning_artifact_staging`` (``implement_cores.py:544-609``). When
+the planning artifacts are *already* committed on the planning/primary
+branch (the normal spec -> plan -> tasks authoring flow, NOT a dirty
+uncommitted edit), ``git status --porcelain`` is clean, so
+``_status_paths_for_commit`` contributes nothing. The only other source is
+``extra_file_paths`` (a plain filesystem walk of every file currently under
+the mission dir), which is then filtered by
+``_files_changed_vs_precondition_ref`` -> ``resolve_precondition_ref``
+(``implement_cores.py:299-327``). ``resolve_precondition_ref`` classifies
+``spec.md`` / ``tasks.md`` / ``meta.json`` as PRIMARY-kind (not
+``is_coord_residue_churn``), so they are diffed against ``HEAD`` -- the
+planning branch itself, where they are already committed and therefore
+byte-identical. They are silently dropped from ``files_to_commit``, which
+becomes empty, and the function no-ops (``implement.py:691-692``). The
+coordination branch's tip is left exactly where ``ensure_coordination_branch``
+minted it -- BEFORE the planning artifacts ever existed. When
+``allocate_lane_worktree`` later branches the lane off that coordination
+branch (``worktree_allocator.py:213-216``, ``_ensure_branch_exists`` is a
+no-op because the branch already exists, ``_create_lane_worktree`` runs
+``git worktree add -b <lane> <path> <coordination_branch>``), the resulting
+lane branch never contains the planning artifacts at all.
+
+This test drives the four real production entry points named in the mission
+ticket, in the exact order that reproduces the defect:
+
+1. ``ensure_coordination_branch`` -- mint the coord branch BEFORE the
+   planning artifacts exist.
+2. A normal ``git commit`` of ``kitty-specs/<slug>/{spec.md,tasks.md,
+   meta.json}`` onto the planning branch (captures the sha).
+3. ``_ensure_planning_artifacts_committed_git`` -- the auto-commit helper,
+   called exactly as the legacy (``placement_ref=None``) fallback path in
+   ``implement.py:1706`` invokes it when context resolution fails
+   (``_resolve_placement_ref`` returns ``None`` on ``ActionContextError``,
+   ``implement_cores.py:617-637``).
+4. ``allocate_lane_worktree`` -- the real WP04 lane allocator.
+
+Related existing coverage this test does NOT contradict:
+``tests/specify_cli/cli/commands/test_implement.py:471-545``
+(``TestPlanningArtifactAutoCommit.test_auto_commit_uses_coordination_worktree_paths``)
+pins a *different* precondition: there the planning artifact is written to
+disk but never committed on the planning branch, so it IS picked up by
+``git status --porcelain`` and correctly lands on the coordination branch.
+That assertion is not disturbed here -- this test's planning artifacts are
+committed BEFORE the auto-commit helper runs, which is the gap the existing
+test does not cover. Whoever fixes #2993 should re-adjudicate that test only
+if the fix changes what counts as "already committed" for the idempotency
+filter.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from specify_cli.cli.commands.implement import _ensure_planning_artifacts_committed_git
+from specify_cli.lanes.models import ExecutionLane, LanesManifest
+from specify_cli.lanes.worktree_allocator import allocate_lane_worktree
+from specify_cli.missions._create import ensure_coordination_branch
+
+MISSION_SLUG = "annoying-bugs-sweep-01KYHQ9F"
+MISSION_ID = "01KYHQ9FTN3W7C5J4K2M6R8QDS"
+MID8 = MISSION_ID[:8]
+WP_ID = "WP03"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "commit", "-q", "-m", "seed")
+
+
+def _write_meta(feature_dir: Path, *, coordination_branch: str) -> None:
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "mission_id": MISSION_ID,
+        "mission_slug": MISSION_SLUG,
+        "mid8": MID8,
+        "mission_type": "software-dev",
+        "target_branch": "main",
+        "created_at": "2026-07-28T00:00:00+00:00",
+        "friendly_name": "Annoying bugs sweep",
+        "coordination_branch": coordination_branch,
+    }
+    (feature_dir / "meta.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )
+
+
+def _make_manifest(coordination_branch: str) -> LanesManifest:
+    return LanesManifest(
+        version=1,
+        mission_slug=MISSION_SLUG,
+        mission_id=MISSION_ID,
+        mission_branch=coordination_branch,
+        target_branch="main",
+        lanes=[
+            ExecutionLane(
+                lane_id="lane-a",
+                wp_ids=(WP_ID,),
+                write_scope=("src/**",),
+                predicted_surfaces=("core",),
+                depends_on_lanes=(),
+                parallel_group=0,
+            )
+        ],
+        computed_at="2026-07-28T10:00:00Z",
+        computed_from="test",
+    )
+
+
+def test_lane_worktree_does_not_descend_from_planning_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Pin #2993: the lane branch must contain the mission's own planning
+    artifacts. Today it does not."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    # Step 1: mint the coordination branch BEFORE the planning artifacts exist.
+    coord_result = ensure_coordination_branch(
+        repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        mission_id=MISSION_ID,
+        target_branch="main",
+    )
+    assert coord_result.created
+    coord_branch = coord_result.branch_name
+
+    # Step 2: commit the planning artifacts on the planning (primary) branch
+    # -- a normal, already-committed spec/tasks authoring commit, not a dirty
+    # uncommitted edit.
+    feature_dir = repo / "kitty-specs" / MISSION_SLUG
+    (feature_dir).mkdir(parents=True, exist_ok=True)
+    (feature_dir / "spec.md").write_text("# Annoying bugs sweep\n", encoding="utf-8")
+    (feature_dir / "tasks.md").write_text(
+        "## WP03 Ledger grammar and census\n\n- [ ] T001 Draft grammar\n",
+        encoding="utf-8",
+    )
+    _write_meta(feature_dir, coordination_branch=coord_branch)
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-q", "-m", f"docs: spec+tasks for {MISSION_SLUG}")
+    planning_artifact_sha = _git(repo, "rev-parse", "HEAD")
+
+    # Step 3: run the real auto-commit helper, legacy (placement_ref=None)
+    # fallback path -- exactly as implement.py falls back to when
+    # _resolve_placement_ref's context resolution fails.
+    _ensure_planning_artifacts_committed_git(
+        repo_root=repo,
+        feature_dir=feature_dir,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        planning_branch="main",
+        auto_commit=True,
+    )
+
+    # Step 4: allocate the lane worktree -- the real WP04 lane allocator.
+    manifest = _make_manifest(coord_branch)
+    worktree_path, lane_branch = allocate_lane_worktree(
+        repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        lanes_manifest=manifest,
+    )
+    assert worktree_path.exists()
+
+    # Assert A -- ancestry: the lane branch must descend from the commit that
+    # introduced the planning artifacts.
+    ancestry = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "--is-ancestor",
+            planning_artifact_sha,
+            lane_branch,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert ancestry.returncode == 0, (
+        f"lane branch {lane_branch!r} should descend from the planning-artifact "
+        f"commit {planning_artifact_sha}, but `git merge-base --is-ancestor` "
+        f"returned {ancestry.returncode} (stderr: {ancestry.stderr!r}). This is "
+        "the #2993 defect: the coordination branch tip was never advanced past "
+        "its pre-artifact mint point before the lane branched off it."
+    )
+
+    # Assert B -- silent-revert half: amend tasks.md on the planning branch
+    # AFTER the lane exists, then union-merge the two branches. A healthy
+    # lane (containing the original tasks.md as an ancestor state) merges
+    # cleanly and picks up the amendment. Today the lane's tree has no
+    # tasks.md at all, so the merge fabricates a stale/absent result instead
+    # of the amended text.
+    (feature_dir / "tasks.md").write_text(
+        "## WP03 Ledger grammar and census (amended)\n\n"
+        "- [ ] T001 Draft grammar\n- [ ] T002 Census sweep\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "kitty-specs")
+    _git(repo, "commit", "-q", "-m", "docs: amend tasks.md for WP03")
+
+    merge_tree = subprocess.run(
+        ["git", "-C", str(repo), "merge-tree", "--write-tree", lane_branch, "main"],
+        capture_output=True,
+        text=True,
+    )
+    assert merge_tree.returncode == 0, (
+        "expected a clean union-merge between the lane branch and the amended "
+        f"planning branch under kitty-specs/, got a conflict:\n{merge_tree.stdout}"
+        f"\n{merge_tree.stderr}"
+    )
+    merged_tree_sha = merge_tree.stdout.strip().splitlines()[0]
+
+    show = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "show",
+            f"{merged_tree_sha}:kitty-specs/{MISSION_SLUG}/tasks.md",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert show.returncode == 0, (
+        f"tasks.md missing from the union-merge tree entirely: {show.stderr!r}"
+    )
+    assert show.stdout == (
+        "## WP03 Ledger grammar and census (amended)\n\n"
+        "- [ ] T001 Draft grammar\n- [ ] T002 Census sweep\n"
+    ), (
+        "the union-merge should carry forward the amended tasks.md; instead it "
+        f"kept the lane's stale copy:\n{show.stdout!r}"
+    )

--- a/tests/regression/test_issue_2993_lane_planning_ancestry.py
+++ b/tests/regression/test_issue_2993_lane_planning_ancestry.py
@@ -45,17 +45,32 @@ git log --oneline <coord> -- kitty-specs/<slug>/  =>  ''
    planning artifacts exist.
 2. A normal ``git commit`` of ``kitty-specs/<slug>/{spec.md,tasks.md,
    meta.json}`` onto the planning branch (captures the sha).
-3. ``_ensure_planning_artifacts_committed_git`` -- the auto-commit helper,
-   called exactly as the legacy (``placement_ref=None``) fallback path in
-   ``implement.py:1706`` invokes it when context resolution fails
-   (``_resolve_placement_ref`` returns ``None`` on ``ActionContextError``,
-   ``implement_cores.py:617-637``). Under this precondition (artifacts
-   already committed on ``HEAD``, so ``git status --porcelain`` is clean)
-   the call is a proven no-op: removing step 3 entirely reproduces the
-   identical failure on Assert A below, byte-for-byte. Step 3 is kept in
-   the drive sequence not because it contributes to the failure, but
-   because it documents the legacy ``placement_ref=None`` fallback path
-   that a fix must also address (Cause B), independently of Cause A.
+3. ``_ensure_planning_artifacts_committed_git`` -- the auto-commit helper.
+   This test is parametrized over BOTH production call shapes at
+   ``implement.py:1706`` (``_ensure_planning_artifacts_committed_git(...,
+   placement_ref=_placement_ref)``):
+
+   - ``legacy-fallback`` (``placement_ref=None``): the fallback ``implement.py``
+     takes when ``_resolve_placement_ref`` hits an ``ActionContextError``
+     (``implement_cores.py:617-637``). Under this precondition (artifacts
+     already committed on ``HEAD``, so ``git status --porcelain`` is clean)
+     the call is a proven no-op that reproduces **Cause B** -- the coord
+     branch tip never moves past its pre-artifact mint point.
+   - ``placement-ref`` (``placement_ref=CommitTarget(ref=coord_branch)``):
+     the path a HEALTHY mission takes, where ``_resolve_placement_ref``
+     successfully resolves a ``CommitTarget``. This drives
+     ``_commit_planning_artifacts_transaction``'s ``placement_ref is not
+     None`` arm, which commits the planning-artifact files VERBATIM onto
+     ``placement_ref.ref`` via ``_run_planning_artifact_commit`` -- a plain
+     content copy, not a git merge/cherry-pick from the planning-branch
+     commit. This reproduces **Cause A** -- the coord branch tip DOES move
+     (a new commit lands on it), but that commit has no ancestry
+     relationship to the planning-artifact commit on the planning branch.
+
+   Both arms leave the lane branch failing Assert A below, for two
+   genuinely different reasons: Cause B never advances the coord tip at
+   all; Cause A advances it with a disconnected copy. #2993's triage
+   requires a fix to close both.
 4. ``allocate_lane_worktree`` -- the real WP04 lane allocator.
 
 Discriminator caveat: the triage note's ``git log --oneline
@@ -67,6 +82,22 @@ history for that path (it is an ancestor, so it is "on" the branch), and
 the same heuristic reports "Cause A" for a correctly-fixed repo. Do not
 re-open #2993 on that false positive post-fix; check ancestry (Assert A
 below), not log non-emptiness.
+
+Coord-descent guard: Assert A alone only requires the lane branch to
+descend from the planning-artifact commit. A fix that satisfies Assert A by
+branching lanes off ``main`` (which also contains the planning artifacts,
+since they are committed there) would satisfy Assert A while silently
+severing the lane from the mission's coordination branch -- discarding
+coordination-branch lifecycle state (status events, WP claim history) this
+repo's coord/primary partition depends on. #2993 does sanction "branch
+lanes off the planning-artifact commit" as one legitimate fix shape, so this
+guard is not forbidding that option outright -- it is requiring that
+whichever commit the lane branches from, the lane must ALSO still descend
+from ``coord_branch``, so a fix cannot silently trade one defect (missing
+planning artifacts) for another (an orphaned lane that never sees coord
+state). This is checked immediately after Assert A (so Assert A keeps
+firing first) via ``git merge-base --is-ancestor <coord_branch>
+<lane_branch>``.
 
 Related existing coverage this test does NOT contradict:
 ``tests/specify_cli/cli/commands/test_implement.py:471-545``
@@ -89,6 +120,7 @@ from pathlib import Path
 
 import pytest
 
+from mission_runtime import CommitTarget
 from specify_cli.cli.commands.implement import _ensure_planning_artifacts_committed_git
 from specify_cli.lanes.models import ExecutionLane, LanesManifest
 from specify_cli.lanes.worktree_allocator import allocate_lane_worktree
@@ -162,11 +194,28 @@ def _make_manifest(coordination_branch: str) -> LanesManifest:
     )
 
 
+@pytest.mark.parametrize(
+    "use_placement_ref",
+    [False, True],
+    ids=["legacy-fallback", "placement-ref"],
+)
 def test_lane_worktree_does_not_descend_from_planning_artifacts(
     tmp_path: Path,
+    use_placement_ref: bool,
 ) -> None:
     """Pin #2993: the lane branch must contain the mission's own planning
-    artifacts. Today it does not."""
+    artifacts. Today it does not, on EITHER of the two production call
+    shapes ``implement.py:1706`` can take:
+
+    - ``legacy-fallback`` (``use_placement_ref=False``): the ``placement_ref
+      is None`` path taken when ``_resolve_placement_ref`` fails to resolve
+      an ``ActionContextError`` -- reproduces Cause B (silent no-op, coord
+      tip never moves).
+    - ``placement-ref`` (``use_placement_ref=True``): the path a healthy
+      mission takes, where a resolved ``CommitTarget`` is threaded through
+      -- reproduces Cause A (the coord tip moves, but via a disconnected
+      verbatim copy, not a merge/cherry-pick preserving ancestry).
+    """
     repo = tmp_path / "repo"
     _init_repo(repo)
 
@@ -200,9 +249,14 @@ def test_lane_worktree_does_not_descend_from_planning_artifacts(
     _git(repo, "commit", "-q", "-m", f"docs: spec+tasks for {MISSION_SLUG}")
     planning_artifact_sha = _git(repo, "rev-parse", "HEAD")
 
-    # Step 3: run the real auto-commit helper, legacy (placement_ref=None)
-    # fallback path -- exactly as implement.py falls back to when
-    # _resolve_placement_ref's context resolution fails.
+    # Step 3: run the real auto-commit helper. ``placement_ref`` reproduces
+    # the exact value ``implement.py:1706`` threads through in production:
+    # ``None`` on the legacy-fallback arm (context resolution failed), or a
+    # resolved ``CommitTarget(ref=coord_branch)`` on the healthy-mission arm
+    # (mirrors what ``_resolve_placement_ref`` returns for a topology whose
+    # ``meta.json`` carries this mission's own ``coordination_branch`` --
+    # exactly the fixture state written by ``_write_meta`` above).
+    placement_ref = CommitTarget(ref=coord_branch) if use_placement_ref else None
     _ensure_planning_artifacts_committed_git(
         repo_root=repo,
         feature_dir=feature_dir,
@@ -210,6 +264,7 @@ def test_lane_worktree_does_not_descend_from_planning_artifacts(
         wp_id=WP_ID,
         planning_branch="main",
         auto_commit=True,
+        placement_ref=placement_ref,
     )
 
     # Step 4: allocate the lane worktree -- the real WP04 lane allocator.
@@ -243,6 +298,35 @@ def test_lane_worktree_does_not_descend_from_planning_artifacts(
         f"returned {ancestry.returncode} (stderr: {ancestry.stderr!r}). This is "
         "the #2993 defect: the coordination branch tip was never advanced past "
         "its pre-artifact mint point before the lane branched off it."
+    )
+
+    # Assert A' -- coord-descent guard: a fix must not satisfy Assert A by
+    # severing the lane from the mission's coordination branch (e.g. by
+    # branching lanes off ``main`` instead). The lane must ALSO still
+    # descend from ``coord_branch``, so coordination-branch lifecycle state
+    # (status events, WP claim history) is never discarded as a side effect
+    # of restoring planning-artifact ancestry. Ordered after Assert A so
+    # Assert A keeps firing first.
+    coord_ancestry = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "merge-base",
+            "--is-ancestor",
+            coord_branch,
+            lane_branch,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert coord_ancestry.returncode == 0, (
+        f"lane branch {lane_branch!r} should still descend from the mission's "
+        f"coordination branch {coord_branch!r}, but `git merge-base "
+        f"--is-ancestor` returned {coord_ancestry.returncode} (stderr: "
+        f"{coord_ancestry.stderr!r}). A fix for #2993 must not restore "
+        "planning-artifact ancestry by orphaning the lane from coordination "
+        "branch lifecycle state."
     )
 
     # Assert B -- silent-revert half: amend tasks.md on the planning branch

--- a/tests/review/test_cycle.py
+++ b/tests/review/test_cycle.py
@@ -141,6 +141,7 @@ WP_ID = "WP03"
 WP_SLUG = "WP03-ledger-grammar"
 
 
+@pytest.mark.regression
 def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
     """Pin #2996(b): handing ``create_rejected_review_cycle`` the WP's OWN
     prior ``review-cycle-N.md`` as ``feedback_source`` must be refused, not
@@ -217,6 +218,7 @@ def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
     assert latest.reviewer_agent == "reviewer-renata"
 
 
+@pytest.mark.regression
 def test_new_cycle_body_never_duplicates_a_prior_cycle_file(tmp_path: Path) -> None:
     """General invariant (#2996(b)): no newly-written review-cycle artifact's
     ``body`` may be byte-identical to the full text of any prior

--- a/tests/review/test_cycle.py
+++ b/tests/review/test_cycle.py
@@ -200,7 +200,16 @@ def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
     # source -- the exact ``--review-feedback-file <review-cycle-1.md path>``
     # shape from the ticket -- with an empty reviewer_agent (also from the
     # ticket).
-    with pytest.raises(ReviewCycleError, match="review-cycle|duplicate|feedback"):
+    #
+    # The match pattern is deliberately narrower than the original
+    # "review-cycle|duplicate|feedback": today's PRE-EXISTING guards ("Review
+    # feedback file not found: ..." / "Review feedback file is empty: ...")
+    # both contain the word "feedback", so that loose an alternation lets an
+    # unrelated failure satisfy this assertion for the wrong reason. Only a
+    # message that names the self-reference explicitly can match here.
+    with pytest.raises(
+        ReviewCycleError, match=r"own review-cycle|self-referential feedback"
+    ) as exc_info:
         create_rejected_review_cycle(
             main_repo_root=repo,
             mission_slug=MISSION_SLUG,
@@ -209,6 +218,23 @@ def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
             feedback_source=created.artifact_path,
             reviewer_agent="",
         )
+
+    # The operator's stated preference is loud failures WITH clear
+    # instructions: the message must name what was wrong (feedback_source is
+    # the WP's own prior review-cycle artifact) and tell the caller what to
+    # do instead (pass the underlying reviewer feedback, not a prior cycle
+    # artifact).
+    message = str(exc_info.value)
+    assert created.artifact_path.name in message, (
+        "error message must name the offending review-cycle artifact so the "
+        f"caller can identify it -- got: {message!r}"
+    )
+    assert any(
+        word in message.lower() for word in ("instead", "use ", "pass ", "provide ")
+    ), (
+        "error message must be actionable -- it must tell the caller what to "
+        f"do instead of the self-referential feedback_source -- got: {message!r}"
+    )
 
     # These hold once the guard exists: no fabricated cycle-2, and the real
     # reviewer's cycle-1 verdict remains the authoritative "latest".
@@ -221,18 +247,25 @@ def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
 @pytest.mark.regression
 def test_new_cycle_body_never_duplicates_a_prior_cycle_file(tmp_path: Path) -> None:
     """General invariant (#2996(b)): no newly-written review-cycle artifact's
-    ``body`` may be byte-identical to the full text of any prior
-    ``review-cycle-*.md`` in the same WP directory.
+    ``body`` may be byte-identical to a prior ``review-cycle-*.md`` artifact's
+    ``body`` in the same WP directory.
 
-    Demonstrates the live fabrication directly (no ``pytest.raises`` --
-    today's code does NOT raise, it succeeds and duplicates): reusing
-    cycle-1's own file as ``feedback_source`` for cycle-2 makes cycle-2's
-    ``body`` equal to cycle-1's ENTIRE on-disk file (frontmatter + body),
-    which trivially also equals cycle-1's own ``body`` is a strict subset --
-    the assertion below pins the general "never a duplicate" contract and is
-    expected to fail (red) today because the duplication is exactly what
-    happens.
+    Pinned INDEPENDENTLY of the self-reference guard exercised by
+    ``test_self_referential_feedback_source_is_rejected``: this test drives
+    ``create_rejected_review_cycle`` with an ORDINARY feedback file (never a
+    review-cycle artifact) whose *content happens to equal* cycle-1's body --
+    modelling a reviewer accidentally re-pasting the same feedback text, not
+    reusing a prior artifact file. That keeps this test outside the
+    self-reference guard's blast radius, so the two tests pin two distinct,
+    independently satisfiable contracts instead of colliding on the same
+    call shape.
+
+    Expected to fail (red) today at the ``not in prior_bodies`` assertion:
+    nothing in ``create_rejected_review_cycle`` deduplicates against prior
+    cycle bodies, so cycle-2 is written with a body identical to cycle-1's.
     """
+    from specify_cli.review.artifacts import ReviewCycleArtifact
+
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_repo(repo)
@@ -254,24 +287,38 @@ def test_new_cycle_body_never_duplicates_a_prior_cycle_file(tmp_path: Path) -> N
         feedback_source=real_feedback,
         reviewer_agent="reviewer-renata",
     )
-    cycle1_full_text = cycle1.artifact_path.read_text(encoding="utf-8")
+
+    # An ORDINARY feedback file -- never a review-cycle artifact -- whose
+    # content happens to duplicate cycle-1's body verbatim.
+    duplicate_feedback = tmp_path / "duplicate-feedback.md"
+    duplicate_feedback.write_text(cycle1.artifact.body, encoding="utf-8")
 
     cycle2 = create_rejected_review_cycle(
         main_repo_root=repo,
         mission_slug=MISSION_SLUG,
         wp_id=WP_ID,
         wp_slug=WP_SLUG,
-        feedback_source=cycle1.artifact_path,
+        feedback_source=duplicate_feedback,
         reviewer_agent="",
     )
 
+    # Compare BODY to BODY (parsed, frontmatter-stripped) -- not raw on-disk
+    # text -- so a fix that merely reshapes ``body`` (e.g. stripping
+    # frontmatter before assignment) cannot cheaply green this assertion
+    # while still writing a duplicate artifact.
     prior_bodies = [
-        p.read_text(encoding="utf-8")
+        ReviewCycleArtifact.from_file(p).body
         for p in wp_dir.glob("review-cycle-*.md")
         if p != cycle2.artifact_path
     ]
     assert cycle2.artifact.body not in prior_bodies, (
         "a newly-written review cycle's body duplicated a prior "
-        f"review-cycle-*.md file verbatim:\n{cycle2.artifact.body!r}"
+        f"review-cycle-*.md artifact's body verbatim:\n{cycle2.artifact.body!r}"
     )
-    assert cycle1_full_text not in (cycle2.artifact.body,)
+
+    latest = ReviewCycleArtifact.latest(wp_dir)
+    assert latest is not None
+    assert latest.reviewer_agent != "unknown", (
+        "a fabricated duplicate cycle must not become 'latest' with an "
+        "unattributed reviewer_agent -- got 'unknown'"
+    )

--- a/tests/review/test_cycle.py
+++ b/tests/review/test_cycle.py
@@ -134,3 +134,142 @@ def test_sentinel_pointer_is_not_feedback_artifact(tmp_path: Path) -> None:
 
     assert resolved.kind == "sentinel"
     assert resolved.path is None
+
+
+MISSION_SLUG = "annoying-bugs-sweep-01KYHQ9F"
+WP_ID = "WP03"
+WP_SLUG = "WP03-ledger-grammar"
+
+
+def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
+    """Pin #2996(b): handing ``create_rejected_review_cycle`` the WP's OWN
+    prior ``review-cycle-N.md`` as ``feedback_source`` must be refused, not
+    silently duplicated into a new cycle.
+
+    Root cause (traced against ``main`` @ upstream/main):
+    ``create_rejected_review_cycle``
+    (``src/specify_cli/review/cycle.py:277-346``) validates ``feedback_source``
+    only for existence / is-a-file / non-empty content
+    (lines 288-295) and computes the next cycle number purely from
+    ``len(sub_artifact_dir.glob("review-cycle-*.md")) + 1``
+    (``ReviewCycleArtifact.next_cycle_number``,
+    ``src/specify_cli/review/artifacts.py:288-295``) -- it never inspects
+    *what* ``feedback_source`` points at. Passing the WP's own
+    ``review-cycle-1.md`` (the ``--review-feedback-file`` shape from the
+    ticket) is accepted: its full text -- frontmatter delimiters and all --
+    is read as plain body content and written out as ``review-cycle-2.md``,
+    fabricating a duplicate cycle that outranks the real reviewer's original
+    verdict (``ReviewCycleArtifact.latest`` always returns the
+    highest-numbered file).
+
+    This test asserts the artifact-first, guard-second contract that would
+    need to hold once #2996(b) is fixed. It is expected to fail (red) at the
+    ``pytest.raises`` line TODAY, before the guard exists -- ``DID NOT RAISE``
+    is the correct failure signature for a regression test pinning a missing
+    guard, not a defect in the test itself.
+    """
+    from specify_cli.review.artifacts import ReviewCycleArtifact
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    tasks_dir = repo / "kitty-specs" / MISSION_SLUG / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / f"{WP_SLUG}.md").write_text("# WP03\n", encoding="utf-8")
+    wp_dir = tasks_dir / WP_SLUG
+
+    real_feedback = tmp_path / "feedback.md"
+    real_feedback.write_text(
+        "**Issue**: Ledger grammar drops the census delimiter.\n",
+        encoding="utf-8",
+    )
+
+    created = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        wp_slug=WP_SLUG,
+        feedback_source=real_feedback,
+        reviewer_agent="reviewer-renata",
+    )
+    assert created.artifact_path == wp_dir / "review-cycle-1.md"
+    assert created.artifact.reviewer_agent == "reviewer-renata"
+
+    # Hand the WP's OWN canonical review-cycle-1.md back in as the feedback
+    # source -- the exact ``--review-feedback-file <review-cycle-1.md path>``
+    # shape from the ticket -- with an empty reviewer_agent (also from the
+    # ticket).
+    with pytest.raises(ReviewCycleError, match="review-cycle|duplicate|feedback"):
+        create_rejected_review_cycle(
+            main_repo_root=repo,
+            mission_slug=MISSION_SLUG,
+            wp_id=WP_ID,
+            wp_slug=WP_SLUG,
+            feedback_source=created.artifact_path,
+            reviewer_agent="",
+        )
+
+    # These hold once the guard exists: no fabricated cycle-2, and the real
+    # reviewer's cycle-1 verdict remains the authoritative "latest".
+    assert not (wp_dir / "review-cycle-2.md").exists()
+    latest = ReviewCycleArtifact.latest(wp_dir)
+    assert latest is not None
+    assert latest.reviewer_agent == "reviewer-renata"
+
+
+def test_new_cycle_body_never_duplicates_a_prior_cycle_file(tmp_path: Path) -> None:
+    """General invariant (#2996(b)): no newly-written review-cycle artifact's
+    ``body`` may be byte-identical to the full text of any prior
+    ``review-cycle-*.md`` in the same WP directory.
+
+    Demonstrates the live fabrication directly (no ``pytest.raises`` --
+    today's code does NOT raise, it succeeds and duplicates): reusing
+    cycle-1's own file as ``feedback_source`` for cycle-2 makes cycle-2's
+    ``body`` equal to cycle-1's ENTIRE on-disk file (frontmatter + body),
+    which trivially also equals cycle-1's own ``body`` is a strict subset --
+    the assertion below pins the general "never a duplicate" contract and is
+    expected to fail (red) today because the duplication is exactly what
+    happens.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    tasks_dir = repo / "kitty-specs" / MISSION_SLUG / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / f"{WP_SLUG}.md").write_text("# WP03\n", encoding="utf-8")
+    wp_dir = tasks_dir / WP_SLUG
+
+    real_feedback = tmp_path / "feedback.md"
+    real_feedback.write_text(
+        "**Issue**: Ledger grammar drops the census delimiter.\n",
+        encoding="utf-8",
+    )
+    cycle1 = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        wp_slug=WP_SLUG,
+        feedback_source=real_feedback,
+        reviewer_agent="reviewer-renata",
+    )
+    cycle1_full_text = cycle1.artifact_path.read_text(encoding="utf-8")
+
+    cycle2 = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        wp_slug=WP_SLUG,
+        feedback_source=cycle1.artifact_path,
+        reviewer_agent="",
+    )
+
+    prior_bodies = [
+        p.read_text(encoding="utf-8")
+        for p in wp_dir.glob("review-cycle-*.md")
+        if p != cycle2.artifact_path
+    ]
+    assert cycle2.artifact.body not in prior_bodies, (
+        "a newly-written review cycle's body duplicated a prior "
+        f"review-cycle-*.md file verbatim:\n{cycle2.artifact.body!r}"
+    )
+    assert cycle1_full_text not in (cycle2.artifact.body,)

--- a/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
+++ b/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
@@ -10,7 +10,12 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from mission_runtime import MissionArtifactKind, is_primary_artifact_kind, kind_for_mission_file
+from mission_runtime import (
+    MissionArtifactKind,
+    is_primary_artifact_kind,
+    kind_for_mission_file,
+    resolve_placement_only,
+)
 from specify_cli import app as cli_app
 
 
@@ -28,6 +33,63 @@ def _init_spec_kitty_repo(repo: Path) -> None:
     (repo / "README.md").write_text("# Test Repo\n", encoding="utf-8")
     subprocess.run(["git", "add", "README.md", ".kittify/config.json"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=repo, check=True, capture_output=True)
+
+
+def _seed_merged_and_pruned_mission(tmp_path: Path, mission_slug: str) -> tuple[Path, str, str]:
+    """Seed a mission whose feature branch is merged into ``main`` and pruned.
+
+    Shared #3033 fixture shape -- exactly what ``spec-kitty merge`` + branch
+    cleanup leaves behind: the mission's ``meta.json`` still names the
+    now-deleted feature branch as ``target_branch``, and the working tree
+    ends up on a *different*, freshly-checked-out branch (mirroring a later
+    pass, e.g. authoring the retrospective, that runs from its own branch).
+
+    Extracted so both the CLI-level #3033 regression
+    (``test_public_safe_commit_succeeds_after_merged_branch_deleted_3033``)
+    and the seam-level #3033 regression
+    (``test_resolve_placement_only_rejects_pruned_target_branch_3033``) drive
+    the identical repo shape without duplicating the git choreography.
+
+    Returns ``(feature_dir, feature_branch, postmerge_branch)``.
+    """
+    feature_branch = f"feat/{mission_slug}"
+    postmerge_branch = f"review/{mission_slug}-postmerge"
+
+    _init_spec_kitty_repo(tmp_path)
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("checkout", "-q", "-b", feature_branch)
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    feature_dir.mkdir(parents=True)
+    meta = {
+        "mission_id": "01KYHHR8RELATIONALCUT0001",
+        "mission_slug": mission_slug,
+        "mission_type": "software-dev",
+        "target_branch": feature_branch,
+        "friendly_name": "Relational cutover",
+    }
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"chore({mission_slug}): seed mission meta"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    # Merge into main and prune the merged branch -- exactly what
+    # `spec-kitty merge` + branch cleanup leaves behind.
+    _git("checkout", "-q", "main")
+    _git("merge", "-q", "--no-ff", feature_branch, "-m", f"Merge {feature_branch}")
+    _git("branch", "-D", feature_branch)
+
+    # A later pass (e.g. the retrospective) works from a fresh branch -- the
+    # merged mission branch no longer exists anywhere in this repo.
+    _git("checkout", "-q", "-b", postmerge_branch)
+
+    return feature_dir, feature_branch, postmerge_branch
 
 
 @pytest.mark.parametrize(
@@ -201,42 +263,9 @@ def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
     monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
 
     mission_slug = "relational-cutover-01KYHHR8"
-    feature_branch = f"feat/{mission_slug}"
-    postmerge_branch = f"review/{mission_slug}-postmerge"
-
-    _init_spec_kitty_repo(tmp_path)
-
-    def _git(*args: str) -> None:
-        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
-
-    _git("checkout", "-q", "-b", feature_branch)
-    feature_dir = tmp_path / "kitty-specs" / mission_slug
-    feature_dir.mkdir(parents=True)
-    meta = {
-        "mission_id": "01KYHHR8RELATIONALCUT0001",
-        "mission_slug": mission_slug,
-        "mission_type": "software-dev",
-        "target_branch": feature_branch,
-        "friendly_name": "Relational cutover",
-    }
-    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
-    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", f"chore({mission_slug}): seed mission meta"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
+    feature_dir, _feature_branch, _postmerge_branch = _seed_merged_and_pruned_mission(
+        tmp_path, mission_slug
     )
-
-    # Merge into main and prune the merged branch -- exactly what
-    # `spec-kitty merge` + branch cleanup leaves behind.
-    _git("checkout", "-q", "main")
-    _git("merge", "-q", "--no-ff", feature_branch, "-m", f"Merge {feature_branch}")
-    _git("branch", "-D", feature_branch)
-
-    # A later retrospective pass works from a fresh branch -- the merged
-    # mission branch no longer exists anywhere in this repo.
-    _git("checkout", "-q", "-b", postmerge_branch)
 
     retro_path = feature_dir / "retrospective.yaml"
     retro_path.write_text(
@@ -317,3 +346,73 @@ def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
         "Post-merge writes must not require the merged branch to still exist."
         in committed_blob
     ), committed_blob
+
+
+@pytest.mark.regression
+def test_resolve_placement_only_rejects_pruned_target_branch_3033(
+    tmp_path: Path,
+) -> None:
+    """#3033: the seam itself hands back a pruned branch -- not a CLI artifact.
+
+    #3033 SS7 is explicit: "Fixing it at one call site is whack-a-field."
+    ``test_public_safe_commit_succeeds_after_merged_branch_deleted_3033``
+    above documents its own "Honest limit": because it drives only the
+    public ``safe-commit`` CLI, a call-site patch inside
+    ``safe_commit_cmd._resolve_commit_target`` that falls back to the
+    checked-out ``HEAD`` branch whenever the resolved ``target_branch``
+    doesn't exist would ALSO satisfy that test's assertions -- ``HEAD`` is by
+    construction an existing, readable ref, so "ref exists" and "content
+    readable back from that ref" are both trivially true for a HEAD
+    fallback. That test alone cannot mechanically force the fix to live at
+    the seam. This test exists BECAUSE of that gap, and the two are meant to
+    be discharged TOGETHER, not interchangeably.
+
+    This test never calls ``safe-commit`` and never goes near
+    ``_resolve_commit_target``. It calls the placement seam directly:
+    ``mission_runtime.resolve_placement_only`` -- which, for a
+    ``MissionArtifactKind.RETROSPECTIVE`` (a PRIMARY-partition kind), returns
+    ``CommitTarget(ref=target_branch)`` where ``target_branch`` comes
+    straight from ``specify_cli.core.paths.get_feature_target_branch``: a
+    bare ``meta.json`` read of ``target_branch`` with NO existence check
+    against git and no lifecycle-phase input (see
+    ``src/mission_runtime/resolution.py`` around ``resolve_placement_only``'s
+    ``if kind in _PRIMARY_ARTIFACT_KINDS: return CommitTarget(ref=target_branch)``
+    arm, and ``get_feature_target_branch`` in
+    ``src/specify_cli/core/paths.py``). A ``_resolve_commit_target``
+    HEAD-fallback patch cannot make this test pass -- it is not on this call
+    path at all; the only way to turn this red pin green is to make the seam
+    itself existence-checked / lifecycle-aware, which is exactly #3033 SS7's
+    binding constraint.
+
+    Contract pinned: for a mission whose ``target_branch`` has been merged
+    and pruned, the placement seam must resolve a destination that actually
+    exists in the repository -- it must not hand back a ref naming a branch
+    that is gone.
+    """
+    mission_slug = "relational-cutover-01KYHHR8"
+    feature_dir, feature_branch, _postmerge_branch = _seed_merged_and_pruned_mission(
+        tmp_path, mission_slug
+    )
+    assert feature_dir.exists()  # sanity: the shared fixture did seed the mission
+
+    target = resolve_placement_only(
+        tmp_path, mission_slug, kind=MissionArtifactKind.RETROSPECTIVE
+    )
+
+    ref_exists = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{target.ref}"],
+        cwd=tmp_path,
+        capture_output=True,
+    )
+    assert ref_exists.returncode == 0, (
+        f"resolve_placement_only resolved {target.ref!r} for a mission whose "
+        "feature branch was merged and pruned -- the placement seam handed "
+        "back a destination git can no longer verify. Per #3033 SS7, the fix "
+        "belongs at the seam (get_feature_target_branch / "
+        "resolve_placement_only gaining post-merge lifecycle awareness), not "
+        "as a call-site HEAD fallback in _resolve_commit_target."
+    )
+    assert target.ref != feature_branch, (
+        f"resolve_placement_only must not hand back the pruned feature "
+        f"branch {feature_branch!r} verbatim"
+    )

--- a/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
+++ b/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from mission_runtime import MissionArtifactKind, is_primary_artifact_kind, kind_for_mission_file
 from specify_cli import app as cli_app
 
 
@@ -172,11 +173,29 @@ def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
     direct ``safe-commit`` of a PRIMARY-kind mission artifact (retrospective,
     spec, plan, tasks, analysis-report, ...) once the feature branch is gone.
 
-    This test asserts the OUTCOME (``success`` / ``committed``), not a
-    particular destination branch: a fix that special-cases "commit to HEAD"
-    would relieve this symptom while leaving the same hole open for the
-    retrospective terminus and the acceptance-matrix refresh, both of which
-    share the same ``get_feature_target_branch`` read.
+    This test asserts the OUTCOME, not a particular destination branch name
+    (#3033 SS7: "asserted through the seam, not through the review command" /
+    "lands on a surface that can be resolved and read back"): beyond
+    ``success`` / ``committed``, it re-resolves the branch the commit actually
+    left ``HEAD`` on, asserts that ref still exists (``git rev-parse
+    --verify``), and reads the artifact content back from it via ``git show
+    <ref>:<path>``. A fix that reports ``committed: true`` without the
+    content being durably retrievable from an existing ref must not pass.
+
+    Honest limit: because this test drives only the public ``safe-commit``
+    CLI (a black-box entry point), a call-site patch in
+    ``_resolve_commit_target`` that falls back to the current ``HEAD`` branch
+    when the resolved ``target_branch`` does not exist would ALSO satisfy
+    these assertions -- ``HEAD`` is by construction an existing, readable ref.
+    These assertions catch a broken/fake "success" (nothing durably
+    committed, or committed somewhere unresolvable); they cannot mechanically
+    prove the fix lives at the seam (``get_feature_target_branch`` /
+    ``resolve_placement_only`` gaining post-merge lifecycle awareness) rather
+    than at this one call site. Per #3033 SS7 that seam-level placement is the
+    binding fix constraint -- whack-a-field call-site patches leave the
+    retrospective terminus (SS6) and the acceptance-matrix refresh exposed to
+    the identical hole -- but confirming that requires a test on the seam
+    itself, not on this command.
     """
     monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
     monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
@@ -227,6 +246,22 @@ def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
         encoding="utf-8",
     )
 
+    # Precondition (MINOR guard): this test's entire value rests on
+    # `retrospective.yaml` classifying to a PRIMARY-partition kind -- an
+    # unclassified basename falls through to the generic HEAD path (see
+    # docstring) and succeeds regardless of the defect. Assert that
+    # classification through the public helpers so a future reclassification
+    # (or a COORD re-home) makes THIS assertion fail loudly instead of the
+    # test silently going green for the wrong reason.
+    retro_kind = kind_for_mission_file(
+        retro_path.relative_to(tmp_path), mission_slug=mission_slug
+    )
+    assert retro_kind is MissionArtifactKind.RETROSPECTIVE, retro_kind
+    assert is_primary_artifact_kind(retro_kind), (
+        "retrospective.yaml must classify to a PRIMARY-partition kind for "
+        "this regression to exercise the #3033 defect"
+    )
+
     old_cwd = os.getcwd()
     try:
         os.chdir(tmp_path)
@@ -248,3 +283,37 @@ def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
 
     assert payload["success"] is True, payload
     assert payload["committed"] is True, payload
+
+    # Strengthened per #3033 SS7 ("lands on a surface that can be resolved and
+    # read back"): a bare success/committed flag is satisfied by a fix that
+    # silently drops the write. Re-resolve the ref the commit actually landed
+    # on (safe_commit's own HEAD-match guard means that ref is whatever branch
+    # is checked out post-invocation) and prove it is (a) a ref git can still
+    # resolve, and (b) the artifact's content is retrievable from it -- not
+    # merely present in the working tree.
+    landed_ref = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "rev-parse", "--verify", landed_ref],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    retro_rel = retro_path.relative_to(tmp_path).as_posix()
+    committed_blob = subprocess.run(
+        ["git", "show", f"{landed_ref}:{retro_rel}"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert (
+        "Post-merge writes must not require the merged branch to still exist."
+        in committed_blob
+    ), committed_blob

--- a/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
+++ b/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
@@ -136,6 +136,7 @@ def test_public_safe_commit_rejects_protected_branch_in_test_mode(
     assert head_after == head_before
 
 
+@pytest.mark.regression
 def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
+++ b/tests/specify_cli/cli/commands/test_safe_commit_cmd.py
@@ -134,3 +134,116 @@ def test_public_safe_commit_rejects_protected_branch_in_test_mode(
     assert payload["success"] is False
     assert "protected branch 'main'" in payload["error"]
     assert head_after == head_before
+
+
+def test_public_safe_commit_succeeds_after_merged_branch_deleted_3033(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#3033: post-merge write fails once the merged mission branch is pruned.
+
+    ``spec-kitty safe-commit`` (no ``--to-branch``, which is load-bearing --
+    passing it short-circuits the defect at
+    ``src/specify_cli/cli/commands/safe_commit_cmd.py:267``) resolves a
+    PRIMARY-kind mission artifact's destination through
+    ``_resolve_mission_aware_target`` ->
+    ``mission_runtime.resolve_placement_only`` ->
+    ``specify_cli.core.paths.get_feature_target_branch``
+    (``src/specify_cli/core/paths.py:696-733``): a bare ``meta.json`` read of
+    ``target_branch`` with NO existence check against git and no
+    lifecycle-phase input. Once the mission's feature branch has been merged
+    and pruned (``git branch -D``) -- exactly what happens after
+    ``spec-kitty merge`` -- and a later pass (e.g. authoring the
+    retrospective) works from a *different* checked-out branch, the resolved
+    ``CommitTarget.ref`` still points at the now-nonexistent feature branch.
+    ``safe_commit``'s embedded HEAD-match guard then refuses the commit with
+    ``safe_commit: worktree ... HEAD is 'review/...', expected 'feat/...'``.
+
+    ``retrospective.yaml`` is deliberately the changeset here because
+    ``mission-review-report.md`` is NOT a member of
+    ``_MISSION_FILE_KIND_BY_BASENAME``
+    (``src/mission_runtime/artifacts.py:195-220``) -- a commit for that
+    basename falls through the mission-aware branch entirely and lands on the
+    generic HEAD path, where it would *succeed* despite the same pruned
+    branch, masking this defect. Also: ``spec-kitty review`` itself performs
+    no commit, so this defect is NOT reachable through the review command
+    despite what issue #3033's body says -- it is reachable through any
+    direct ``safe-commit`` of a PRIMARY-kind mission artifact (retrospective,
+    spec, plan, tasks, analysis-report, ...) once the feature branch is gone.
+
+    This test asserts the OUTCOME (``success`` / ``committed``), not a
+    particular destination branch: a fix that special-cases "commit to HEAD"
+    would relieve this symptom while leaving the same hole open for the
+    retrospective terminus and the acceptance-matrix refresh, both of which
+    share the same ``get_feature_target_branch`` read.
+    """
+    monkeypatch.delenv("SPEC_KITTY_TEST_MODE", raising=False)
+    monkeypatch.delenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", raising=False)
+
+    mission_slug = "relational-cutover-01KYHHR8"
+    feature_branch = f"feat/{mission_slug}"
+    postmerge_branch = f"review/{mission_slug}-postmerge"
+
+    _init_spec_kitty_repo(tmp_path)
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    _git("checkout", "-q", "-b", feature_branch)
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    feature_dir.mkdir(parents=True)
+    meta = {
+        "mission_id": "01KYHHR8RELATIONALCUT0001",
+        "mission_slug": mission_slug,
+        "mission_type": "software-dev",
+        "target_branch": feature_branch,
+        "friendly_name": "Relational cutover",
+    }
+    (feature_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"chore({mission_slug}): seed mission meta"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+
+    # Merge into main and prune the merged branch -- exactly what
+    # `spec-kitty merge` + branch cleanup leaves behind.
+    _git("checkout", "-q", "main")
+    _git("merge", "-q", "--no-ff", feature_branch, "-m", f"Merge {feature_branch}")
+    _git("branch", "-D", feature_branch)
+
+    # A later retrospective pass works from a fresh branch -- the merged
+    # mission branch no longer exists anywhere in this repo.
+    _git("checkout", "-q", "-b", postmerge_branch)
+
+    retro_path = feature_dir / "retrospective.yaml"
+    retro_path.write_text(
+        "summary: Relational cutover retrospective\n"
+        "lessons_learned:\n"
+        "  - Post-merge writes must not require the merged branch to still exist.\n",
+        encoding="utf-8",
+    )
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        result = runner.invoke(
+            cli_app,
+            [
+                "safe-commit",
+                "--message",
+                f"chore({mission_slug}): record retrospective",
+                "--json",
+                str(retro_path.relative_to(tmp_path)),
+            ],
+            catch_exceptions=False,
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    payload = json.loads(result.stdout)
+
+    assert payload["success"] is True, payload
+    assert payload["committed"] is True, payload

--- a/tests/sync/test_sync_consent_capture_gap_3031.py
+++ b/tests/sync/test_sync_consent_capture_gap_3031.py
@@ -1,0 +1,109 @@
+"""P0 red-main pin for the #3031 capture-gate gap (Defect 3, ungated capture).
+
+Companion to ``tests/sync/test_sync_consent_default_deny.py`` (#3031). That
+file's own docstring names two gaps its five tests do NOT cover:
+
+    Not covered here, and tracked in #3031 as separate work: capture is
+    ungated (Defect 3 — events reach the journal regardless of consent) and
+    drain selection filters per checkout rather than per event (Defect 5).
+    Both need their own fixtures; neither is pinned by this file.
+
+This file is additive — a NEW file, per the same-file docstring's own
+instruction that these need their own fixtures. It does not edit
+``test_sync_consent_default_deny.py``.
+
+Defect 5 (per-event drain filtering) is already pinned by
+``tests/delivery/test_dispatch_honours_drain_blocked_3030.py::test_dispatch_excludes_events_with_recorded_drain_blocked_reason``,
+which drains one blocked and one unblocked event in a SINGLE ``dispatch()``
+call (one process tick) and asserts differential treatment — a fix that
+filters per-*process* rather than per-*event* cannot pass that test. No
+duplicate is added here for Defect 5.
+
+Defect 3 (ungated capture) is pinned below. ``capture_teamspace_bound``
+(``event_journal/journal.py:370-403``) documents ``gate`` as deciding "only
+... the recorded drain_blocked_reason (delivery eligibility), never whether
+the write happens" for Teamspace-bound families — a deliberate, C-008-backed
+invariant for events that ARE Teamspace-bound. But the same function's
+``skip_journal`` parameter is the caller's signal that a particular capture
+should NOT be written at all (its docstring: "A request to skip the write for
+a Teamspace-bound family fails loudly"). Reading the implementation
+
+    if is_teamspace_bound and skip_journal:
+        raise TeamspaceBoundDropError(event_id=event_id)
+    event = Event(...)
+    journal.append(event)
+    return event
+
+shows ``skip_journal`` is honoured ONLY as a trigger for the loud-refusal
+branch when ``is_teamspace_bound=True``. When ``is_teamspace_bound=False``
+(the caller asserting "this fact is not Teamspace-bound, and I am asking you
+not to persist it"), ``skip_journal=True`` is silently discarded — execution
+falls straight through to the unconditional ``journal.append(event)``. There
+is no code path in this function that ever actually skips the write; the gate
+snapshot only ever affects the *recorded reason*, never the write itself,
+exactly as the docstring for the Teamspace-bound branch says — except the
+docstring implies that is a deliberate scope limit, and this test demonstrates
+it is actually a total gap: the non-Teamspace-bound, explicit-skip-request
+path silently does the opposite of what its caller asked.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.event_journal.journal import CaptureGateState, capture_teamspace_bound
+from specify_cli.event_journal.models import Event
+
+pytestmark = pytest.mark.fast
+
+_OCCURRED_AT = "2026-06-29T00:00:00+00:00"
+
+# A non-consenting gate snapshot: every gate closed, exactly the state a
+# non-consenting checkout (#3031's incident shape) evaluates to.
+_NON_CONSENTING_GATE = CaptureGateState(
+    saas_enabled=False,
+    checkout_enabled=False,
+    authenticated=False,
+    team_slug=None,
+)
+
+
+def test_non_consenting_capture_request_does_not_write_the_journal(tmp_path: Path) -> None:
+    """A caller that asserts "not Teamspace-bound, please skip the write" must be honoured.
+
+    Reds today: ``capture_teamspace_bound`` writes the event into the journal
+    regardless of ``is_teamspace_bound=False, skip_journal=True`` — the write
+    is unconditional in every code path through this function, not only the
+    (correctly) unconditional Teamspace-bound one. A non-consenting checkout
+    calling this with an accurate "do not persist this" signal still gets a
+    durable, drainable journal row.
+    """
+    from specify_cli.event_journal.journal import EventJournal
+
+    journal = EventJournal(tmp_path / "journal.db")
+    event_id = "evt-client-confidential-0"
+
+    result = capture_teamspace_bound(
+        journal=journal,
+        event_id=event_id,
+        event_type="WorkPackageApproved",
+        payload=b'{"event_id": "evt-client-confidential-0", "project_slug": "client-confidential"}',
+        occurred_at=_OCCURRED_AT,
+        gate=_NON_CONSENTING_GATE,
+        is_teamspace_bound=False,
+        skip_journal=True,
+    )
+
+    assert isinstance(result, Event)  # the function still returns a value; capture didn't raise
+    stored = journal.read_by_id(event_id)
+    assert stored is None, (
+        "capture_teamspace_bound(is_teamspace_bound=False, skip_journal=True) "
+        "must not write the event into the journal at all — the caller "
+        "explicitly said this fact is not Teamspace-bound and should be "
+        "skipped, but the function falls through to an unconditional "
+        "journal.append(event) regardless of is_teamspace_bound/skip_journal "
+        "(event_journal/journal.py:390-402); only the Teamspace-bound + "
+        "skip_journal combination is gated (by raising), never honoured as "
+        "an actual skip for either branch"
+    )

--- a/tests/sync/test_sync_consent_capture_gap_3031.py
+++ b/tests/sync/test_sync_consent_capture_gap_3031.py
@@ -55,7 +55,7 @@ import pytest
 from specify_cli.event_journal.journal import CaptureGateState, capture_teamspace_bound
 from specify_cli.event_journal.models import Event
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.regression, pytest.mark.fast]
 
 _OCCURRED_AT = "2026-06-29T00:00:00+00:00"
 

--- a/tests/sync/test_sync_consent_capture_gap_3031.py
+++ b/tests/sync/test_sync_consent_capture_gap_3031.py
@@ -19,91 +19,202 @@ call (one process tick) and asserts differential treatment — a fix that
 filters per-*process* rather than per-*event* cannot pass that test. No
 duplicate is added here for Defect 5.
 
-Defect 3 (ungated capture) is pinned below. ``capture_teamspace_bound``
-(``event_journal/journal.py:370-403``) documents ``gate`` as deciding "only
-... the recorded drain_blocked_reason (delivery eligibility), never whether
-the write happens" for Teamspace-bound families — a deliberate, C-008-backed
-invariant for events that ARE Teamspace-bound. But the same function's
-``skip_journal`` parameter is the caller's signal that a particular capture
-should NOT be written at all (its docstring: "A request to skip the write for
-a Teamspace-bound family fails loudly"). Reading the implementation
+Defect 3 (ungated capture) is pinned below, against the #3031 issue's own
+stated contract (Proposed resolution, item 3): "A non-consenting project's
+events must never reach the journal." This test drives that contract through
+the ONE real production entry point for a capture — ``EventEmitter._emit``
+(via ``EventEmitter._capture_to_journal``, ``sync/emitter.py:1935-1970``) —
+rather than calling ``capture_teamspace_bound`` directly.
 
-    if is_teamspace_bound and skip_journal:
-        raise TeamspaceBoundDropError(event_id=event_id)
-    event = Event(...)
-    journal.append(event)
-    return event
+Why not call ``capture_teamspace_bound`` directly (as an earlier revision of
+this file did, with ``is_teamspace_bound=False, skip_journal=True``): that
+parameter combination is unreachable from production.
+``capture_teamspace_bound`` has exactly one production caller
+(``EventEmitter._capture_to_journal``, ``sync/emitter.py:1961``), and that
+caller passes neither ``is_teamspace_bound`` nor ``skip_journal`` — both take
+their defaults (``True`` / ``False``). A test built on that combination can be
+greened by a two-line ``if skip_journal: return event`` guard inside
+``capture_teamspace_bound`` while every real capture keeps landing in the
+machine-global journal unconditionally — i.e. Defect 3 would survive the fix
+100% intact. This revision instead drives the real caller with a real
+non-consenting gate, so nothing inside ``capture_teamspace_bound``'s unused
+parameters can satisfy it; the write path that actually runs in production is
+what has to change.
 
-shows ``skip_journal`` is honoured ONLY as a trigger for the loud-refusal
-branch when ``is_teamspace_bound=True``. When ``is_teamspace_bound=False``
-(the caller asserting "this fact is not Teamspace-bound, and I am asking you
-not to persist it"), ``skip_journal=True`` is silently discarded — execution
-falls straight through to the unconditional ``journal.append(event)``. There
-is no code path in this function that ever actually skips the write; the gate
-snapshot only ever affects the *recorded reason*, never the write itself,
-exactly as the docstring for the Teamspace-bound branch says — except the
-docstring implies that is a deliberate scope limit, and this test demonstrates
-it is actually a total gap: the non-Teamspace-bound, explicit-skip-request
-path silently does the opposite of what its caller asked.
+Consent, for this test, is the per-project signal ``EventEmitter`` already
+computes and already threads into ``CaptureGateState.checkout_enabled`` (via
+``is_sync_enabled_for_checkout``, ``sync/routing.py``) — the #3031 Defect
+1/2 fix. Today that signal reaches only
+``classify_drain_blocked_reason`` -> ``Event.drain_blocked_reason``, a column
+read at *drain* time; it never gates the *write*. Two stub emitters below
+override ``_capture_gate_state`` per-instance (mirrors
+``tests/delivery/test_dispatch_project_consent_3030.py``'s
+``_open_capture_gate`` fixture) so ``checkout_enabled`` is the ONLY thing
+that differs between them — proving non-consent, not some other knob (SaaS
+globally disabled, no auth, capture disabled outright), is what decides the
+outcome. A fix that disables capture wholesale would also fail the
+consenting half of this test.
+
+Doctrinal tension, named rather than resolved here: ``event_journal/journal.py``
+documents the journal write as deliberately unconditional for Teamspace-bound
+families — FR-017 / C-008, enforced by ``TeamspaceBoundDropError`` so a
+Teamspace-bound fact is never silently dropped
+(``capture_teamspace_bound``'s docstring: "The journal write is unconditional
+for Teamspace-bound families; ``gate`` only decides the recorded
+``drain_blocked_reason`` ... never whether the write happens"). #3031 Defect 3
+asks for the opposite outcome for *non-consenting* projects: no write at all.
+Reconciling "unconditional durable write for Teamspace-bound facts" with "a
+non-consenting project's events must never reach the journal" is an
+architecture question (which axis wins, and whether "Teamspace-bound" and
+"consenting" turn out to be the same predicate) being filed separately. This
+test pins only what #3031 explicitly asks for; it does not adjudicate the
+tension, and the fix that satisfies it must not do so by quietly deciding
+every event is not Teamspace-bound.
 """
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
-from specify_cli.event_journal.journal import CaptureGateState, capture_teamspace_bound
-from specify_cli.event_journal.models import Event
+from specify_cli.event_journal import (
+    CaptureGateState,
+    get_journal,
+    reset_coalesce_strategy,
+    reset_journal_cache,
+)
+
+if TYPE_CHECKING:
+    from specify_cli.sync.emitter import EventEmitter
 
 pytestmark = [pytest.mark.regression, pytest.mark.fast]
 
 _OCCURRED_AT = "2026-06-29T00:00:00+00:00"
 
-# A non-consenting gate snapshot: every gate closed, exactly the state a
-# non-consenting checkout (#3031's incident shape) evaluates to.
-_NON_CONSENTING_GATE = CaptureGateState(
-    saas_enabled=False,
-    checkout_enabled=False,
-    authenticated=False,
-    team_slug=None,
-)
 
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Isolate the journal under a fresh, per-test ``SPEC_KITTY_HOME``.
 
-def test_non_consenting_capture_request_does_not_write_the_journal(tmp_path: Path) -> None:
-    """A caller that asserts "not Teamspace-bound, please skip the write" must be honoured.
-
-    Reds today: ``capture_teamspace_bound`` writes the event into the journal
-    regardless of ``is_teamspace_bound=False, skip_journal=True`` — the write
-    is unconditional in every code path through this function, not only the
-    (correctly) unconditional Teamspace-bound one. A non-consenting checkout
-    calling this with an accurate "do not persist this" signal still gets a
-    durable, drainable journal row.
+    Mirrors ``tests/delivery/test_dispatch_project_consent_3030.py``'s
+    ``_isolated_home`` fixture: ``resolve_journal_path``
+    (``event_journal/journal.py:78-89``) honours ``SPEC_KITTY_HOME`` verbatim,
+    so this test never touches the real ``~/.spec-kitty/event_journal/``.
+    ``SPEC_KITTY_ENABLE_SAAS_SYNC`` is cleared so the SaaS-enabled axis stays
+    off regardless of the invoking shell's environment — this test's only
+    load-bearing axis is per-project consent (``checkout_enabled``), not the
+    global rollout flag.
     """
-    from specify_cli.event_journal.journal import EventJournal
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path))
+    monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+    reset_journal_cache()
+    reset_coalesce_strategy()
+    yield
+    reset_journal_cache()
+    reset_coalesce_strategy()
 
-    journal = EventJournal(tmp_path / "journal.db")
-    event_id = "evt-client-confidential-0"
 
-    result = capture_teamspace_bound(
-        journal=journal,
-        event_id=event_id,
-        event_type="WorkPackageApproved",
-        payload=b'{"event_id": "evt-client-confidential-0", "project_slug": "client-confidential"}',
-        occurred_at=_OCCURRED_AT,
-        gate=_NON_CONSENTING_GATE,
-        is_teamspace_bound=False,
-        skip_journal=True,
+def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
+    """A real ``EventEmitter`` with a stubbed identity/git resolver.
+
+    Mirrors ``tests/delivery/test_dispatch_project_consent_3030.py``'s
+    ``_stub_emitter``: everything downstream of identity/git resolution
+    (Lamport clock, capture, validation, contract gate) is the real
+    production code path — only the two I/O-bound resolvers that would
+    otherwise require a real git checkout are stubbed.
+    """
+    from specify_cli.sync.emitter import EventEmitter
+    from specify_cli.sync.git_metadata import GitMetadata
+
+    em = EventEmitter()
+    em._identity = SimpleNamespace(
+        build_id=build_id, project_uuid=uuid4(), project_slug=project_slug
+    )
+    em._get_git_metadata = lambda: GitMetadata()
+    return em
+
+
+def _consenting_gate(_team_slug: str | None) -> CaptureGateState:
+    """The per-project consent signal open (``checkout_enabled=True``)."""
+    return CaptureGateState(
+        saas_enabled=False, checkout_enabled=True, authenticated=False, team_slug=None
     )
 
-    assert isinstance(result, Event)  # the function still returns a value; capture didn't raise
-    stored = journal.read_by_id(event_id)
-    assert stored is None, (
-        "capture_teamspace_bound(is_teamspace_bound=False, skip_journal=True) "
-        "must not write the event into the journal at all — the caller "
-        "explicitly said this fact is not Teamspace-bound and should be "
-        "skipped, but the function falls through to an unconditional "
-        "journal.append(event) regardless of is_teamspace_bound/skip_journal "
-        "(event_journal/journal.py:390-402); only the Teamspace-bound + "
-        "skip_journal combination is gated (by raising), never honoured as "
-        "an actual skip for either branch"
+
+def _non_consenting_gate(_team_slug: str | None) -> CaptureGateState:
+    """The per-project consent signal closed — the #3031 incident shape.
+
+    ``saas_enabled`` and ``authenticated`` are held identical to
+    ``_consenting_gate`` above; ``checkout_enabled`` is the ONLY field that
+    differs, so a fix that keys capture on the wrong axis (e.g. SaaS-enabled,
+    or auth) rather than per-project consent cannot pass this test by
+    accident.
+    """
+    return CaptureGateState(
+        saas_enabled=False, checkout_enabled=False, authenticated=False, team_slug=None
+    )
+
+
+def test_non_consenting_project_event_never_reaches_the_journal() -> None:
+    """#3031 Defect 3: a non-consenting project's events must never reach the journal.
+
+    Reds today: both emitters' events land in the same machine-global
+    journal file. ``EventEmitter._capture_to_journal`` calls
+    ``capture_teamspace_bound`` unconditionally (``sync/emitter.py:1961``),
+    and ``capture_teamspace_bound`` itself only ever uses ``gate`` to compute
+    the *recorded* ``drain_blocked_reason`` column (``classify_drain_blocked_reason``,
+    ``event_journal/journal.py:400``) before an unconditional
+    ``journal.append(event)`` (``event_journal/journal.py:402``) — the write
+    itself never consults ``gate.checkout_enabled``. So today the
+    non-consenting project's event is captured exactly like its consenting
+    sibling's, differing only in the ``drain_blocked_reason`` value stamped
+    on the row already sitting in the journal.
+    """
+    consenting = _stub_emitter(project_slug="engagement-assistant", build_id="build-consenting-1")
+    consenting._capture_gate_state = _consenting_gate
+    nonconsenting = _stub_emitter(project_slug="client-confidential", build_id="build-confidential-1")
+    nonconsenting._capture_gate_state = _non_consenting_gate
+
+    consenting_envelope = consenting._emit(
+        event_type="ErrorLogged",
+        aggregate_id="WP04",
+        aggregate_type="WorkPackage",
+        payload={"error_type": "runtime", "error_message": "boom", "wp_id": "WP04"},
+        occurred_at=_OCCURRED_AT,
+    )
+    nonconsenting_envelope = nonconsenting._emit(
+        event_type="ErrorLogged",
+        aggregate_id="WP04",
+        aggregate_type="WorkPackage",
+        payload={"error_type": "runtime", "error_message": "boom", "wp_id": "WP04"},
+        occurred_at=_OCCURRED_AT,
+    )
+
+    assert consenting_envelope is not None, "the consenting project's emit must succeed"
+    assert nonconsenting_envelope is not None, (
+        "emit itself must not raise for a non-consenting project — the gap is "
+        "at capture time, not at emission"
+    )
+
+    # Both emitters have SaaS globally disabled (is_saas_sync_enabled() is
+    # False), so both resolve team_slug=None and therefore share the SAME
+    # producer-scoped journal file — the incident's shared-store premise,
+    # asserted by construction rather than by inspecting internals.
+    journal = get_journal(team_slug=None)
+
+    assert journal.read_by_id(consenting_envelope["event_id"]) is not None, (
+        "sanity: the consenting project's event must be captured — this "
+        "proves checkout_enabled is what decides the outcome below, not "
+        "capture being disabled wholesale"
+    )
+    assert journal.read_by_id(nonconsenting_envelope["event_id"]) is None, (
+        "#3031 Defect 3: 'a non-consenting project's events must never reach "
+        "the journal.' The non-consenting emitter's CaptureGateState "
+        "(checkout_enabled=False) must gate the journal WRITE itself, not "
+        "merely the drain_blocked_reason recorded on a row that gets written "
+        "regardless"
     )

--- a/tests/sync/test_sync_consent_default_deny.py
+++ b/tests/sync/test_sync_consent_default_deny.py
@@ -41,7 +41,13 @@ from specify_cli.sync.routing import (
     resolve_checkout_sync_routing_readonly,
 )
 
-pytestmark = pytest.mark.fast
+# ``regression`` is the live index of open-P0 red-first reproductions: the
+# blocking ``regression tests`` CI job selects on it, and the marker is removed
+# once a pin goes green (see ``tests/delivery/test_poison_batch_2736.py``).
+# Without it this file's five reds — #3031's fail-open-default arm, i.e. the
+# arm behind the live 1,322-event leak — never appear in that index, leaving it
+# showing only a partial view of #3031.
+pytestmark = [pytest.mark.fast, pytest.mark.regression]
 
 # A realistic owner/repo pair: consent must not depend on the slug looking
 # special, and this is the shape ``git_metadata.parse_repo_slug`` produces.


### PR DESCRIPTION
## ⚠️ CI on this PR is EXPECTED TO BE RED. The red is the deliverable.

These ten tests pin **six live P0 defects that exist on `main` today**. They are
evidence, not breakage. Per ADR `2026-07-17-1`, `main` may be honestly red and
known-P0 reds must not be green-washed — this PR converts six asserted P0s into
six *evidenced* ones.

Nothing here fixes a defect. No `Closes #N` anywhere: each test makes its issue
visible to CI, and the issue closes when the product changes.

## What reds, and why

| Issue | Node ID | Failure signature |
|---|---|---|
| #2993 | `tests/regression/test_issue_2993_lane_planning_ancestry.py::test_lane_worktree_does_not_descend_from_planning_artifacts` | `git merge-base --is-ancestor <planning-artifact-sha> <lane-branch>` returns 1 — the coord tip was never advanced past its pre-artifact mint point before the lane branched off it |
| #2996(a) | `tests/integration/test_review_cycle_rejection_only.py::test_approving_a_rejected_wp_writes_no_verdict_artifact` | After a full rework+resubmit lifecycle, `move-task --to approved` still exits 1 on the rejected-artifact guard and `latest.cycle_number` is still 1 — no approved verdict is ever written |
| #2996(b) | `tests/review/test_cycle.py::test_self_referential_feedback_source_is_rejected` | `DID NOT RAISE ReviewCycleError` — `create_rejected_review_cycle` never inspects what `feedback_source` points at |
| #2996(b) | `tests/review/test_cycle.py::test_new_cycle_body_never_duplicates_a_prior_cycle_file` | Cycle 2's body is byte-identical to cycle 1's body, written with `reviewer_agent: unknown` |
| #3031 (D5) | `tests/delivery/test_dispatch_honours_drain_blocked_3031.py::test_dispatch_excludes_events_with_recorded_drain_blocked_reason` | An event captured with `drain_blocked_reason` set is delivered anyway — the drain has no predicate over it |
| #3031 (D5) | `tests/delivery/test_dispatch_honours_drain_blocked_3031.py::test_consent_predicate_must_apply_before_limit_not_after` | With a 10-event blocked backlog older than 1 consenting event and `limit=5`, the drain ships the 5 oldest (all blocked) and never reaches the consenting event |
| #3030 | `tests/delivery/test_dispatch_project_consent_3030.py::test_consenting_project_leaks_sibling_project_event_through_shared_journal` | A project with **no consent record at all** has its event shipped because it shares a journal file with a project that did consent |
| #3031 (D3) | `tests/sync/test_sync_consent_capture_gap_3031.py::test_non_consenting_project_event_never_reaches_the_journal` | A non-consenting checkout's event is written to the machine-global journal anyway — the capture gate decides only the recorded `drain_blocked_reason`, never the write |
| #3033 | `tests/specify_cli/cli/commands/test_safe_commit_cmd.py::test_public_safe_commit_succeeds_after_merged_branch_deleted_3033` | `safe_commit: worktree ... HEAD is 'review/...-postmerge', expected 'feat/...'` — the destination resolves from `meta.json` with no git-existence check |
| #3045 | `tests/agent/cli/commands/test_charter_cli.py::test_sync_command_human_and_json_surfaces_do_not_contradict_3045` | For one repo state the JSON surface reports `success: False` / `stale_before: true` while the human surface exits 0 printing `Charter already in sync` |

`#3031` already had a partial RED pin on `main`
(`tests/sync/test_sync_consent_default_deny.py`, landed at `765cdcc59`); this PR
adds the ungated-capture gap that file's own docstring calls out as uncovered,
and gives that file the `regression` marker it was missing.

## Markers

Every test carries `pytest.mark.regression` (registered at `pytest.ini:48`).
The `regression tests (blocking)` job (`ci-quality.yml:2939`) runs
`pytest tests/ -m regression` on every PR with no path-filter gate, so these
reds are seen regardless of which shards a diff activates.

## Post-review remediation (landing pass)

A four-lens adversarial squad (`reviewer-renata`, `debugger-debbie`,
`architect-alphonso`, `paula-patterns`) reviewed these pins against one
question: *does each test pin the behaviour we want, or the arithmetic inverse
of today's?* It found four blocking defects. All are now folded in — see the
review comment for the full evidence, and the fold commits for the changes.

1. **#2996(b) — the two new tests were mutually unsatisfiable.** One required
   `create_rejected_review_cycle(feedback_source=<own review-cycle-1.md>)` to
   *raise*; the other made the identical call and required it to *return*.
   Installing the guard made the second **error before reaching its
   assertion**. Resolved in favour of the loud guard; the duplicate-body test
   now drives an ordinary feedback file whose *content* duplicates a prior
   cycle, and compares body-to-body rather than body-vs-full-file-text (which
   was cheap-greenable by stripping frontmatter).
2. **#3030 — the two `tests/delivery/` files pinned contradictory contracts.**
   `drain_blocked_reason` is a capture-time snapshot of *machine-global* gates,
   so a predicate over it implements no per-project consent at all.
   `test_dispatch_honours_drain_blocked_*` is therefore **rescoped to #3031
   Defect 5** (per-event vs per-process drain filtering) and renamed
   accordingly. The #3030 consent fixture is fixed: the consenting emitter now
   carries a real `repo_slug` matching the consent key it writes (consent is
   keyed on `repo_slug` at `sync/config.py:190`; the fixture previously wrote a
   key nothing could match) with an open capture gate, so the two files key on
   orthogonal properties.
3. **#3031 — the capture pin drove a dead API arm.** It called
   `capture_teamspace_bound(is_teamspace_bound=False, skip_journal=True)`, a
   combination **no production caller emits** (`emitter.py:1961` passes
   neither). Two lines of parameter plumbing would have greened it with the
   defect fully alive, and the real fix would have left it red. Re-anchored on
   `EventEmitter._emit` with a non-consenting checkout, asserting the journal
   stays empty.
4. **#3045 — the stale pin was left standing.** #3045's body is explicit that
   the redding test must *replace* `test_charter_cli.py:83-99`, not sit beside
   it. Done. The new test's `exit_code == 0` preconditions (which forbade the
   *honest reporter* remedy the ticket sanctions) are dropped, and it now
   asserts the positive surface-agreement contract from a single invocation —
   closing both the reword cheap-green and an ordering bug that would have
   redded a correct repair-mode fix.

Also folded: the **deletion-only** case #2993 calls "the sharp one" (the
existing leg only covered an amendment); the `--feature` → `--mission` fix for
two pre-existing vacuous tests in `test_review_cycle_rejection_only.py` (there
is no `--feature` option, so every invocation exited 2 on a usage error and the
tests "proved" implement reruns don't inflate the counter *by never running
implement*); the missing `regression` marker on
`test_sync_consent_default_deny.py`; and a CI path-filter gap where
`tests/regression/**` and `tests/regressions/**` were unclaimed by the
`core_misc` filter despite the `misc` shard owning them.

## Inverted pin that the fix must delete

This PR **deliberately does not touch it**. Two contradictory tests coexist
until the fix lands — deleting an assertion is part of fixing the defect, not
part of evidencing it.

- `tests/specify_cli/cli/commands/test_implement.py:533-545` —
  `TestPlanningArtifactAutoCommit::test_auto_commit_uses_coordination_worktree_paths`
  asserts #2993's snapshot as correct: the artifact present on coord **and
  absent from the planning branch**.

  *Caveat, added in review:* that pin's precondition is the
  **dirty-uncommitted** case (`tasks.md` is written but never `git add`ed), which
  #2993 says works correctly — so it may well survive the fix untouched.
  Re-adjudicate it rather than deleting it reflexively. (The #3045 inverted pin
  previously listed here has been removed from the suite, per that issue's own
  first implementation step.)

## False greens these supersede

- `tests/post_merge/test_review_artifact_consistency.py:214` — writes the approved
  artifact directly via a fixture helper, substituting for the exact step #2996(a)
  removes. The gate is proven; the producer is never exercised.
- `tests/sync/test_sync_e2e_integration.py:611-614` — asserts
  `e["project_slug"] == identity.project_slug`, which is *nearly* the right
  assertion, but the fixture has one emitter bound to one identity so it cannot fail.
- `tests/integration/test_review_cycle_rejection_only.py:274,307` — invoked
  `agent action implement --feature`, an option that does not exist
  (`workflow.py:1128` declares only `--mission`), so every call exited 2 on a
  usage error and the no-op assertions were vacuous. **Fixed in this PR** rather
  than merely catalogued; the contract holds once implement genuinely runs.

## Mechanism corrections found while writing these

Two tickets describe a mechanism that does not match the traced code. Implementers
should read these before starting.

- **#3033** — `MISSION_REVIEW_EVIDENCE_PERSISTENCE_FAILED` is **not a spec-kitty
  diagnostic** (zero occurrences repo-wide, no commit ever introduced it), and
  `spec-kitty review` performs no commit at all. The defect reproduces through
  `spec-kitty safe-commit` on a *classified* PRIMARY artifact.
  `mission-review-report.md` is not in `_MISSION_FILE_KIND_BY_BASENAME`, so it
  falls through to HEAD and would succeed. #3033's body and title are corrected.
- **#3030** — the ticket pins `sync/batch.py:1064-1080`, which is the **legacy**
  `OfflineQueue` transport. The live path is `delivery/dispatcher.dispatch`, which
  `cli/commands/sync.py:296` calls *"the sole event-delivery path"*. These tests
  target the live path; an implementer following the ticket literally would fix
  `batch.py` and leave them red. A correction is filed on the issue.
- **#2993** — the ticket describes **one** mechanism; there are **two independent
  causes** of the same symptom. They share a structural root (coord is minted from
  `target_branch` before spec/plan/tasks exist; lanes branch off it) but have
  different observables and different remediation.
  - **Cause A — copy without ancestry**: artifact *bytes* are written into the
    coord worktree and committed onto the coord tip. The planning commit is never
    in history. A later amendment on the planning branch produces `CONFLICT (add/add)`.
  - **Cause B — silent no-op** (legacy `placement_ref is None` fallback): PRIMARY
    files are diffed against `HEAD`, found byte-identical, dropped; the plan is
    empty and the helper returns with no commit. Lane carries **no planning
    artifacts at all**.
  - **This test reproduces Cause B**, confirmed empirically. Its assertions
    nonetheless catch Cause A: simulating the partial "repair the idempotency
    filter" fix (which converts B into A) in pure git leaves the ancestry
    assertion red (rc=1) and produces `CONFLICT (add/add)` on merge-tree, while a
    genuine ancestry fix greens both legs.
  - **Discriminator caveat:** `git log --oneline <coord-branch> -- kitty-specs/<slug>/`
    non-empty → A, empty → B — but this misclassifies a *correctly fixed* coord as
    Cause A, since ancestry legitimately puts the artifacts in that log. It is a
    triage heuristic for a live pre-fix incident only.
  - **Load-bearing for the fix:** the fix must establish **ancestry**, not a more
    reliable byte-copy. Acceptance asserts `--is-ancestor` == 0, that a post-allocation
    amendment merges cleanly and wins, *and* that a post-allocation **deletion**
    survives the merge — the sharp case, since it vanishes under a union merge.

## Gates

`ruff check` and `mypy` are clean on all nine changed test files (the one
pre-existing `mypy` error in `test_review_cycle_rejection_only.py` is fixed
here too). The architectural collection-completeness, gate-coverage, and
terminology suites pass on the rebased tip (81 passed). Rebased onto
post-#3007 `main` (`ed470756e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsJfT4pKcjgnotT2o2XMfu
