### PR TITLE
docs(plans): 3.2.x open-core delivery plan, verified status re-anchor + executive overview

### DIFF
--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -7860,12 +7860,24 @@ pages:
     - {slug: "7-open-decisions-for-the-operator", text: "7. Open decisions for the operator", level: 2}
     - {slug: "fact-check-corrections", text: "Fact-check corrections", level: 2}
     - {slug: "appendix-method-participants", text: "Appendix: method & participants", level: 2}
+  - path: "docs/plans/3-2-x-executive-overview.md"
+    title: "3.2.x Executive Overview"
+    divio_type: "none"
+    abstract: "Executive/stakeholder synthesis of 3.2.x goals and progress since the 3.2.4 release — from a PO, C-suite, and customer point of view."
+    anchors:
+    - {slug: "bottom-line", text: "Bottom line", level: 2}
+    - {slug: "what-3-2-x-is-for-in-business-terms", text: "What 3.2.x is for (in business terms)", level: 2}
+    - {slug: "progress-since-3-2-4-what-it-means-for-customers", text: "Progress since 3.2.4 — what it means for customers", level: 2}
+    - {slug: "strategic-position-the-open-core-pivot-is-closer-than-the-roadmap-showed", text: "Strategic position: the open-core pivot is closer than the roadmap showed", level: 2}
+    - {slug: "release-readiness-risk-candid", text: "Release readiness & risk (candid)", level: 2}
+    - {slug: "what-s-next-the-strategic-call-for-the-po", text: "What's next & the strategic call for the PO", level: 2}
   - path: "docs/plans/3-2-x-milestone-roadmap.md"
     title: "3.2.x Milestone — Roadmap"
     divio_type: "none"
     abstract: "Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items."
     anchors:
     - {slug: "intent-of-3-2-x", text: "Intent of 3.2.x", level: 2}
+    - {slug: "addendum-2026-07-30-verified-status-re-read-spine-re-anchoring", text: "Addendum 2026-07-30 — verified status re-read + spine re-anchoring", level: 2}
     - {slug: "the-dependency-spine", text: "The dependency spine", level: 2}
     - {slug: "the-g1-doctrine-charter-arc-off-spine", text: "The G1 doctrine & charter arc (off-spine)", level: 2}
     - {slug: "doctrine-canonical-structure-remediation-programme-2026-07-26", text: "Doctrine canonical-structure remediation programme (2026-07-26)", level: 2}
@@ -7877,6 +7889,26 @@ pages:
     - {slug: "exit-criteria-for-3-2-x", text: "Exit criteria for 3.2.x", level: 2}
     - {slug: "risks-watch-items", text: "Risks / watch items", level: 2}
     - {slug: "immediate-next-steps", text: "Immediate next steps", level: 2}
+  - path: "docs/plans/3-2-x-open-core-delivery-plan.md"
+    title: "3.2.x Open-Core Delivery Plan"
+    divio_type: "none"
+    abstract: "PO-facing 3.2.x synthesis: a verified status re-read, the open-core breaking-change delivery strategy, and the bounded remaining-work sequence."
+    anchors:
+    - {slug: "tl-dr-for-the-po", text: "TL;DR for the PO", level: 2}
+    - {slug: "1-status-re-read-verified", text: "1. Status re-read (verified)", level: 2}
+    - {slug: "1-1-g1-doctrine-charter-drg-drives-the-runtime-the-capability-is-built-and-active", text: "1.1 G1 — doctrine/charter/DRG drives the runtime: **the capability is BUILT and ACTIVE**", level: 3}
+    - {slug: "1-2-g2-strangle-the-core-domains-onto-ssots-substantially-delivered", text: "1.2 G2 — strangle the core domains onto SSOTs: **substantially DELIVERED**", level: 3}
+    - {slug: "1-3-g3-devex-enablers-substantially-delivered", text: "1.3 G3 — DevEx enablers: **substantially delivered**", level: 3}
+    - {slug: "1-4-the-traceability-gap-the-roadmap-s-real-defect", text: "1.4 The traceability gap (the roadmap's real defect)", level: 3}
+    - {slug: "1-5-release-posture-not-tag-ready", text: "1.5 Release posture — **NOT tag-ready**", level: 3}
+    - {slug: "2-the-delivery-strategy-open-core-breaking-change-window", text: "2. The delivery strategy: open-core breaking-change window", level: 2}
+    - {slug: "2-1-organizing-principle", text: "2.1 Organizing principle", level: 3}
+    - {slug: "2-2-the-done-bar-operator-stated", text: "2.2 The done-bar (operator-stated)", level: 3}
+    - {slug: "2-3-dual-track-no-hard-freeze", text: "2.3 Dual-track, no hard freeze", level: 3}
+    - {slug: "2-4-the-minimal-hurt-machinery-for-the-small-consenting-consumer-set", text: "2.4 The \"minimal-hurt\" machinery (for the small, consenting consumer set)", level: 3}
+    - {slug: "3-remaining-work-sequenced", text: "3. Remaining work, sequenced", level: 2}
+    - {slug: "4-consumer-communication-plan", text: "4. Consumer communication plan", level: 2}
+    - {slug: "5-open-decisions-for-the-po", text: "5. Open decisions for the PO", level: 2}
   - path: "docs/plans/doctrine/391-doctrine-usage-test.md"
     title: "#391 Doctrine Usage Test (WP11 dogfood)"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -2540,7 +2540,19 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/plans/3-2-x-executive-overview.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/plans/3-2-x-milestone-roadmap.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/plans/3-2-x-open-core-delivery-plan.md
   tag: current
   divio_type: none
   owning_workstream: none

