### PR TITLE
test(#3086): red-first repro — merge --delete-branch strands coordination_branch in meta.json

### DIFF
--- a/tests/regression/test_issue_3086_merge_delete_branch_flattens_coordination_metadata.py
+++ b/tests/regression/test_issue_3086_merge_delete_branch_flattens_coordination_metadata.py
@@ -1,0 +1,182 @@
+"""Red-first reproduction for issue #3086.
+
+``spec-kitty merge --delete-branch`` (the default) deletes a Mission's
+coordination branch (``kitty/mission-<slug>``) from git inside
+``_phase_cleanup_worktrees_and_branches``, but never clears the paired
+``coordination_branch`` key from that Mission's ``kitty-specs/<slug>/meta.json``.
+Every successfully-merged Mission is therefore left permanently divergent:
+``meta.json`` declares a ``coordination_branch`` that git no longer has. Any
+later command routing through ``resolve_status_surface_with_anchor``
+(``coordination/surface_resolver.py``) then hits ``CoordState.DELETED`` and
+raises ``CoordinationBranchDeleted`` — confirmed hard-crash on
+``retrospect create --update``, ``agent retrospect`` and ``implement``.
+
+Red-first note: on current ``main`` this test FAILS. After the branch-deletion
+phase runs, ``meta.json`` still contains ``coordination_branch`` (and
+``flattened`` is still ``False``, ``topology`` still present). It goes green
+only when merge's teardown mirrors the canonical *flatten* already performed by
+``spec-kitty mission close --discard`` and ``spec-kitty doctor coordination
+--fix``: ``clear_coordination_metadata`` (``mission_metadata.py``) + pop
+``topology`` + set ``flattened=True`` (see ``_coordination_doctor.py``).
+
+The anchor assertion is the *absence of* ``coordination_branch`` — the invariant
+``surface_resolver`` actually keys the ``CoordState.DELETED`` hard-fail on — so
+this repro cannot be greened by a downstream point-guard (e.g. adding an
+``except`` to ``retrospect.py``) while the root-cause divergence remains.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from specify_cli.merge import executor as ex
+from specify_cli.merge.state import MergeState
+from specify_cli.mission_metadata import load_meta
+
+pytestmark = [pytest.mark.regression, pytest.mark.git_repo]
+
+# Production-shaped identity (26-char ULID); ``mid8`` is the branch/worktree
+# disambiguator, slug is ``<human>-<mid8>`` per the mission-identity model.
+_MISSION_ID = "01JQANARZAP70V8DVJZ8XN0M3T"
+_MID8 = _MISSION_ID[:8].lower()
+_SLUG = f"coordination-flatten-repro-{_MID8}"
+_MISSION_BRANCH = f"kitty/mission-{_SLUG}"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", f"refs/heads/{branch}"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        ).returncode
+        == 0
+    )
+
+
+@pytest.fixture
+def merged_coord_repo(tmp_path: Path) -> Path:
+    """A real git repo mirroring a lane/coord Mission *at merge time*.
+
+    The coordination branch exists in git (so the cleanup phase can delete it),
+    and ``meta.json`` declares that same branch as ``coordination_branch`` — the
+    state that ``merge --delete-branch`` acts on.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Spec Kitty Test")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "seed")
+    # HEAD stays on the default branch; the coordination branch is a *separate*
+    # ref so ``git branch -D`` can delete it during cleanup.
+    _git(repo, "branch", _MISSION_BRANCH)
+
+    feature_dir = repo / "kitty-specs" / _SLUG
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_id": _MISSION_ID,
+                "mid8": _MISSION_ID[:8],
+                "mission_slug": _SLUG,
+                "coordination_branch": _MISSION_BRANCH,
+                "topology": "coord",
+                "flattened": False,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return repo
+
+
+def test_issue_3086_merge_delete_branch_flattens_coordination_metadata(
+    merged_coord_repo: Path,
+) -> None:
+    repo = merged_coord_repo
+    feature_dir = repo / "kitty-specs" / _SLUG
+
+    lanes_manifest = SimpleNamespace(
+        target_branch="main",
+        mission_branch=_MISSION_BRANCH,
+        lanes=[SimpleNamespace(lane_id="lane-a", wp_ids=["WP01"])],
+    )
+    state = MergeState(
+        mission_id=_MISSION_ID,
+        mission_slug=_SLUG,
+        target_branch="main",
+        wp_order=["WP01"],
+    )
+    run = ex._MergeRunState(
+        main_repo=repo,
+        mission_slug=_SLUG,
+        canonical_id=_MISSION_ID,
+        canonical_mission_id=_MISSION_ID,
+        feature_dir=feature_dir,
+        target_feature_dir=feature_dir,
+        lanes_manifest=lanes_manifest,
+        all_wp_ids=["WP01"],
+        push=False,
+        delete_branch=True,
+        # Isolate the branch-deletion block: ``remove_worktree=False`` skips the
+        # worktree removal + ``teardown_coordination_topology`` seam, so only the
+        # ``delete_branch`` path (the one that strands ``meta.json``) is exercised.
+        remove_worktree=False,
+        strategy=ex.MergeStrategy.SQUASH,
+        assume_yes=True,
+        planning_artifact_only=False,
+        state=state,
+        is_resume=False,
+        baseline_mission_id=_MISSION_ID,
+    )
+
+    # Fixture sanity: the coordination branch must exist before cleanup, else a
+    # false-red (the fix is gated on the branch actually being deleted).
+    assert _branch_exists(repo, _MISSION_BRANCH), (
+        "fixture invalid: coordination branch must exist before cleanup"
+    )
+
+    ex._phase_cleanup_worktrees_and_branches(run)
+
+    # Corroboration: the delete path actually fired (branch gone from git). This
+    # guards against a name mismatch silently no-op'ing the cleanup.
+    assert not _branch_exists(repo, _MISSION_BRANCH), (
+        "cleanup did not delete the coordination branch — fixture/wiring error"
+    )
+
+    # ANCHOR (red on current main): after deleting the coordination branch from
+    # git, merge MUST clear ``coordination_branch`` from meta.json so the Mission
+    # is flattened and later status-surface resolves route to primary instead of
+    # raising CoordinationBranchDeleted. Read fresh from disk.
+    meta = load_meta(feature_dir)
+    assert meta is not None
+    assert "coordination_branch" not in meta, (
+        "issue #3086: merge deleted the coordination branch from git but left "
+        "'coordination_branch' in meta.json — every later status-surface resolve "
+        "(retrospect create --update, agent retrospect, implement) then raises "
+        "CoordinationBranchDeleted on this merged Mission"
+    )
+
+    # Canonical flatten parity with ``mission close --discard`` /
+    # ``doctor coordination --fix`` (the fix must do all three mutations).
+    assert meta.get("flattened") is True, (
+        "issue #3086: a flattened Mission must record flattened=True"
+    )
+    assert "topology" not in meta, (
+        "issue #3086: flatten must pop the stale 'topology' key"
+    )


### PR DESCRIPTION
## Red-first P0 reproduction for #3086 (no fix)

⚠️ **This PR intentionally reds CI.** It adds a single honest-red reproduction test that anchors the P0 in #3086 — the fix lands in a follow-up. Per the red-main policy (ADR `2026-07-17-1`), an honest-P0 repro may be committed red.

### The bug
`spec-kitty merge --delete-branch` (the default) deletes a Mission's coordination branch (`kitty/mission-<slug>`) from git in `_phase_cleanup_worktrees_and_branches` (`src/specify_cli/merge/executor.py`), but **never clears the paired `coordination_branch` key from `kitty-specs/<slug>/meta.json`**. Every successfully-merged Mission is left permanently divergent: `meta.json` declares a `coordination_branch` git no longer has.

Any later command routing through `resolve_status_surface_with_anchor` (`coordination/surface_resolver.py`) then hits `CoordState.DELETED` and raises `CoordinationBranchDeleted`. Confirmed 100% hit rate across ~10 historical merged Missions in a downstream repo.

### Blast radius (squad-confirmed)
- **Hard-crashes (raw `CoordinationBranchDeleted`):** `retrospect create --update` (reported), `agent retrospect`, `implement` — plus likely `tasks mark-status`, `tasks`, retrospective `gate`, `support`.
- **Already guarded:** `status aggregate`, `agent status`, coord status write, and the `resolve_action_context` family (`agent context`/`workflow`, `implement_cores`, `decision`, `runtime_bridge`).

The inconsistent guarding (some catch `CoordinationBranchDeleted`, some `StatusReadPathNotFound`, some `ActionContextError`, some nothing) is itself evidence of ad-hoc symptom-patching around one systemic root cause — `merge` never flattening.

### What this PR contains
`tests/regression/test_issue_3086_merge_delete_branch_flattens_coordination_metadata.py` — drives the branch-deletion phase over a **real** coord-topology Mission (coordination branch present in git) with `remove_worktree=False` to isolate the delete path, then asserts `meta.json` is flattened afterwards:
- **anchor:** `coordination_branch` absent (the invariant `surface_resolver` keys `CoordState.DELETED` on)
- **parity:** `flattened == True`, `topology` popped

It **anchors on `coordination_branch` absence deliberately** so it cannot be greened by a downstream point-guard (e.g. an `except` in `retrospect.py`) while the root-cause divergence remains — only a real merge-side flatten greens it.

**Validation:** confirmed red on `main` for the anchor reason (branch deletion fires, key remains), and confirmed green after the documented fix (applied throwaway, reverted). No production code changed in this PR.

### Suggested fix (follow-up)
In `_phase_cleanup_worktrees_and_branches`, immediately after the mission branch is confirmed deleted, mirror `doctor coordination --fix` (`_coordination_doctor.py`): `clear_coordination_metadata(run.feature_dir)` **+** pop `topology` **+** set `flattened=True`. Note `clear_coordination_metadata` alone only pops `coordination_branch` — the topology-pop and `flattened` set are separate mutations. Optional defense-in-depth: have `retrospect.py`'s `_check_mission_completed`/`_canonical_events_path` degrade gracefully like `next_cmd.py`/`agent status`.

Refs #3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788033206&installation_model_id=427282&pr_number=3089&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3089&signature=8fafbafff8445a7020b90af28db36d588e3fdaab85862b6ed283512487d9b0fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->