### PR TITLE
fix(sync): deny hosted sync without project consent

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -4265,8 +4265,8 @@ _Synchronization commands_
  Enable SaaS sync for this checkout.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --checkout-only            Enable only this checkout; do not update the      │
-│                            remembered default for future checkouts.          │
+│ --checkout-only            Deprecated: sync consent is always stored in this │
+│                            project's .kittify/config.yaml.                   │
 │ --help           -h        Show this message and exit.                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -4279,8 +4279,8 @@ _Synchronization commands_
  Disable SaaS sync for this checkout and purge its pending uploads.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --checkout-only                  Disable only this checkout; do not remember │
-│                                  the repo default for future checkouts.      │
+│ --checkout-only                  Deprecated: sync consent is always stored   │
+│                                  in this project's .kittify/config.yaml.     │
 │ --delete-private-data            After disabling sync, offer to delete       │
 │                                  already-synced private-only SaaS data for   │
 │                                  this checkout.                              │

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1425,7 +1425,7 @@ def opt_out(
     checkout_only: bool = typer.Option(
         False,
         "--checkout-only",
-        help="Disable only this checkout; do not remember the repo default for future checkouts.",
+        help="Deprecated: sync consent is always stored in this project's .kittify/config.yaml.",
     ),
     delete_private_data: bool = typer.Option(
         False,
@@ -1446,13 +1446,12 @@ def opt_out(
         list_repository_shares_sync,
     )
 
+    del checkout_only
+
     _require_daemon_owner_coherence("spec-kitty sync opt-out")
 
     routing = _require_active_checkout()
-    result = disable_checkout_sync(
-        routing.repo_root,
-        remember_repo_default=not checkout_only,
-    )
+    result = disable_checkout_sync(routing.repo_root)
 
     console.print(
         f"[green]✓[/green] Disabled SaaS sync for this checkout "
@@ -1462,9 +1461,6 @@ def opt_out(
         f"[dim]Removed {result.removed_events} queued event(s) and "
         f"{result.removed_body_uploads} queued body upload(s) for this checkout.[/dim]"
     )
-    if result.remembered_for_repo:
-        console.print("[dim]Future checkouts of this repository will also default to sync disabled.[/dim]")
-
     if not delete_private_data or not routing.project_uuid:
         return
 
@@ -1569,11 +1565,13 @@ def opt_in(
     checkout_only: bool = typer.Option(
         False,
         "--checkout-only",
-        help="Enable only this checkout; do not update the remembered default for future checkouts.",
+        help="Deprecated: sync consent is always stored in this project's .kittify/config.yaml.",
     ),
 ) -> None:
     """Enable SaaS sync for this checkout."""
     from specify_cli.sync.routing import enable_checkout_sync
+
+    del checkout_only
 
     if not is_saas_sync_enabled():
         # Non-green + non-zero (#2264 item 3): opt-in cannot take effect while
@@ -1596,10 +1594,7 @@ def opt_in(
     )
 
     routing = _require_active_checkout()
-    refreshed = enable_checkout_sync(
-        routing.repo_root,
-        remember_repo_default=not checkout_only,
-    )
+    refreshed = enable_checkout_sync(routing.repo_root)
 
     # Honest confirmation (#2264): opt-in writes LOCAL routing flags only — no
     # auth, no remote round-trip, no history import. The message must not imply
@@ -1607,11 +1602,6 @@ def opt_in(
     # false-green that escalated #2264 to P1).
     scope_label = refreshed.repo_slug or refreshed.project_slug or refreshed.project_uuid
     console.print(f"[green]✓[/green] {saas_sync_opt_in_recorded_message(scope_label)}")
-    if not checkout_only and refreshed.repo_slug:
-        console.print(
-            "[dim]Future checkouts of this repository will also default to this local preference.[/dim]"
-        )
-
 
 def _detect_workspace_context() -> tuple[Path, str | None]:
     """Detect current workspace and feature context.

--- a/src/specify_cli/delivery/dispatcher.py
+++ b/src/specify_cli/delivery/dispatcher.py
@@ -211,7 +211,12 @@ def _select_undelivered(
     past events that made no progress this pass); it never changes durable ledger
     state, so the ledger's non-terminal re-selection contract is preserved.
     """
-    universe = journal.read_all()
+    # A captured drain blocker is an event-level eligibility decision.  Filter
+    # it before the ledger query and limit so a blocked backlog cannot either
+    # leak or starve a later eligible event.
+    universe = [
+        event for event in journal.read_all() if event.drain_blocked_reason is None
+    ]
     by_id = {event.event_id: event for event in universe}
     selected_ids = ledger.select_undelivered(
         target_id=target_id,

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -1941,12 +1941,13 @@ class EventEmitter:
         occurred_at: str,
         team_slug: str | None,
     ) -> None:
-        """Capture-first durable write to the producer-scoped event journal.
+        """Capture a consented event in the producer-scoped event journal.
 
-        Runs before every delivery gate so a Teamspace-bound fact survives even
-        when all gates block (FR-017, contract §2; SC-009). Producer-scoped,
-        never server-scoped (FR-003). A journal I/O error is warned but never
-        propagated — capture-first must not make emission fail.
+        Consent is the first storage gate: a project that has not explicitly
+        opted in does not create a journal row.  For consented Teamspace-bound
+        facts this remains the durable capture-before-delivery path (FR-017,
+        contract §2; SC-009). A refusal is logged with the project identity so
+        the no-write decision is observable rather than silent.
 
         The journal payload BLOB stores the **full wire envelope** (``event``),
         not just the inner ``payload`` field. The dispatcher decodes this BLOB
@@ -1956,6 +1957,14 @@ class EventEmitter:
         ``lamport_clock``, ``schema_version``) survives the capture→drain path.
         The ``event_id``/``event_type`` journal columns still index the envelope.
         """
+        gate = self._capture_gate_state(team_slug)
+        if not gate.checkout_enabled:
+            logger.warning(
+                "Skipping event journal capture because project sync consent is disabled: %s",
+                event.get("project_slug") or event.get("project_uuid") or "unknown-project",
+            )
+            return
+
         try:
             payload_bytes = json.dumps(event, sort_keys=True, default=str).encode("utf-8")
             capture_teamspace_bound(
@@ -1964,7 +1973,7 @@ class EventEmitter:
                 event_type=event_type,
                 payload=payload_bytes,
                 occurred_at=occurred_at,
-                gate=self._capture_gate_state(team_slug),
+                gate=gate,
             )
         except Exception as exc:
             _console.print(f"[yellow]Warning: event journal capture failed: {exc}[/yellow]")
@@ -2048,12 +2057,9 @@ class EventEmitter:
             if envelope_fields:
                 event.update(envelope_fields)
 
-            # Capture-first (FR-017, contract §2; SC-009): durably record the
-            # Teamspace-bound fact in the producer-scoped event journal BEFORE
-            # any delivery gate (validation, contract gate, project routing,
-            # WebSocket, drain) can decide whether to ship it. The journal write
-            # is unconditional; the gates only set the recorded
-            # drain_blocked_reason, never whether the durable write happens.
+            # Capture after the project-consent gate: a consented Teamspace-bound
+            # fact is durable before later delivery gates, while an opted-out
+            # project leaves no shared-journal row to leak on a later drain.
             self._capture_to_journal(
                 event_id=event_id,
                 event_type=event_type,

--- a/src/specify_cli/sync/routing.py
+++ b/src/specify_cli/sync/routing.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 
+from ruamel.yaml import YAML
+
+from specify_cli.core.atomic import atomic_write
 from specify_cli.core.paths import locate_project_root
 
 from .body_queue import OfflineBodyUploadQueue
@@ -79,12 +83,11 @@ def _build_checkout_sync_routing(repo_root: Path, identity: ProjectIdentity) -> 
         else None
     )
 
-    if local_sync_enabled is not None:
-        effective_sync_enabled = local_sync_enabled
-    elif repo_default_sync_enabled is not None:
-        effective_sync_enabled = repo_default_sync_enabled
-    else:
-        effective_sync_enabled = True
+    # Hosted-sync consent belongs to the project it governs.  The legacy
+    # machine-global repository preference remains observable for migration and
+    # diagnostics, but is deliberately not an authority that can widen consent.
+    # An absent or malformed project setting therefore denies by default.
+    effective_sync_enabled = local_sync_enabled is True
 
     return CheckoutSyncRouting(
         repo_root=repo_root,
@@ -113,18 +116,60 @@ def is_sync_enabled_for_checkout(start: Path | None = None) -> bool:
     """
     routing = resolve_checkout_sync_routing_readonly(start=start)
     if routing is None:
-        return True
+        return False
     return routing.effective_sync_enabled
 
 
 def read_local_sync_enabled(repo_root: Path) -> bool | None:
-    """Read the checkout-local sync override from global machine config."""
-    return SyncConfig().get_checkout_sync_enabled(repo_root)
+    """Read the project-owned hosted-sync consent decision.
+
+    ``.kittify/config.yaml`` is the canonical authority because it travels with
+    the checkout, is reviewable, and cannot spill consent into another project.
+    Invalid or absent values return ``None``; the caller's deny-by-default
+    policy turns either state into a closed gate.
+    """
+    config_path = repo_root / ".kittify" / "config.yaml"
+    if not config_path.exists():
+        return None
+
+    try:
+        config = YAML(typ="safe").load(config_path)
+    except Exception:
+        return None
+    if not isinstance(config, dict):
+        return None
+
+    sync = config.get("sync")
+    if not isinstance(sync, dict):
+        return None
+    enabled = sync.get("enabled")
+    return enabled if isinstance(enabled, bool) else None
 
 
 def write_local_sync_enabled(repo_root: Path, enabled: bool) -> None:
-    """Persist the checkout-local sync override in global machine config."""
-    SyncConfig().set_checkout_sync_enabled(repo_root, enabled)
+    """Persist hosted-sync consent in the project's canonical configuration."""
+    config_path = repo_root / ".kittify" / "config.yaml"
+    yaml = YAML()
+    yaml.preserve_quotes = True
+
+    try:
+        config = yaml.load(config_path) if config_path.exists() else {}
+    except Exception as exc:
+        raise ValueError(f"Could not update project sync consent: {exc}") from exc
+    if not isinstance(config, dict):
+        raise ValueError("Could not update project sync consent: config root must be a mapping")
+
+    sync = config.get("sync")
+    if sync is None:
+        sync = {}
+        config["sync"] = sync
+    if not isinstance(sync, dict):
+        raise ValueError("Could not update project sync consent: sync must be a mapping")
+    sync["enabled"] = bool(enabled)
+
+    rendered = StringIO()
+    yaml.dump(config, rendered)
+    atomic_write(config_path, rendered.getvalue(), mkdir=True)
 
 
 def enable_checkout_sync(
@@ -132,14 +177,17 @@ def enable_checkout_sync(
     *,
     remember_repo_default: bool = True,
 ) -> CheckoutSyncRouting:
-    """Enable SaaS sync for this checkout and optionally future repo checkouts."""
+    """Record hosted-sync consent in this project's configuration.
+
+    ``remember_repo_default`` is retained for API compatibility, but cannot
+    widen consent beyond this project.
+    """
+    del remember_repo_default
     routing = resolve_checkout_sync_routing(repo_root)
     if routing is None:
         raise ValueError("Could not resolve the active checkout.")
 
     write_local_sync_enabled(repo_root, True)
-    if remember_repo_default and routing.repo_slug:
-        SyncConfig().set_repository_sync_enabled(routing.repo_slug, True)
     refreshed = resolve_checkout_sync_routing(repo_root)
     assert refreshed is not None
     return refreshed
@@ -150,14 +198,17 @@ def disable_checkout_sync(
     *,
     remember_repo_default: bool = True,
 ) -> SyncOptOutResult:
-    """Disable SaaS sync for this checkout and purge its pending uploads."""
+    """Revoke this project's hosted-sync consent and purge its pending uploads.
+
+    ``remember_repo_default`` is retained for API compatibility, but cannot
+    alter consent for another project.
+    """
+    del remember_repo_default
     routing = resolve_checkout_sync_routing(repo_root)
     if routing is None:
         raise ValueError("Could not resolve the active checkout.")
 
     write_local_sync_enabled(repo_root, False)
-    if remember_repo_default and routing.repo_slug:
-        SyncConfig().set_repository_sync_enabled(routing.repo_slug, False)
 
     queue = OfflineQueue()
     removed_events = (
@@ -178,5 +229,5 @@ def disable_checkout_sync(
         routing=refreshed,
         removed_events=removed_events,
         removed_body_uploads=removed_body_uploads,
-        remembered_for_repo=bool(remember_repo_default and routing.repo_slug),
+        remembered_for_repo=False,
     )

--- a/src/specify_cli/sync/runtime.py
+++ b/src/specify_cli/sync/runtime.py
@@ -62,8 +62,9 @@ def _safe_queue_size(queue_obj: object) -> int:
 def _auto_start_enabled() -> bool:
     """Check if sync auto-start is enabled via config.
 
-    Local checkout overrides win. If none is present, the remembered
-    repository default from ``~/.spec-kitty/config.toml`` is used.
+    ``sync.auto_start`` can explicitly control the local runtime. Otherwise,
+    project-owned hosted-sync consent determines whether a background runtime
+    is useful; absence or ambiguity denies by default.
     """
     project_root = locate_project_root(Path.cwd())
     if project_root is None:

--- a/tests/delivery/test_dispatch_project_consent_3030.py
+++ b/tests/delivery/test_dispatch_project_consent_3030.py
@@ -1,50 +1,13 @@
-"""RED pin: one consenting checkout must not ship a sibling project's events (#3030).
+"""Regression: an opted-out project is never captured or dispatched (#3030/#3031).
 
-Background. The producer journal is scoped on ``(user_id, team_slug)`` only
-(``event_journal/journal.py:_producer_token``) — one DB per producer covering
-EVERY project on the machine. ``project_slug`` IS present inside the wire
-envelope payload the emitter builds (``sync/emitter.py:2038``), but nothing on
-the drain path decodes it to make a delivery decision:
-``EventJournal.read_all()`` (``event_journal/journal.py:258``) runs
-``SELECT_ALL_SQL`` (``event_journal/models.py:78``), which has no WHERE
-clause, and ``_select_undelivered`` (``delivery/dispatcher.py:192-223``) never
-looks inside the payload — ``_decode_payload`` (``dispatcher.py:231-245``) is
-only reached in the *post* phase, after selection has already happened.
+This drives the real emit -> capture -> dispatch -> receiver path with two
+projects sharing one local runtime root. The consented project must be captured
+and delivered; the opted-out project's envelope may be emitted for local caller
+semantics, but it must not create a journal row that a later drain could ship.
 
-This drives the REAL emit -> capture -> dispatch -> receiver path end to end
-(no hand-built journal rows), mirroring
-``tests/delivery/test_envelope.py::test_journal_stores_full_envelope_so_dispatch_posts_contract_event``,
-with TWO distinct project identities that land in the SAME shared journal —
-the shared-journal premise is the point, not an accident, and is asserted
-explicitly below before the drain even runs.
-
-Consent bookkeeping (``~/.spec-kitty/config.toml`` -> ``[sync.repo_defaults]``,
-same shape as ``tests/sync/test_sync_consent_default_deny.py:203-207``) is
-recorded for the FIRST project only. The second project deliberately has NO
-entry at all — not an explicit opt-out — because a predicate that reads
-absence-of-a-decision as consent is the actual defect this incident turned on
-(#3031); an explicit opt-out fixture would pass today's code while the real
-leak (silence, not refusal) sailed through.
-
-Distinct from, and orthogonal to, the sibling
-``tests/delivery/test_dispatch_honours_drain_blocked_3031.py`` (#3031 Defect
-5, per-event drain filtering). That file pins that a drain-blocked-reason
-predicate must inspect each ``Event`` row rather than gating a whole
-process/checkout; it says nothing about *who* consented, because
-``drain_blocked_reason`` is a machine-global gate snapshot, not a per-project
-decision (see that file's docstring). THIS file pins the orthogonal, genuine
-per-project defect: two projects sharing one machine-global journal, where
-only ONE of them ever recorded consent. To keep the two files mutually
-satisfiable (an earlier revision pinned both against fixtures that stamped
-BOTH events with the same ``drain_blocked_reason=saas_disabled``, which made
-this file's "must ship" demand and the sibling's "any such row must never
-ship" demand directly contradictory — no implementation could satisfy both),
-the consenting checkout's capture gate is forced open below so its journal
-row is genuinely unblocked (``drain_blocked_reason=None``); only the
-non-consenting checkout's row is left machine-gate-blocked. The two files now
-key on different, non-overlapping columns: 3031 on
-``Event.drain_blocked_reason`` values it constructs directly; this file on
-``repo_slug``-keyed consent-record resolution via a real emitter round-trip.
+The sibling ``test_dispatch_honours_drain_blocked_3031.py`` independently pins
+the defence-in-depth selection rule for legacy or otherwise blocked rows. This
+test covers the stronger storage boundary through the production emitter.
 """
 from __future__ import annotations
 
@@ -72,18 +35,9 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.regression, pytest.mark.fast]
 
-# A realistic owner/repo pair — consent keying must not depend on the slug
-# looking special (mirrors tests/sync/test_sync_consent_default_deny.py:48).
-_CONSENTING_REPO_SLUG = "my-org/engagement-assistant"
-
-
 @pytest.fixture(autouse=True)
 def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """One shared ``SPEC_KITTY_HOME``, mirroring ``test_envelope.py:55-63``.
-
-    A single shared journal across the two "checkouts" simulated below is the
-    premise of this test, not an accident.
-    """
+    """One shared ``SPEC_KITTY_HOME`` to exercise the shared-store boundary."""
     monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path))
     reset_journal_cache()
     reset_coalesce_strategy()
@@ -92,44 +46,13 @@ def _isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[
     reset_coalesce_strategy()
 
 
-def _write_consent_for_first_project_only(spec_kitty_home: Path) -> None:
-    """Record hosted-sync consent for ONE project only, in machine-global config.
-
-    Shape matches ``tests/sync/test_sync_consent_default_deny.py:203-207``
-    (``[sync.repo_defaults."<repo-slug>"]`` / ``enabled = true``).
-    ``SPEC_KITTY_HOME`` is used verbatim as the runtime-root base
-    (``paths/windows_paths.py:65-68`` — "the env path is not suffixed with
-    .spec-kitty"), so the config file lands at ``$SPEC_KITTY_HOME/config.toml``
-    directly. The second project gets NO entry — absence, not an explicit
-    opt-out.
-    """
-    config_path = spec_kitty_home / "config.toml"
-    config_path.write_text(
-        f'[sync.repo_defaults."{_CONSENTING_REPO_SLUG}"]\nenabled = true\n',
-        encoding="utf-8",
-    )
-
-
-def _stub_emitter(
-    *, project_slug: str, build_id: str, repo_slug: str | None = None
-) -> EventEmitter:
+def _stub_emitter(*, project_slug: str, build_id: str) -> EventEmitter:
     """A real ``EventEmitter`` with a stubbed identity/git resolver.
 
     Mirrors ``tests/delivery/test_envelope.py:65-74``'s ``_stub_emitter`` but
-    with REAL, distinct project identities (production-shaped project slugs
-    and distinct ``project_uuid``s per instance) rather than the envelope
-    test's ``None`` placeholders — the point being that two checkouts for two
-    different projects on the same machine still resolve to the SAME journal
-    file (``team_slug=None``) once SaaS sync is globally disabled.
-
-    ``repo_slug`` is the ONLY field a per-project consent lookup can key on
-    (``sync/config.py:get_repository_sync_enabled`` does
-    ``repo_defaults.get(repo_slug)``) — a resolver that instead tried to
-    match on ``project_slug`` would be the fragile fuzzy correspondence
-    #3031 Defect 2 exists to eliminate, so this fixture never invents one.
-    Passing ``repo_slug=None`` (the default) reproduces an unresolvable git
-    identity — genuinely absent from the consent record, not an explicit
-    opt-out.
+    with real, distinct project identities rather than the envelope test's
+    ``None`` placeholders. Both instances share a local runtime root so the
+    test proves the capture gate, not filesystem isolation, prevents leakage.
     """
     from specify_cli.sync.emitter import EventEmitter
     from specify_cli.sync.git_metadata import GitMetadata
@@ -138,7 +61,7 @@ def _stub_emitter(
     em._identity = SimpleNamespace(
         build_id=build_id, project_uuid=uuid4(), project_slug=project_slug
     )
-    em._get_git_metadata = lambda: GitMetadata(repo_slug=repo_slug)
+    em._get_git_metadata = lambda: GitMetadata()
     return em
 
 
@@ -170,46 +93,32 @@ def _open_capture_gate(_team_slug: str | None) -> CaptureGateState:
     )
 
 
-def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
+def _closed_capture_gate(_team_slug: str | None) -> CaptureGateState:
+    """Model an explicitly opted-out project's storage gate."""
+    return CaptureGateState(
+        saas_enabled=True,
+        checkout_enabled=False,
+        authenticated=True,
+        team_slug="team",
+    )
+
+
+def test_opted_out_project_never_reaches_shared_journal_or_dispatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A consenting checkout's drain must not also ship a non-consenting sibling's event.
-
-    #3030 (per-project consent) — orthogonal to the rescoped
-    ``test_dispatch_honours_drain_blocked_3031.py`` (#3031 Defect 5,
-    machine-global drain-blocked-reason filtering). The consenting emitter's
-    capture gate is forced open below (``_open_capture_gate``) so its journal
-    row carries ``drain_blocked_reason=None``, while the non-consenting
-    emitter's row stays machine-gate-blocked (``is_saas_sync_enabled`` is
-    patched ``False`` for the whole process, and its gate is left
-    unoverridden). That keeps this file's "the consenting event must ship"
-    demand from ever colliding with the sibling's "any drain-blocked row must
-    never ship" demand — the two rows are no longer classified identically.
-
-    Reds today: the dispatcher ships BOTH events. The journal has no project
-    scoping at all (only ``user_id``/``team_slug``), and the drain never
-    decodes ``project_slug`` from the payload to gate delivery — so once two
-    projects share a journal (the common case: no per-project journal
-    partitioning exists), a single active sync target drains every project's
-    events indiscriminately, exactly as the incident (five non-consenting
-    projects' events shipped alongside a consenting one) played out. No
-    consent-checking code exists on the drain path at all today, so both
-    events ship regardless of ``repo_slug``/consent-record resolution.
-    """
+    """An opted-out event cannot reach a consenting project's drain."""
     from specify_cli.sync import emitter as emitter_mod
 
     monkeypatch.setattr(emitter_mod, "is_saas_sync_enabled", lambda: False)
-    _write_consent_for_first_project_only(tmp_path)
-
     consenting = _stub_emitter(
         project_slug="engagement-assistant",
         build_id="engagement-build-1",
-        repo_slug=_CONSENTING_REPO_SLUG,
     )
     consenting._capture_gate_state = _open_capture_gate
     nonconsenting = _stub_emitter(
         project_slug="client-confidential", build_id="confidential-build-1"
     )
+    nonconsenting._capture_gate_state = _closed_capture_gate
 
     consenting_envelope = consenting._emit(
         event_type="ErrorLogged",
@@ -225,37 +134,12 @@ def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
     )
     assert consenting_envelope is not None, "the consenting project's emit must succeed"
     assert nonconsenting_envelope is not None, (
-        "the non-consenting project's emit must ALSO durably capture (FR-017 "
-        "capture-first) — the defect is at drain time, not capture time"
+        "an opted-out emit remains a local caller success; consent gates storage"
     )
 
-    # The shared-journal premise, asserted explicitly before the drain runs:
-    # both events landed in the SAME journal file (team_slug=None for both,
-    # since is_saas_sync_enabled() is stubbed False for this process).
     journal = get_journal(team_slug=None)
-    assert journal.count() == 2, (
-        "both projects' events must land in the same producer-scoped journal "
-        "for this test to exercise the real cross-project leak"
-    )
-
-    # Distinguishability premise, asserted before the drain runs: the two
-    # rows must NOT collide on drain_blocked_reason (that collision was the
-    # earlier defect that made this file and the #3031 sibling mutually
-    # unsatisfiable) — the consenting row is genuinely open, the
-    # non-consenting row is genuinely blocked, and consent resolution must
-    # be what separates their outcomes below, not drain_blocked_reason alone.
     rows_by_id = {event.event_id: event for event in journal.read_all()}
-    assert rows_by_id[consenting_envelope["event_id"]].drain_blocked_reason is None, (
-        "the consenting row's capture-gate override must have produced an "
-        "open (drain_blocked_reason=None) journal row"
-    )
-    assert (
-        rows_by_id[nonconsenting_envelope["event_id"]].drain_blocked_reason is not None
-    ), (
-        "the non-consenting row must remain machine-gate-blocked so this "
-        "test's premise is that consent — not drain_blocked_reason — is the "
-        "only thing distinguishing the two events"
-    )
+    assert set(rows_by_id) == {consenting_envelope["event_id"]}
 
     ledger = SqliteDeliveryLedger(":memory:")
     registry = SqliteDeliveryTargetRegistry(":memory:")
@@ -274,9 +158,6 @@ def test_consenting_project_leaks_sibling_project_event_through_shared_journal(
         "about breaking a healthy consenting drain"
     )
     assert nonconsenting_envelope["event_id"] not in received_ids, (
-        "a project that never consented (no repo_defaults entry at all for "
-        f"{_CONSENTING_REPO_SLUG!r}'s sibling) must not have its event "
-        "shipped merely because it shares a journal file with a project "
-        "that did consent — today it does, because the drain has no notion "
-        "of project identity at all"
+        "an opted-out event must be absent from the journal before dispatch, "
+        "even when a consenting project shares the same local runtime root"
     )

--- a/tests/delivery/test_envelope.py
+++ b/tests/delivery/test_envelope.py
@@ -21,6 +21,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import pytest
 
@@ -29,6 +30,7 @@ from specify_cli.delivery.ledger import SqliteDeliveryLedger
 from specify_cli.delivery.receivers import StubReceiver, _build_payload
 from specify_cli.delivery.targets import SqliteDeliveryTargetRegistry
 from specify_cli.event_journal import (
+    CaptureGateState,
     get_journal,
     reset_coalesce_strategy,
     reset_journal_cache,
@@ -68,7 +70,7 @@ def _stub_emitter() -> EventEmitter:
 
     em = EventEmitter()
     em._identity = SimpleNamespace(
-        build_id="build-1", project_uuid=None, project_slug=None
+        build_id="build-1", project_uuid=uuid4(), project_slug="envelope-contract"
     )
     em._get_git_metadata = lambda: GitMetadata()  # type: ignore[method-assign]
     return em
@@ -81,7 +83,14 @@ def test_journal_stores_full_envelope_so_dispatch_posts_contract_event(
     from specify_cli.sync import emitter as emitter_mod
 
     monkeypatch.setattr(emitter_mod, "is_saas_sync_enabled", lambda: False)
+    monkeypatch.setattr(emitter_mod, "is_sync_enabled_for_checkout", lambda: True)
     em = _stub_emitter()
+    em._capture_gate_state = lambda _team_slug: CaptureGateState(
+        saas_enabled=True,
+        checkout_enabled=True,
+        authenticated=True,
+        team_slug="team",
+    )
 
     inner = {"error_type": "runtime", "error_message": "boom", "wp_id": "WP01"}
     envelope = em._emit(

--- a/tests/event_journal/test_capture_first.py
+++ b/tests/event_journal/test_capture_first.py
@@ -1,9 +1,8 @@
-"""Capture-first durability tests (WP03 / T016-T019, contract §2 + SC-009).
+"""Journal durability tests for consented Teamspace-bound facts (WP03 / T016-T019).
 
-Observable acceptance (NFR-001): with sync disabled or missing auth/team, a
-Teamspace-bound fact is durably journaled with a ``drain_blocked_reason`` and
-no delivery is attempted. We assert the *result* (a row exists even though the
-gate blocked), never the internal call order.
+``capture_teamspace_bound`` remains the durable writer after the emitter has
+accepted a project's explicit consent. The live emit-path tests below separately
+assert that a disabled consent gate never reaches this writer.
 """
 from __future__ import annotations
 
@@ -176,7 +175,7 @@ def _stub_emitter():
     return em
 
 
-def test_emit_writes_journal_before_delivery_gates_when_disabled(
+def test_emit_does_not_write_journal_when_sync_consent_is_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from specify_cli.sync import emitter as emitter_mod
@@ -192,13 +191,11 @@ def test_emit_writes_journal_before_delivery_gates_when_disabled(
     )
 
     rows = get_journal(team_slug=None).read_all()
-    assert len(rows) == 1
-    assert rows[0].event_type == "ErrorLogged"
-    assert rows[0].drain_blocked_reason == DRAIN_BLOCKED_SAAS_DISABLED
+    assert rows == []
     assert em.ws_client is None  # no delivery channel was opened
 
 
-def test_emit_n_events_when_disabled_yields_n_distinct_journal_rows(
+def test_emit_n_events_when_sync_consent_is_disabled_yields_no_journal_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from specify_cli.sync import emitter as emitter_mod
@@ -214,7 +211,4 @@ def test_emit_n_events_when_disabled_yields_n_distinct_journal_rows(
             payload={"i": i},
         )
 
-    rows = get_journal(team_slug=None).read_all()
-    assert len(rows) == 3
-    assert len({r.event_id for r in rows}) == 3
-    assert all(r.drain_blocked_reason == DRAIN_BLOCKED_SAAS_DISABLED for r in rows)
+    assert get_journal(team_slug=None).read_all() == []

--- a/tests/sync/test_batch_400_no_details_poison_2736.py
+++ b/tests/sync/test_batch_400_no_details_poison_2736.py
@@ -73,8 +73,9 @@ def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.fixture(autouse=True)
 def _enable_saas_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the SaaS-sync feature flag on for every test in this module."""
+    """Model an explicitly consented checkout for batch-transport tests."""
     monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
 
 
 @pytest.fixture

--- a/tests/sync/test_batch_error_surfacing.py
+++ b/tests/sync/test_batch_error_surfacing.py
@@ -83,11 +83,12 @@ def small_queue(temp_queue):
 
 @pytest.fixture(autouse=True)
 def private_ingress_scope(monkeypatch):
-    """These tests exercise batch response handling, not auth/team resolution."""
+    """Model consented private ingress for batch response-handling tests."""
     monkeypatch.setattr(
         "specify_cli.sync.batch._current_team_slug",
         lambda: "private-teamspace-id",
     )
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
 
 
 # ────────────────────────────────────────────────────────────────

--- a/tests/sync/test_batch_retry_hygiene.py
+++ b/tests/sync/test_batch_retry_hygiene.py
@@ -77,8 +77,9 @@ def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.fixture(autouse=True)
 def _enable_saas_sync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the SaaS-sync feature flag on for every test in this module."""
+    """Model an explicitly consented checkout for batch-transport tests."""
     monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
 
 
 @pytest.fixture

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -73,6 +73,7 @@ def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None
     fake_tm.get_current_session.return_value = fake_session
     fake_tm.is_authenticated = True
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: fake_tm)
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
 
 
 @pytest.fixture

--- a/tests/sync/test_edge_cases.py
+++ b/tests/sync/test_edge_cases.py
@@ -358,6 +358,7 @@ class TestNonBlockingEmission:
             raise RuntimeError("Not authenticated")
 
         monkeypatch.setattr("specify_cli.auth.get_token_manager", _boom)
+        monkeypatch.setattr("specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True)
 
         em = EventEmitter(clock=clock, config=config, queue=queue, ws_client=None)
 

--- a/tests/sync/test_events.py
+++ b/tests/sync/test_events.py
@@ -143,6 +143,7 @@ class TestEventEnvelope:
             raise RuntimeError("Not authenticated")
 
         monkeypatch.setattr("specify_cli.auth.get_token_manager", _boom)
+        monkeypatch.setattr("specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True)
         em = EventEmitter(
             clock=temp_clock,
             config=mock_config,

--- a/tests/sync/test_integration.py
+++ b/tests/sync/test_integration.py
@@ -24,6 +24,13 @@ from specify_cli.sync.queue import OfflineQueue
 from specify_cli.sync.clock import LamportClock
 
 
+@pytest.fixture(autouse=True)
+def consented_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep this emit-to-upload suite focused on its transport contract."""
+    monkeypatch.setattr("specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True)
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
+
+
 class TestFullFlow:
     """Test emit → queue → batch sync → server."""
 

--- a/tests/sync/test_lifecycle_readiness.py
+++ b/tests/sync/test_lifecycle_readiness.py
@@ -134,6 +134,9 @@ def test_event_durable_when_unauthenticated(
     def _boom():
         raise RuntimeError("Not authenticated")
 
+    monkeypatch.setattr(
+        "specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True
+    )
     monkeypatch.setattr("specify_cli.auth.get_token_manager", _boom)
 
     em = _make_emitter(fresh_queue, fresh_clock, identity_with_remote, "org/repo")
@@ -161,6 +164,9 @@ def test_event_durable_when_no_private_teamspace(
     tm.get_current_session.return_value = MagicMock()
     monkeypatch.setattr("specify_cli.auth.get_token_manager", lambda: tm)
     monkeypatch.setattr(
+        "specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True
+    )
+    monkeypatch.setattr(
         "specify_cli.sync._team.resolve_private_team_id_for_ingress",
         lambda *_a, **_kw: None,
     )
@@ -175,7 +181,7 @@ def test_event_durable_when_no_private_teamspace(
 
 
 def test_build_registered_succeeds_without_repo_slug(
-    fresh_queue, fresh_clock, identity_with_remote, authed_token_manager
+    fresh_queue, fresh_clock, identity_with_remote, authed_token_manager, monkeypatch
 ):
     """FR-5 / issue #1074: BuildRegistered requires only build_id (project_uuid is enrichment).
 
@@ -183,6 +189,9 @@ def test_build_registered_succeeds_without_repo_slug(
     ``project_uuid`` + ``build_id`` but no git remote slug. The event
     must validate, queue, and be drainable once auth/team are in place.
     """
+    monkeypatch.setattr(
+        "specify_cli.sync.emitter.is_sync_enabled_for_checkout", lambda: True
+    )
     em = _make_emitter(
         fresh_queue,
         fresh_clock,
@@ -322,6 +331,10 @@ def test_init_emits_project_init_event_offline(tmp_path: Path, monkeypatch):
     project_path = tmp_path / "fresh-project"
     project_path.mkdir()
     (project_path / ".kittify").mkdir()
+    (project_path / ".kittify" / "config.yaml").write_text(
+        "sync:\n  enabled: true\n",
+        encoding="utf-8",
+    )
     outside_path = tmp_path / "outside"
     outside_path.mkdir()
     monkeypatch.chdir(outside_path)

--- a/tests/sync/test_offline_replay.py
+++ b/tests/sync/test_offline_replay.py
@@ -34,11 +34,12 @@ def temp_queue():
 
 @pytest.fixture(autouse=True)
 def private_ingress_scope(monkeypatch):
-    """These replay tests exercise batching, not auth/team resolution."""
+    """Model consented private ingress for replay tests."""
     monkeypatch.setattr(
         "specify_cli.sync.batch._current_team_slug",
         lambda: "private-teamspace-id",
     )
+    monkeypatch.setattr("specify_cli.sync.batch.is_sync_enabled_for_checkout", lambda: True)
 
 
 def create_test_event(index: int, node_id: str = "test-node") -> dict:

--- a/tests/sync/test_routing.py
+++ b/tests/sync/test_routing.py
@@ -20,28 +20,31 @@ from specify_cli.sync.routing import (
 pytestmark = pytest.mark.fast
 
 
-def _write_repo_config(repo_root: Path, *, project_uuid: str | None = None, repo_slug: str = "acme/spec-kitty") -> None:
+def _write_repo_config(
+    repo_root: Path,
+    *,
+    project_uuid: str | None = None,
+    repo_slug: str = "acme/spec-kitty",
+    sync_enabled: bool | None = None,
+) -> None:
     config_dir = repo_root / ".kittify"
     config_dir.mkdir(parents=True, exist_ok=True)
     if project_uuid is None:
         project_uuid = str(uuid4())
-    (config_dir / "config.yaml").write_text(
-        "\n".join(
-            [
-                "project:",
-                f"  uuid: {project_uuid}",
-                "  slug: spec-kitty-local",
-                "  node_id: node12345678",
-                f"  repo_slug: {repo_slug}",
-                "  build_id: build-123",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
+    lines = [
+        "project:",
+        f"  uuid: {project_uuid}",
+        "  slug: spec-kitty-local",
+        "  node_id: node12345678",
+        f"  repo_slug: {repo_slug}",
+        "  build_id: build-123",
+    ]
+    if sync_enabled is not None:
+        lines.extend(["sync:", f"  enabled: {str(sync_enabled).lower()}"])
+    (config_dir / "config.yaml").write_text("\n".join([*lines, ""]), encoding="utf-8")
 
 
-def test_resolve_checkout_sync_routing_uses_global_repo_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_checkout_sync_routing_does_not_use_global_repo_default_as_consent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     repo_root = tmp_path / "repo"
     home.mkdir()
@@ -53,7 +56,7 @@ def test_resolve_checkout_sync_routing_uses_global_repo_default(tmp_path: Path, 
     config_file = home / ".spec-kitty" / "config.toml"
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.write_text(
-        '[sync.repo_defaults."acme/spec-kitty"]\nenabled = false\n',
+        '[sync.repo_defaults."acme/spec-kitty"]\nenabled = true\n',
         encoding="utf-8",
     )
 
@@ -62,7 +65,7 @@ def test_resolve_checkout_sync_routing_uses_global_repo_default(tmp_path: Path, 
     assert routing is not None
     assert routing.repo_slug == "acme/spec-kitty"
     assert routing.local_sync_enabled is None
-    assert routing.repo_default_sync_enabled is False
+    assert routing.repo_default_sync_enabled is True
     assert routing.effective_sync_enabled is False
 
 
@@ -84,12 +87,12 @@ def test_readonly_routing_does_not_create_project_identity(tmp_path: Path, monke
     assert not (repo_root / ".kittify" / "config.yaml").exists()
 
 
-def test_local_override_beats_global_repo_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_project_consent_beats_legacy_global_repo_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     repo_root = tmp_path / "repo"
     home.mkdir()
     repo_root.mkdir()
-    _write_repo_config(repo_root)
+    _write_repo_config(repo_root, sync_enabled=True)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.chdir(repo_root)
 
@@ -99,8 +102,6 @@ def test_local_override_beats_global_repo_default(tmp_path: Path, monkeypatch: p
         '[sync.repo_defaults."acme/spec-kitty"]\nenabled = false\n',
         encoding="utf-8",
     )
-    write_local_sync_enabled(repo_root, True)
-
     routing = resolve_checkout_sync_routing()
 
     assert routing is not None
@@ -109,7 +110,7 @@ def test_local_override_beats_global_repo_default(tmp_path: Path, monkeypatch: p
     assert routing.effective_sync_enabled is True
 
 
-def test_local_override_is_persisted_outside_repo_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_project_consent_is_persisted_in_repo_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
     repo_root = tmp_path / "repo"
     home.mkdir()
@@ -117,15 +118,12 @@ def test_local_override_is_persisted_outside_repo_config(tmp_path: Path, monkeyp
     _write_repo_config(repo_root)
     monkeypatch.setenv("HOME", str(home))
 
-    original_repo_config = (repo_root / ".kittify" / "config.yaml").read_text(encoding="utf-8")
-
     write_local_sync_enabled(repo_root, False)
 
-    assert (repo_root / ".kittify" / "config.yaml").read_text(encoding="utf-8") == original_repo_config
-    config_toml = (home / ".spec-kitty" / "config.toml").read_text(encoding="utf-8")
-    assert str(repo_root.resolve()) in config_toml
-    assert "checkout_overrides" in config_toml
-    assert "enabled = false" in config_toml
+    config_yaml = (repo_root / ".kittify" / "config.yaml").read_text(encoding="utf-8")
+    assert "sync:" in config_yaml
+    assert "enabled: false" in config_yaml
+    assert not (home / ".spec-kitty" / "config.toml").exists()
 
 
 def test_disable_checkout_sync_purges_only_matching_project_data(
@@ -194,6 +192,6 @@ def test_disable_checkout_sync_purges_only_matching_project_data(
     assert result.removed_body_uploads == 1
     assert queue.size() == 1
     assert body_queue.size() == 1
-    config_toml = (home / ".spec-kitty" / "config.toml").read_text(encoding="utf-8")
-    assert "acme/spec-kitty" in config_toml
-    assert "enabled = false" in config_toml
+    config_yaml = (repo_root / ".kittify" / "config.yaml").read_text(encoding="utf-8")
+    assert "sync:" in config_yaml
+    assert "enabled: false" in config_yaml

--- a/tests/sync/test_runtime.py
+++ b/tests/sync/test_runtime.py
@@ -50,21 +50,21 @@ class TestAutoStartEnabled:
         monkeypatch.chdir(tmp_path)
         assert _auto_start_enabled() is True
 
-    def test_returns_true_when_config_has_no_sync_section(self, tmp_path, monkeypatch):
-        """Returns True when config exists but has no sync section."""
+    def test_returns_false_when_config_has_no_sync_section(self, tmp_path, monkeypatch):
+        """Absent project consent prevents an unnecessary background runtime."""
         monkeypatch.chdir(tmp_path)
         config_dir = tmp_path / ".kittify"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text("agents:\n  available: []\n")
-        assert _auto_start_enabled() is True
+        assert _auto_start_enabled() is False
 
-    def test_returns_true_when_auto_start_not_set(self, tmp_path, monkeypatch):
-        """Returns True when sync section exists but auto_start not set."""
+    def test_returns_false_when_consent_is_not_set(self, tmp_path, monkeypatch):
+        """A sync section without ``enabled: true`` remains deny-by-default."""
         monkeypatch.chdir(tmp_path)
         config_dir = tmp_path / ".kittify"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text("sync:\n  server_url: https://example.com\n")
-        assert _auto_start_enabled() is True
+        assert _auto_start_enabled() is False
 
     def test_returns_true_when_auto_start_true(self, tmp_path, monkeypatch):
         """Returns True when auto_start is explicitly True."""
@@ -83,13 +83,13 @@ class TestAutoStartEnabled:
         ):
             assert _auto_start_enabled() is False
 
-    def test_returns_true_on_invalid_yaml(self, tmp_path, monkeypatch):
-        """Returns True when config file is invalid YAML."""
+    def test_returns_false_on_invalid_yaml(self, tmp_path, monkeypatch):
+        """Invalid consent configuration cannot start a sync runtime."""
         monkeypatch.chdir(tmp_path)
         config_dir = tmp_path / ".kittify"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text("invalid: yaml: content: [")
-        assert _auto_start_enabled() is True
+        assert _auto_start_enabled() is False
 
 
 class TestSyncRuntime:

--- a/tests/sync/test_sync_consent_default_deny.py
+++ b/tests/sync/test_sync_consent_default_deny.py
@@ -203,7 +203,11 @@ def test_machine_global_opt_in_does_not_leak_to_sibling_projects(
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.delenv("SPEC_KITTY_HOME", raising=False)
 
-    _write_project_config(consenting, repo_slug="my-org/intended-project")
+    _write_project_config(
+        consenting,
+        repo_slug="my-org/intended-project",
+        sync_enabled=True,
+    )
     _write_project_config(unrelated, repo_slug="client-org/confidential-work")
 
     config_file = home / ".spec-kitty" / "config.toml"

--- a/tests/sync/test_sync_e2e_integration.py
+++ b/tests/sync/test_sync_e2e_integration.py
@@ -283,7 +283,10 @@ class TestUnauthenticatedGracefulDegradation:
         monkeypatch.chdir(temp_repo)
 
         mock_service = MagicMock()
-        with patch("specify_cli.sync.background.get_sync_service") as mock_get_service:
+        with (
+            patch("specify_cli.sync.background.get_sync_service") as mock_get_service,
+            patch("specify_cli.sync.runtime.is_sync_enabled_for_checkout", return_value=True),
+        ):
             mock_get_service.return_value = mock_service
             # Mission 080: ``SyncRuntime`` now reads auth state via
             # ``specify_cli.auth.get_token_manager`` instead of the deleted


### PR DESCRIPTION
## Summary

- make `.kittify/config.yaml` `sync.enabled` the sole hosted-sync consent authority, with deny-by-default behavior
- prevent non-consenting projects from entering the shared journal and exclude legacy blocked rows before dispatch limits
- remove misleading repository-wide opt-in claims from the CLI and reference docs

## Validation

- `uv run --python 3.13 --extra test python -m pytest tests/sync tests/delivery -q` — 2240 passed, 18 skipped
- `uv run --python 3.13 --extra lint ruff check …` — passed
- `uv run --python 3.13 --extra lint mypy --strict …` — passed
- `check_cli_reference_freshness` — clean

## Scope

Addresses the active #3031 consent regressions and the #3030 shared-journal leak witness. It deliberately does **not** claim to complete #3053: per-project journal partitioning, migration, and purge remain separate follow-up work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909056&installation_model_id=427282&pr_number=3069&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3069&signature=2dd8d5791eee5dbab9906fb0ddacff85debbc14cf6b903036a55347cb9b7da73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->