--- a/docs/plans/3-2-x-executive-overview.md
+++ b/docs/plans/3-2-x-executive-overview.md
@@ -1,0 +1,120 @@
+---
+title: '3.2.x Executive Overview'
+description: 'Executive/stakeholder synthesis of 3.2.x goals and progress since the 3.2.4 release — from a PO, C-suite, and customer point of view.'
+doc_status: active
+updated: '2026-07-30'
+related:
+- docs/release-goals/3.2.x.md
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/plans/3-2-x-open-core-delivery-plan.md
+- docs/changelog/index.md
+---
+
+# 3.2.x Executive Overview
+
+*Point-in-time stakeholder synthesis, 2026-07-30. Covers everything since the 3.2.4
+release (2026-07-05): the shipped 3.2.5 release and the in-flight 3.2.6 cycle. Reads
+the milestone from a PO / C-suite / customer point of view; the durable goal
+declaration is [release-goals/3.2.x](../release-goals/3.2.x.md), the operator execution
+detail is the [milestone roadmap](3-2-x-milestone-roadmap.md), the delivery strategy is
+the [open-core delivery plan](3-2-x-open-core-delivery-plan.md), and what actually
+shipped is the [changelog](../changelog/index.md). Status was verified by two read-only
+audits on 2026-07-30; the delivery plan carries the evidence and the unverified-item
+flags.*
+
+## Bottom line
+
+3.2.x is our **stabilization-and-foundations cycle** — no flashy new surface, by design.
+Since 3.2.4 we shipped one full release (3.2.5) and have a rich sixth (3.2.6) in flight.
+**The hard structural work this cycle exists to do is largely done** — our core data now
+has single sources of truth, our governance layer now genuinely drives the product, and
+our doctrine is becoming independently shippable. Two honest caveats: **3.2.6 is not yet
+releasable** (our release gate is red by policy — see [Risk](#release-readiness--risk-candid)),
+and the *remaining* work is small and well-understood rather than open-ended.
+
+## What 3.2.x is for (in business terms)
+
+Three goals, each a customer outcome:
+
+- **G1 — Governance drives the product.** Our "doctrine" (the configurable rules for how
+  missions, docs, and workflows behave) now actually controls runtime behavior instead
+  of being documentation. **This is the foundation of our open-core model:** customers
+  can tailor governance without forking our source.
+- **G2 — One source of truth for core data.** We have been consolidating the places that
+  decide *where mission data lives and how identity/state are derived* down to single
+  authorities — the root cause of a whole class of reliability bugs.
+- **G3 — Faster, more honest engineering.** CI and quality gates that make G1/G2 safe to
+  keep changing.
+
+## Progress since 3.2.4 — what it means for customers
+
+**Customization & open-core (the strategic thread).** Doctrine is now **shippable and
+forkable**: organizations can ship their own governance, docs standards, and supporting
+files to their repos *without patching our code*. Pack locations are now portable across
+machines and CI (no more hardcoded paths breaking teammates). This is the groundwork for
+selling and supporting a customizable product on a stable public core.
+
+**Reliability (the bulk of the work).** The changes customers will *feel*:
+
+- Quality gates **stopped emitting confident-but-wrong verdicts**, and approved review
+  evidence now survives a merge instead of being silently discarded.
+- Work-package state now has **one authoritative record**, closing a class of "the tool
+  says X but reality is Y" bugs.
+- **Upgrades no longer strand or dirty** parallel work areas; the dashboard now correctly
+  shows in-flight work that used to silently disappear.
+- Connections to our hosted service **fail safely** instead of silently pointing at the
+  wrong server.
+
+**Robustness & automation.** Agent-driven and scripted/CI runs **no longer hang** waiting
+for input — increasingly important as customers automate on top of us.
+
+**Velocity & honesty.** CI is meaningfully faster, and regressions are now caught **at
+review time rather than at merge**, shrinking the feedback loop.
+
+**One breaking change customers must action:** very old (pre-3.2.x) missions need a
+**one-command migration** to keep working. This was a deliberate trade — retiring a
+dual-support path that was itself a persistent bug source.
+
+## Strategic position: the open-core pivot is closer than the roadmap showed
+
+A verified re-audit this week found our internal roadmap had **understated our
+progress**. The core-data-consolidation work (G2) is substantially *delivered* — it was
+simply tracked under the wrong labels. The governance layer (G1) is *already live* in the
+product (three mission types run entirely off configurable doctrine today). The remaining
+work to reach a clean open-core boundary is **bounded**: the doctrine module is ~90% ready
+to stand alone as an independent package, and the last real gap is making our governance
+layer the single, stable entry point that external adopters build against.
+
+## Release readiness & risk (candid)
+
+- **3.2.6 is not tag-ready.** Our mainline CI has been red for 10+ consecutive runs. This
+  is **partly by design** — our policy is that mainline honestly reflects known
+  release-blocking bugs rather than hiding them, and CI (not opinion) is the release
+  authority. It is a discipline, not a fire.
+- **The one open question:** whether *all* of the red reduces to those known, tracked
+  blockers, or whether a recent change introduced something new. Resolving that
+  classification is the single gating item before any release conversation — an
+  hours-not-weeks task.
+
+## What's next & the strategic call for the PO
+
+The plan (see the [open-core delivery plan](3-2-x-open-core-delivery-plan.md)) is an
+**open-core breaking-change window**: get the remaining breaking/design changes out **as
+fast as possible** to our small set of consenting early-adopter customers, **without ever
+stalling bug fixes for them**, and make each change cheap to absorb (automated migrations
++ backward-compatible shims + advance notice). After this window, the external surface
+stabilizes and stops disrupting customers.
+
+**Decisions that need product ownership:**
+
+1. How to sequence the remaining breaking changes into releases (the "3.2.6 / 3.2.7"
+   numbers are urgency signals, not commitments).
+2. Whether to hold the honest-red mainline through the window, or stabilize the baseline
+   first.
+3. Confirming the named early-adopter customers who receive pre-releases and migration
+   notes.
+
+**In one sentence for the board:** *the risky structural rework of 3.2.x is largely
+behind us and has de-risked our open-core direction; what remains is a bounded,
+well-understood push to lock a stable customer-facing contract — the main open question is
+release timing, not whether the foundation holds.*

--- a/docs/plans/3-2-x-milestone-roadmap.md
+++ b/docs/plans/3-2-x-milestone-roadmap.md
@@ -12,11 +12,58 @@ related:
 ---
 # 3.2.x Milestone — Roadmap
 
-*Planner synthesis (planner-priti), 2026-07-04. Sources: milestone #4 census, the native epic dependency graph encoded in the tracker on 2026-07-04, [`degod-unshim-roadmap.md`](refactor/degod-unshim-roadmap.md), and the epic bodies of #1619 / #1797 / #2071 / #1868 / #2173 / #1746. Addendum, 2026-07-10: #2519 hot-list entry from epic #2519, member issues #2520/#2521/#2522/#2526, and current tracker metadata. Addendum, 2026-07-13: CI test-topology-performance mission shipped (PR #2609, under #1931); #1797 ↔ #2071 tidy-first intra-pair sequencing ruling recorded in Watch items + [`qa-tidy-first-sequencing.md`](testing/qa-tidy-first-sequencing.md). Addendum, 2026-07-26: doctrine canonical-structure remediation programme recorded — one mission specced then split into five sequenced missions (#2948–#2952) by operator ruling; see the dedicated section below.*
+*Planner synthesis (planner-priti), 2026-07-04. Sources: milestone #4 census, the native epic dependency graph encoded in the tracker on 2026-07-04, [`degod-unshim-roadmap.md`](refactor/degod-unshim-roadmap.md), and the epic bodies of #1619 / #1797 / #2071 / #1868 / #2173 / #1746. Addendum, 2026-07-10: #2519 hot-list entry from epic #2519, member issues #2520/#2521/#2522/#2526, and current tracker metadata. Addendum, 2026-07-13: CI test-topology-performance mission shipped (PR #2609, under #1931); #1797 ↔ #2071 tidy-first intra-pair sequencing ruling recorded in Watch items + [`qa-tidy-first-sequencing.md`](testing/qa-tidy-first-sequencing.md). Addendum, 2026-07-26: doctrine canonical-structure remediation programme recorded — one mission specced then split into five sequenced missions (#2948–#2952) by operator ruling; see the dedicated section below. **Addendum, 2026-07-30: verified status re-read + spine re-anchoring — the body below (2026-07-04 vintage) predates the work that delivered the milestone's goals and mis-reads it as idle; see [Addendum 2026-07-30](#addendum-2026-07-30--verified-status-re-read--spine-re-anchoring) immediately below, and the PO-facing [3.2.x Open-Core Delivery Plan](3-2-x-open-core-delivery-plan.md) which supersedes the "G2-is-the-blocking-spine / G1-is-off-spine" framing.*
 
 ## Intent of 3.2.x
 
 3.2.x is the **stabilization + structural debt paydown** cycle: (G1) deepen Doctrine/Charter/DRG impact on runtime execution, (G2) strangle the core domains — naming, identity, read/write paths — onto canonical SSOTs by *adopting* the existing execution-context machinery rather than building new construction, and (G3) land the DevEx enablers that make (G1)/(G2) enforceable. No new shadow paths. The milestone stays open until all three goals hold (full declaration: [`docs/release-goals/3.2.x.md`](../release-goals/3.2.x.md)). Everything experience-shaped — UX, dashboard, SaaS tie-in — is deliberately deferred to 3.3.x, which builds on the SSOTs this cycle establishes.
+
+## Addendum 2026-07-30 — verified status re-read + spine re-anchoring
+
+*Two read-only audits (G1 doctrine/charter; G2/G3 + release posture) grounded in the
+code and the live tracker on 2026-07-30 found the body below has drifted from reality.
+The corrections, in brief — full PO-facing detail in the
+[3.2.x Open-Core Delivery Plan](3-2-x-open-core-delivery-plan.md):*
+
+1. **The G2 "spine" is substantially DELIVERED, not idle — filed under new numbers.**
+   The placement-seam swarm is the delivery of the named spine, and burn-down keys on
+   the wrong anchors:
+   - #2906 (read) / #2841 (write) / #2917 (birth-cutover) **deliver #1619** exec-context
+     unification (old `core/execution_context.py` deleted, not shimmed; SSOT in
+     `src/mission_runtime/`).
+   - #2884 / #2262 / the MissionResolver port **deliver #2173** infra-port binding.
+   - the coord-authority trio degod (`workflow.py` / `review.py` → 0 LOC) +
+     `runtime_bridge` decomposition **deliver #1797** (shim registry drained to
+     `shims: []`). Only `_read_path_resolver` (~1677 LOC) is parked.
+   **Action R (re-anchor):** adopt the swarm as executing children of #1619/#2173/#1797
+   and re-score the milestone against real coverage. The spine is not idle; its anchors
+   went stale — the inverse of this doc's own "anchor to issue numbers" watch item.
+
+2. **G1 mission-types-as-doctrine is BUILT and ACTIVE, not an unbuilt keystone.** The
+   three types (+`plan`) resolve through charter → mission-type-profile → runtime; the
+   data plane is 100% doctrine-sourced (profiles, step contracts, action indices,
+   templates, prompts). Only the execution engine is code. **G1's done-signal is
+   demonstrated doctrine→runtime governance (already true), not pack-split completion.**
+   The real open G1 work is a bounded ~22-door list to make the **charter the sole
+   access path** to provisioned assets (it gates only ~3 of ~10 kinds today).
+
+3. **The cycle's organizing frame is an open-core breaking-change window**, not a
+   feature-completeness sprint: draw + version the consumer seam, extract built-in
+   doctrine into the already-declared `spec-kitty-doctrine` module (~90% done
+   structurally; one import-cycle blocker), and ship the still-design-only schema
+   (Creed / Values / the ADR-accepted `impacts` relation) behind migration rails +
+   deprecation shims to a small consenting consumer set. No hard freeze. See the
+   delivery plan and [3.2.x Delivery Approach](3-2-x-approach.md) (doctrine-first,
+   confirmed).
+
+4. **Release posture: `main` is NOT tag-ready** — CI red 10+ consecutive runs
+   (2026-07-28→07-30), 9 failing jobs incl. `regression tests (blocking)`. Partly the
+   red-main-is-honest baseline P0 pins (#2736/#2772/#1834); **unverified** whether a
+   fresh write-side-seam regression is mixed in. Resolve that classification before any
+   tag conversation.
+
+*The dependency-spine section below is retained as the historical 2026-07-04 encoding;
+read it through the corrections above.*
 
 ## The dependency spine
 

--- a/docs/plans/3-2-x-open-core-delivery-plan.md
+++ b/docs/plans/3-2-x-open-core-delivery-plan.md
@@ -1,0 +1,245 @@
+---
+title: '3.2.x Open-Core Delivery Plan'
+description: 'PO-facing synthesis: verified 3.2.x status re-read, the open-core breaking-change delivery strategy (charter-as-sole-door, built-in→module extraction, engineer-to-non-impact), and the bounded remaining-work sequence.'
+doc_status: proposed
+updated: '2026-07-30'
+related:
+- docs/plans/3-2-x-approach.md
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/release-goals/3.2.x.md
+- docs/development/manage-issue-tracker.md
+- docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md
+---
+
+# 3.2.x Open-Core Delivery Plan
+
+*Synthesis for the product owner, 2026-07-30. Supersedes the "G2 is the blocking
+spine / G1 is off-spine" framing of the [milestone roadmap](3-2-x-milestone-roadmap.md)
+where the two disagree — see [Status re-read](#1-status-re-read-verified). Status
+verified against remote `main` (`b04da00e1`) by two read-only audits on 2026-07-30;
+load-bearing claims carry file/issue evidence, and every unverified claim is marked.*
+
+## TL;DR for the PO
+
+- **3.2.x is far more done than its roadmap shows.** The structural "brain surgery"
+  — moving the core domains onto single sources of truth, and making the doctrine
+  layer drive the runtime — is **substantially landed**. The roadmap reads "spine
+  idle" only because the work landed under different issue numbers than it tracks.
+- **What actually remains is a small, bounded set** (§3): close the charter's
+  "back doors" so it's the single entry point; lift the already-packaged built-in
+  doctrine into its own module; build the still-design-only schema (Creed / Values /
+  the signed relationship model); one parked refactor; and recover the release gate.
+- **The delivery strategy is an open-core breaking-change window** (§2): ship the
+  breaking + design changes **as soon as possible** to a small, known, consenting set
+  of early-adopter consumers, **without ever stalling P0 fixes**, and make each break
+  cheap to absorb. There is **no hard freeze** — we engineer our way to "no longer
+  noticeably impacts downstream," we don't schedule it.
+- **One honest caveat up front:** `main` is **not release-ready** — CI has been red
+  for 10+ consecutive runs (partly by the red-main-is-honest policy, partly TBD). See
+  [Release posture](#15-release-posture--not-tag-ready).
+
+---
+
+## 1. Status re-read (verified)
+
+The milestone roadmap (last substantive pass 2026-07-04 / -17) predates the work that
+actually delivered the milestone's goals. Re-audited against the code and tracker on
+2026-07-30:
+
+### 1.1 G1 — doctrine/charter/DRG drives the runtime: **the capability is BUILT and ACTIVE**
+
+- **Mission-types-as-doctrine ships today.** `research`, `software-dev`, and
+  `documentation` (plus `plan`) resolve through the charter → mission-type-profile →
+  runtime path. The **entire data plane is doctrine-sourced** — governance profiles,
+  per-action indices, step contracts, templates, expected-artifacts, step prompts, and
+  the DRG identity node are 100% overlayable YAML/MD under `src/doctrine/missions/`
+  (built-in → org → project). `resolve_step_contract_ids()`
+  (`src/doctrine/missions/step_contracts.py`) is the *sole* step-contract authority —
+  no `specify_cli` copy. Only the **execution engine** (per-type state machine, gate
+  handler dispatch, an action-sequence YAML fallback) is still in code.
+  - *Correction to the roadmap:* earlier framing called mission-types-as-a-doctrine-kind
+    an unbuilt "keystone." It is built. G1's done-signal is **demonstrated
+    doctrine→runtime governance** — already true and observable in the three shipping
+    types — not "a pack-split epic is 100% complete."
+- **The one real G1 gap: the charter is not yet the *sole* door.** A canonical factory
+  exists but is one of many entry points; the charter wrapper activation-gates only
+  ~3 of ~10 artefact kinds and forwards the rest straight to the raw service. The audit
+  enumerated **~22 bypass doors** (the 5-tier template/command resolver axis, direct
+  repository construction across runtime/review/invocation, two hardcoded source-tree
+  paths, unwrapped service builds). This is a **defined, closeable list**, not
+  open-ended work. *(Unverified: the exact 22 file/line anchors came from a grep sweep;
+  a scoping pass should confirm the closed set before a mission is cut.)*
+- **Creed / Values / signed relationship model — still ahead.** Creed and
+  Foundational-Values exist **as design docs only, not in code**. The signed `impacts`
+  relation (ADR [2026-07-26-3]) is **accepted but unimplemented**; note that
+  `in_tension_with` already exists as a *full symmetric* DRG relation, so this is a
+  fold-and-extend, not a from-scratch build.
+
+### 1.2 G2 — strangle the core domains onto SSOTs: **substantially DELIVERED**
+
+- The execution-context SSOT lives in `src/mission_runtime/`; the Strangler migration
+  relocated `resolve_action_context` there and **deleted** the old
+  `core/execution_context.py` (removed, not shimmed — no parallel resolver survives).
+  Naming/identity derive once; the identity primitive moved to the lower layer.
+- Read / write / coord authority each sit on the SSOT with **measured, gated** residual
+  bypasses (6 read / 12 write, per the seam doc's honest-bounds table) — not hidden
+  shadow paths.
+- **Degod/unshim is largely landed, not idle:** shim registry drained to `shims: []`;
+  the coord-authority trio degod is done (`workflow.py` / `review.py` reduced to 0 LOC);
+  `runtime_bridge` decomposed. The one remaining god-module is `_read_path_resolver`
+  (~1677 LOC), explicitly parked for its own scoped mission.
+
+### 1.3 G3 — DevEx enablers: **substantially delivered**
+
+CI is sharded by domain; the architectural-adversarial pole is de-serialized into an
+always-on parallel job; the `-m unit`/`-m contract` selection gap is closed;
+non-vacuity gate twins and shrink-only ratchets are pervasive and enforced; the
+zero-producer / inert-slot silence guards landed this cycle.
+
+### 1.4 The traceability gap (the roadmap's real defect)
+
+The placement-seam work **is** the delivery of the named spine — filed under new
+numbers the roadmap never adopted:
+
+| De-facto work (landed) | Delivers the named spine epic |
+|---|---|
+| #2906 read-side · #2841 write-side · #2917 birth-cutover | **#1619** execution-context unification |
+| #2884 · #2262 · MissionResolver port | **#2173** infra-port binding |
+| coord-authority trio degod · runtime_bridge decomposition | **#1797** degod/unshim delivery |
+
+Because burn-down keys on #1619/#1797/#2173 and those show as open parents, the
+milestone *looks* stalled while it is in fact largely delivered. This is the exact
+inverse of the roadmap's own "anchor to issue numbers" watch item — **the anchors went
+stale.** The fix is re-anchoring (§3, item R), not more work.
+
+### 1.5 Release posture — **NOT tag-ready**
+
+`pyproject` = 3.2.6; the Unreleased changelog is rich (asset kind, silence guards,
+CLI UX, import-history, fork hooks). But **`main` CI Quality has been red on every run
+for 10+ consecutive pushes (2026-07-28 → 07-30), 9 failing jobs including the
+release-gating `regression tests (blocking)`.** Red CI is the release authority
+([ADR 2026-07-17-1]); the baseline P0 pins (#2736/#2772/#1834) are intentionally red.
+- **Open item (unverified):** whether all 9 red jobs reduce to those known baseline
+  pins, or include a fresh regression from the write-side-seam landing. **This must be
+  resolved before any tag conversation** — it is the difference between "honest baseline
+  red, tag when the P0s clear" and "we shipped a regression."
+
+---
+
+## 2. The delivery strategy: open-core breaking-change window
+
+### 2.1 Organizing principle
+
+3.2.x is the **last permitted breaking-change window** for the doctrine/charter
+surface. The goal is not "finish the doctrine system" — it is **draw the
+consumer-facing seam and get every breaking change through it**, so a small set of
+consenting early-adopter consumers absorbs the churn once and then lives on a stable
+surface. The success metric is *"the seam is drawn and the breaking changes are
+spent,"* not feature-completeness.
+
+### 2.2 The done-bar (operator-stated)
+
+1. **All provisioned assets reachable by the runtime *through the charter* — charter
+   as the sole door.** This is a *no-bypass* condition: any path that reaches assets
+   around the charter is a second seam that leaks internals and forces a *second*
+   break later. (Concretely = close the ~22 doors in §1.1.)
+2. **Active and consumer-usable is the bar.** Internals may shift freely; the **entry
+   points and usage must stay consistent and stable**. You cannot promise a stable seam
+   you have not enumerated and versioned — so enumerating the consumer surface (charter
+   access path, CLI verbs, pack/manifest layout, resolution API) *is* the stability
+   contract, and doubles as the fix for the traceability problem: once the consumer
+   contract is the tracked artefact, internal churn stops being externally visible.
+3. **Built-in artefacts extracted from `src/` into a root-level module.** Good enough
+   for the current version; a later move to a **separate repo happens transparently**
+   for consumers because they already consume across the boundary. *Verified: this is
+   ~90% done structurally — `src/doctrine/pyproject.toml` already declares a standalone
+   `spec-kitty-doctrine` v1.0.0 with kernel-only deps, guarded by a layer test. The one
+   blocker is a charter↔doctrine import cycle (two misfiled function-local imports in
+   `agent_profiles/repository.py`); resolve it and the lift mirrors the
+   runtime/events/tracker cutover already done.*
+
+### 2.3 Dual-track, no hard freeze
+
+- **P0 fixes for early adopters flow continuously and are never stalled.** Drawing the
+  module boundary *protects* the P0 lane — once built-ins live behind the boundary, a
+  P0 fix lands in one place instead of being re-landed on both sides. Do the boundary
+  extraction **in-place on `main` via small strangler steps** (move → shim → repoint →
+  delete), **never a long-lived branch** that diverges from the P0 stream.
+- **"No longer noticeably impacts downstream" is engineered, not scheduled.** A break
+  stops being noticeable when it is **(a) auto-migrated and (b) deprecation-shimmed.**
+  With both, breaks can ship continuously and still feel stable.
+
+### 2.4 The "minimal-hurt" machinery (for the small, consenting consumer set)
+
+1. **Every schema break rides the migration rail** (`spec-kitty migrate …` +
+   doctor/upgrade framework): a pack-schema change ships *with* the codemod that moves
+   a consumer's pack forward — adapting is "run one command," not "read a diff."
+2. **Deprecation shims, not hard cutovers:** land the new path, keep the old working
+   with an in-band warning naming the replacement + removal version, remove a cycle
+   later. The warning is the communication (seen at runtime, not only in release notes).
+3. **A versioned contract + one predictable migration-note stream** the consumers can
+   pin against and watch.
+4. **Batch the consumer-visible breaks; stream the invisible ones.** The real cost is
+   *adaptation-event count*, not speed: cluster consumer-visible breaks into a few
+   deliberate, pre-announced adaptation points, and hand the named consumers an **RC to
+   test each break before it reaches a stable tag.** With a handful of known consumers
+   this is a heads-up message + a pre-release — a relationship, not a broadcast.
+
+---
+
+## 3. Remaining work, sequenced
+
+The re-audited backlog is small and mostly known. Ordered so each step de-risks the
+next; **P0 fixes run continuously alongside all of it.**
+
+| # | Work | Why here | Verified state |
+|---|---|---|---|
+| **R** | **Re-anchor the tracker** — adopt the placement-seam swarm as executing children of #1619/#2173/#1797; re-score the milestone against real coverage; reconcile this plan / the approach doc / the roadmap so "doctrine-first" is canonical and the spine reflects reality. | Cheapest, highest-value: makes 3.2.x *measurable* again. Prerequisite to any honest PO burn-down. | Pure tracker/doc work. ~½ day. |
+| **0** | **Resolve the CI-red question** — classify the 9 red jobs: baseline P0 pins vs fresh write-side-seam regression. | Gates every release conversation; distinguishes "honest red" from "shipped a bug." | Unverified today — needs per-job failed-test logs. |
+| **1** | **Boundary extraction** — resolve the charter↔doctrine import cycle, lift built-ins into `spec-kitty-doctrine`, in-place via strangler steps + import shims. | Lowest-risk break; removes the P0/restructure rework collision; unblocks the transparent repo split later. | ~90% structural; one named blocker. |
+| **2** | **Charter-as-sole-door** — close the ~22 bypass doors so all provisioned assets resolve through the charter. | The G1 done-bar; the *no-bypass* half of the stability contract. | Bounded ~22-door list; confirm closed set first. |
+| **3** | **Enumerate + version the consumer surface** — charter access path, CLI verbs, pack/manifest layout, resolution API. | Turns "stable entry points" from aspiration into a checkable contract; the tracked artefact going forward. | New work; small once #2 lands. |
+| **4** | **Schema build** — signed `impacts` relation (fold `in_tension_with` in), then Creed + Foundational-Values. | Schema-shaping = a consumer-visible break → must land *inside* the window, schema-first, then migrate content, then the batched adaptation point. | `impacts` = ADR-accepted, unimplemented; Creed/Values = design-only. |
+| **5** | **Parked degod** — `_read_path_resolver` (~1677 LOC) as its own scoped mission. | Independent of the doctrine work; not a rider. | Known, parked. |
+
+**Sequencing rule for the breaks:** boundary (1) → sole-door (2) → contract (3) → schema
+(4), with the content migration and its batched, pre-announced adaptation point last.
+Schema-first, freeze-last — landing that order backwards is the one way the strategy
+fails (you'd promise stability, then break it).
+
+---
+
+## 4. Consumer communication plan
+
+For the small, known, consenting early-adopter set:
+- One **"held/adapting until <adaptation point>"** note per consumer-visible break —
+  not silent staleness.
+- Each break ships **codemod + deprecation shim + a migration note** in the single
+  contract-version stream.
+- **RC pre-release** to the named consumers before each break reaches a stable tag.
+- Cluster breaks into **as few adaptation points as possible** — a consenting consumer
+  would rather adapt once to five coordinated changes than five times to one.
+
+---
+
+## 5. Open decisions for the PO
+
+1. **Sequencing of the breaks into tags** — the version numbers (3.2.6 / 3.2.7) are
+   urgency signals, not commitments. Confirm whether the boundary (item 1) and the
+   schema (item 4) ship as one adaptation point or two.
+2. **CI-red disposition (item 0)** — is red-main-is-honest acceptable to hold through
+   the window, or do we want a green-able baseline before the first consumer-visible
+   break?
+3. **Charter-sole-door scope (item 2)** — confirm the closed door-set before cutting
+   the mission (the ~22 count is a grep estimate).
+4. **`_read_path_resolver` (item 5)** — spec now as an independent mission, or leave
+   parked behind the doctrine work?
+5. **Consumer roster** — confirm the named early-adopter set that receives RCs and
+   migration notes.
+
+---
+
+*Method: two read-only status audits (G1 doctrine/charter; G2/G3 + release posture),
+each grounded independently in the code and the live `Priivacy-ai/spec-kitty` tracker,
+2026-07-30. Unverified items are flagged inline and gathered as open items in §1.4,
+§1.5, and §3 item 0.*

--- a/docs/plans/3-2-x-open-core-delivery-plan.md
+++ b/docs/plans/3-2-x-open-core-delivery-plan.md
@@ -1,6 +1,6 @@
 ---
 title: '3.2.x Open-Core Delivery Plan'
-description: 'PO-facing synthesis: verified 3.2.x status re-read, the open-core breaking-change delivery strategy (charter-as-sole-door, built-in→module extraction, engineer-to-non-impact), and the bounded remaining-work sequence.'
+description: 'PO-facing 3.2.x synthesis: a verified status re-read, the open-core breaking-change delivery strategy, and the bounded remaining-work sequence.'
 doc_status: proposed
 updated: '2026-07-30'
 related:

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -17,6 +17,10 @@ durable architecture/reference docs it is retired.
 
 ## Portfolio-level planning
 
+- [3.2.x Executive Overview](3-2-x-executive-overview.md) — **PO / C-suite / customer
+  synthesis (2026-07-30):** goals and progress since the 3.2.4 release, framed as
+  business outcomes; the top-level entry point that distils the delivery plan, roadmap,
+  and release goals for a stakeholder audience.
 - [3.2.x Open-Core Delivery Plan](3-2-x-open-core-delivery-plan.md) — **PO-facing
   synthesis (2026-07-30):** verified status re-read (what's actually delivered vs what
   the roadmap shows), the open-core breaking-change delivery strategy

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -17,10 +17,18 @@ durable architecture/reference docs it is retired.
 
 ## Portfolio-level planning
 
+- [3.2.x Open-Core Delivery Plan](3-2-x-open-core-delivery-plan.md) — **PO-facing
+  synthesis (2026-07-30):** verified status re-read (what's actually delivered vs what
+  the roadmap shows), the open-core breaking-change delivery strategy
+  (charter-as-sole-door, built-in→module extraction, engineer-to-non-impact), and the
+  bounded remaining-work sequence. Supersedes the roadmap's "G2-is-the-blocking-spine"
+  framing where they disagree.
 - [3.2.x Delivery Approach — Operator Plan, Dialectically Challenged](3-2-x-approach.md) —
   cross-mission sequencing intent (which missions run first and why), distinct from the
   per-mission/per-refactor implementation plans elsewhere in this section; stress-tested by
   a two-round dialectic squad and synthesised into an actionable, fact-checked plan.
+  Doctrine-first confirmed; the delivery plan above builds on it with the open-core /
+  breaking-change dimension.
 - [Glossary Doctrine Overhaul — Program Plan](glossary-doctrine-overhaul-program.md) —
   four-mission program promoting the glossary to a first-order doctrine artefact (new
   `GLOSSARY_PACK` kind), retiring the runtime glossary, wiring data-driven terminology


### PR DESCRIPTION
## What

Docs-only. Adds a PO/C-suite/customer-facing **3.2.x executive overview** and a **PO-facing open-core delivery plan**, and corrects the milestone roadmap's drift against **verified** current state (two read-only audits, 2026-07-30).

## Why

The milestone roadmap (2026-07-04 vintage) predates the work that actually delivered the milestone's goals and reads it as idle. Verified re-audit:

- **G2 "spine" is substantially delivered** — under new issue numbers the roadmap never adopted (placement-seam swarm #2906/#2841/#2917 → #1619; #2884/#2262 → #2173; coord-trio degod → #1797). The anchors went stale, not the work.
- **G1 mission-types-as-doctrine is built & active** (data plane 100% doctrine-sourced); the real open G1 work is the bounded ~22-door "charter as sole access path" list.
- **G3 substantially delivered.**
- **`main` is NOT tag-ready** — CI red 10+ consecutive runs; classifying baseline P0 pins vs a possible fresh regression is the gating open item.

## Changes (4 files, all under `docs/plans/`)

- **New** `3-2-x-executive-overview.md` — stakeholder synthesis of goals + progress since the 3.2.4 release (shipped 3.2.5 + in-flight 3.2.6), framed as business outcomes.
- **New** `3-2-x-open-core-delivery-plan.md` — verified status re-read, the open-core breaking-change delivery strategy (charter-as-sole-door, built-in→`spec-kitty-doctrine` module extraction, engineer-to-non-impact via migration rails + deprecation shims for the consenting consumer set), bounded remaining-work sequence, and open PO decisions.
- `3-2-x-milestone-roadmap.md` — dated 2026-07-30 addendum re-anchoring the spine + correcting drift; historical body retained (distil-then-retire).
- `index.md` — surface both new docs in portfolio-level planning.

Placement follows DIRECTIVE_042 Common Docs: `plans/` for distil-then-retire synthesis, distinct from the durable `release-goals/` intent declaration and the mechanical `changelog/`.

## Verification

- `tests/architectural/test_no_legacy_terminology.py` + full `tests/docs/` suite green (**606 passed**) on the `main` base; all `related:` cross-references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788015336&installation_model_id=427282&pr_number=3083&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3083&signature=692be95acc875f7293bd965b47a0421f2c9c024690beae587c225554e387277d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->