### PR TITLE
test(acceptance): cover detached HEAD and branch flow-through (#2909)

### DIFF
--- a/tests/acceptance/test_gate_execution_context.py
+++ b/tests/acceptance/test_gate_execution_context.py
@@ -22,12 +22,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
+from typer.testing import CliRunner
 
 from mission_runtime import MissionArtifactKind, TopologySurface
-from specify_cli import acceptance as acceptance_module
-from specify_cli.acceptance import gates_core as gates_core_module
+from specify_cli import app as cli_app
 from specify_cli.acceptance.execution_context import (
     CannotEvaluate,
     CannotEvaluateReason,
@@ -84,6 +85,18 @@ def _seed_matrix(feature_dir: Path, *, verdict: str, marker: str) -> None:
         ],
     )
     write_acceptance_matrix(feature_dir, matrix)
+
+
+def _run_public_accept_diagnosis(mission_slug: str) -> dict[str, Any]:
+    """Invoke ``spec-kitty accept`` and return its read-only JSON result."""
+    result = CliRunner().invoke(
+        cli_app,
+        ["accept", "--mission", mission_slug, "--diagnose", "--json", "--lenient"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    return cast(dict[str, Any], json.loads(result.output))
 
 
 def _plain_context(
@@ -257,6 +270,41 @@ def test_git_head_of_detached_checkout_returns_head_sentinel(
     assert ctf._git(ctx.repo, "branch", "--show-current") == ""
 
     assert _git_head_of(ctx.repo) == "HEAD"
+
+
+def test_accept_command_normalizes_detached_head_before_matrix_gate(
+    flat_topology_mission: ctf.FlatTopologyContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public command normalizes detached HEAD and refuses at its branch gate.
+
+    On the current operator path, a detached invocation becomes ``branch=None``
+    and is rejected before an acceptance-matrix ``GateExecutionContext`` can be
+    built. The observable contract is therefore the JSON branch value, blocker,
+    and skipped matrix checks rather than a private HEAD-resolver return value.
+    """
+    ctx = flat_topology_mission
+    ctf._git(ctx.repo, "checkout", "--detach", "HEAD")
+    _seed_matrix(
+        ctx.primary_feature_dir,
+        verdict="fail",
+        marker="DETACHED-HEAD-MUST-NOT-REACH-MATRIX",
+    )
+    assert ctf._git(ctx.repo, "branch", "--show-current") == ""
+    monkeypatch.chdir(ctx.repo)
+
+    payload = _run_public_accept_diagnosis(ctx.slug)
+
+    assert payload["branch"] is None
+    assert any("detached HEAD" in issue for issue in payload["activity_issues"])
+    assert any(
+        item["check"] == "mission_branch" for item in payload["blocked_checks"]
+    )
+    assert any(
+        item["check"] == "acceptance_matrix_presence"
+        for item in payload["skipped_checks"]
+    )
+    assert not any("verdict is" in issue for issue in payload["activity_issues"])
 
 
 # ===========================================================================
@@ -547,17 +595,16 @@ def test_gec2_primary_ref_agreement_still_judges(
     assert any("verdict is 'fail'" in issue for issue in activity_issues), activity_issues
 
 
-def test_collect_feature_summary_forwards_invocation_branch_to_matrix_context(
+def test_accept_command_forwards_normal_branch_to_matrix_gate(
     flat_topology_mission: ctf.FlatTopologyContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The full accept-gate call chain preserves the invocation checkout branch.
+    """The public accept path preserves the invocation branch through matrix judgement.
 
-    The real validation entry point resolves a mission branch that deliberately
-    differs from the target branch (``main``). A terminal-only spy records what
-    reaches the acceptance-matrix context; every intermediate forwarding hop stays
-    production code. Dropping ``branch`` at any hop would record ``None`` and fall
-    back to the distinct target branch, so this assertion cannot false-green.
+    The mission branch deliberately differs from target ``main``. The seeded FAIL
+    verdict remains observable only when every production forwarding hop preserves
+    that branch: dropping it either trips the branch gate or yields a surface-ref
+    mismatch before the matrix can be judged.
     """
     ctx = flat_topology_mission
     mission_branch = f"kitty/mission-{ctx.slug}"
@@ -567,35 +614,19 @@ def test_collect_feature_summary_forwards_invocation_branch_to_matrix_context(
         verdict="fail",
         marker="INVOCATION-BRANCH-FLOW-THROUGH",
     )
+    monkeypatch.chdir(ctx.repo)
 
-    received_branches: list[str | None] = []
-    build_context = gates_core_module._acceptance_gate_context
+    payload = _run_public_accept_diagnosis(ctx.slug)
 
-    def _record_matrix_context(
-        repo_root: Path,
-        mission_dir: Path,
-        *,
-        branch: str | None = None,
-    ) -> GateExecutionContext:
-        received_branches.append(branch)
-        return build_context(repo_root, mission_dir, branch=branch)
-
-    monkeypatch.setattr(
-        gates_core_module,
-        "_acceptance_gate_context",
-        _record_matrix_context,
+    assert payload["branch"] == mission_branch
+    assert any("verdict is 'fail'" in issue for issue in payload["activity_issues"])
+    assert not any(
+        item["check"] in {"mission_branch", "acceptance_matrix_cannot_evaluate"}
+        for item in payload["blocked_checks"]
     )
-
-    summary = acceptance_module.collect_feature_summary(
-        ctx.repo,
-        ctx.slug,
-        strict_metadata=False,
-        mutate_matrix=False,
+    assert not any(
+        "GATE_SURFACE_REF_MISMATCH" in issue for issue in payload["activity_issues"]
     )
-
-    assert summary.branch == mission_branch
-    assert received_branches == [mission_branch]
-    assert any("verdict is 'fail'" in issue for issue in summary.activity_issues)
 
 
 # ===========================================================================

--- a/tests/acceptance/test_gate_execution_context.py
+++ b/tests/acceptance/test_gate_execution_context.py
@@ -26,12 +26,15 @@ from pathlib import Path
 import pytest
 
 from mission_runtime import MissionArtifactKind, TopologySurface
+from specify_cli import acceptance as acceptance_module
+from specify_cli.acceptance import gates_core as gates_core_module
 from specify_cli.acceptance.execution_context import (
     CannotEvaluate,
     CannotEvaluateReason,
     GateExecutionContext,
     GateSurfaceRefMismatch,
     LifecyclePhase,
+    _git_head_of,
     build_gate_execution_context,
     declared_home_surface,
 )
@@ -243,6 +246,17 @@ def test_assert_at_ref_passes_on_agreement() -> None:
     """C5: when the surface is at its ref, the gate proceeds (no raise)."""
     ctx = _plain_context(surface=Path("/p"), surface_kind=TopologySurface.COORD, ref="sha-abc")
     ctx.assert_at_ref(head_of=lambda _s: "sha-abc")  # must not raise
+
+
+def test_git_head_of_detached_checkout_returns_head_sentinel(
+    flat_topology_mission: ctf.FlatTopologyContext,
+) -> None:
+    """C5: a real detached checkout resolves to the no-branch ``HEAD`` sentinel."""
+    ctx = flat_topology_mission
+    ctf._git(ctx.repo, "checkout", "--detach", "HEAD")
+    assert ctf._git(ctx.repo, "branch", "--show-current") == ""
+
+    assert _git_head_of(ctx.repo) == "HEAD"
 
 
 # ===========================================================================
@@ -531,6 +545,57 @@ def test_gec2_primary_ref_agreement_still_judges(
 
     assert not any(c.check == "acceptance_matrix_cannot_evaluate" for c in blocked), blocked
     assert any("verdict is 'fail'" in issue for issue in activity_issues), activity_issues
+
+
+def test_collect_feature_summary_forwards_invocation_branch_to_matrix_context(
+    flat_topology_mission: ctf.FlatTopologyContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full accept-gate call chain preserves the invocation checkout branch.
+
+    The real validation entry point resolves a mission branch that deliberately
+    differs from the target branch (``main``). A terminal-only spy records what
+    reaches the acceptance-matrix context; every intermediate forwarding hop stays
+    production code. Dropping ``branch`` at any hop would record ``None`` and fall
+    back to the distinct target branch, so this assertion cannot false-green.
+    """
+    ctx = flat_topology_mission
+    mission_branch = f"kitty/mission-{ctx.slug}"
+    ctf._git(ctx.repo, "switch", "-c", mission_branch)
+    _seed_matrix(
+        ctx.primary_feature_dir,
+        verdict="fail",
+        marker="INVOCATION-BRANCH-FLOW-THROUGH",
+    )
+
+    received_branches: list[str | None] = []
+    build_context = gates_core_module._acceptance_gate_context
+
+    def _record_matrix_context(
+        repo_root: Path,
+        mission_dir: Path,
+        *,
+        branch: str | None = None,
+    ) -> GateExecutionContext:
+        received_branches.append(branch)
+        return build_context(repo_root, mission_dir, branch=branch)
+
+    monkeypatch.setattr(
+        gates_core_module,
+        "_acceptance_gate_context",
+        _record_matrix_context,
+    )
+
+    summary = acceptance_module.collect_feature_summary(
+        ctx.repo,
+        ctx.slug,
+        strict_metadata=False,
+        mutate_matrix=False,
+    )
+
+    assert summary.branch == mission_branch
+    assert received_branches == [mission_branch]
+    assert any("verdict is 'fail'" in issue for issue in summary.activity_issues)
 
 
 # ===========================================================================

--- a/tests/acceptance/test_gate_execution_context.py
+++ b/tests/acceptance/test_gate_execution_context.py
@@ -224,7 +224,7 @@ def test_gate_execution_context_is_immutable() -> None:
     """GEC-1 shape: the value object a gate is handed is frozen — no in-place patch."""
     ctx = _plain_context(surface=Path("/p"), surface_kind=TopologySurface.PRIMARY)
     with pytest.raises((AttributeError, TypeError)):
-        ctx.surface = Path("/elsewhere")  # type: ignore[misc]
+        ctx.surface = Path("/elsewhere")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Retains focused real-git coverage for the detached-HEAD sentinel.
- Drives detached and normal branch cases through the root `spec-kitty accept --diagnose --json` CLI boundary.
- Replaces the private acceptance-context spy with assertions on operator-visible diagnostics.

## Why Now

PR #2906 introduced these two low-risk branches, and #2909 tracks the remaining coverage gaps. Maintainer review requested proof through the active public acceptance path rather than helper-level coverage alone.

## What This PR Does

- Keeps the focused `_git_head_of` sentinel regression requested by #2909.
- Verifies detached HEAD is normalized to `branch=null`, blocked by `mission_branch`, and prevented from reaching matrix judgment.
- Verifies a normal mission branch reaches matrix evaluation and exposes the seeded failing verdict.
- Proves both paths by mutation: dropping branch forwarding or preserving literal detached `HEAD` makes the corresponding CLI test fail.

## Effect on Existing Projects

- Runtime / compatibility: None; this is test-only.
- Upgrade / migration: None.
- Reviewer impact: Regressions in detached normalization or branch forwarding now fail at the public operator boundary.

## Validation

- [x] `uv run pytest -q tests/acceptance/test_gate_execution_context.py` — 28 passed
- [x] `uv run pytest -q tests/acceptance/` — 61 passed
- [x] `uv run ruff check tests/acceptance/test_gate_execution_context.py`
- [x] `uv run mypy --strict tests/acceptance/test_gate_execution_context.py`
- [x] Mutation checks for detached normalization and normal-branch forwarding
- [x] `git diff --check`

## Tickets / Contracts

| Ticket | Relationship |
|---|---|
| #2909 | Implements both requested coverage cases |

## Mission Artifacts

- Spec: N/A - focused issue follow-up
- Plan: N/A
- Tasks: N/A
- Checklist: N/A

## Follow-ups

- None.

## AI Assistance Disclosure

AI assistance was used to inspect the repository, draft the tests, and run validation.

Closes #2909

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788261203&installation_model_id=427282&pr_number=3151&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3151&signature=8bad91bec64a49a5d80acc08ed2c9e3bbd31ea906e23481847b18e784b63fdd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->