### PR TITLE
fix(migration): retain legacy typed lane transitions

### DIFF
--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -1410,6 +1410,20 @@ def _row_sort_key(item: Mapping[str, Any]) -> tuple[str, str]:
     return (str(when), str(item.get("event_id", "")))
 
 
+def _is_legacy_typed_lane_transition(row: Mapping[str, Any]) -> bool:
+    """Return whether a typed legacy row carries the flat lane-transition shape.
+
+    Older writers added ``event_type: \"WPStatusChanged\"`` to the same flat
+    row shape consumed by the local lane reducer.  That field must not reclassify
+    a row carrying the lane-transition discriminator as a non-lane side-log
+    mirror.  TeamSpace envelopes remain non-lane here because their transition
+    fields live under ``payload`` rather than at the row's top level.
+    """
+    return row.get("event_type") == "WPStatusChanged" and all(
+        key in row for key in ("wp_id", "from_lane", "to_lane")
+    )
+
+
 def _is_preserved_non_lane_row(row: Mapping[str, Any]) -> bool:
     """Return True for non-lane rows the repair MUST keep in status.events.jsonl.
 
@@ -1474,6 +1488,9 @@ def _rule_reject_non_status_event(
 ) -> CanonicalStepResult[_Row]:
     """Rule 1: route non-lane rows that share status.events.jsonl.
 
+    - Typed legacy ``WPStatusChanged`` rows with the flat lane-transition
+      discriminator are routed to the lane canonicalizer.  They are durable
+      transition history, not non-lane mirrors.
     - Rows whose only per-mission home is this file
       (:func:`_is_preserved_non_lane_row`: retrospective + canonical lifecycle
       events) are PRESERVED in place — the runtime reader skips them during lane
@@ -1483,6 +1500,8 @@ def _rule_reject_non_status_event(
       state, if any, lives elsewhere). ``_scan_raw_status_rows`` flags the same
       class before a TeamSpace dry-run.
     """
+    if _is_legacy_typed_lane_transition(row):
+        return CanonicalStepResult.passthrough(row)
     if _is_preserved_non_lane_row(row):
         return CanonicalStepResult(
             state=row,

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -204,6 +204,77 @@ def test_repair_canonicalizes_historical_meta_and_status_events(tmp_path: Path) 
     )
 
 
+def test_repair_canonicalizes_legacy_typed_wp_status_changed_row(tmp_path: Path) -> None:
+    """A typed legacy lane transition remains a transition, not a side-log mirror."""
+    repo = tmp_path
+    mission = repo / "kitty-specs" / "001-legacy-wpstatus"
+    mission.mkdir(parents=True)
+    _write_json(
+        mission / "meta.json",
+        {
+            "mission_id": "01KQHRB8GCFJAX7HM4ZY52AQGV",
+            "mission_slug": "001-legacy-wpstatus",
+            "mission_type": "software-dev",
+            "slug": "001-legacy-wpstatus",
+            "target_branch": "main",
+        },
+    )
+    legacy_transition = {
+        "actor": "codex",
+        "at": "2026-01-01T00:00:00+00:00",
+        "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGW",
+        "event_type": "WPStatusChanged",
+        "from_lane": "planned",
+        "to_lane": "claimed",
+        "wp_id": "WP01",
+    }
+    typed_mirror = {
+        "at": "2026-01-01T00:00:01+00:00",
+        "event_id": "01KQHRB8GCFJAX7HM4ZY52AQGX",
+        "event_type": "DecisionPointOpened",
+        "payload": {"decision_point_id": "DP01"},
+    }
+    (mission / "status.events.jsonl").write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in (legacy_transition, typed_mirror))
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = repair_repo(repo)
+
+    result = report.missions[0]
+    assert result.quarantined_rows == 1
+    rows = [
+        json.loads(line)
+        for line in (mission / "status.events.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == legacy_transition["event_id"]
+    assert rows[0]["wp_id"] == "WP01"
+    assert rows[0]["from_lane"] == "planned"
+    assert rows[0]["to_lane"] == "claimed"
+    assert "event_type" not in rows[0]
+
+    status = _read_json(mission / "status.json")
+    work_packages = cast(dict[str, dict[str, object]], status["work_packages"])
+    assert work_packages["WP01"]["lane"] == "claimed"
+
+    quarantine = (
+        repo
+        / ".kittify"
+        / "migrations"
+        / "mission-state"
+        / "quarantine"
+        / report.run_id
+        / "001-legacy-wpstatus"
+        / "status.events.jsonl"
+    )
+    quarantine_text = quarantine.read_text(encoding="utf-8")
+    assert "DecisionPointOpened" in quarantine_text
+    assert "WPStatusChanged" not in quarantine_text
+
+
 def test_repair_is_idempotent_after_first_canonicalization(tmp_path: Path) -> None:
     repo = tmp_path
     mission = repo / "kitty-specs" / "001-modern"


### PR DESCRIPTION
## Summary

- route flat legacy `WPStatusChanged` rows through the canonical lane-transition migration path
- keep typed non-lane mirrors quarantined
- add a red-first regression that verifies both the repaired event log and materialized work-package lane

Fixes #3066.

## Validation

- `uv run --python 3.13 --extra test pytest tests/migration/test_mission_state_repair.py -q` — 48 passed
- `uv run --python 3.13 --extra lint ruff check src/specify_cli/migration/mission_state.py tests/migration/test_mission_state_repair.py`
- `uv run --python 3.13 --extra lint mypy --strict src/specify_cli/migration/mission_state.py`
- Live `spec-kitty doctor mission-state --fix` reproduction: retained the lane transition, materialized `WP01` as `claimed`, quarantined only `DecisionPointOpened`, and audit reported no errors or TeamSpace blockers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787897810&installation_model_id=427282&pr_number=3067&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3067&signature=9a0265beb5c064ed7946e52f712cc11bd066c1bc6dae23af1dbf94cb9fe53b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->