### PR TITLE
fix(retrospect): normalize wrapped YAML whitespace + extract shared kernel YAML writer (fixes #3058)

### DIFF
--- a/src/kernel/yaml_io.py
+++ b/src/kernel/yaml_io.py
@@ -1,0 +1,140 @@
+"""Shared YAML serialization and durable-write primitives for the kernel layer.
+
+Canonical home for the house YAML-dump conventions used by every writer that
+persists a mapping (dict / ``CommentedMap``) as YAML: round-trip dumper (so
+``ruamel`` comment/quote/anchor fidelity and ``CommentedMap`` inputs survive),
+a wide fixed line width (so wrapped prose never fragments a scalar across
+lines), and a post-dump normalizer that strips the non-semantic trailing
+whitespace ``ruamel`` leaves on wrapped-scalar continuation lines.
+
+Adopted by ``specify_cli.retrospective.writer`` (moved here verbatim) and
+``specify_cli.review.arbiter`` (#3058) so both surfaces share one seam instead
+of hand-rolling the same dump-then-normalize dance with drifting width
+settings.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Mapping
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+# Matches the house "prevent line wrapping" width used across writers
+# (e.g. ``specify_cli.review.artifacts._make_yaml``): wide enough that no
+# reviewer-prose or retrospective-detail scalar wraps under normal use.
+CANONICAL_YAML_WIDTH = 4096
+
+
+def serialize_mapping(data: Mapping[str, Any], *, width: int = CANONICAL_YAML_WIDTH) -> bytes:
+    """Serialize a mapping to canonical YAML bytes.
+
+    Uses a round-trip (``typ="rt"``) dumper, not a safe dumper: a safe dumper
+    raises ``RepresenterError`` on a ``ruamel.yaml.comments.CommentedMap``
+    (arbiter and other frontmatter-merge callers pass one in, since they load
+    existing frontmatter with ``preserve_quotes=True`` before mutating it),
+    and it would also strip the comment/quote fidelity round-trip is for.
+
+    The dump is post-processed by :func:`_normalize_nonsemantic_trailing_whitespace`
+    to remove the trailing-space/tab artifacts ``ruamel`` leaves on wrapped
+    scalar continuation lines, without touching semantically-significant
+    trailing whitespace inside literal block scalars.
+    """
+    yaml = YAML(typ="rt")
+    yaml.default_flow_style = False
+    yaml.preserve_quotes = True
+    yaml.width = width
+
+    buf = BytesIO()
+    yaml.dump(data, buf)
+    return _normalize_nonsemantic_trailing_whitespace(buf.getvalue())
+
+
+def _normalize_nonsemantic_trailing_whitespace(serialized: bytes) -> bytes:
+    """Remove writer wrapping artifacts only when YAML meaning remains unchanged.
+
+    Falls back to the original bytes if the safety re-parse cannot confirm the
+    normalized form is semantically identical, so normalization is never worse
+    than emitting the un-normalized dump.
+    """
+    normalized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
+    if normalized == serialized:
+        return serialized
+
+    yaml = YAML(typ="safe")
+    try:
+        original_data = yaml.load(serialized)
+        normalized_data = yaml.load(normalized)
+    except YAMLError:
+        return serialized
+    return normalized if normalized_data == original_data else serialized
+
+
+def write_mapping_atomic(
+    data: Mapping[str, Any],
+    path: Path,
+    *,
+    width: int = CANONICAL_YAML_WIDTH,
+    mkdir: bool = False,
+) -> None:
+    """Atomically write ``data`` as YAML to ``path``, fsyncing for durability.
+
+    This is a durability-enhanced sibling of :func:`kernel.atomic.atomic_write`
+    (which does write-temp-then-rename but does NOT ``fsync``). It is not
+    reused here because canonical mission records (retrospective, review
+    artifacts) need the extra fsync/dir-fsync durability delta: without it, a
+    crash immediately after ``os.replace`` can still lose the rename on some
+    filesystems/power-loss scenarios, because the directory entry update was
+    never flushed. ``atomic_write`` is the right choice for lower-stakes
+    generated/regenerable files; this function is for records whose loss is a
+    correctness problem.
+
+    Sequence:
+    1. Serialize ``data`` via :func:`serialize_mapping`.
+    2. Write to a uniquely-named ``.tmp`` file in ``path.parent`` (created
+       ``O_WRONLY | O_CREAT | O_EXCL`` so two concurrent writers never
+       collide), ``fsync`` the file descriptor, close.
+    3. ``os.replace(tmp, path)`` — atomic rename.
+    4. Best-effort ``fsync`` on the parent directory fd to flush the rename
+       into the directory inode (non-fatal on failure).
+
+    On any failure the tempfile is unlinked and the original exception
+    propagates — this function raises no kernel-specific exception type so
+    callers remain free to translate failures into their own domain errors.
+    """
+    if mkdir:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    serialized = serialize_mapping(data, width=width)
+
+    tmp_name = f"{path.name}.tmp.{os.getpid()}.{os.urandom(4).hex()}"
+    tmp_path = path.parent / tmp_name
+
+    try:
+        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        try:
+            os.write(fd, serialized)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+        os.replace(str(tmp_path), str(path))
+
+        # Best-effort dir fsync.
+        try:
+            dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except Exception:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/specify_cli/retrospective/writer.py
+++ b/src/specify_cli/retrospective/writer.py
@@ -13,14 +13,12 @@ WP03 additions:
 from __future__ import annotations
 
 import dataclasses
-import io
-import os
 from pathlib import Path
 from typing import Any, Literal
 
 from ruamel.yaml import YAML
-from ruamel.yaml.error import YAMLError
 
+from kernel.yaml_io import write_mapping_atomic
 from specify_cli.core.constants import RETROSPECTIVE_FILENAME
 from specify_cli.retrospective.schema import (
     GenActor,
@@ -159,86 +157,32 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
     """Atomically write a dict as YAML to ``canonical``.
 
     Shared primitive used by both ``write_record`` and ``write_gen_record``.
+    Delegates the serialize + fsync + atomic-rename sequence to the
+    kernel-layer :func:`kernel.yaml_io.write_mapping_atomic` primitive, which
+    every caller here already invokes with ``target_dir == canonical.parent``
+    (both call sites ``mkdir`` the target directory before reaching this
+    function) — asserted below so a future caller that passes a divergent
+    directory fails loudly instead of silently fsyncing the wrong directory.
 
-    Sequence:
-    1. Serialize ``data`` via ruamel.yaml round-trip dumper to a uniquely-named
-       tempfile in ``target_dir`` (same filesystem as ``canonical`` →
-       ``os.replace`` is guaranteed atomic on POSIX/APFS/NTFS).
-    2. ``fsync()`` the tempfile fd, close.
-    3. ``os.replace(tmp, canonical)`` — atomic rename.
-    4. Best-effort ``fsync()`` on the parent directory fd to flush the rename
-       into the inode (non-fatal on failure).
+    Width stays 120 here (not the kernel's wider 4096 default): retrospective
+    records intentionally keep the narrower wrap; widening it is a separate,
+    open decision tracked by #3059.
 
     Raises:
         WriterError: On any IO or serialization error.  The tempfile is
             unlinked on failure so no partial file remains.
     """
-    tmp_name = f"{RETROSPECTIVE_FILENAME}.tmp.{os.getpid()}.{os.urandom(4).hex()}"
-    tmp_path = target_dir / tmp_name
+    if target_dir != canonical.parent:
+        raise WriterError(
+            f"target_dir {target_dir} must equal canonical.parent {canonical.parent}"
+        )
 
     try:
-        yaml = YAML(typ="rt")
-        yaml.default_flow_style = False
-        yaml.preserve_quotes = True
-        yaml.width = 120
-
-        buf = io.BytesIO()
-        yaml.dump(data, buf)
-        serialized = _normalize_nonsemantic_trailing_whitespace(buf.getvalue())
-
-        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
-        try:
-            os.write(fd, serialized)
-            os.fsync(fd)
-        finally:
-            os.close(fd)
-
-        os.replace(str(tmp_path), str(canonical))
-
-        # Best-effort dir fsync.
-        try:
-            dir_fd = os.open(str(target_dir), os.O_RDONLY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-        except OSError:
-            pass
-
-    except WriterError:
-        raise
+        write_mapping_atomic(data, canonical, width=120)
     except OSError as exc:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         raise WriterError(f"IO error writing retrospective record: {exc}") from exc
     except Exception as exc:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
         raise WriterError(f"Unexpected error writing retrospective record: {exc}") from exc
-
-
-def _normalize_nonsemantic_trailing_whitespace(serialized: bytes) -> bytes:
-    """Remove writer wrapping artifacts only when YAML meaning remains unchanged.
-
-    Falls back to the original bytes if the safety re-parse cannot confirm the
-    normalized form is semantically identical, so normalization is never worse
-    than emitting the un-normalized dump.
-    """
-    normalized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
-    if normalized == serialized:
-        return serialized
-
-    yaml = YAML(typ="safe")
-    try:
-        original_data = yaml.load(serialized)
-        normalized_data = yaml.load(normalized)
-    except YAMLError:
-        return serialized
-    return normalized if normalized_data == original_data else serialized
 
 
 def write_record(record: RetrospectiveRecord, *, repo_root: Path) -> Path:

--- a/src/specify_cli/retrospective/writer.py
+++ b/src/specify_cli/retrospective/writer.py
@@ -184,6 +184,10 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
         buf = io.BytesIO()
         yaml.dump(data, buf)
         serialized = buf.getvalue()
+        # ruamel can retain the wrap separator at the end of an indented scalar
+        # line. Retrospectives are tracked artifacts, so normalize that writer
+        # artifact without changing scalar content or newline structure.
+        serialized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
 
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
         try:

--- a/src/specify_cli/retrospective/writer.py
+++ b/src/specify_cli/retrospective/writer.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
 
 from specify_cli.core.constants import RETROSPECTIVE_FILENAME
 from specify_cli.retrospective.schema import (
@@ -221,14 +222,22 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
 
 
 def _normalize_nonsemantic_trailing_whitespace(serialized: bytes) -> bytes:
-    """Remove writer wrapping artifacts only when YAML meaning remains unchanged."""
+    """Remove writer wrapping artifacts only when YAML meaning remains unchanged.
+
+    Falls back to the original bytes if the safety re-parse cannot confirm the
+    normalized form is semantically identical, so normalization is never worse
+    than emitting the un-normalized dump.
+    """
     normalized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
     if normalized == serialized:
         return serialized
 
     yaml = YAML(typ="safe")
-    original_data = yaml.load(serialized)
-    normalized_data = yaml.load(normalized)
+    try:
+        original_data = yaml.load(serialized)
+        normalized_data = yaml.load(normalized)
+    except YAMLError:
+        return serialized
     return normalized if normalized_data == original_data else serialized
 
 

--- a/src/specify_cli/retrospective/writer.py
+++ b/src/specify_cli/retrospective/writer.py
@@ -183,11 +183,7 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
 
         buf = io.BytesIO()
         yaml.dump(data, buf)
-        serialized = buf.getvalue()
-        # ruamel can retain the wrap separator at the end of an indented scalar
-        # line. Retrospectives are tracked artifacts, so normalize that writer
-        # artifact without changing scalar content or newline structure.
-        serialized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
+        serialized = _normalize_nonsemantic_trailing_whitespace(buf.getvalue())
 
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
         try:
@@ -222,6 +218,18 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
         except OSError:
             pass
         raise WriterError(f"Unexpected error writing retrospective record: {exc}") from exc
+
+
+def _normalize_nonsemantic_trailing_whitespace(serialized: bytes) -> bytes:
+    """Remove writer wrapping artifacts only when YAML meaning remains unchanged."""
+    normalized = b"\n".join(line.rstrip(b" \t\r") for line in serialized.split(b"\n"))
+    if normalized == serialized:
+        return serialized
+
+    yaml = YAML(typ="safe")
+    original_data = yaml.load(serialized)
+    normalized_data = yaml.load(normalized)
+    return normalized if normalized_data == original_data else serialized
 
 
 def write_record(record: RetrospectiveRecord, *, repo_root: Path) -> Path:

--- a/src/specify_cli/review/arbiter.py
+++ b/src/specify_cli/review/arbiter.py
@@ -437,7 +437,8 @@ def persist_arbiter_decision(
 def _persist_in_artifact(artifact_path: Path, decision: ArbiterDecision) -> Path:
     """Add arbiter_override section to a review-cycle artifact's frontmatter."""
     from ruamel.yaml import YAML
-    from io import StringIO
+
+    from kernel.yaml_io import serialize_mapping
 
     content = artifact_path.read_text(encoding="utf-8")  # NOSONAR(pythonsecurity:S2083) - path is resolved from trusted project structure, not user-controlled input
 
@@ -456,18 +457,18 @@ def _persist_in_artifact(artifact_path: Path, decision: ArbiterDecision) -> Path
         # Add arbiter_override section
         data["arbiter_override"] = decision.to_dict()
 
-        stream = StringIO()
-        yaml.dump(data, stream)
-        new_fm = stream.getvalue().rstrip("\n")
+        # #3058: serialize_mapping's rt dumper (default width 4096) — not the
+        # prior bare YAML()/width~80 dump, which wrapped reviewer prose and
+        # left trailing-whitespace continuation lines. This intentionally
+        # widens the on-disk wrap from ~80 to 4096, unifying arbiter with
+        # review/artifacts.py's own frontmatter width (#3058).
+        new_fm = serialize_mapping(data).decode("utf-8").rstrip("\n")
 
         new_content = f"---\n{new_fm}\n---\n{body_text}"
     else:
         # No frontmatter: prepend it
         fm_dict = {"arbiter_override": decision.to_dict()}
-        yaml = YAML()
-        stream = StringIO()
-        yaml.dump(fm_dict, stream)
-        fm_text = stream.getvalue().rstrip("\n")
+        fm_text = serialize_mapping(fm_dict).decode("utf-8").rstrip("\n")
         new_content = f"---\n{fm_text}\n---\n{content}"
 
     write_text_within_directory(artifact_path, new_content, root=artifact_path.parent, encoding="utf-8")

--- a/src/specify_cli/review/artifacts.py
+++ b/src/specify_cli/review/artifacts.py
@@ -14,12 +14,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from io import StringIO
 from pathlib import Path
 from typing import Any
 
 from ruamel.yaml import YAML
 
+from kernel.yaml_io import serialize_mapping
 from specify_cli.status import ReviewOverride
 
 TERMINAL_REVIEW_LANES = frozenset({"approved", "done"})
@@ -200,12 +200,16 @@ class ReviewCycleArtifact:
         """Write this artifact to disk as a markdown file with YAML frontmatter.
 
         The parent directory is created if it does not exist.
+
+        Serialization is delegated to :func:`kernel.yaml_io.serialize_mapping`
+        (#3058 follow-up): its rt/preserve_quotes/default_flow_style/width=4096
+        configuration is byte-for-byte identical to :func:`_make_yaml`'s for
+        every frontmatter shape this artifact produces (verified by
+        ``tests/review/test_artifacts_yaml_seam.py``), so this migration is a
+        pure internal seam consolidation with no observable output change.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        yaml = _make_yaml()
-        stream = StringIO()
-        yaml.dump(self.to_dict(), stream)
-        frontmatter_text = stream.getvalue()
+        frontmatter_text = serialize_mapping(self.to_dict()).decode("utf-8")
 
         content = f"---\n{frontmatter_text}---\n"
         if self.body:

--- a/src/specify_cli/review/artifacts.py
+++ b/src/specify_cli/review/artifacts.py
@@ -204,9 +204,14 @@ class ReviewCycleArtifact:
         Serialization is delegated to :func:`kernel.yaml_io.serialize_mapping`
         (#3058 follow-up): its rt/preserve_quotes/default_flow_style/width=4096
         configuration is byte-for-byte identical to :func:`_make_yaml`'s for
-        every frontmatter shape this artifact produces (verified by
-        ``tests/review/test_artifacts_yaml_seam.py``), so this migration is a
-        pure internal seam consolidation with no observable output change.
+        every frontmatter scalar within the 4096 wrap width (verified by
+        ``tests/review/test_artifacts_yaml_seam.py``) — the payloads this
+        artifact produces. The sole divergence is a scalar long enough to wrap
+        past 4096 columns, where ``serialize_mapping`` additionally strips the
+        non-semantic trailing whitespace the old path left (a strict
+        improvement, semantically identical). So this migration is a pure
+        internal seam consolidation with no observable output change for real
+        review-cycle payloads.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
         frontmatter_text = serialize_mapping(self.to_dict()).decode("utf-8")

--- a/tests/kernel/test_yaml_io.py
+++ b/tests/kernel/test_yaml_io.py
@@ -1,0 +1,285 @@
+"""Unit tests for kernel.yaml_io — shared YAML serialize/atomic-write seam.
+
+The kernel module is zero-dependency shared infrastructure used by
+specify_cli, charter, and doctrine. These tests must remain independent of
+all higher-level modules.
+
+Coverage:
+- serialize_mapping: trailing-whitespace normalization on wrapped scalars,
+  safe-load round-trip equality, literal-scalar whitespace preservation,
+  CommentedMap round-trip (pins the rt-dumper requirement — a safe dumper
+  raises RepresenterError on a CommentedMap, which arbiter relies on).
+- write_mapping_atomic: temp-then-rename atomicity, no trailing-whitespace
+  lines in the written file.
+- _normalize_nonsemantic_trailing_whitespace: YAMLError fallback returns the
+  original bytes unchanged.
+
+Red-first note: before src/kernel/yaml_io.py existed, every test in this file
+failed at collection with ModuleNotFoundError: No module named 'kernel.yaml_io'.
+That is the red-first evidence for this whole module — it was verified by
+running this suite against the pre-migration tree (writer.py held the only
+copy of the normalizer) before src/kernel/yaml_io.py was created.
+"""
+
+from __future__ import annotations
+
+import os as _os
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
+
+from kernel.yaml_io import (
+    CANONICAL_YAML_WIDTH,
+    _normalize_nonsemantic_trailing_whitespace,
+    serialize_mapping,
+    write_mapping_atomic,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# serialize_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_mapping_strips_trailing_whitespace_from_wrapped_scalars() -> None:
+    """A long prose scalar that wraps at a NARROW width leaves trailing
+    whitespace on the wrap-continuation line; serialize_mapping must strip it,
+    and the safe-load round-trip must still equal the original data.
+    """
+    details = (
+        "An analysis-report.md artifact is present for this mission. Review "
+        "its findings to understand documented issues and decisions that were "
+        "made during implementation, then reconcile them against the record."
+    )
+    data = {
+        "not_helpful": [
+            {
+                "id": "n-001",
+                "category": "doc",
+                "summary": "analysis-report.md present with findings",
+                "evidence_refs": ["e-007"],
+                "details": details,
+            }
+        ]
+    }
+
+    # Precondition guard: prove a dump at a narrow width genuinely wraps and
+    # leaves a trailing-whitespace line, so this test cannot silently go
+    # vacuous if a future ruamel stops emitting the artifact. Use width=80 to
+    # force wrapping regardless of CANONICAL_YAML_WIDTH's own default.
+    probe = YAML(typ="rt")
+    probe.default_flow_style = False
+    probe.preserve_quotes = True
+    probe.width = 80
+    from io import BytesIO
+
+    probe_buf = BytesIO()
+    probe.dump(data, probe_buf)
+    raw = probe_buf.getvalue().decode("utf-8")
+    assert any(line.endswith((" ", "\t")) for line in raw.splitlines()), (
+        "expected the raw dump to contain a trailing-whitespace line; test is vacuous otherwise"
+    )
+
+    serialized = serialize_mapping(data, width=80)
+    text = serialized.decode("utf-8")
+
+    assert all(not line.endswith((" ", "\t")) for line in text.splitlines())
+    assert YAML(typ="safe").load(text) == data
+
+
+@pytest.mark.parametrize("trailing", [" ", "\t"])
+def test_serialize_mapping_preserves_literal_scalar_trailing_whitespace(trailing: str) -> None:
+    """A literal block scalar (``|``) may legitimately end a line in
+    whitespace — that whitespace is semantically part of the content and
+    must survive normalization untouched.
+    """
+    details = LiteralScalarString(f"first line ends in semantic whitespace{trailing}\nsecond line")
+
+    serialized = serialize_mapping({"details": details})
+    loaded = YAML(typ="safe").load(serialized.decode("utf-8"))
+
+    assert loaded == {"details": str(details)}
+
+
+def test_serialize_mapping_round_trips_commented_map_without_representer_error() -> None:
+    """Pin the rt-dumper requirement: a CommentedMap loaded via a round-trip
+    YAML instance must serialize through serialize_mapping with NO
+    RepresenterError. This is exactly what arbiter's frontmatter-merge does
+    (load existing frontmatter, mutate it, re-dump) — a safe (typ='safe')
+    dumper raises RepresenterError on a CommentedMap, which is why
+    serialize_mapping is contractually rt, not safe.
+    """
+    loader = YAML(typ="rt")
+    loader.preserve_quotes = True
+    source = "wp_id: WP07\nreviewer: reviewer-renata\nverdict: rejected\n"
+    commented_map = loader.load(source)
+
+    commented_map["arbiter_override"] = {"decided_by": "arbiter", "reason": "override"}
+
+    # Must not raise RepresenterError.
+    serialized = serialize_mapping(commented_map)
+
+    loaded = YAML(typ="safe").load(serialized.decode("utf-8"))
+    assert loaded["wp_id"] == "WP07"
+    assert loaded["arbiter_override"] == {"decided_by": "arbiter", "reason": "override"}
+
+
+def test_canonical_yaml_width_is_4096() -> None:
+    assert CANONICAL_YAML_WIDTH == 4096
+
+
+# ---------------------------------------------------------------------------
+# write_mapping_atomic
+# ---------------------------------------------------------------------------
+
+
+def test_write_mapping_atomic_uses_temp_then_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The write must go through a .tmp sibling file and an os.replace rename
+    — never a direct write to the target path.
+    """
+    target = tmp_path / "record.yaml"
+    captured_replace: list[tuple[str, str]] = []
+    original_replace = _os.replace
+
+    def capturing_replace(src: str, dst: str) -> None:
+        captured_replace.append((src, dst))
+        original_replace(src, dst)
+
+    monkeypatch.setattr(_os, "replace", capturing_replace)
+
+    write_mapping_atomic({"x": 1}, target)
+
+    assert len(captured_replace) == 1
+    src_path, dst_path = captured_replace[0]
+    assert Path(src_path).parent == target.parent
+    assert ".tmp" in Path(src_path).name
+    assert Path(dst_path) == target
+    assert target.exists()
+    assert not Path(src_path).exists()
+
+
+def test_write_mapping_atomic_output_has_no_trailing_whitespace_lines(tmp_path: Path) -> None:
+    target = tmp_path / "record.yaml"
+    details = (
+        "An analysis-report.md artifact is present for this mission. Review "
+        "its findings to understand documented issues and decisions that were "
+        "made during implementation, then reconcile them against the record."
+    )
+    write_mapping_atomic({"details": details}, target, width=80)
+
+    text = target.read_text(encoding="utf-8")
+    assert all(not line.endswith((" ", "\t")) for line in text.splitlines())
+    assert YAML(typ="safe").load(text) == {"details": details}
+
+
+def test_write_mapping_atomic_mkdir_creates_parent(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir" / "record.yaml"
+    assert not target.parent.exists()
+
+    write_mapping_atomic({"x": 1}, target, mkdir=True)
+
+    assert target.exists()
+    assert YAML(typ="safe").load(target.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_write_mapping_atomic_cleans_up_tempfile_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "record.yaml"
+
+    def failing_write(fd: int, data: bytes) -> int:
+        raise OSError("Simulated disk full")
+
+    monkeypatch.setattr(_os, "write", failing_write)
+
+    with pytest.raises(OSError):
+        write_mapping_atomic({"x": 1}, target)
+
+    assert not target.exists()
+    leftover = [f for f in tmp_path.iterdir() if ".tmp" in f.name]
+    assert leftover == [], f"Unexpected tempfiles left behind: {leftover}"
+
+
+def test_write_mapping_atomic_crash_leaves_no_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "record.yaml"
+
+    def crashing_replace(src: str, dst: str) -> None:
+        raise OSError("Simulated crash mid-replace")
+
+    monkeypatch.setattr(_os, "replace", crashing_replace)
+
+    with pytest.raises(OSError):
+        write_mapping_atomic({"x": 1}, target)
+
+    assert not target.exists()
+
+
+def test_write_mapping_atomic_dir_fsync_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Best-effort dir fsync failure does not propagate; the write still
+    succeeds.
+    """
+    target = tmp_path / "record.yaml"
+    original_fsync = _os.fsync
+    fsync_call_count = [0]
+
+    def flaky_fsync(fd: int) -> None:
+        fsync_call_count[0] += 1
+        # Fail only the second call (the directory fsync, after the file fsync).
+        if fsync_call_count[0] >= 2:
+            raise OSError("Simulated directory fsync failure")
+        original_fsync(fd)
+
+    monkeypatch.setattr(_os, "fsync", flaky_fsync)
+
+    write_mapping_atomic({"x": 1}, target)
+
+    assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_nonsemantic_trailing_whitespace — YAMLError fallback
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_yaml_error_fallback_returns_original_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the safety re-parse cannot confirm the normalized form is
+    semantically identical (because it can't be parsed at all), the original
+    (un-normalized) bytes must be returned unchanged.
+    """
+    from ruamel.yaml.error import YAMLError
+
+    original = b"key: value \nother: thing\t\n"
+
+    class ExplodingYAML:
+        def __init__(self, typ: str = "safe") -> None:
+            pass
+
+        def load(self, stream: object) -> None:
+            raise YAMLError("simulated unparsable input")
+
+    import kernel.yaml_io as yaml_io_module
+
+    monkeypatch.setattr(yaml_io_module, "YAML", ExplodingYAML)
+
+    result = _normalize_nonsemantic_trailing_whitespace(original)
+    assert result == original
+
+
+def test_normalize_no_trailing_whitespace_is_a_noop() -> None:
+    """When there is nothing to strip, the normalizer must return the exact
+    same bytes object content without touching the YAML parser at all.
+    """
+    original = b"key: value\nother: thing\n"
+    assert _normalize_nonsemantic_trailing_whitespace(original) == original

--- a/tests/retrospective/test_writer_atomicity.py
+++ b/tests/retrospective/test_writer_atomicity.py
@@ -271,6 +271,32 @@ def test_atomic_write_yaml_writes_data_to_canonical(tmp_path: Path) -> None:
     assert loaded == data
 
 
+def test_atomic_write_yaml_strips_trailing_whitespace_from_wrapped_scalars(tmp_path: Path) -> None:
+    """Wrapped retrospective details must not leave a whitespace-only suffix."""
+    canonical = tmp_path / "retrospective.yaml"
+    details = "An analysis-report.md artifact is present for this mission. Review its findings to understand documented issues and decisions."
+    data = {
+        "not_helpful": [
+            {
+                "id": "n-001",
+                "category": "doc",
+                "summary": "analysis-report.md present with findings",
+                "evidence_refs": ["e-007"],
+                "details": details,
+            }
+        ]
+    }
+
+    _atomic_write_yaml(data, canonical, tmp_path)
+
+    text = canonical.read_text(encoding="utf-8")
+    assert all(not line.endswith((" ", "\t")) for line in text.splitlines())
+
+    from ruamel.yaml import YAML
+
+    assert YAML(typ="safe").load(text) == data
+
+
 def test_atomic_write_yaml_uses_temp_then_rename(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Helper must write to a .tmp file FIRST, then rename it to canonical atomically."""
     import os as _os

--- a/tests/retrospective/test_writer_atomicity.py
+++ b/tests/retrospective/test_writer_atomicity.py
@@ -297,6 +297,23 @@ def test_atomic_write_yaml_strips_trailing_whitespace_from_wrapped_scalars(tmp_p
     assert YAML(typ="safe").load(text) == data
 
 
+@pytest.mark.parametrize("trailing", [" ", "\t"])
+def test_atomic_write_yaml_preserves_literal_scalar_trailing_whitespace(
+    tmp_path: Path, trailing: str
+) -> None:
+    """Literal scalar content may intentionally end a line with whitespace."""
+    from ruamel.yaml import YAML
+    from ruamel.yaml.scalarstring import LiteralScalarString
+
+    canonical = tmp_path / "retrospective.yaml"
+    details = LiteralScalarString(f"first line ends in semantic whitespace{trailing}\nsecond line")
+
+    _atomic_write_yaml({"details": details}, canonical, tmp_path)
+
+    loaded = YAML(typ="safe").load(canonical.read_text(encoding="utf-8"))
+    assert loaded == {"details": str(details)}
+
+
 def test_atomic_write_yaml_uses_temp_then_rename(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Helper must write to a .tmp file FIRST, then rename it to canonical atomically."""
     import os as _os

--- a/tests/retrospective/test_writer_atomicity.py
+++ b/tests/retrospective/test_writer_atomicity.py
@@ -287,12 +287,28 @@ def test_atomic_write_yaml_strips_trailing_whitespace_from_wrapped_scalars(tmp_p
         ]
     }
 
+    # Precondition guard: prove the un-normalized dump genuinely wraps and
+    # leaves a trailing-whitespace line, so this test cannot silently go vacuous
+    # if a future ruamel stops emitting the artifact.
+    import io as _io
+
+    from ruamel.yaml import YAML
+
+    probe = YAML(typ="rt")
+    probe.default_flow_style = False
+    probe.preserve_quotes = True
+    probe.width = 120
+    probe_buf = _io.BytesIO()
+    probe.dump(data, probe_buf)
+    raw = probe_buf.getvalue().decode("utf-8")
+    assert any(line.endswith((" ", "\t")) for line in raw.splitlines()), (
+        "expected the raw dump to contain a trailing-whitespace line; test is vacuous otherwise"
+    )
+
     _atomic_write_yaml(data, canonical, tmp_path)
 
     text = canonical.read_text(encoding="utf-8")
     assert all(not line.endswith((" ", "\t")) for line in text.splitlines())
-
-    from ruamel.yaml import YAML
 
     assert YAML(typ="safe").load(text) == data
 

--- a/tests/review/test_arbiter.py
+++ b/tests/review/test_arbiter.py
@@ -287,6 +287,77 @@ def test_persist_decision_in_artifact(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# #3058: persisted frontmatter must not wrap long prose into trailing-
+# whitespace continuation lines.
+#
+# Red-first note: before the arbiter dump sites were migrated to
+# kernel.yaml_io.serialize_mapping (width=4096), _persist_in_artifact used a
+# bare ``YAML()`` instance whose default wrap width breaks long reviewer
+# prose across lines and leaves a trailing space/tab on the wrap-continuation
+# line (verified interactively: dumping a ~300-char explanation through the
+# pre-change bare-YAML() dump produced 4 such trailing-whitespace lines).
+# This test was confirmed to fail against that pre-change code — restored
+# temporarily during authoring, then reverted — before landing here green.
+# ---------------------------------------------------------------------------
+
+
+def test_persist_decision_frontmatter_has_no_trailing_whitespace_on_wrapped_prose(
+    tmp_path: Path,
+) -> None:
+    """Long rationale prose must round-trip through frontmatter with NO
+    trailing-whitespace line and the safe-load of the frontmatter must equal
+    the override that was persisted.
+    """
+    feature_dir = tmp_path / "kitty-specs" / "066-test"
+    wp_subdir = feature_dir / "tasks" / "WP01"
+    wp_subdir.mkdir(parents=True)
+
+    artifact = wp_subdir / "review-cycle-001.md"
+    artifact.write_text(
+        "---\nreview_ref: review-cycle://066-test/WP01/001\n---\n\n# Review\n\nSome feedback.\n",
+        encoding="utf-8",
+    )
+
+    long_explanation = (
+        "This override was granted because the failing check flagged a "
+        "pre-existing gap unrelated to this change and the reviewer confirmed "
+        "via git blame that the same assertion was already broken on main "
+        "before this work package branched off, so blocking merge on it would "
+        "be incorrect and contrary to the pre-existing-failure carve-out "
+        "documented in the review policy."
+    )
+    checklist = _make_checklist(is_pre_existing=True)
+    decision = ArbiterDecision(
+        arbiter="robert",
+        category=ArbiterCategory.PRE_EXISTING_FAILURE,
+        explanation=long_explanation,
+        checklist=checklist,
+        decided_at="2026-04-06T14:00:00+00:00",
+    )
+
+    result_path = persist_arbiter_decision(
+        feature_dir=feature_dir,
+        wp_id="WP01",
+        review_ref="review-cycle://066-test/WP01/001",
+        decision=decision,
+    )
+
+    content = result_path.read_text(encoding="utf-8")
+    fm_match_result = content.split("---\n")
+    # content shape: "" , frontmatter, body...
+    frontmatter = fm_match_result[1]
+
+    assert all(not line.endswith((" ", "\t")) for line in frontmatter.splitlines()), (
+        f"frontmatter has a trailing-whitespace line:\n{frontmatter!r}"
+    )
+
+    from ruamel.yaml import YAML
+
+    loaded = YAML(typ="safe").load(frontmatter)
+    assert loaded["arbiter_override"]["explanation"] == long_explanation
+
+
+# ---------------------------------------------------------------------------
 # T13: Standalone fallback when no artifact
 # ---------------------------------------------------------------------------
 

--- a/tests/review/test_artifacts_yaml_seam.py
+++ b/tests/review/test_artifacts_yaml_seam.py
@@ -5,10 +5,13 @@
 width=4096) is an exact configuration match for
 ``serialize_mapping``'s defaults. This test proves that match holds for a
 representative frontmatter payload — including the optional
-affected-files / override fields — so the migration in
-``src/specify_cli/review/artifacts.py`` (``write()``) is provably a pure
-internal seam consolidation with zero on-disk byte change, not a silent
-format drift.
+affected-files / override fields — with every scalar within the 4096 wrap
+width, so the migration in ``src/specify_cli/review/artifacts.py``
+(``write()``) is a pure internal seam consolidation with no on-disk byte
+change for real review-cycle payloads, not a silent format drift. (The one
+input where the two diverge — a scalar that wraps past 4096 columns —
+strips non-semantic trailing whitespace the old path left, a strict
+improvement, not covered here.)
 
 If this test ever goes red because ``_make_yaml()``'s dump legitimately
 diverges from ``serialize_mapping``, that is the signal to REVERT the

--- a/tests/review/test_artifacts_yaml_seam.py
+++ b/tests/review/test_artifacts_yaml_seam.py
@@ -1,0 +1,93 @@
+"""Byte-stability pin for the #3058 follow-up migration of
+``ReviewCycleArtifact.write`` to ``kernel.yaml_io.serialize_mapping``.
+
+``_make_yaml()`` (rt, preserve_quotes=True, default_flow_style=False,
+width=4096) is an exact configuration match for
+``serialize_mapping``'s defaults. This test proves that match holds for a
+representative frontmatter payload — including the optional
+affected-files / override fields — so the migration in
+``src/specify_cli/review/artifacts.py`` (``write()``) is provably a pure
+internal seam consolidation with zero on-disk byte change, not a silent
+format drift.
+
+If this test ever goes red because ``_make_yaml()``'s dump legitimately
+diverges from ``serialize_mapping``, that is the signal to REVERT the
+``write()`` migration (per the mission instructions), not to "fix" this test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from ruamel.yaml import YAML
+
+from kernel.yaml_io import serialize_mapping
+from specify_cli.review.artifacts import _make_yaml
+
+pytestmark = pytest.mark.fast
+
+
+def _dump_with_make_yaml(data: dict[str, Any]) -> bytes:
+    from io import StringIO
+
+    yaml = _make_yaml()
+    stream = StringIO()
+    yaml.dump(data, stream)
+    return stream.getvalue().encode("utf-8")
+
+
+def _representative_payloads() -> list[dict[str, Any]]:
+    return [
+        {
+            "affected_files": [],
+            "cycle_number": 1,
+            "mission_slug": "066-test",
+            "reproduction_command": None,
+            "reviewed_at": "2026-04-06T14:00:00+00:00",
+            "reviewer_agent": "reviewer-renata",
+            "verdict": "approved",
+            "wp_id": "WP01",
+        },
+        {
+            "affected_files": [
+                {"path": "src/kernel/yaml_io.py"},
+                {
+                    "path": "src/specify_cli/retrospective/writer.py",
+                    "line_range": "150-200",
+                },
+            ],
+            "cycle_number": 2,
+            "mission_slug": "read-side-seam-primary-primitive-closure-01KYKMMT",
+            "reproduction_command": "uv run pytest tests/kernel/test_yaml_io.py -q",
+            "reviewed_at": "2026-07-28T09:30:00+00:00",
+            "reviewer_agent": "unknown",
+            "verdict": "rejected",
+            "wp_id": "WP03-ledger-grammar",
+            "override_actor": "operator",
+            "override_reason": (
+                "Reviewer flagged a pre-existing gap unrelated to this change; "
+                "confirmed via git blame that the assertion was already broken "
+                "on main before this work package branched off."
+            ),
+        },
+    ]
+
+
+def test_serialize_mapping_matches_make_yaml_byte_for_byte() -> None:
+    for data in _representative_payloads():
+        old_bytes = _dump_with_make_yaml(data)
+        new_bytes = serialize_mapping(data)
+        assert new_bytes == old_bytes, (
+            f"serialize_mapping diverged from _make_yaml for payload {data!r}:\n"
+            f"old={old_bytes!r}\nnew={new_bytes!r}"
+        )
+
+
+def test_serialize_mapping_output_still_parses_identically_to_make_yaml_load() -> None:
+    for data in _representative_payloads():
+        new_bytes = serialize_mapping(data)
+        loaded_via_make_yaml = _make_yaml().load(new_bytes.decode("utf-8"))
+        loaded_via_safe = YAML(typ="safe").load(new_bytes.decode("utf-8"))
+        assert dict(loaded_via_make_yaml) == data
+        assert loaded_via_safe == data


### PR DESCRIPTION
## Summary

Two related pieces:

1. **Retrospective YAML whitespace fix** (cherry-picked verbatim from @samuelgoff's #3034, authorship preserved). `ruamel.yaml` left a wrapping separator as trailing whitespace in nested retrospective scalars; the writer now removes trailing horizontal whitespace **only when** a `typ="safe"` round-trip confirms YAML meaning is unchanged, so literal-scalar content that legitimately ends in a space/tab stays intact.

2. **Extract a shared YAML-writer seam into the `kernel` layer** and adopt it — turning the one-off retrospective fix into an SSOT primitive, and **fixing the sibling bug #3058** (arbiter review-artifact writer wrapped reviewer prose at ruamel's default width → same trailing-whitespace artifact in committed review frontmatter).

## What changed

**New `src/kernel/yaml_io.py`** (dependency-free root layer):
- `CANONICAL_YAML_WIDTH = 4096`
- `serialize_mapping(data, *, width=4096) -> bytes` — canonical rt config (`default_flow_style=False`, `preserve_quotes=True`, width) + the trailing-whitespace normalizer. Pinned to `typ="rt"` (a safe dumper can't represent the `CommentedMap` the arbiter mutates — enforced by test).
- `write_mapping_atomic(data, path, *, width=4096, mkdir=False)` — durable atomic write (O_EXCL tmp + `fsync` + `os.replace` + best-effort dir `fsync`); a durability-enhanced sibling of `kernel.atomic.atomic_write`.
- The trailing-whitespace normalizer moved here verbatim from `retrospective/writer.py`.

**Adopters:**
- `retrospective/writer.py` → delegates to `write_mapping_atomic(width=120)`, keeping `WriterError` translation. **Width stays 120** — issue #3059 owns that decision; the normalizer (not the width) is what cures the bug.
- `review/arbiter.py` → both frontmatter dump sites use `serialize_mapping` (80→4096 + normalizer). **Fixes #3058.**
- `review/artifacts.py` → `write()` migrated to `serialize_mapping` (exact-match config; byte-stable within the 4096 wrap width, pinned by test) — closes the #3058 class for the whole review-cycle artifact family.

Deliberately **not** touched: `frontmatter.py` (its `preserve_quotes=False` + custom indent would churn every WP task file), plus charter/migration writers — left as opportunistic follow-ups.

## Validation

- `ruff` ✅ · `mypy --strict` ✅ (all 4 touched src files, zero suppressions)
- New tests: `tests/kernel/test_yaml_io.py` (13), arbiter regression (+1, red-first confirmed), `tests/review/test_artifacts_yaml_seam.py` byte-stability pin (2). Touched-area suites: **106 passed**.
- Layer rules: `kernel/yaml_io.py` imports only stdlib + ruamel — `test_layer_rules.py` kernel-is-root invariant passes.
- Two `tests/review/test_cycle.py` failures are **pre-existing on upstream/main** (confirmed on the true base), unrelated to this change.
- **Two adversarial-review passes** (correctness + SSOT/boundary on the retro fix; behavior-preservation on the consolidation): clean, no blockers. One wording overstatement folded.

## Provenance

Maintainer landing of #3034's retrospective fix (that PR was a stale 13-commit stack bundling an unrelated charter change; closed with a note). This PR carries only the genuine retrospective fix plus the kernel consolidation it motivated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
