### PR TITLE
test(doctrine-delivery): cover landing-fold branches that missed #3070's squash-merge

### DIFF
--- a/tests/specify_cli/cli/commands/test_doctrine_asset.py
+++ b/tests/specify_cli/cli/commands/test_doctrine_asset.py
@@ -16,10 +16,13 @@ proof (SC-003) lives in ``tests/docs/test_asset_resolution_wheel.py``.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
+from ruamel.yaml import YAML
 from typer.testing import CliRunner
 
+from specify_cli.cli.commands import _doctrine_asset as asset_module
 from specify_cli.cli.commands.doctrine import app as doctrine_app
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
@@ -29,6 +32,15 @@ runner = CliRunner()
 #: The single built-in asset shipped today (WP04). Its blob is the structural
 #: docs-lint script; the manifest declares this stable identifier.
 _SHIPPED_ASSET_ID = "common-docs-structural-lint"
+
+
+def _write_asset_manifest(path: Path, *, asset_id: str, mime: str, blob_path: str) -> None:
+    """Write one ``*.asset.yaml`` sidecar manifest (mirrors ``tests/doctrine/assets``)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    yaml = YAML()
+    yaml.default_flow_style = False
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.dump({"id": asset_id, "mime": mime, "path": blob_path}, handle)
 
 
 def test_asset_path_resolves_shipped_asset() -> None:
@@ -121,3 +133,51 @@ def test_resolved_path_str_renders_marker_on_not_found_not_just_escape() -> None
     repo.resolve_path.side_effect = AssetNotFoundError("orphaned-org-asset")
 
     assert _resolved_path_str(repo, "orphaned-org-asset") == _UNRESOLVABLE
+
+
+def test_asset_list_empty_prints_message_and_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No resolvable manifests at all -> a friendly message, exit 0 (not a crash)."""
+    from doctrine.assets.repository import AssetRepository
+
+    empty_built_in = tmp_path / "shipped" / "assets" / "built-in"
+    empty_built_in.mkdir(parents=True)
+    monkeypatch.setattr(
+        asset_module, "_build_asset_repository", lambda: AssetRepository(built_in_dir=empty_built_in)
+    )
+
+    result = runner.invoke(doctrine_app, ["asset", "list"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "No doctrine assets found." in result.output
+
+
+def test_asset_path_escape_exits_nonzero_naming_it(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A manifest whose blob path escapes its anchoring root refuses fail-closed (NFR-006)."""
+    from doctrine.assets.repository import AssetRepository
+
+    built_in = tmp_path / "shipped" / "assets" / "built-in"
+    _write_asset_manifest(
+        built_in / "evil.asset.yaml",
+        asset_id="evil",
+        mime="text/plain",
+        blob_path="../../../../etc/passwd",
+    )
+    monkeypatch.setattr(
+        asset_module, "_build_asset_repository", lambda: AssetRepository(built_in_dir=built_in)
+    )
+
+    result = runner.invoke(doctrine_app, ["asset", "path", "evil"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "evil" in result.output
+
+
+def test_asset_path_unknown_id_json_carries_id_and_error() -> None:
+    """``path --json`` on a failure renders the id/error record, not rich text."""
+    result = runner.invoke(
+        doctrine_app,
+        ["asset", "path", "no-such-asset-xyz", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert payload["id"] == "no-such-asset-xyz"
+    assert "no-such-asset-xyz" in payload["error"]

--- a/tests/specify_cli/upgrade/test_normalize_activation_absence.py
+++ b/tests/specify_cli/upgrade/test_normalize_activation_absence.py
@@ -22,6 +22,10 @@ from specify_cli.upgrade.migrations.m_3_2_x_normalize_activation_absence import 
     MIGRATION_ID,
     NormalizeActivationAbsenceMigration,
     _PER_ARTIFACT_ACTIVATION_KEYS,
+    _config_carries_any_activation,
+    _legacy_bundle_present,
+    _should_defer_bare_config_write,
+    _unify_promotion_pending,
 )
 from specify_cli.upgrade.registry import MigrationRegistry
 
@@ -173,3 +177,151 @@ def test_absent_keys_become_empty_in_legacy_config(tmp_path: Path) -> None:
     for key in _PER_ARTIFACT_ACTIVATION_KEYS:
         if key != "activated_directives":
             assert config[key] == [], key
+
+
+# ---------------------------------------------------------------------------
+# Two-invocation churn guard predicates (NFR-006, landing-fold fix for #3070)
+#
+# ``_should_defer_bare_config_write`` only defers when config.yaml is the
+# resolved store (no charter.yaml) AND none of three signals already arms
+# the sibling fold migration this pass: a legacy bundle file, an
+# already-activation-carrying config, or a pending answers-only promotion.
+# These tests exercise each predicate's true/false branches directly, then
+# the detect()/apply() decisions they gate.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_bundle_present_true_when_a_bundle_file_exists(tmp_path: Path) -> None:
+    _write(tmp_path / ".kittify" / "charter" / "governance.yaml", "testing: {}\n")
+    assert _legacy_bundle_present(tmp_path) is True
+
+
+def test_legacy_bundle_present_false_when_no_charter_dir(tmp_path: Path) -> None:
+    assert _legacy_bundle_present(tmp_path) is False
+
+
+def test_config_carries_any_activation_true_for_per_artifact_key() -> None:
+    assert _config_carries_any_activation({"activated_directives": []}) is True
+
+
+def test_config_carries_any_activation_true_for_coarse_key() -> None:
+    """The coarse gates (excluded from FR-018 normalization) still arm the guard."""
+    assert _config_carries_any_activation({"activated_kinds": ["directive"]}) is True
+
+
+def test_config_carries_any_activation_false_for_bare_config() -> None:
+    assert _config_carries_any_activation({"vcs": {"type": "git"}}) is False
+
+
+def test_unify_promotion_pending_false_without_answers_yaml(tmp_path: Path) -> None:
+    """No answers.yaml -> the sibling migration's own detect() short-circuits False."""
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    assert _unify_promotion_pending(tmp_path) is False
+
+
+def test_unify_promotion_pending_true_with_answers_only_selection(tmp_path: Path) -> None:
+    """An answers-only selection not yet mirrored into config.yaml is pending promotion."""
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    _write(
+        tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml",
+        "selected_directives:\n  - 010-specification-fidelity-requirement\n",
+    )
+    assert _unify_promotion_pending(tmp_path) is True
+
+
+def test_should_defer_bare_config_write_false_when_charter_path_given(tmp_path: Path) -> None:
+    """Once charter.yaml exists, config.yaml is never the resolved store -- never defer."""
+    assert (
+        _should_defer_bare_config_write(tmp_path, {}, tmp_path / ".kittify" / "charter" / "charter.yaml")
+        is False
+    )
+
+
+def test_should_defer_bare_config_write_false_when_legacy_bundle_present(tmp_path: Path) -> None:
+    _write(tmp_path / ".kittify" / "charter" / "governance.yaml", "testing: {}\n")
+    assert _should_defer_bare_config_write(tmp_path, {}, None) is False
+
+
+def test_should_defer_bare_config_write_false_when_config_carries_activation(tmp_path: Path) -> None:
+    config_data = {"vcs": {"type": "git"}, "activated_kinds": ["directive"]}
+    assert _should_defer_bare_config_write(tmp_path, config_data, None) is False
+
+
+def test_should_defer_bare_config_write_true_on_bare_project(tmp_path: Path) -> None:
+    """No charter.yaml, no legacy bundle, no config activation, no pending promotion -> defer."""
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    config_data = {"vcs": {"type": "git"}}
+    assert _should_defer_bare_config_write(tmp_path, config_data, None) is True
+
+
+# ---------------------------------------------------------------------------
+# detect()/apply() decisions the guard gates
+# ---------------------------------------------------------------------------
+
+
+def test_bare_config_defers_normalization_when_nothing_arms_the_fold(tmp_path: Path) -> None:
+    """A freshly-init'd project (no charter.yaml/legacy bundle/activation/answers)
+    reports detect() False and apply() is a true no-op -- the write is deferred
+    rather than becoming the sole, premature trigger for the sibling fold.
+    """
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    migration = NormalizeActivationAbsenceMigration()
+
+    assert migration.detect(tmp_path) is False
+    result = migration.apply(tmp_path)
+    assert result.success
+    assert result.changes_made == []
+
+    config = _load(tmp_path / ".kittify" / "config.yaml")
+    for key in _PER_ARTIFACT_ACTIVATION_KEYS:
+        assert key not in config, key
+
+
+def test_proceeds_immediately_when_legacy_bundle_present(tmp_path: Path) -> None:
+    """A surviving legacy bundle file already arms the fold -- write now, not deferred."""
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    _write(tmp_path / ".kittify" / "charter" / "governance.yaml", "testing: {}\n")
+    migration = NormalizeActivationAbsenceMigration()
+
+    assert migration.detect(tmp_path) is True
+    result = migration.apply(tmp_path)
+    assert result.success
+    assert result.changes_made != []
+
+    config = _load(tmp_path / ".kittify" / "config.yaml")
+    for key in _PER_ARTIFACT_ACTIVATION_KEYS:
+        assert config[key] == [], key
+
+
+def test_proceeds_immediately_when_config_already_carries_coarse_activation(tmp_path: Path) -> None:
+    """A pre-existing coarse activation key already arms the fold -- write now."""
+    _write(
+        tmp_path / ".kittify" / "config.yaml",
+        "vcs:\n  type: git\nactivated_kinds:\n  - directive\n",
+    )
+    migration = NormalizeActivationAbsenceMigration()
+
+    assert migration.detect(tmp_path) is True
+    migration.apply(tmp_path)
+
+    config = _load(tmp_path / ".kittify" / "config.yaml")
+    assert config["activated_kinds"] == ["directive"]
+    for key in _PER_ARTIFACT_ACTIVATION_KEYS:
+        assert config[key] == [], key
+
+
+def test_proceeds_immediately_when_answers_only_promotion_pending(tmp_path: Path) -> None:
+    """A pending answers->config promotion already arms the fold -- write now."""
+    _write(tmp_path / ".kittify" / "config.yaml", "vcs:\n  type: git\n")
+    _write(
+        tmp_path / ".kittify" / "charter" / "interview" / "answers.yaml",
+        "selected_directives:\n  - 010-specification-fidelity-requirement\n",
+    )
+    migration = NormalizeActivationAbsenceMigration()
+
+    assert migration.detect(tmp_path) is True
+    migration.apply(tmp_path)
+
+    config = _load(tmp_path / ".kittify" / "config.yaml")
+    for key in _PER_ARTIFACT_ACTIVATION_KEYS:
+        assert config[key] == [], key


### PR DESCRIPTION
## What this is

A small **test-only** follow-up to the #3070 landing pass. During that pass I applied 23 `landing fold:` commits; #3070 was **squash-merged at head `e52780e18` (folds 1–22)**, and the final fold — added-coverage for branches the landing folds themselves introduced — was pushed to the branch *after* the merge, so it missed the squash. This PR carries just that one fold onto current `main`.

## Contents (test-only, +212 lines, 2 files)

Covers the new branches this landing pass's own folds introduced, per the "every new branch needs tests in the same PR" rule:

- **`tests/specify_cli/upgrade/test_normalize_activation_absence.py`** — the idempotency fold added a two-invocation churn guard (`_should_defer_bare_config_write` / `_legacy_bundle_present` / `_config_carries_any_activation` / `_unify_promotion_pending`) whose only exercised path was the happy "defer" branch. Adds direct predicate-level tests for each true/false branch plus `detect()`/`apply()` decision tests for the three "proceed immediately" triggers and the "defer" no-op. Module coverage 78% → 82% (remaining misses are pre-existing dry-run / `can_apply` / pointer-write lines outside this fold's scope).
- **`tests/specify_cli/cli/commands/test_doctrine_asset.py`** — covers the `asset list` / `asset path` catch-net widened during the pass (empty-list message, `AssetPathEscapeError` on `../` traversal, unknown-id JSON record). Module coverage 91% → **100%**.

No production code changes. Verified on current `main`: **30 passed**; `ruff` + `mypy` clean on both files.

## Tickets

**Closes: none.** Refs #3070 (the merged landing pass this completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787949840&installation_model_id=427282&pr_number=3077&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3077&signature=48a2a58a002bb2118c8c244230a0156be7f0411d6bfaf4f08d4aa2432add5104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->