### PR TITLE
docs: name the hosted product Team Kitty

### DIFF
--- a/.github/workflows/teamspace-mission-state-readiness.yml
+++ b/.github/workflows/teamspace-mission-state-readiness.yml
@@ -1,4 +1,4 @@
-name: TeamSpace Mission-State Readiness
+name: Team Kitty Mission-State Readiness
 
 on:
   workflow_dispatch:

--- a/MANUAL_TEST_PLAN.md
+++ b/MANUAL_TEST_PLAN.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-03-01
 **Scope**: Full ecosystem verification across all repositories
-**Goal**: Validate Beta/GA readiness for the Spec Kitty SaaS platform
+**Goal**: Validate Beta/GA readiness for the Team Kitty platform
 
 ---
 
@@ -10,7 +10,7 @@
 
 ### Accounts Required
 
-- [ ] Spec Kitty SaaS staging account (https://spec-kitty-dev.fly.dev)
+- [ ] Team Kitty staging account (https://spec-kitty-dev.fly.dev)
 - [ ] Jira Cloud test project with API token
 - [ ] Linear test workspace with API key
 - [ ] GitHub test repository with configured webhook

--- a/docs/adr/3.x/2026-04-21-1-private-teamspace-and-repository-sharing-boundary.md
+++ b/docs/adr/3.x/2026-04-21-1-private-teamspace-and-repository-sharing-boundary.md
@@ -1,5 +1,5 @@
 ---
-title: Private Teamspace and Repository Sharing Boundary
+title: private workspace and Repository Sharing Boundary
 status: Accepted
 date: '2026-04-21'
 ---
@@ -13,7 +13,7 @@ The product requirement is not merely better filtering. The system must answer t
 1. what repository/build activity belongs to a user privately?
 2. what repository activity has been intentionally shared into a team?
 
-The existing product direction around Teamspace and the observed dashboard behavior show a domain mismatch:
+The existing product direction around Team Kitty and the observed dashboard behavior show a domain mismatch:
 
 1. teams can see too many historical projects/builds by default
 2. users who belong to multiple teams do not have a strong enough routing boundary
@@ -25,27 +25,27 @@ The existing product direction around Teamspace and the observed dashboard behav
 * **User-owned first** — data should belong to a user before it becomes team-visible.
 * **Local-first execution** — build execution and mission progress remain local-first and repository-native.
 * **Clear vocabulary** — `repository`, `project`, and `build` must describe distinct domain objects.
-* **Active-work emphasis** — default Teamspace must answer "what is happening now?" rather than act as a historical registry.
+* **Active-work emphasis** — default Team Kitty must answer "what is happening now?" rather than act as a historical registry.
 
 ## Considered Options
 
-* **Option 1:** Keep team-owned ingress and improve Teamspace filtering only.
+* **Option 1:** Keep team-owned ingress and improve Team Kitty filtering only.
 * **Option 2:** Make repositories opt-in to SaaS globally from the CLI with no user-owned private surface.
-* **Option 3 (chosen):** User-owned first, `Private Teamspace` by default, explicit repository sharing into teams, and activity-ranked Teamspace surfaces.
+* **Option 3 (chosen):** User-owned first, `private workspace` by default, explicit repository sharing into teams, and activity-ranked Team Kitty surfaces.
 
 ## Decision Outcome
 
-**Chosen option: Option 3**, because it establishes the missing trust boundary while preserving local-first behavior and giving Teamspace a product shape that matches how teams actually work.
+**Chosen option: Option 3**, because it establishes the missing trust boundary while preserving local-first behavior and giving Team Kitty a product shape that matches how teams actually work.
 
 ### Core Decisions
 
-**Decision 1 — New checkouts/builds default to `Private Teamspace`.**
+**Decision 1 — New checkouts/builds default to `private workspace`.**
 
 Every newly observed repository/build belongs to its owning user first. No team sees it until the user explicitly shares the repository into that team.
 
 **Decision 2 — `Repository` is the share/admission unit.**
 
-The first team admission decision is made for `repository + destination team`. Sharing is explicit and non-destructive: the repository remains visible in `Private Teamspace` after sharing.
+The first team admission decision is made for `repository + destination team`. Sharing is explicit and non-destructive: the repository remains visible in `private workspace` after sharing.
 
 **Decision 3 — `Project` is the team-facing collaboration surface.**
 
@@ -53,7 +53,7 @@ A `Project` is created or reused when a repository is shared to a team. It is no
 
 **Decision 4 — `Build` remains the checkout/worktree identity.**
 
-A `Build` is one checkout/worktree on one machine at one local path. `build_id` remains the canonical build key. Machine and absolute local path are required provenance for Teamspace presentation.
+A `Build` is one checkout/worktree on one machine at one local path. `build_id` remains the canonical build key. Machine and absolute local path are required provenance for Team Kitty presentation.
 
 **Decision 5 — Team approval is one-time per `repository + team`.**
 
@@ -63,13 +63,13 @@ The first share to a team requires approval unless that team has an explicit aut
 
 Admin disconnect removes the repository/project from one team's visibility, search, and discoverable history within that team. It does not delete user-owned data and does not affect other teams.
 
-**Decision 7 — Default Teamspace is activity-ranked, not history-ranked.**
+**Decision 7 — Default Team Kitty is activity-ranked, not history-ranked.**
 
-The default Teamspace project card shows only the 1-3 most relevant `active now` or `recently completed` mission/build items. Historical missions/builds remain discoverable via drilldown/history rather than the landing page.
+The default Team Kitty project card shows only the 1-3 most relevant `active now` or `recently completed` mission/build items. Historical missions/builds remain discoverable via drilldown/history rather than the landing page.
 
 **Decision 8 — GitHub canonicalization ages work off the default surface.**
 
-`merged_local_only` may remain discoverable briefly, but once the work is canonicalized on GitHub it leaves the default Teamspace surface and GitHub becomes the canonical inspection point.
+`merged_local_only` may remain discoverable briefly, but once the work is canonicalized on GitHub it leaves the default Team Kitty surface and GitHub becomes the canonical inspection point.
 
 **Decision 9 — Forks are separate repositories by default.**
 
@@ -80,7 +80,7 @@ Forks may expose a visible relationship to upstream, but they do not collapse au
 ### Positive
 
 * Users get a clear safety boundary between private work and team-visible work.
-* Teamspace can become a live operational board rather than a project graveyard.
+* Team Kitty can become a live operational board rather than a project graveyard.
 * Vocabulary aligns cleanly: repository for sharing, project for team collaboration, build for checkout.
 * The same repository can appear in multiple teams without blurring ownership or disconnect semantics.
 
@@ -99,13 +99,13 @@ Forks may expose a visible relationship to upstream, but they do not collapse au
 
 This decision is validated when all of the following are true:
 
-1. a brand-new checkout/build appears only in the user's `Private Teamspace` until explicit share
+1. a brand-new checkout/build appears only in the user's `private workspace` until explicit share
 2. no team sees repository/build data without explicit share plus approval, unless that team chose auto-approval
 3. once a repository is approved for a team, later teammates sharing the same repository join automatically
-4. default Teamspace project cards show only 1-3 relevant active/recent mission/build items
+4. default Team Kitty project cards show only 1-3 relevant active/recent mission/build items
 5. each surfaced card includes mission progress plus build provenance including machine and local path
 6. admin disconnect removes visibility from one team only without deleting user-owned data
-7. canonicalized GitHub work leaves the default Teamspace surface and remains discoverable through history/drilldown
+7. canonicalized GitHub work leaves the default Team Kitty surface and remains discoverable through history/drilldown
 
 ## Pros and Cons of the Options
 
@@ -119,7 +119,7 @@ This decision is validated when all of the following are true:
 **Cons:**
 
 * Does not create a real trust boundary.
-* Keeps Teamspace conceptually backwards.
+* Keeps Team Kitty conceptually backwards.
 * Leaves multi-team routing safety weak.
 
 ### Option 2: Global CLI opt-in without a private surface
@@ -140,7 +140,7 @@ This decision is validated when all of the following are true:
 **Pros:**
 
 * Matches the trust and routing requirements.
-* Gives Teamspace the right default behavior.
+* Gives Team Kitty the right default behavior.
 * Supports multi-team participation without collapsing boundaries.
 
 **Cons:**
@@ -163,7 +163,7 @@ deployed `spec-kitty-dev` SaaS environment.
 
 The current monorepo implementation now reflects this ADR in the CLI layer:
 
-1. checkout routing resolves to `Private Teamspace` by default
+1. checkout routing resolves to `private workspace` by default
 2. repository sharing is explicit through CLI sync commands
 3. per-checkout opt-in and opt-out persist locally without git-tracked side effects
 4. future new checkouts can inherit a remembered repository-level sync preference
@@ -204,5 +204,5 @@ stale/abandoned mission lane required for the MVP:
    encrypted auth session, and permanent upload failures persist structured
    diagnostics instead of collapsing to `bad_request: unknown`
 
-With this slice validated, the active MVP lane moves back to SaaS Teamspace
+With this slice validated, the active MVP lane moves back to Team Kitty
 projection/backfill completion under `Priivacy-ai/spec-kitty-saas#101`.

--- a/docs/adr/3.x/2026-05-10-1-deterministic-historical-mission-state-repair.md
+++ b/docs/adr/3.x/2026-05-10-1-deterministic-historical-mission-state-repair.md
@@ -6,7 +6,7 @@ date: '2026-05-10'
 
 ## Context
 
-Historical `kitty-specs/` directories may predate `mission_id`. TeamSpace import
+Historical `kitty-specs/` directories may predate `mission_id`. Team Kitty import
 requires stable mission identity, but public migration must be safe in
 distributed Git: two clones of the same historical repository must produce the
 same repaired artifacts without consulting a server, a clock, or randomness.
@@ -48,10 +48,10 @@ repository-local mission material:
 ## Consequences
 
 - Repair is reproducible across clones and CI runners.
-- Repair does not need hosted TeamSpace, tracker, auth, or sync configuration.
+- Repair does not need hosted Team Kitty, tracker, auth, or sync configuration.
 - Sparse historical missions remain repairable, but the manifest and audit
   output show what was defaulted.
-- Operators must coordinate the repair commit before TeamSpace import so forked
+- Operators must coordinate the repair commit before Team Kitty import so forked
   branches inherit the same persisted `mission_id`.
 
 ## Confirmation
@@ -62,4 +62,4 @@ This ADR is implemented when tests prove:
 - running repair twice yields no second diff;
 - existing valid IDs are preserved;
 - divergent pre-repair seed material produces different deterministic IDs;
-- TeamSpace dry-run refuses audit-blocking historical shapes before import.
+- Team Kitty dry-run refuses audit-blocking historical shapes before import.

--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -1138,7 +1138,7 @@ _Project health diagnostics_
 │                     hints.                                                   │
 │ restart-daemon      Stop the registered sync daemon and respawn it at the    │
 │                     foreground.                                              │
-│ mission-state       Audit, repair, or TeamSpace-validate mission-state       │
+│ mission-state       Audit, repair, or Team Kitty-validate mission-state       │
 │                     shapes.                                                  │
 │ doctrine            Check org doctrine snapshot status and list installed    │
 │                     pack artifacts.                                          │
@@ -1369,14 +1369,14 @@ _Project health diagnostics_
 ```
  Usage: spec-kitty doctor mission-state [OPTIONS]
 
- Audit, repair, or TeamSpace-validate mission-state shapes.
+ Audit, repair, or Team Kitty-validate mission-state shapes.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --audit                            Run mission-state audit (required to      │
 │                                    proceed)                                  │
 │ --fix                              Repair mission-state artifacts in place   │
 │                                    and write a migration manifest            │
-│ --teamspace-dry-run                Synthesize canonical TeamSpace envelopes  │
+│ --teamspace-dry-run                Synthesize canonical Team Kitty envelopes  │
 │                                    from local state and validate them        │
 │ --json                             Emit JSON report to stdout                │
 │ --mission                    TEXT  Scope to a single mission handle          │
@@ -2750,7 +2750,7 @@ _Migration commands: update .kittify/ layout and backfill identity fields in leg
  This command repairs enough historical mission state to make the canonical
  lifecycle model reliable across old repositories. It backfills identity
  where needed, rebuilds missing event logs from legacy state, and regenerates
- status/progress/lifecycle projections used by the CLI and Teamspace.
+ status/progress/lifecycle projections used by the CLI and Team Kitty.
 
  Exit codes:
 
@@ -4181,7 +4181,7 @@ _Synchronization commands_
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ routes          Show where the current checkout sends data and which teams   │
 │                 it is shared with.                                           │
-│ share           Share the current repository from Private Teamspace into a   │
+│ share           Share the current repository from private workspace into a   │
 │                 team.                                                        │
 │ unshare         Stop sharing the current repository from this developer to   │
 │                 one team.                                                    │
@@ -4592,7 +4592,7 @@ _Synchronization commands_
 ```
  Usage: spec-kitty sync share [OPTIONS] TEAM_SLUG
 
- Share the current repository from Private Teamspace into a team.
+ Share the current repository from private workspace into a team.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    team_slug      TEXT  Team slug to share this repository into.           │
@@ -4869,7 +4869,7 @@ _Work-package mapping commands_
  List supported tracker providers, categorized by backend type.
 
  SaaS-backed providers authenticate through ``spec-kitty auth login`` and
- route sync operations through the Spec Kitty SaaS control plane.
+ route sync operations through the Team Kitty control plane.
 
  Local providers use direct connectors with locally stored credentials.
 

--- a/docs/api/environment-variables.md
+++ b/docs/api/environment-variables.md
@@ -157,12 +157,12 @@ spec-kitty auth login
   for the full operator walkthrough of the hidden hosted-readiness
   mode this flag enables today.
 - [Launch-Readiness Behavior (Coming Soon)](../architecture/launch-readiness-future.md)
-  for how this variable's meaning changes at the public Teamspace
+  for how this variable's meaning changes at the public Team Kitty
   launch.
 
 ### SPEC_KITTY_SAAS_URL
 
-Override the Spec Kitty SaaS base URL.
+Override the Team Kitty base URL.
 
 **Scope**: machine-global (see the warning at the top of this section). Combined
 with `SPEC_KITTY_ENABLE_SAAS_SYNC`, exporting this in a shell points every

--- a/docs/architecture/diagrams/01_context/README.md
+++ b/docs/architecture/diagrams/01_context/README.md
@@ -44,7 +44,7 @@ flowchart LR
     hic["Human In Charge (operator)"]
     agent["Agent Tooling — Claude/Codex/Copilot/etc."]
     orch["External Orchestrator Provider"]
-    saas["Spec Kitty SaaS — hosted sync and dashboard"]
+    saas["Team Kitty — hosted sync and dashboard"]
     tracker["External Tracker Systems"]
     repo["Project Repository Artifacts — kitty-specs, doctrine, glossary, architecture"]
     sk["Spec Kitty 3.x Host (CLI)"]
@@ -65,7 +65,7 @@ flowchart LR
 | Human In Charge | Command invocation and approval checkpoints | Final acceptance authority stays human-owned. |
 | Agent Tooling | Prompt-, skill-, and Op-driven workflow execution | Agents execute within host constraints and the resolved profile's governance scope. |
 | External Orchestrator Provider | Orchestrator API calls | Provider is adapter-only; host remains lifecycle authority. |
-| Spec Kitty SaaS | Browser-mediated OAuth auth + hosted status projection | Auth is browser-OAuth, not password (`2026-04-09-2`); the host remains the canonical state authority. |
+| Team Kitty | Browser-mediated OAuth auth + hosted status projection | Auth is browser-OAuth, not password (`2026-04-09-2`); the host remains the canonical state authority. |
 | External Tracker Systems | Status/event projection | Tracker sync is optional and discovered, not user-supplied (`2026-04-04-1`). |
 | Project Repository Artifacts | Filesystem state read/write | Repository artifacts are canonical persistent state. |
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -74,7 +74,7 @@ boundary rule and layout).
 - [The Artifact Placement Seam](artifact-placement-seam.md) — the layer model deciding which physical tree a mission artifact resolves to, and where callers bypass it.
 - [Branch-target routing](branch-target-routing.md) — which git branch receives each type of change.
 - [WP runtime-state eviction](wp-runtime-state-eviction.md) — evicting runtime-mutable state into the event log.
-- [Launch-readiness behavior (coming soon)](launch-readiness-future.md) — pre-launch Teamspace design intent.
+- [Launch-readiness behavior (coming soon)](launch-readiness-future.md) — pre-launch Team Kitty design intent.
 - [Architecture: centralized feature detection](feature-detection.md) — how Spec Kitty detects project frameworks and capabilities.
 
 ## Connector & installation notes

--- a/docs/architecture/launch-readiness-future.md
+++ b/docs/architecture/launch-readiness-future.md
@@ -1,6 +1,6 @@
 ---
 title: Launch-Readiness Behavior (Coming Soon)
-description: "Pre-launch design intent for Teamspace: how hosted-readiness defaults flip from opt-in to on, and the launch-coordinator playbook. None of it is in effect today."
+description: "Pre-launch design intent for Team Kitty: how hosted-readiness defaults flip from opt-in to on, and the launch-coordinator playbook. None of it is in effect today."
 doc_status: active
 updated: '2026-06-03'
 type: explanation
@@ -9,7 +9,7 @@ audience: launch coordinators
 # Launch-Readiness Behavior (Coming Soon)
 
 > **Status: pre-launch.** This page describes the behavior the Spec
-> Kitty CLI will adopt at the public Teamspace launch milestone.
+> Kitty CLI will adopt at the public Team Kitty launch milestone.
 > **None of this is in effect today.** For today's local-first
 > experience, see the [README](https://github.com/Priivacy-ai/spec-kitty/blob/main/README.md). For the internal
 > hosted-readiness preview that lets contributors dogfood the hidden
@@ -20,7 +20,7 @@ audience: launch coordinators
 
 The Spec Kitty CLI today is local-first. Hosted auth, sync, and
 tracker flows are opt-in behind the `SPEC_KITTY_ENABLE_SAAS_SYNC=1`
-environment variable. At the public Teamspace launch, the user-facing
+environment variable. At the public Team Kitty launch, the user-facing
 defaults change. This doc is the reference the launch coordinator
 flips on. Until that flip happens, treat every section below as a
 **design intent**, not a description of current behavior.
@@ -39,10 +39,10 @@ describe behavior that will ship at the launch milestone.**
 |---|---|---|
 | `SPEC_KITTY_ENABLE_SAAS_SYNC` | **Opt-in gate.** Unset / falsy = local-first; truthy = hidden hosted-readiness mode for internal operators. | **Override only.** Hosted readiness is on by default; the variable becomes an internal escape hatch (e.g., `SPEC_KITTY_ENABLE_SAAS_SYNC=0` to force local-only). |
 | Default SaaS URL | Operators must set `SPEC_KITTY_SAAS_URL` explicitly to dial dev / staging. There is no user-facing default. | A user-facing default URL ships baked into the CLI. End users do not set `SPEC_KITTY_SAAS_URL`. |
-| Sync default | Sync commands no-op unless hosted mode is explicitly enabled. | Sync runs by default for Teamspace-connected repos. The same suppression contract still applies (interactive / non-interactive / machine-output). |
-| Tracker discovery | Tracker calls only happen behind the opt-in gate. | Tracker discovery happens by default for Teamspace-connected repos; unreachable-tracker states surface via the readiness coordinator. |
-| `spec-kitty auth login` | Documented as the canonical hosted login flow for internal operators dogfooding the hidden mode. | Documented as the canonical hosted login flow for **all** users joining a Teamspace. |
-| Public docs framing | Local-first. Hosted is "optional / opt-in / later". | Local-first remains the on-ramp; Teamspace becomes "available" — never retroactively backdated as "always was". |
+| Sync default | Sync commands no-op unless hosted mode is explicitly enabled. | Sync runs by default for Team Kitty-connected repos. The same suppression contract still applies (interactive / non-interactive / machine-output). |
+| Tracker discovery | Tracker calls only happen behind the opt-in gate. | Tracker discovery happens by default for Team Kitty-connected repos; unreachable-tracker states surface via the readiness coordinator. |
+| `spec-kitty auth login` | Documented as the canonical hosted login flow for internal operators dogfooding the hidden mode. | Documented as the canonical hosted login flow for **all** users joining a Team Kitty. |
+| Public docs framing | Local-first. Hosted is "optional / opt-in / later". | Local-first remains the on-ramp; Team Kitty becomes "available" — never retroactively backdated as "always was". |
 
 ## Dev / staging overrides still apply after launch
 
@@ -77,7 +77,7 @@ spec-kitty sync doctor
 
 | Scenario at launch | Command users will run |
 |---|---|
-| Logged out on a connected Teamspace | `spec-kitty auth login` |
+| Logged out on a connected Team Kitty workspace | `spec-kitty auth login` |
 | CLI upgrade required for compatibility with the hosted side | `spec-kitty upgrade --cli` |
 | Sync / tracker subsystem unreachable | `spec-kitty sync doctor` |
 
@@ -136,7 +136,7 @@ in the release-cut documentation in `architecture/` and the
 2. Cut a CLI release where the **default** behavior of the rollout
    gate inverts: hosted readiness is on unless explicitly disabled.
 3. Update public docs (README, `docs/index.md`, the relevant
-   tutorials) to introduce Teamspace as **available** — never as
+   tutorials) to introduce Team Kitty as **available** — never as
    "always was". The current pre-launch local-first framing remains
    the on-ramp.
 4. Move this doc from `docs/architecture/` to a launch-day "what's

--- a/docs/assets/spec-kitty-backlog.html
+++ b/docs/assets/spec-kitty-backlog.html
@@ -616,8 +616,8 @@ body { padding-top: 56px; }
   <div class="issue-card issue-card--saas" style="--i:4"><div class="issue-card__num">#565</div><div class="issue-card__body"><div class="issue-card__title">Remove password-era CLI auth code, tests, and token assumptions</div></div></div>
   <div class="issue-card issue-card--saas" style="--i:5"><div class="issue-card__num">#617</div><div class="issue-card__body"><div class="issue-card__title">Wire MissionAudit and operator-override event families across CLI, events, and SaaS</div></div></div>
   <div class="issue-card issue-card--saas" style="--i:6"><div class="issue-card__num">#717</div><div class="issue-card__body"><div class="issue-card__title">Token refresh failures should be silent or deduplicated per session</div></div></div>
-  <div class="issue-card issue-card--saas" style="--i:7"><div class="issue-card__num">#738</div><div class="issue-card__body"><div class="issue-card__title">Default new checkouts to Private Teamspace and add repository share routing</div></div></div>
-  <div class="issue-card issue-card--saas" style="--i:8"><div class="issue-card__num">#739</div><div class="issue-card__body"><div class="issue-card__title">Persist per-checkout Teamspace opt-out and future checkout share preference</div></div></div>
+  <div class="issue-card issue-card--saas" style="--i:7"><div class="issue-card__num">#738</div><div class="issue-card__body"><div class="issue-card__title">Default new checkouts to private workspace and add repository share routing</div></div></div>
+  <div class="issue-card issue-card--saas" style="--i:8"><div class="issue-card__num">#739</div><div class="issue-card__body"><div class="issue-card__title">Persist per-checkout Team Kitty opt-out and future checkout share preference</div></div></div>
 </div>
 
 <!-- ════════ DOCTRINE ════════ -->

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1473,7 +1473,7 @@ speed up how fast we catch one.
   (the runtime-hygiene migrations previously only knew a hardcoded subset of
   entries). The six meaningful accept checks still gate.
 - **Mission-state repair no longer empties `status.events.jsonl` of a healthy
-  mission (#2376).** The repair (run by `spec-kitty upgrade` via the TeamSpace
+  mission (#2376).** The repair (run by `spec-kitty upgrade` via the Team Kitty
   mission-state gate, and by `doctor mission-state --fix`) quarantined _every_
   `event_type` row except retrospective ones — including the canonical lifecycle
   events (`MissionCreated`, `SpecifyStarted`, `WPCreated`, …) that
@@ -2925,7 +2925,7 @@ Ships the Phase 4 canary unblock work landed via PR `#1180`:
   `src/specify_cli/audit/shape_registry.py` to accept all four canonical
   aggregate types (`Project`, `Mission`, `WorkPackage`, `MissionDossier`)
   rather than `Mission` alone. Fresh missions no longer trip the
-  `FORBIDDEN_KEY` TeamSpace gate when `sync now` runs.
+  `FORBIDDEN_KEY` Team Kitty gate when `sync now` runs.
 - Closes `#1141`: adds a diagnostic breadcrumb at `fire_saas_fanout` entry in
   `src/specify_cli/status/adapters.py` plus regression coverage that the
   backward `in_review → planned` rollback reaches fanout with the expected
@@ -2979,7 +2979,7 @@ Ships a focused sync-boundary hotfix for pipx-style CLI installs:
 
 ## [3.2.0rc12] - 2026-05-18
 
-Ships the MVP CLI sync-boundary preflight surface required by the Teamspace
+Ships the MVP CLI sync-boundary preflight surface required by the Team Kitty
 auth-boundary hardening launch gate:
 
 - Includes `#1115`: `specify_cli.sync.owner` daemon owner record with
@@ -3009,7 +3009,7 @@ surface:
 
 ## [3.2.0rc10] - 2026-05-17
 
-Rolls forward `3.2.0rc9` (never tagged) and adds the Teamspace MVP
+Rolls forward `3.2.0rc9` (never tagged) and adds the Team Kitty MVP
 canonical-lifecycle / sync-daemon launch-gate followups:
 
 - **#1067 follow-up.** `core/mission_creation.py:create_mission_core`
@@ -3018,7 +3018,7 @@ canonical-lifecycle / sync-daemon launch-gate followups:
   artifact path. Previously the constant was defined but never emitted,
   so the canonical lifecycle stream skipped straight from
   `MissionCreated` to `SpecifyCompleted` at setup-plan time — leaving
-  TeamSpace replay and the local dashboard blind to in-progress
+  Team Kitty replay and the local dashboard blind to in-progress
   specifying. Regression coverage in
   `tests/specify_cli/core/test_mission_creation_specify_started.py`.
 - **#1071 follow-up.** `sync status --check` and `sync doctor` now
@@ -3179,7 +3179,7 @@ Sonar restoration (#825) is the only remaining operator-action gate.
 
 ## [3.2.0rc8] - 2026-05-14
 
-3.2.0rc8 rolls up the post-rc7 TeamSpace launch fixes and compatibility
+3.2.0rc8 rolls up the post-rc7 Team Kitty launch fixes and compatibility
 cleanup needed before the final 3.2.0 cut. It includes defensive sync batching
 for real edge-proxy limits, the Mission Dossier event-envelope migration for
 `spec-kitty-events>=5.0.0`, and the small compatibility/quality fixes that
@@ -3189,7 +3189,7 @@ landed after rc7.
 
 - Reduced the CLI's default sync batch decompressed byte budget to 256 KiB and
   added a 512 KiB hard ceiling for over-generous server-advertised limits, so
-  large TeamSpace queue drains split into safe requests instead of relying on
+  large Team Kitty queue drains split into safe requests instead of relying on
   HTTP 413 retry shrinkage.
 - Migrated all four Mission Dossier event emitters to the namespaced envelope
   required by `spec-kitty-events>=5.0.0`, including `namespace`,
@@ -3204,7 +3204,7 @@ landed after rc7.
 - Restored agent profile list compatibility after the rc7 candidate.
 - Reduced SonarCloud noise in path helper and charter synthesizer code without
   changing runtime behavior.
-- Fixed the deployed-dev TeamSpace sync canary failure where a 1200-event
+- Fixed the deployed-dev Team Kitty sync canary failure where a 1200-event
   backlog could cascade into 1000 HTTP 413 failures.
 - Fixed SaaS ingestion rejection of CLI-emitted Mission Dossier artifact events
   caused by the old flat payload shape being rejected with
@@ -3262,31 +3262,31 @@ new-code gate cleanup, and CI portability fixes folded in.
 
 ## [3.2.0rc6] - 2026-05-11
 
-3.2.0rc6 includes the post-rc5 TeamSpace migration enforcement and dry-run
-compatibility fixes needed before publishing the next TeamSpace-ready CLI
+3.2.0rc6 includes the post-rc5 Team Kitty migration enforcement and dry-run
+compatibility fixes needed before publishing the next Team Kitty-ready CLI
 candidate.
 
 ### Changed
 
-- Surface pending TeamSpace mission-state migration during `spec-kitty upgrade`
-  and require a clean migration before hosted TeamSpace connection flows.
+- Surface pending Team Kitty mission-state migration during `spec-kitty upgrade`
+  and require a clean migration before hosted Team Kitty connection flows.
 - Allow the release compatibility gate to prove SaaS-supported dependency
   versions when the candidate CLI declares a compatible range instead of an
   exact pin.
 
 ### Fixed
 
-- Render user-friendly TeamSpace migration gate failures when mission-state
+- Render user-friendly Team Kitty migration gate failures when mission-state
   repair raises unexpected payload or filesystem errors.
 - Preserve SaaS-disabled sync opt-in behavior while still enforcing
   mission-state readiness for hosted sync paths.
-- Synthesize historical approval evidence during TeamSpace dry-run conversion
+- Synthesize historical approval evidence during Team Kitty dry-run conversion
   so approved/done mission-state rows can validate against the canonical event
   contract.
 
 ## [3.2.0rc5] - 2026-05-11
 
-3.2.0rc5 closes the remaining CLI-side TeamSpace migration readiness gaps found
+3.2.0rc5 closes the remaining CLI-side Team Kitty migration readiness gaps found
 while rechecking the historical mission-state migration parent issue.
 
 ### Changed
@@ -3296,30 +3296,30 @@ while rechecking the historical mission-state migration parent issue.
 
 ### Fixed
 
-- Block TeamSpace dry-run/import envelope synthesis when audit findings still
-  contain TeamSpace blockers, so legacy mission-state rows cannot bypass the
+- Block Team Kitty dry-run/import envelope synthesis when audit findings still
+  contain Team Kitty blockers, so legacy mission-state rows cannot bypass the
   readiness audit.
 - Reject historical mission-state sync batches with legacy status fields before
   network submission, preserving the local queue and returning remediation.
 
 ## [3.2.0rc4] - 2026-05-11
 
-3.2.0rc4 tightens the TeamSpace release candidate against the published
+3.2.0rc4 tightens the Team Kitty release candidate against the published
 `spec-kitty-events` 5.0.0 contract and includes the latest migration rehearsal
 diagnostics.
 
 ### Changed
 
 - Tightened the CLI `spec-kitty-events` dependency to `>=5.0.0,<6.0.0` now
-  that the 5.0.0 TeamSpace canonical event contract is published to PyPI
+  that the 5.0.0 Team Kitty canonical event contract is published to PyPI
   (#978).
-- Included the TeamSpace dry-run row mapping diagnostics merged after rc3 so
-  migration rehearsals can trace source rows to synthesized TeamSpace envelopes
+- Included the Team Kitty dry-run row mapping diagnostics merged after rc3 so
+  migration rehearsals can trace source rows to synthesized Team Kitty envelopes
   (#1014).
 
 ## [3.2.0rc3] - 2026-05-06
 
-3.2.0rc3 fixes a TeamSpace dry-run compatibility gap found during the
+3.2.0rc3 fixes a Team Kitty dry-run compatibility gap found during the
 historical mission-state migration rehearsal.
 
 ### Fixed
@@ -3331,9 +3331,9 @@ historical mission-state migration rehearsal.
 
 ## [3.2.0rc2] - 2026-05-05
 
-3.2.0rc2 adds the TeamSpace mission-state repair and validation surface needed
-before public TeamSpace import. The repair command is available now; the
-TeamSpace dry-run path requires `spec-kitty-events>=5.0.0` once that contract
+3.2.0rc2 adds the Team Kitty mission-state repair and validation surface needed
+before public Team Kitty import. The repair command is available now; the
+Team Kitty dry-run path requires `spec-kitty-events>=5.0.0` once that contract
 package is published.
 
 ### Added
@@ -3343,23 +3343,23 @@ package is published.
   key cleanup, typed-row quarantine, lane normalization, and production
   `status.json` rematerialization (#980).
 - Added `doctor mission-state --teamspace-dry-run` to synthesize canonical
-  TeamSpace envelopes in memory and validate them with the 5.0.0 event contract
+  Team Kitty envelopes in memory and validate them with the 5.0.0 event contract
   when available (#980).
 - Documented the distributed Git repair workflow for coordinated repository
-  migration before TeamSpace launch (#980).
+  migration before Team Kitty launch (#980).
 - Added `doctor mission-state --include-fixtures` and the packaged
-  mission-state survey fixture pack used by the TeamSpace readiness audit
+  mission-state survey fixture pack used by the Team Kitty readiness audit
   contract (#920, #922, #929).
-- Added an opt-in `TeamSpace Mission-State Readiness` GitHub Actions workflow
+- Added an opt-in `Team Kitty Mission-State Readiness` GitHub Actions workflow
   that runs `doctor mission-state --audit --fail-on teamspace-blocker` and
   uploads the JSON audit artifact (#920, #934).
 
 ### Changed
 
 - Aligned CLI sync emission for `WPStatusChanged` and `MissionClosed` with the
-  canonical TeamSpace event payload shape while keeping launch dry-run gated on
+  canonical Team Kitty event payload shape while keeping launch dry-run gated on
   the published events contract (#980).
-- `doctor mission-state --audit` JSON reports now expose TeamSpace blocker
+- `doctor mission-state --audit` JSON reports now expose Team Kitty blocker
   counts, and `--fail-on teamspace-blocker` gates import/sync readiness
   without requiring network access (#920, #934).
 
@@ -3472,26 +3472,26 @@ release-blocker triage.
 ## [3.2.0a8] - 2026-05-01
 
 3.2.0a8 is a prerelease that hardens direct SaaS sync ingress around the
-Private Teamspace boundary. CLI sync side effects now resolve a canonical
-Private Teamspace target, rehydrate session membership once when needed, and
+private workspace boundary. CLI sync side effects now resolve a canonical
+private workspace target, rehydrate session membership once when needed, and
 skip direct ingress with a diagnostic instead of falling back to a shared team.
 
 ### Fixed
 
 - Direct sync ingress for `/api/v1/events/batch/` and `/api/v1/ws-token` now
-  uses a strict Private Teamspace resolver and refuses shared-team fallbacks
+  uses a strict private workspace resolver and refuses shared-team fallbacks
   from stale `default_team_id`, `teams[0]`, or websocket state (#943).
 - Auth refresh and session rehydration now update team membership from
   `/api/v1/me`, recomputing `default_team_id` from the refreshed private team
   list instead of preserving stale shared defaults (#943).
 - `--json` command stdout remains parseable when SaaS sync cannot connect or
-  cannot resolve a Private Teamspace; sync diagnostics route to stderr or
+  cannot resolve a private workspace; sync diagnostics route to stderr or
   structured logs rather than contaminating stdout (#943).
 
 ### Internal
 
 - Added strict resolver, sync call-site, websocket, offline queue, and
-  strict-JSON regression coverage for the Private Teamspace ingress boundary.
+  strict-JSON regression coverage for the private workspace ingress boundary.
 - Added mission review evidence for
   `private-teamspace-ingress-safeguards-01KQH03Y`.
 

--- a/docs/context/orchestration.md
+++ b/docs/context/orchestration.md
@@ -284,7 +284,7 @@ Terms describing lifecycle and runtime orchestration semantics.
 | **Status** | canonical |
 | **Applicable to** | `1.x`, `2.x`, `3.x` |
 | **Lifecycle** | In event-backed runtimes, opened by [Decision Input Request](#decision-input-request); closed by [Decision Input Answer](#decision-input-answer). |
-| **SaaS projection** | Materialised as a `DecisionInboxItem` (pending → answered) in the TeamSpace. |
+| **SaaS projection** | Materialised as a `DecisionInboxItem` (pending → answered) in the Team Kitty. |
 | **Not to be confused with** | SaaS `Decision` (an immutable recorded past collaboration choice); SaaS `DecisionPoint` (a first-class team-consultation entity that can be widened, deferred, or resolved independently of the loop). See the SaaS domain glossary at `architecture/domain-glossary.md`. |
 | **Related terms** | [Decision Kind](#decision-kind), [Decision Input Request](#decision-input-request), [Decision Input Answer](#decision-input-answer), [Human-in-Charge (HiC)](./identity.md#human-in-charge-hic) |
 

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -1439,7 +1439,7 @@ pages:
     - {slug: "consequences", text: "Consequences", level: 2}
     - {slug: "related", text: "Related", level: 2}
   - path: "docs/adr/3.x/2026-04-21-1-private-teamspace-and-repository-sharing-boundary.md"
-    title: "Private Teamspace and Repository Sharing Boundary"
+    title: "private workspace and Repository Sharing Boundary"
     divio_type: "none"
     abstract: "Spec Kitty's collaboration model needs a stronger trust boundary than the current \"team sees whatever has synced\" behavior."
     anchors:
@@ -1560,7 +1560,7 @@ pages:
   - path: "docs/adr/3.x/2026-05-10-1-deterministic-historical-mission-state-repair.md"
     title: "ADR 1 (2026-05-10): Deterministic Historical Mission-State Repair Identity"
     divio_type: "none"
-    abstract: "Historical `kitty-specs/` directories may predate `mission_id`. TeamSpace import requires stable mission identity, but public migration must be safe in distributed Git: two clones of the same historical repository must produce the same repaired artifacts without consulting a server, a clock, or randomness."
+    abstract: "Historical `kitty-specs/` directories may predate `mission_id`. Team Kitty import requires stable mission identity, but public migration must be safe in distributed Git: two clones of the same historical repository must produce the same repaired artifacts without consulting a server, a clock, or randomness."
     anchors:
     - {slug: "context", text: "Context", level: 2}
     - {slug: "decision", text: "Decision", level: 2}
@@ -4107,7 +4107,7 @@ pages:
   - path: "docs/architecture/launch-readiness-future.md"
     title: "Launch-Readiness Behavior (Coming Soon)"
     divio_type: "explanation"
-    abstract: "Pre-launch design intent for Teamspace: how hosted-readiness defaults flip from opt-in to on, and the launch-coordinator playbook. None of it is in effect today."
+    abstract: "Pre-launch design intent for Team Kitty: how hosted-readiness defaults flip from opt-in to on, and the launch-coordinator playbook. None of it is in effect today."
     anchors:
     - {slug: "why-this-doc-exists", text: "Why this doc exists", level: 2}
     - {slug: "what-changes-at-launch", text: "What changes at launch", level: 2}
@@ -7597,17 +7597,17 @@ pages:
     - {slug: "why-this-happened", text: "Why this happened", level: 2}
     - {slug: "supersedes", text: "Supersedes", level: 2}
   - path: "docs/migrations/teamspace-mission-state-920-closeout.md"
-    title: "TeamSpace Mission-State 920 Closeout Evidence"
+    title: "Team Kitty Mission-State 920 Closeout Evidence"
     divio_type: "none"
-    abstract: "Closeout evidence for TeamSpace mission-state issue #920, generated from a clean workspace: the artifacts proving the mission-state repair landed correctly."
+    abstract: "Closeout evidence for Team Kitty mission-state issue #920, generated from a clean workspace: the artifacts proving the mission-state repair landed correctly."
     anchors:
     - {slug: "current-conclusion", text: "Current conclusion", level: 2}
     - {slug: "evidence-by-issue", text: "Evidence by issue", level: 2}
     - {slug: "verification-run", text: "Verification run", level: 2}
   - path: "docs/migrations/teamspace-mission-state-repair.md"
-    title: "TeamSpace Mission-State Repair"
+    title: "Team Kitty Mission-State Repair"
     divio_type: "none"
-    abstract: "How Spec Kitty deterministically repairs historical kitty-specs/ mission state before a repository connects to TeamSpace, starting with the audit-first run."
+    abstract: "How Spec Kitty deterministically repairs historical kitty-specs/ mission state before a repository connects to Team Kitty, starting with the audit-first run."
     anchors:
     - {slug: "distributed-git-safety", text: "Distributed Git Safety", level: 2}
     - {slug: "what-the-repair-canonicalizes", text: "What The Repair Canonicalizes", level: 2}

--- a/docs/migrations/cross-repo-e2e-gate.md
+++ b/docs/migrations/cross-repo-e2e-gate.md
@@ -64,7 +64,7 @@ From the spec-kitty repo:
 ```bash
 export SPEC_KITTY_ENABLE_SAAS_SYNC=1
 
-# 0. TeamSpace mission-state gate
+# 0. Team Kitty mission-state gate
 spec-kitty doctor mission-state --audit --fail-on teamspace-blocker
 
 # 1. Contract gate
@@ -82,7 +82,7 @@ If all three exit zero AND the issue matrix is fully populated, the
 mission is gate-clean.
 
 For launch-readiness checks that should run in GitHub without a full release
-candidate, use the manual `TeamSpace Mission-State Readiness` workflow. It
+candidate, use the manual `Team Kitty Mission-State Readiness` workflow. It
 executes the mission-state audit with the selected `--fail-on` threshold and
 uploads the JSON report as a workflow artifact.
 

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -59,8 +59,8 @@ These pages are preserved for older cutovers, closeouts, and engineering context
 
 - [Historical 2.1 cutover](2-1-main-cutover-checklist.md)
 - [Historical upgrade to 0.12.0](upgrade-to-0-12-0.md)
-- [TeamSpace mission-state repair](teamspace-mission-state-repair.md)
-- [TeamSpace mission-state closeout](teamspace-mission-state-920-closeout.md)
+- [Team Kitty mission-state repair](teamspace-mission-state-repair.md)
+- [Team Kitty mission-state closeout](teamspace-mission-state-920-closeout.md)
 - [Charter ownership consolidation](charter-ownership-consolidation.md)
 - [Cross-repo E2E gate](cross-repo-e2e-gate.md)
 - [Retrospective events upstream](retrospective-events-upstream.md)

--- a/docs/migrations/teamspace-mission-state-920-closeout.md
+++ b/docs/migrations/teamspace-mission-state-920-closeout.md
@@ -1,12 +1,12 @@
 ---
-title: TeamSpace Mission-State 920 Closeout Evidence
-description: 'Closeout evidence for TeamSpace mission-state issue #920, generated from a clean workspace: the artifacts proving the mission-state repair landed correctly.'
+title: Team Kitty Mission-State 920 Closeout Evidence
+description: 'Closeout evidence for Team Kitty mission-state issue #920, generated from a clean workspace: the artifacts proving the mission-state repair landed correctly.'
 doc_status: active
 updated: '2026-07-04'
 ---
 > Migration note: This page documents a migration path or historical transition. It is not the current 3.2 happy path.
 
-# TeamSpace Mission-State #920 Closeout Evidence
+# Team Kitty Mission-State #920 Closeout Evidence
 
 Generated from clean workspace
 `spec-kitty-20260510-191702-gGiW54`.
@@ -22,12 +22,12 @@ operational and cross-repo work outside this branch:
 
 - `Priivacy-ai/spec-kitty#979` is open: the actual coordinated repair commits
   have not been run across active repositories.
-- Active repository audits still report TeamSpace blockers:
-  - `spec-kitty`: 140 missions, 86 missions with TeamSpace blockers, 2455
+- Active repository audits still report Team Kitty blockers:
+  - `spec-kitty`: 140 missions, 86 missions with Team Kitty blockers, 2455
     total blockers.
-  - `spec-kitty-saas`: 48 missions, 33 missions with TeamSpace blockers, 1773
+  - `spec-kitty-saas`: 48 missions, 33 missions with Team Kitty blockers, 1773
     total blockers.
-  - `spec-kitty-events`: 18 missions, 15 missions with TeamSpace blockers, 499
+  - `spec-kitty-events`: 18 missions, 15 missions with Team Kitty blockers, 499
     total blockers.
 - `Priivacy-ai/spec-kitty-runtime#17` is still open.
 - `Priivacy-ai/spec-kitty-saas#143`, `#144`, `#145`, and `#146` are still open.
@@ -42,7 +42,7 @@ operational and cross-repo work outside this branch:
 | spec-kitty `#924` local canonicalizer | implemented | `tests/migration/test_mission_state_repair.py` covers canonicalization, idempotency, deterministic IDs, event preservation, quarantine, and manifest evidence. |
 | spec-kitty `#925` distributed Git safety | implemented on this branch | Added tests for held common-dir lock and dirty relevant paths in a linked worktree. No commit mode exists, so path-whitelisted staging is not applicable. |
 | spec-kitty `#926` deterministic public migration | implemented | Two-clone rehearsal verifies byte-identical diffs and deterministic dry-run output. |
-| spec-kitty `#927` TeamSpace dry-run | closed | Dry-run validates against `spec-kitty-events` 5.0.0 and reports row mappings/side logs. |
+| spec-kitty `#927` Team Kitty dry-run | closed | Dry-run validates against `spec-kitty-events` 5.0.0 and reports row mappings/side logs. |
 | spec-kitty `#928` side logs | implemented | Dry-run reports decision/runtime/mission side logs with skipped disposition; audit/dry-run prevent them being reduced as status transitions. |
 | spec-kitty `#929` fixture pack | implemented | Packaged and test fixtures are exercised by `tests/audit`. |
 | spec-kitty `#930` manifest | implemented | `RepairReport` records schema version, run id, repo head, targets, file checksums, row transformations, quarantine counts, and validation results. |
@@ -54,7 +54,7 @@ operational and cross-repo work outside this branch:
 | spec-kitty `#978` events dependency | implemented on this branch | `pyproject.toml` now requires `spec-kitty-events>=5.0.0,<6.0.0`; `uv.lock` resolves 5.0.0 from PyPI; release metadata advanced to `3.2.0rc5`. |
 | spec-kitty `#979` actual repair commit | open | Not done. Audits above prove the active repositories still need coordinated repair commits. |
 | spec-kitty-events `#18`, `#19`, `#20` | closed | GitHub state is closed; local dependency now resolves `spec-kitty-events` 5.0.0. |
-| spec-kitty-tracker `#13` | closed | Existing issue comments record focused tracker verification: canonical TeamSpace/no-rollout tests passed. |
+| spec-kitty-tracker `#13` | closed | Existing issue comments record focused tracker verification: canonical Team Kitty/no-rollout tests passed. |
 | spec-kitty-saas `#149` | closed | GitHub state is closed. |
 | spec-kitty-saas `#143`-`#146` | open | Still open in GitHub and listed by the parent epic. |
 | spec-kitty-runtime `#17` | open | Still open in GitHub and listed by the parent epic. |

--- a/docs/migrations/teamspace-mission-state-repair.md
+++ b/docs/migrations/teamspace-mission-state-repair.md
@@ -1,14 +1,14 @@
 ---
-title: TeamSpace Mission-State Repair
-description: How Spec Kitty deterministically repairs historical kitty-specs/ mission state before a repository connects to TeamSpace, starting with the audit-first run.
+title: Team Kitty Mission-State Repair
+description: How Spec Kitty deterministically repairs historical kitty-specs/ mission state before a repository connects to Team Kitty, starting with the audit-first run.
 doc_status: active
 updated: '2026-06-03'
 ---
 > Migration note: This page documents a migration path or historical transition. It is not the current 3.2 happy path.
 
-# TeamSpace Mission-State Repair
+# Team Kitty Mission-State Repair
 
-Spec Kitty can repair historical `kitty-specs/` mission state before a repository is connected to TeamSpace. The repair is deterministic and writes only repository-local mission artifacts plus a manifest under `.kittify/migrations/mission-state/`.
+Spec Kitty can repair historical `kitty-specs/` mission state before a repository is connected to Team Kitty. The repair is deterministic and writes only repository-local mission artifacts plus a manifest under `.kittify/migrations/mission-state/`.
 
 Run the audit first:
 
@@ -16,14 +16,14 @@ Run the audit first:
 spec-kitty doctor mission-state --audit --json
 ```
 
-For a launch/readiness gate, fail on TeamSpace blockers:
+For a launch/readiness gate, fail on Team Kitty blockers:
 
 ```bash
 spec-kitty doctor mission-state --audit --fail-on teamspace-blocker
 ```
 
 `teamspace-blocker` includes all error findings plus warning-level
-historical shapes that TeamSpace must not import as authoritative state:
+historical shapes that Team Kitty must not import as authoritative state:
 legacy keys, forbidden typed side-log keys, snapshot drift, corrupt JSONL,
 missing/invalid identity, and duplicate mission IDs. JSON reports include
 `repo_summary.teamspace_blockers` and
@@ -36,7 +36,7 @@ spec-kitty doctor mission-state --audit --include-fixtures --json
 ```
 
 The repository also ships an opt-in GitHub Actions gate,
-`TeamSpace Mission-State Readiness`, which can be run manually from Actions.
+`Team Kitty Mission-State Readiness`, which can be run manually from Actions.
 It runs the same audit with a selectable `--fail-on` threshold and uploads
 `mission-state-audit.json` even when the gate fails.
 
@@ -46,7 +46,7 @@ Then repair the repository:
 spec-kitty doctor mission-state --fix
 ```
 
-After repair, validate the TeamSpace import shape without sending anything to the server:
+After repair, validate the Team Kitty import shape without sending anything to the server:
 
 ```bash
 spec-kitty doctor mission-state --teamspace-dry-run --json
@@ -77,9 +77,9 @@ If another contributor has mission changes in flight, merge those changes first 
 - `status.events.jsonl` rows are normalized from historical status-row shapes to current status event fields.
 - Known lane aliases such as `doing` are normalized to current lane names.
 - `status.json` is regenerated with the same production reducer/materializer semantics used by normal status writes.
-- Typed side-log rows found in `status.events.jsonl` are quarantined under the migration manifest directory instead of being imported into TeamSpace.
+- Typed side-log rows found in `status.events.jsonl` are quarantined under the migration manifest directory instead of being imported into Team Kitty.
 
-Runtime and decision side logs are launch-local evidence. The dry-run reports them with an explicit skipped disposition; they are not treated as TeamSpace status authority during the launch migration.
+Runtime and decision side logs are launch-local evidence. The dry-run reports them with an explicit skipped disposition; they are not treated as Team Kitty status authority during the launch migration.
 
 ## Cross-Repo Rehearsal
 
@@ -87,7 +87,7 @@ The launch rehearsal for historical mission-state import is encoded in
 `tests/migration/test_teamspace_migration_rehearsal.py`. It creates two
 independent clones of the same historical fixture repository, runs repair on
 both, verifies byte-identical local migration diffs, reruns repair to prove
-idempotency, and validates that TeamSpace dry-run output is identical across
+idempotency, and validates that Team Kitty dry-run output is identical across
 clones. It also proves raw historical status rows are rejected by the
 `spec-kitty-events` 5.0.0 envelope model before they can reach live ingress.
 
@@ -111,7 +111,7 @@ identity behavior when the CLI supplies a mission ID.
 
 ## Release Sequencing
 
-Use this rollout order for public TeamSpace launch:
+Use this rollout order for public Team Kitty launch:
 
 1. Phase 0: finalize the event contracts, identity ADR, and repair manifest
    shape. Do not enable public import while contracts are still moving.
@@ -121,13 +121,13 @@ Use this rollout order for public TeamSpace launch:
    historical repositories, and review generated manifests.
 4. Phase 3: ship `--teamspace-dry-run` and validate against SaaS dev without
    uploading raw historical rows.
-5. Phase 4: enable the explicit TeamSpace import/sync path only after audit
+5. Phase 4: enable the explicit Team Kitty import/sync path only after audit
    and dry-run pass. Keep the GitHub readiness gate opt-in for repositories
    that want CI enforcement.
 6. Phase 5: publish public launch documentation after the internal repair
    window and dry-run evidence are complete.
 
 No public user should be forced through an untested repo-wide rewrite. Local
-CLI workflows continue to tolerate legacy missions where safe; TeamSpace
+CLI workflows continue to tolerate legacy missions where safe; Team Kitty
 import remains an explicit operator step after audit, repair, manifest review,
 and dry-run pass.

--- a/docs/operations/internal-hosted-readiness.md
+++ b/docs/operations/internal-hosted-readiness.md
@@ -21,7 +21,7 @@ Read on if all of the following hold:
 
 - You are running a build of `spec-kitty-cli` that includes the SaaS
   rollout gate (`src/specify_cli/saas/rollout.py`).
-- You want the CLI to surface Teamspace-aware readiness output —
+- You want the CLI to surface Team Kitty-aware readiness output —
   hosted auth status, sync compatibility, tracker reachability — from
   any `spec-kitty` command.
 - You accept that everything below is **pre-launch** and may change
@@ -34,7 +34,7 @@ page.
 
 A single environment variable, `SPEC_KITTY_ENABLE_SAAS_SYNC`, gates every
 hosted code path. With the variable unset (or any non-truthy value), the
-central CLI startup readiness coordinator is a no-op: no Teamspace-labeled
+central CLI startup readiness coordinator is a no-op: no Team Kitty-labeled
 output, no hosted auth probe, no tracker calls. With the variable set
 to a truthy value (`1`, `true`, `yes`, `on`, case-insensitive), the
 coordinator wakes up and the hosted readiness states become observable.
@@ -93,9 +93,9 @@ operator-visible behavior, not the enum literal.
 
 | Session state | What the operator sees | Remediation |
 |---|---|---|
-| Hosted mode disabled (variable unset / falsy) | No Teamspace-labeled output. Coordinator is a no-op. The stable disabled-message string is emitted only by commands that explicitly ask for it (e.g., `spec-kitty sync now` without opt-in). | None — this is the local-first default. |
+| Hosted mode disabled (variable unset / falsy) | No Team Kitty-labeled output. Coordinator is a no-op. The stable disabled-message string is emitted only by commands that explicitly ask for it (e.g., `spec-kitty sync now` without opt-in). | None — this is the local-first default. |
 | Hosted mode enabled, authenticated | Hosted output flows normally. | None. |
-| Hosted mode enabled, logged out on a connected Teamspace | Interactive: a Rich panel offers `[L]ogin / [S]kip / [Q]uit`. Non-interactive: a stable stderr line plus exit code `4`. See [Recovery: Logged out on a connected teamspace](../operations/logged-out-teamspace.md). | `spec-kitty auth login` |
+| Hosted mode enabled, logged out on a connected Team Kitty workspace | Interactive: a Rich panel offers `[L]ogin / [S]kip / [Q]uit`. Non-interactive: a stable stderr line plus exit code `4`. See [Recovery: Logged out on a connected teamspace](../operations/logged-out-teamspace.md). | `spec-kitty auth login` |
 | Hosted mode enabled, tracker unreachable | The relevant sync / tracker command surfaces the failure with a doctor pointer. | `spec-kitty sync doctor` |
 | Hosted mode enabled, CLI upgrade required | The startup-readiness path nag-renders the upgrade guidance (already gated by the Wave 1 suppression contract). | `spec-kitty upgrade --cli` |
 
@@ -109,7 +109,7 @@ spec-kitty sync doctor
 hosted-mode-enabled path. It prints which sub-systems are reachable,
 what credentials are available, and which command would resolve each
 broken state. When the readiness coordinator fires the
-"logged out on a connected Teamspace" path, `sync doctor` will also
+"logged out on a connected Team Kitty workspace" path, `sync doctor` will also
 offer the interactive recovery prompt.
 
 ## Suppression contract

--- a/docs/plans/3-2-doc-publication/3-2-navigation-plan.md
+++ b/docs/plans/3-2-doc-publication/3-2-navigation-plan.md
@@ -521,7 +521,7 @@ into the Migration group; that is deferred.)
 ```yaml
 - name: Migrating from 2.x / Early 3.x
   href: from-charter-2x.md
-- name: TeamSpace Mission-State Repair
+- name: Team Kitty Mission-State Repair
   href: teamspace-mission-state-repair.md
 - name: Migrating Shared Doctrine to the Org Layer
   href: doctrine-local-overlay-to-org-layer.md
@@ -548,9 +548,9 @@ into the Migration group; that is deferred.)
   href: retrospective-events-upstream.md
 - name: Shared-Package Boundary Cutover
   href: shared-package-boundary-cutover.md
-- name: TeamSpace Mission-State 920 Closeout
+- name: Team Kitty Mission-State 920 Closeout
   href: teamspace-mission-state-920-closeout.md
-- name: TeamSpace Mission-State Repair
+- name: Team Kitty Mission-State Repair
   href: teamspace-mission-state-repair.md
 ```
 
@@ -559,7 +559,7 @@ into the Migration group; that is deferred.)
 ```diff
  - name: Migrating from 2.x / Early 3.x
    href: from-charter-2x.md
--- name: TeamSpace Mission-State Repair
+-- name: Team Kitty Mission-State Repair
 -  href: teamspace-mission-state-repair.md
 +- name: Charter Ownership Consolidation
 +  href: charter-ownership-consolidation.md
@@ -577,9 +577,9 @@ into the Migration group; that is deferred.)
 +  href: retrospective-events-upstream.md
 +- name: Shared-Package Boundary Cutover
 +  href: shared-package-boundary-cutover.md
-+- name: TeamSpace Mission-State 920 Closeout
++- name: Team Kitty Mission-State 920 Closeout
 +  href: teamspace-mission-state-920-closeout.md
-+- name: TeamSpace Mission-State Repair
++- name: Team Kitty Mission-State Repair
 +  href: teamspace-mission-state-repair.md
 ```
 

--- a/docs/plans/engineering-notes/architecture-audits/2026-05-11-issue-992-984-audit-comments.md
+++ b/docs/plans/engineering-notes/architecture-audits/2026-05-11-issue-992-984-audit-comments.md
@@ -24,7 +24,7 @@ updated: '2026-06-12'
 
 Issue 992 is a holistic queue-drain epic built on a survey of 10 open `bug` issues and 46 closed since 2026-04-21. Its core diagnosis: *"Spec Kitty currently has too many places acting as if they own workflow truth"* — `spec-kitty next`, `agent action implement/review`, `agent tasks move-task`, `agent tasks status`, `review`, `merge --dry-run`, real `merge`, dashboard materializers, SaaS sync, release/mission-review gates. Each is a projection of a few aggregates whose invariants are not centralized, producing the observed "whack-a-mole" pattern.
 
-The epic proposes seven workstreams (W0–W6): TeamSpace canonical-import boundary, `WorkPackageLifecycle` authority, `ReviewCycle` aggregate, `MergeReadiness` parity, `SyncPublication` outcome model, `ReleaseEvidence` + review gates, and input/upgrade/encoding hygiene. Each names North Star invariants and concrete acceptance bullets. Queue-drain order is sequenced into Phase −1 (land 4 in-flight TeamSpace PRs), Phase 0 (cross-surface fixture harness), Phase 1 (active release bleeding: #991, #990, #988, #989, #889, #971), Phase 2 (promote aggregates), Phase 3 (older debt: #644, #662, #391). Definition-of-done requires *cross-boundary regression tests* and *dry-run-equals-real* parity.
+The epic proposes seven workstreams (W0–W6): Team Kitty canonical-import boundary, `WorkPackageLifecycle` authority, `ReviewCycle` aggregate, `MergeReadiness` parity, `SyncPublication` outcome model, `ReleaseEvidence` + review gates, and input/upgrade/encoding hygiene. Each names North Star invariants and concrete acceptance bullets. Queue-drain order is sequenced into Phase −1 (land 4 in-flight Team Kitty PRs), Phase 0 (cross-surface fixture harness), Phase 1 (active release bleeding: #991, #990, #988, #989, #889, #971), Phase 2 (promote aggregates), Phase 3 (older debt: #644, #662, #391). Definition-of-done requires *cross-boundary regression tests* and *dry-run-equals-real* parity.
 
 The single comment, from stijn-dejongh (2026-05-07): the bug queue is accurate, but the work should *"start by reshaping the domain contracts and entry-points, then use the bug queue as a code-level acceptance criterion."* Reshape first, drain as proof.
 
@@ -47,10 +47,10 @@ The single comment, from stijn-dejongh (2026-05-07): the bug queue is accurate, 
 | #952, #735, #746, #745, #744, #936 | closed sync bugs | CLOSED | W4 |
 | #975, #967, #805, #830, #833, #968, #964 | closed release/CI bugs | CLOSED | W5 |
 | #722, #721, #720, #674, #673, #760, #541, #539, #542 | closed input/upgrade bugs | CLOSED | W6 |
-| Priivacy-ai/spec-kitty#980 | CLI TeamSpace mission-state repair | OPEN PR | Phase −1 cutover set |
-| Priivacy-ai/spec-kitty-saas#150 | enforce TeamSpace ingress event contracts | OPEN PR | Phase −1 |
+| Priivacy-ai/spec-kitty#980 | CLI Team Kitty mission-state repair | OPEN PR | Phase −1 cutover set |
+| Priivacy-ai/spec-kitty-saas#150 | enforce Team Kitty ingress event contracts | OPEN PR | Phase −1 |
 | Priivacy-ai/spec-kitty-runtime#19 | runtime side-log classification | OPEN PR | Phase −1 |
-| Priivacy-ai/spec-kitty-tracker#14 | tracker TeamSpace mission payloads | OPEN PR | Phase −1 |
+| Priivacy-ai/spec-kitty-tracker#14 | tracker Team Kitty mission payloads | OPEN PR | Phase −1 |
 | Priivacy-ai/spec-kitty-events#20 | publish events 5.0.0 | OPEN PR | Phase −1 |
 
 ### Code paths the issue names
@@ -239,6 +239,6 @@ Not a blocker for the fix; just noting the surrounding terrain.
 - **No state changes** were made during this read: no comments posted, no labels altered, no issues touched. `gh issue view` calls were read-only.
 - **Function names** cited in #984 (`_ensure_target_branch_checked_out`, `get_main_repo_root`) were not verified against current source. They are plausible based on naming conventions but a fix scoper should grep before committing to them.
 - **Audit-file-vs-issue-file alignment**: the audit measured `src/specify_cli/agent_utils/status.py` at 570 SLOC with an F-53 `_display_status_board`. #984 does not explicitly name this file, only the CLI surface and two helper-function names. The link is inferential — strong, but inferential. The draft comments call this out honestly.
-- **#992's Phase −1 (TeamSpace cutover PR set)** is not addressed by the audit at all; the audit's lens is structural-complexity, not migration-coordination. If a reviewer expects the audit to weigh in on Phase −1, they will be disappointed; that's not a contradiction, it's a scope mismatch.
+- **#992's Phase −1 (Team Kitty cutover PR set)** is not addressed by the audit at all; the audit's lens is structural-complexity, not migration-coordination. If a reviewer expects the audit to weigh in on Phase −1, they will be disappointed; that's not a contradiction, it's a scope mismatch.
 - **No PR-level scan** was performed for in-flight fixes that might already address #984. The body cites no linked PR; the issue is plausibly still unowned.
 - **Audit data is as of 2026-05-09 multi-window expansion**. Any commits to F2-cluster files between then and 2026-05-11 are not reflected in the numbers cited.

--- a/docs/plans/engineering-notes/common-docs-section-audit.md
+++ b/docs/plans/engineering-notes/common-docs-section-audit.md
@@ -102,7 +102,7 @@ populated; `plans/investigations/`, `plans/doctrine/`, `plans/refactor/`, `plans
 
 | File | Current | Bucket | Proposed target | Rationale |
 |---|---|---|---|---|
-| `teamspace-mission-state-920-closeout.md` | `migrations/` | (c) | **`plans/engineering-notes/`** | "Closeout evidence for TeamSpace mission-state issue #920, generated from clean workspace `spec-kitty-20260510-…`." A dated mission closeout record, not a reusable migration runbook. **MISFILED (borderline** — carries a migration-note banner; verify it is not the sole runbook for that path before moving). |
+| `teamspace-mission-state-920-closeout.md` | `migrations/` | (c) | **`plans/engineering-notes/`** | "Closeout evidence for Team Kitty mission-state issue #920, generated from clean workspace `spec-kitty-20260510-…`." A dated mission closeout record, not a reusable migration runbook. **MISFILED (borderline** — carries a migration-note banner; verify it is not the sole runbook for that path before moving). |
 | `teamspace-mission-state-repair.md`, `2-1-main-cutover-checklist.md`, `06_migration_and_shim_rules.md` | `migrations/` | (a)/(b) | stays | Durable repair runbook / checklist / rules. `06_`-numbered file is an odd naming residue — normalize name, keep in place. **STAYS.** |
 
 **Verdict:** clean bar one closeout relocation.

--- a/docs/plans/initiatives/2026-04-tracker-binding-context-discovery/spec-kitty-tracker-team-prompt.md
+++ b/docs/plans/initiatives/2026-04-tracker-binding-context-discovery/spec-kitty-tracker-team-prompt.md
@@ -61,7 +61,7 @@ Relevant current code:
 Non-goals:
 
 1. Do not implement SaaS mapping resolution or CLI UX in this repo.
-2. Do not hard-code Spec Kitty SaaS model assumptions into the tracker library.
+2. Do not hard-code Team Kitty model assumptions into the tracker library.
 3. Do not reduce discovery back to provider-specific ad hoc dicts with no shared
    structure.
 

--- a/docs/plans/investigations/wp-op-schema-related-tickets.md
+++ b/docs/plans/investigations/wp-op-schema-related-tickets.md
@@ -119,10 +119,10 @@ The whole-file hashing of `wp*.md` lives here, but **no issue isolates the churn
 
 | # | Title (abbrev) | Relationship |
 |---|---|---|
-| 2180 | P0: make Teamspace dossier sync required, replayable, automatic | friction |
+| 2180 | P0: make Team Kitty dossier sync required, replayable, automatic | friction |
 | 1133 | 3.3.0: Include analyze.md in dossier sync and body upload | friction / formalization |
 | 1058 | Legacy cleanup: split dossier queue migration from live emitter APIs | move / friction |
-| 2144 | Guarantee every Teamspace-bound event has SQLite or git durability | friction |
+| 2144 | Guarantee every Team Kitty-bound event has SQLite or git durability | friction |
 
 ## Unticketed gaps
 

--- a/docs/plans/research/2026-06-25-event-sync-retention-delivery-synthesis.md
+++ b/docs/plans/research/2026-06-25-event-sync-retention-delivery-synthesis.md
@@ -25,10 +25,10 @@ sits in the SaaS sync durability cluster:
   auth/readiness, WebSocket, tracker, status, and network calls cannot diverge.
 - **#2124 — retained event journal + per-target ledger**: this note's primary
   design spike.
-- **#2144 — Teamspace durability registry + git/SaaS replay**: sibling/follow-on,
+- **#2144 — Team Kitty durability registry + git/SaaS replay**: sibling/follow-on,
   but its capture-before-drain invariant applies here: feature flags, auth/team
   gaps, and network gates must block drain eligibility only, not silently drop
-  Teamspace-bound facts.
+  Team Kitty-bound facts.
 - **#1800 / #1666 / #1619**: parent sync/event-envelope hardening and execution
   context/domain-boundary architecture.
 - **#2165**: docs-layout reorganization context only. This mission keeps its
@@ -47,7 +47,7 @@ target. It is wrong for transient SaaS test environments (Upsun PR envs), where
 the operator wants to drain the same local events to env A, destroy it, and
 drain the same events again to env B.
 
-Robert opened #2124 to fix this at the CLI level before Teamspace is exposed to
+Robert opened #2124 to fix this at the CLI level before Team Kitty is exposed to
 users. Stijn added the operator-config framing and a hard requirement on module
 boundaries. This note folds both into one design.
 
@@ -76,13 +76,13 @@ for exactly the retention-vs-delivery separation above. Under the hood it resolv
 to **two orthogonal axes**:
 
 - **Retention** (the journal): on = keep payloads locally · off = discard
-- **Delivery** (the target + ledger): none · Teamspace · external-receiver
+- **Delivery** (the target + ledger): none · Team Kitty · external-receiver
 
 The four named modes are the useful presets over those axes:
 
 | Mode | Retention | Delivery |
 |---|---|---|
-| `TEAMSPACE` | journal on | → SaaS Teamspace target (default for connected users) |
+| `TEAMSPACE` | journal on | → Team Kitty target (default for connected users) |
 | `EXTERNAL_RECEIVER` | journal on | → operator-configured endpoint (just another target type) |
 | `LOCAL_RETENTION` | journal on | none — retain now, choose a target and drain later (the replay case) |
 | `OPT_OUT` / `TRASH` | off | none |
@@ -101,7 +101,7 @@ settle this matrix:
 | `EventSyncConfig` | Selects retention/delivery policy only; does not independently choose a network target. |
 | `SyncConfig.server_url` / `config.toml` | Canonical runtime target unless an explicit whole-process override is active. |
 | `SPEC_KITTY_SAAS_URL` | Either setup/dev-only, or a deliberate override that affects auth, sync, tracker, queue scope, WebSocket, readiness, and diagnostics consistently. |
-| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Affects drain eligibility only; Teamspace-bound capture still lands in SQLite or git. |
+| `SPEC_KITTY_ENABLE_SAAS_SYNC` | Affects drain eligibility only; Team Kitty-bound capture still lands in SQLite or git. |
 | Auth session + team scope | Supplies identity for delivery target and ledger rows when known; not required for initial local capture. |
 | Queue scope | Derived isolation key, not an independent target selector. |
 | Network calls | Must use the same resolved target as queue scope and status diagnostics. |
@@ -112,11 +112,11 @@ scope for one target while network calls go to another, and stale
 
 ### The testing stub falls out for free
 
-Stijn wants a stub receiver so fork CI stops depending on a real Teamspace and
+Stijn wants a stub receiver so fork CI stops depending on a real Team Kitty and
 the `teamspace_key` in core that keeps breaking his runs. A stub is just an
 `EXTERNAL_RECEIVER` pointed at a localhost sink that accepts and records events
 for assertions. It is a configuration of the design, not a special case — and it
-gets CI off the Teamspace dependency.
+gets CI off the Team Kitty dependency.
 
 ## Module boundary (Stijn's hard requirement)
 
@@ -187,8 +187,8 @@ lifting is the journal/ledger split + the migration, not the dispatch logic.
 2. **Target reset under stable URL**: advisory follow-on. URL+scope identity is
    enough for the immediate transient-env replay use case; consuming SaaS
    `/api/v1/sync/health/` deployment metadata waits for the SaaS-side change.
-3. **Teamspace durability**: #2144 full registry/replay is follow-on, but
-   #2131 must not introduce any silent discard of Teamspace-bound facts. Capture
+3. **Team Kitty durability**: #2144 full registry/replay is follow-on, but
+   #2131 must not introduce any silent discard of Team Kitty-bound facts. Capture
    comes before drain gates.
 4. **Docs structure**: #2165 is not folded into this mission. No docs-root move
    or frontmatter normalization is part of #2131.

--- a/src/specify_cli/_completion_manifest.json
+++ b/src/specify_cli/_completion_manifest.json
@@ -659,7 +659,7 @@
      "deprecated": false
     },
     "mission-state": {
-     "help": "Audit, repair, or TeamSpace-validate mission-state shapes.",
+     "help": "Audit, repair, or Team Kitty-validate mission-state shapes.",
      "hidden": false,
      "deprecated": false
     },
@@ -913,7 +913,7 @@
      "deprecated": false
     },
     "normalize-lifecycle": {
-     "help": "Normalize legacy ``kitty-specs`` missions for the MVP lifecycle model.\n\nThis command repairs enough historical mission state to make the canonical\nlifecycle model reliable across old repositories. It backfills identity\nwhere needed, rebuilds missing event logs from legacy state, and regenerates\nstatus/progress/lifecycle projections used by the CLI and Teamspace.\n\nExit codes:\n\n- ``0`` — all targeted missions normalized or skipped cleanly\n- ``1`` — one or more missions hit an unrecoverable error",
+     "help": "Normalize legacy ``kitty-specs`` missions for the MVP lifecycle model.\n\nThis command repairs enough historical mission state to make the canonical\nlifecycle model reliable across old repositories. It backfills identity\nwhere needed, rebuilds missing event logs from legacy state, and regenerates\nstatus/progress/lifecycle projections used by the CLI and Team Kitty.\n\nExit codes:\n\n- ``0`` — all targeted missions normalized or skipped cleanly\n- ``1`` — one or more missions hit an unrecoverable error",
      "hidden": false,
      "deprecated": false
     },
@@ -1251,7 +1251,7 @@
      "deprecated": false
     },
     "share": {
-     "help": "Share the current repository from Private Teamspace into a team.",
+     "help": "Share the current repository from private workspace into a team.",
      "hidden": false,
      "deprecated": false
     },
@@ -1343,7 +1343,7 @@
    "deprecated": false,
    "commands": {
     "providers": {
-     "help": "List supported tracker providers, categorized by backend type.\n\nSaaS-backed providers authenticate through ``spec-kitty auth login`` and\nroute sync operations through the Spec Kitty SaaS control plane.\n\nLocal providers use direct connectors with locally stored credentials.\n\nThis command is purely informational and prints the hard-coded provider\ncategories.  It does **not** consult hosted readiness — the rollout gate\nitself is enforced by ``tracker_callback`` (and by the conditional\nregistration in ``cli/commands/__init__.py``), which is all the gating\nthis static output needs.",
+     "help": "List supported tracker providers, categorized by backend type.\n\nSaaS-backed providers authenticate through ``spec-kitty auth login`` and\nroute sync operations through the Team Kitty control plane.\n\nLocal providers use direct connectors with locally stored credentials.\n\nThis command is purely informational and prints the hard-coded provider\ncategories.  It does **not** consult hosted readiness — the rollout gate\nitself is enforced by ``tracker_callback`` (and by the conditional\nregistration in ``cli/commands/__init__.py``), which is all the gating\nthis static output needs.",
      "hidden": false,
      "deprecated": false
     },

--- a/src/specify_cli/audit/models.py
+++ b/src/specify_cli/audit/models.py
@@ -97,7 +97,7 @@ class MissionFinding:
 
 
 def is_teamspace_blocker(finding: MissionFinding) -> bool:
-    """Return True when a finding should block TeamSpace import/sync readiness."""
+    """Return True when a finding should block Team Kitty import/sync readiness."""
     return finding.severity == Severity.ERROR or finding.code in TEAMSPACE_BLOCKER_CODES
 
 
@@ -125,7 +125,7 @@ class MissionAuditResult:
 
     @property
     def has_teamspace_blockers(self) -> bool:
-        """True if any finding blocks TeamSpace import/sync readiness."""
+        """True if any finding blocks Team Kitty import/sync readiness."""
         return any(is_teamspace_blocker(f) for f in self.findings)
 
     @property

--- a/src/specify_cli/audit/shape_registry.py
+++ b/src/specify_cli/audit/shape_registry.py
@@ -185,7 +185,7 @@ KNOWN_TOP_LEVEL_KEYS_BY_ARTIFACT: dict[str, frozenset[str]] = {
 # status-transition rows. The audit engine then raised ``FORBIDDEN_KEY``
 # findings against legitimate lifecycle keys (``event_type``,
 # ``aggregate_type``), blocking canary scenarios 1 + 2 with
-# ``TeamSpace migration required. Finding codes: FORBIDDEN_KEY``.
+# ``Team Kitty migration required. Finding codes: FORBIDDEN_KEY``.
 LIFECYCLE_AGGREGATE_TYPES: frozenset[str] = frozenset(
     {"Mission", "Project", "WorkPackage", "MissionDossier"}
 )

--- a/src/specify_cli/auth/flows/authorization_code.py
+++ b/src/specify_cli/auth/flows/authorization_code.py
@@ -272,7 +272,7 @@ class AuthorizationCodeFlow:
                 "User has no team memberships. Contact your administrator."
             )
         # Client-picked default (see C-011): the SaaS does not return
-        # ``default_team_id``; we prefer Private Teamspace when available.
+        # ``default_team_id``; we prefer private workspace when available.
         default_team_id = pick_default_team_id(teams)
 
         now = datetime.now(UTC)

--- a/src/specify_cli/auth/flows/device_code.py
+++ b/src/specify_cli/auth/flows/device_code.py
@@ -281,7 +281,7 @@ class DeviceCodeFlow:
                 "User has no team memberships. Contact your administrator."
             )
         # Client-picked default (see C-011): the SaaS does not return
-        # ``default_team_id``; we prefer Private Teamspace when available.
+        # ``default_team_id``; we prefer private workspace when available.
         default_team_id = pick_default_team_id(teams)
 
         now = datetime.now(UTC)

--- a/src/specify_cli/auth/session.py
+++ b/src/specify_cli/auth/session.py
@@ -58,7 +58,7 @@ class Team:
 def pick_default_team_id(teams: list[Team]) -> str:
     """Return the preferred default team id for new-session UI/login default display.
 
-    Private Teamspace wins when present; otherwise preserves the legacy first-team
+    private workspace wins when present; otherwise preserves the legacy first-team
     fallback. This is *display-only* — it is **not** valid as a fallback for direct
     sync ingress. Direct-ingress code paths must use ``require_private_team_id`` paired
     with ``TokenManager.rehydrate_membership_if_needed()`` instead, which fails closed
@@ -71,7 +71,7 @@ def pick_default_team_id(teams: list[Team]) -> str:
 
 
 def get_private_team_id(teams: list[Team]) -> str | None:
-    """Return the user's Private Teamspace id when one is present."""
+    """Return the user's private workspace id when one is present."""
     for team in teams:
         if bool(getattr(team, "is_private_teamspace", False)):
             return team.id
@@ -79,7 +79,7 @@ def get_private_team_id(teams: list[Team]) -> str | None:
 
 
 def require_private_team_id(session: StoredSession) -> str | None:
-    """Return the Private Teamspace id for direct sync ingress, else None.
+    """Return the private workspace id for direct sync ingress, else None.
 
     Pure function. No I/O. No mutation.
 

--- a/src/specify_cli/auth/token_manager.py
+++ b/src/specify_cli/auth/token_manager.py
@@ -280,15 +280,15 @@ class TokenManager:
     def rehydrate_membership_if_needed(self, *, force: bool = False) -> bool:
         """Sync one-shot ``/api/v1/me`` rehydrate.
 
-        Returns ``True`` iff the in-memory session ends with a Private
-        Teamspace membership. Returns ``False`` for: no session loaded,
+        Returns ``True`` iff the in-memory session ends with private-workspace
+        membership. Returns ``False`` for: no session loaded,
         negative-cache hit (without ``force=True``), HTTP failure, or a
-        successful fetch that still contained no Private Teamspace.
+        successful fetch that still contained no private workspace.
 
         Contract (see contracts/api.md §3):
 
         - Early-return ``True`` when the current session already exposes a
-          Private Teamspace.
+          private workspace.
         - Honor the process-scoped negative cache as a fast path; ``force=True``
           bypasses it (refresh hook + explicit caller-driven retries).
         - Single-flight via ``threading.Lock``: concurrent threads that race
@@ -330,7 +330,7 @@ class TokenManager:
             raw_teams = payload.get("teams", [])
             teams = [Team.from_dict(t) for t in raw_teams]
             if get_private_team_id(teams) is None:
-                # Authoritative: SaaS confirmed no Private Teamspace exists for
+                # Authoritative: SaaS confirmed no private workspace exists for
                 # this user. Set the process-scoped negative cache so direct
                 # ingress paths fail fast without re-issuing the GET.
                 self._membership_negative_cache = True

--- a/src/specify_cli/cli/commands/_auth_login.py
+++ b/src/specify_cli/cli/commands/_auth_login.py
@@ -49,11 +49,11 @@ async def login_impl(*, headless: bool, force: bool) -> None:
             present. Defaults to False.
 
     Note:
-        Identity acquisition is intentionally decoupled from TeamSpace
-        mission-state readiness (DDD: Identity & Access vs TeamSpace
+        Identity acquisition is intentionally decoupled from Team Kitty
+        mission-state readiness (DDD: Identity & Access vs Team Kitty
         contexts). Sync / tracker / connect commands continue to call
         ``enforce_teamspace_mission_state_ready`` themselves — those are
-        the commands that actually depend on TeamSpace state.
+        the commands that actually depend on Team Kitty state.
     """
     try:
         saas_url = get_saas_base_url()
@@ -167,7 +167,7 @@ def _print_success(session: StoredSession) -> None:
             None,
         )
         if default_team:
-            suffix = " [Private Teamspace]" if default_team.is_private_teamspace else ""
+            suffix = " [private workspace]" if default_team.is_private_teamspace else ""
             console.print(f"  Default team: {default_team.name}{suffix}")
 
 

--- a/src/specify_cli/cli/commands/_mission_state_doctor.py
+++ b/src/specify_cli/cli/commands/_mission_state_doctor.py
@@ -88,7 +88,7 @@ def _print_rich_audit_report(report: object) -> None:
         f"Total missions: {summary['total_missions']} | "
         f"With errors: {summary['missions_with_errors']} | "
         f"With warnings: {summary['missions_with_warnings']} | "
-        f"TeamSpace blockers: {summary['teamspace_blockers']}"
+        f"Team Kitty blockers: {summary['teamspace_blockers']}"
     )
 
 
@@ -287,13 +287,13 @@ def _run_teamspace_dry_run_mode(
         report = cast(TeamspaceDryRunReport, r)
         if report.valid:
             console.print(
-                "[green]TeamSpace dry-run valid[/green] "
+                "[green]Team Kitty dry-run valid[/green] "
                 f"({report.envelope_count} envelopes, "
                 f"spec-kitty-events {report.events_package_version})."
             )
         else:
             console.print(
-                "[red]TeamSpace dry-run failed[/red] "
+                "[red]Team Kitty dry-run failed[/red] "
                 f"({len(report.errors)} validation errors)."
             )
 

--- a/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
+++ b/src/specify_cli/cli/commands/_teamspace_mission_state_gate.py
@@ -1,4 +1,4 @@
-"""TeamSpace mission-state migration prompt and connection gate helpers."""
+"""Team Kitty mission-state migration prompt and connection gate helpers."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from rich.panel import Panel
 
 @dataclass(frozen=True)
 class TeamspaceMissionStateReadiness:
-    """Readiness summary for TeamSpace historical mission-state import."""
+    """Readiness summary for Team Kitty historical mission-state import."""
 
     repo_root: Path
     total_missions: int = 0
@@ -32,7 +32,7 @@ class TeamspaceMissionStateReadiness:
 
 
 def check_teamspace_mission_state_readiness(repo_root: Path) -> TeamspaceMissionStateReadiness:
-    """Return mission-state readiness for TeamSpace connect/import paths."""
+    """Return mission-state readiness for Team Kitty connect/import paths."""
     repo_root = repo_root.resolve()
     if not (repo_root / KITTY_SPECS_DIR).is_dir():
         return TeamspaceMissionStateReadiness(repo_root=repo_root)
@@ -77,15 +77,15 @@ def _guidance_lines(readiness: TeamspaceMissionStateReadiness) -> list[str]:
             "Spec Kitty could not verify local mission-state readiness.",
             f"Audit error: {readiness.audit_error}",
             "",
-            "Run the audit before connecting to TeamSpace:",
+            "Run the audit before connecting to Team Kitty:",
             "  spec-kitty doctor mission-state --audit --fail-on teamspace-blocker",
         ]
 
     codes = ", ".join(readiness.blocker_codes) if readiness.blocker_codes else "unknown"
     return [
-        "TeamSpace mission-state migration is required before connecting.",
+        "Team Kitty mission-state migration is required before connecting.",
         (
-            f"Found {readiness.blocker_count} TeamSpace blocker(s) "
+            f"Found {readiness.blocker_count} Team Kitty blocker(s) "
             f"across {readiness.missions_with_blockers} mission(s)."
         ),
         f"Finding codes: {codes}",
@@ -115,7 +115,7 @@ def _print_notice(
 
 
 def enforce_teamspace_mission_state_ready(*, console: Console, command_name: str) -> None:
-    """Block TeamSpace connect/sync commands until local mission-state is ready."""
+    """Block Team Kitty connect/sync commands until local mission-state is ready."""
     try:
         from specify_cli.core.paths import locate_project_root
 
@@ -133,7 +133,7 @@ def enforce_teamspace_mission_state_ready(*, console: Console, command_name: str
     _print_notice(
         readiness,
         console=console,
-        title="TeamSpace Migration Required",
+        title="Team Kitty Migration Required",
         border_style="red",
     )
     console.print(f"[red]Blocked:[/red] `{command_name}` will not connect until this migration is complete.")
@@ -147,7 +147,7 @@ def offer_teamspace_mission_state_migration(
     dry_run: bool,
     assume_yes: bool,
 ) -> tuple[bool, bool]:
-    """Surface and optionally run the TeamSpace mission-state migration.
+    """Surface and optionally run the Team Kitty mission-state migration.
 
     Returns ``(migration_was_pending, repair_ran)``.
     """
@@ -158,7 +158,7 @@ def offer_teamspace_mission_state_migration(
     _print_notice(
         readiness,
         console=console,
-        title="TeamSpace Mission-State Migration",
+        title="Team Kitty Mission-State Migration",
         border_style="yellow",
     )
 
@@ -174,7 +174,7 @@ def offer_teamspace_mission_state_migration(
         default=True,
     )
     if not should_run:
-        console.print("[yellow]Skipped TeamSpace mission-state repair.[/yellow]")
+        console.print("[yellow]Skipped Team Kitty mission-state repair.[/yellow]")
         return True, False
 
     from specify_cli.migration.mission_state import MissionStateRepairError, repair_repo
@@ -204,10 +204,10 @@ def offer_teamspace_mission_state_migration(
         _print_notice(
             post_repair,
             console=console,
-            title="TeamSpace Migration Still Blocked",
+            title="Team Kitty Migration Still Blocked",
             border_style="red",
         )
         raise typer.Exit(1)
 
-    console.print("[green]TeamSpace mission-state blockers cleared.[/green]")
+    console.print("[green]Team Kitty mission-state blockers cleared.[/green]")
     return True, True

--- a/src/specify_cli/cli/commands/decision.py
+++ b/src/specify_cli/cli/commands/decision.py
@@ -523,7 +523,7 @@ def cmd_verify(
 @decision_app.command("widen", hidden=True)
 def cmd_widen(
     decision_id: str = typer.Argument(..., help="ULID of the DecisionPoint to widen"),
-    invited: str = typer.Option(..., "--invited", help="Comma-separated Teamspace user IDs to invite"),
+    invited: str = typer.Option(..., "--invited", help="Comma-separated Team Kitty member IDs to invite"),
     mission_slug: str | None = typer.Option(None, "--mission-slug", help="Mission slug"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print what would be called without calling it"),
 ) -> None:
@@ -537,7 +537,7 @@ def cmd_widen(
     try:
         invited_list = [int(value) for value in invited_raw]
     except ValueError:
-        typer.echo("Error: --invited must contain Teamspace user IDs, not display names", err=True)
+        typer.echo("Error: --invited must contain Team Kitty member IDs, not display names", err=True)
         raise typer.Exit(1) from None
 
     if dry_run:

--- a/src/specify_cli/cli/commands/doctor.py
+++ b/src/specify_cli/cli/commands/doctor.py
@@ -1001,7 +1001,7 @@ def mission_state(
         bool,
         typer.Option(
             "--teamspace-dry-run",
-            help="Synthesize canonical TeamSpace envelopes from local state and validate them",
+            help="Synthesize canonical Team Kitty envelopes from local state and validate them",
         ),
     ] = False,
     json_output: Annotated[
@@ -1042,7 +1042,7 @@ def mission_state(
         typer.Option("--allow-dirty", help="Allow --fix when relevant git paths are already dirty"),
     ] = False,
 ) -> None:
-    """Audit, repair, or TeamSpace-validate mission-state shapes."""
+    """Audit, repair, or Team Kitty-validate mission-state shapes."""
     # Resolve the project root HERE, through the shim's ``locate_project_root``
     # binding — the patchable seam (#2059, mirrors the ``workspaces`` shell). A
     # ``None`` root is valid for a fixtures-only run, so it is forwarded as-is;

--- a/src/specify_cli/cli/commands/init.py
+++ b/src/specify_cli/cli/commands/init.py
@@ -98,7 +98,7 @@ _GITHUB_DIFF_GITATTRIBUTES_ENTRIES = (
 def _emit_project_init_event(project_path: Path) -> None:
     """Append a project-init lifecycle event to the durable outbox.
 
-    Issue #1073: ``spec-kitty init`` must register a Teamspace-visible
+    Issue #1073: ``spec-kitty init`` must register a Team Kitty-visible
     project through the durable outbox after identity exists, regardless
     of authentication or sync state. We accomplish this by materializing
     the project identity (which mints ``build_id``, ``project_uuid``,
@@ -876,7 +876,7 @@ def init(  # noqa: C901
             # an existing repo leaves the repo untouched.
 
             # Persist a local canonical ProjectInitialized event before any
-            # SaaS fan-out so local dashboards and TeamSpace import always
+            # SaaS fan-out so local dashboards and Team Kitty import always
             # see a complete project history (issue #1067).
             try:
                 from specify_cli.identity.project import ensure_identity

--- a/src/specify_cli/cli/commands/migrate_cmd.py
+++ b/src/specify_cli/cli/commands/migrate_cmd.py
@@ -655,7 +655,7 @@ def normalize_lifecycle(
     This command repairs enough historical mission state to make the canonical
     lifecycle model reliable across old repositories. It backfills identity
     where needed, rebuilds missing event logs from legacy state, and regenerates
-    status/progress/lifecycle projections used by the CLI and Teamspace.
+    status/progress/lifecycle projections used by the CLI and Team Kitty.
 
     Exit codes:
 

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -167,7 +167,7 @@ _DRAIN_BLOCKED_HELP = {
     "ready": "Ready to drain.",
     "sync_disabled": "SaaS sync disabled for this checkout — run `spec-kitty sync opt-in`.",
     "no_auth": "Not authenticated — run `spec-kitty auth login`.",
-    "no_team": "No Private Teamspace available — refresh membership in dashboard.",
+    "no_team": "No private workspace available — refresh membership in dashboard.",
 }
 
 
@@ -267,7 +267,7 @@ def _render_top_event_types(stats: QueueStats, target_console: Console) -> None:
 def _handle_sync_now_unauthenticated(strict: bool) -> None:
     """Route the unauthenticated/blocked ``sync now`` case through recovery.
 
-    Teamspace-aware recovery: TTY operators get an interactive prompt, CI gets a
+    Team Kitty-aware recovery: TTY operators get an interactive prompt, CI gets a
     structured stderr line + exit code 4. When no teamspace is detected
     (NO_TEAMSPACE / SKIPPED / QUIT) the behaviour is byte-identical to the legacy
     path — the operator message naming ``spec-kitty auth login`` is printed and
@@ -635,7 +635,7 @@ def _write_event_sync_config(mode: Mode, external_endpoint: str | None) -> None:
 
 
 def _event_sync_access_token() -> str:
-    """Best-effort Bearer token for the Teamspace receiver (empty when absent).
+    """Best-effort Bearer token for the Team Kitty receiver (empty when absent).
 
     The dispatcher never POSTs an empty selection, so an absent token degrades
     safely to no delivery rather than an error.
@@ -668,7 +668,7 @@ def _resolve_active_receiver(
     """Resolve the WP06 receiver for the active mode via WP09 (or ``None``).
 
     Mode→receiver resolution is owned by ``EventSyncConfig.resolve``; the CLI
-    only supplies the Teamspace Bearer token to the default factory.
+    only supplies the Team Kitty Bearer token to the default factory.
     """
     from specify_cli.delivery.config import DefaultReceiverFactory
 
@@ -947,7 +947,7 @@ def _empty_selection_cause(report: PerProjectStoreReport) -> str:
     That last branch is deliberately the weakest claim. Distinguishing "already
     delivered" from "terminally drain-blocked" needs ledger state the report does not
     carry, so it names both possibilities instead of asserting one. Guessing here
-    would recreate exactly the wrong-and-actionable diagnosis the no-Private-Teamspace
+    would recreate exactly the wrong-and-actionable diagnosis the no-private-workspace
     message was: an operator told the wrong cause acts on the wrong thing.
 
     Sourced entirely from :func:`build_per_project_store_report` — the same grouping
@@ -1949,7 +1949,7 @@ def routes() -> None:
         raise typer.Exit(1)
 
     console.print()
-    console.print("[cyan]Spec Kitty Teamspace Routing[/cyan]")
+    console.print("[cyan]Team Kitty Workspace Routing[/cyan]")
     console.print()
 
     table = Table(show_header=False, box=None)
@@ -1989,7 +1989,7 @@ def routes() -> None:
 
     private_team_name = _private_team_name(session)
     if private_team_name:
-        table.add_row("Private Teamspace", private_team_name)
+        table.add_row("private workspace", private_team_name)
 
     console.print(table)
     console.print()
@@ -2044,7 +2044,7 @@ def routes() -> None:
 def share(
     team_slug: str = typer.Argument(..., help="Team slug to share this repository into."),
 ) -> None:
-    """Share the current repository from Private Teamspace into a team."""
+    """Share the current repository from private workspace into a team."""
     from specify_cli.sync.sharing_client import (
         RepositorySharingClientError,
         request_repository_share_sync,
@@ -2088,7 +2088,7 @@ def share(
                 _materialize_private_source_project()
             except Exception as materialize_error:
                 console.print(
-                    "[red]Error:[/red] Could not materialize this checkout in Private Teamspace: "
+                    "[red]Error:[/red] Could not materialize this checkout in private workspace: "
                     f"{materialize_error}"
                 )
                 raise typer.Exit(1) from materialize_error
@@ -2159,7 +2159,7 @@ def unshare(
         f"[green]✓[/green] Stopped sharing [cyan]{routing.repo_slug or routing.project_slug or routing.project_uuid}[/cyan] "
         f"to [cyan]{team_slug}[/cyan] from this developer."
     )
-    console.print("[dim]Private Teamspace data was kept intact.[/dim]")
+    console.print("[dim]private workspace data was kept intact.[/dim]")
 
 
 @app.command(name="opt-out")
@@ -2231,11 +2231,11 @@ def opt_out(
         return
 
     confirmed = yes or typer.confirm(
-        "Delete already-synced private Teamspace data for this checkout from SaaS?",
+        "Delete already-synced private workspace data for this checkout from SaaS?",
         default=False,
     )
     if not confirmed:
-        console.print("[dim]Kept private Teamspace data on SaaS.[/dim]")
+        console.print("[dim]Kept private workspace data on SaaS.[/dim]")
         return
 
     try:
@@ -2588,7 +2588,7 @@ def import_history(
 def _resolve_history_import_receiver(
     runtime: _EventSyncRuntime, *, token: str
 ) -> tuple[DeliveryReceiver, str]:
-    """Resolve one gated Teamspace authority for preflight and delivery.
+    """Resolve one gated Team Kitty authority for preflight and delivery.
 
     Fails closed on the operator's *persisted* event-sync mode (#2884 P1):
     import-history uploads a mission's full history, so it must honor
@@ -2661,7 +2661,7 @@ def _render_upload_report(report: UploadReport) -> bool:
 def _run_import_apply(mission: str | None) -> None:
     """The ``import-history --apply`` path: preflight + upload under the real UUID.
 
-    Resolves the authed Teamspace receiver (fail-closed when unauthenticated /
+    Resolves the authed Team Kitty receiver (fail-closed when unauthenticated /
     unconfigured), then delegates to ``apply_import`` which builds the plan with
     the real persisted project UUID, server-preflights the whole stream, and
     uploads it. The server dedups on ``event_id`` so a re-run is idempotent.
@@ -4683,7 +4683,7 @@ def mode(
     )
     if config.mode is Mode.OPT_OUT:
         console.print(
-            "[yellow]Note:[/yellow] OPT_OUT never silently drops Teamspace-bound "
+            "[yellow]Note:[/yellow] OPT_OUT never silently drops Team Kitty-bound "
             "events (C-008 fail-closed); such families are refused or audited at "
             "capture time."
         )
@@ -6049,7 +6049,7 @@ def doctor() -> None:  # noqa: C901
         console.print("[bold green]No issues detected. Sync is healthy.[/bold green]")
         console.print()
 
-    # --- 6. Teamspace-aware recovery (issue #829, Mission 7) ---
+    # --- 6. Team Kitty-aware recovery (issue #829, Mission 7) ---
     # If we surfaced an auth-missing or token-expired issue AND the repo was
     # previously connected to a teamspace, offer interactive recovery (TTY) or
     # emit a structured stderr line + exit 4 (CI). When no teamspace is

--- a/src/specify_cli/cli/commands/tracker.py
+++ b/src/specify_cli/cli/commands/tracker.py
@@ -1,7 +1,7 @@
 """Tracker commands for provider bindings, mappings, and sync operations.
 
 Dispatches to SaaS-backed providers (linear, jira, github, gitlab) via the
-Spec Kitty SaaS control plane, or to local providers (beads, fp) via
+Team Kitty control plane, or to local providers (beads, fp) via
 direct connectors.  Provider credentials are never accepted for SaaS-backed
 providers -- authentication flows through ``spec-kitty auth login``.
 """
@@ -42,7 +42,7 @@ app = typer.Typer(
     help=(
         "Task tracker integration commands.\n\n"
         "SaaS-backed providers (linear, jira, github, gitlab) route through "
-        "the Spec Kitty SaaS control plane.  Local providers (beads, fp) use "
+        "the Team Kitty control plane.  Local providers (beads, fp) use "
         "direct connectors."
     )
 )
@@ -400,7 +400,7 @@ def providers_command(
     """List supported tracker providers, categorized by backend type.
 
     SaaS-backed providers authenticate through ``spec-kitty auth login`` and
-    route sync operations through the Spec Kitty SaaS control plane.
+    route sync operations through the Team Kitty control plane.
 
     Local providers use direct connectors with locally stored credentials.
 

--- a/src/specify_cli/cli/helpers.py
+++ b/src/specify_cli/cli/helpers.py
@@ -267,7 +267,7 @@ def callback(ctx: typer.Context) -> None:
     if ctx.invoked_subcommand is None and "--help" not in sys.argv and "-h" not in sys.argv:
         click.echo(ctx.get_help(), color=ctx.color)
 
-    # Teamspace CLI auth/upgrade readiness coordinator
+    # Team Kitty CLI auth/upgrade readiness coordinator
     # (Priivacy-ai/spec-kitty#1093). First-gated on is_saas_sync_enabled();
     # no-ops when hosted mode is disabled. The coordinator owns the call to
     # _render_nag_if_needed() so downstream missions (WS2 auth, WS3 upgrade

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -510,7 +510,7 @@ def create_mission_core(
     # 8. Event emission
     #
     # Local canonical persistence MUST happen before any SaaS fan-out so
-    # downstream dashboards and TeamSpace can replay a mission's full
+    # downstream dashboards and Team Kitty can replay a mission's full
     # history even when SaaS sync is offline (issue #1067).
     # ------------------------------------------------------------------
     try:
@@ -542,12 +542,12 @@ def create_mission_core(
 
     # Mission creation immediately scaffolds ``spec.md`` and opens
     # the specify phase. Record ``SpecifyStarted`` against the canonical
-    # local log so that TeamSpace replay can show "currently specifying"
+    # local log so that Team Kitty replay can show "currently specifying"
     # before the agent commits substantive spec content (which is where
     # ``setup-plan`` later emits ``SpecifyCompleted``). Without this event
     # the canonical lifecycle stream skips straight from ``MissionCreated``
     # to ``SpecifyCompleted``, leaving the specify-phase entry point
-    # invisible to dashboards and TeamSpace — see issue #1067.
+    # invisible to dashboards and Team Kitty — see issue #1067.
     try:
         from specify_cli.status import (
             SPECIFY_STARTED,

--- a/src/specify_cli/delivery/config.py
+++ b/src/specify_cli/delivery/config.py
@@ -14,7 +14,7 @@ delivery NONE) is genuinely distinct from ``OPT_OUT`` (retention OFF × delivery
 NONE).
 
 **Boundary — policy, never target authority (FR-016, C-007, contract §1).**
-``EventSyncConfig`` MUST NOT resolve or store the Teamspace network server URL.
+``EventSyncConfig`` MUST NOT resolve or store the Team Kitty network server URL.
 When the ``TEAMSPACE`` mode needs a URL it reads it from the WP01-resolved target
 passed into :meth:`EventSyncConfig.resolve` (the :class:`ResolvedTarget`), never
 from this config. The config only carries *operator* parameters that are not
@@ -23,10 +23,10 @@ WP06 :class:`~specify_cli.delivery.receivers.ExternalReceiver`.
 
 **Opt-out safety — never silently drop (C-008, contract §2 rule 4).**
 ``OPT_OUT``/``TRASH`` discards a family **only** when a durability classification
-proves it is local-only or explicitly discardable. A Teamspace-bound discard is
+proves it is local-only or explicitly discardable. A Team Kitty-bound discard is
 *refused* (with an audit-visible reason) or *audit-recorded* through a durable
 source — never a silent no-op. An unknown/unclassified family fails **closed**
-(treated as potentially Teamspace-bound).
+(treated as potentially Team Kitty-bound).
 
 Per **C-001** this module imports only the WP06 receivers; it never imports
 ``sync/queue.py`` or :mod:`specify_cli.events`. The WP01 resolved target is
@@ -54,10 +54,10 @@ from specify_cli.delivery.receivers import (
 # -- Audit-visible reason strings (S1192: referenced across helpers/tests) ------
 _REASON_LOCAL_ONLY = "family classified local-only/explicitly-discardable; safe to discard"
 _REASON_REFUSED = (
-    "refusing to discard a Teamspace-bound family without durable audit evidence "
+    "refusing to discard a Team Kitty-bound family without durable audit evidence "
     "(C-008 fail-closed): no silent drop"
 )
-_REASON_AUDITED = "Teamspace-bound discard recorded to a durable audit source: {ref}"
+_REASON_AUDITED = "Team Kitty-bound discard recorded to a durable audit source: {ref}"
 _ERR_NO_ENDPOINT = "EXTERNAL_RECEIVER mode requires an operator endpoint URL"
 _ERR_NO_TARGET = (
     "TEAMSPACE delivery requires a WP01-resolved target; none was supplied "
@@ -237,7 +237,7 @@ class EventSyncConfig:
     """Retention × delivery policy. Constructed from a named mode (FR-006).
 
     Holds the two axes plus the EXTERNAL_RECEIVER operator parameters
-    (``external_endpoint`` / ``external_auth``). It carries **no** Teamspace
+    (``external_endpoint`` / ``external_auth``). It carries **no** Team Kitty
     server URL — that is target authority (WP01), not policy (FR-016/C-007).
     """
 
@@ -326,7 +326,7 @@ class FamilyClassification(StrEnum):
     """How a durability registry classifies an event family for discard safety.
 
     ``UNKNOWN`` is the fail-closed default: an unclassified family is treated as
-    potentially Teamspace-bound and is never silently dropped.
+    potentially Team Kitty-bound and is never silently dropped.
     """
 
     LOCAL_ONLY = "local_only"
@@ -350,7 +350,7 @@ class DiscardDecisionKind(StrEnum):
 
 @dataclass(frozen=True)
 class DiscardAuditRecord:
-    """A durable record of a Teamspace-bound discard, so the fact is never lost."""
+    """A durable record of a Team Kitty-bound discard, so the fact is never lost."""
 
     event_family: str
     classification: FamilyClassification
@@ -389,7 +389,7 @@ class DiscardDecision:
 
 
 class AuditSink(Protocol):
-    """A durable sink for Teamspace-bound discard evidence (SQLite/JSONL/git audit)."""
+    """A durable sink for Team Kitty-bound discard evidence (SQLite/JSONL/git audit)."""
 
     def record(self, record: DiscardAuditRecord) -> str: ...
 
@@ -438,9 +438,9 @@ def discard_decision(
     """Decide whether ``OPT_OUT`` may discard *event_family* (C-008, contract §2 rule 4).
 
     * local-only / explicitly-discardable → ``discard_allowed``.
-    * Teamspace-bound or unknown (fail-closed) with a durable *audit_sink* →
+    * Team Kitty-bound or unknown (fail-closed) with a durable *audit_sink* →
       ``audit_recorded`` (durable evidence written; the fact is not lost).
-    * Teamspace-bound or unknown with no durable sink → ``refused`` with an
+    * Team Kitty-bound or unknown with no durable sink → ``refused`` with an
       audit-visible reason — **never** a silent drop.
     """
     if classification in _DISCARDABLE_CLASSIFICATIONS:
@@ -460,7 +460,7 @@ def discard_decision(
     record = DiscardAuditRecord(
         event_family=event_family,
         classification=classification,
-        reason="Teamspace-bound family discarded under OPT_OUT; preserved durably",
+        reason="Team Kitty-bound family discarded under OPT_OUT; preserved durably",
         at=now_utc_iso(),
     )
     ref = audit_sink.record(record)

--- a/src/specify_cli/delivery/dispatcher.py
+++ b/src/specify_cli/delivery/dispatcher.py
@@ -16,7 +16,7 @@ orchestrator (T044, complexity ceiling 15; ruff ``C901`` / Sonar ``S3776``):
    active target (FR-004 / FR-015). No SQL lives here; no ``queue.py`` import.
 2. **Post** (:func:`_post`) — hand the selected events to the active target's
    :class:`~specify_cli.delivery.receivers.DeliveryReceiver` (WP06). One dispatch
-   path drives Teamspace / external / stub equivalently — there is **no** target-type
+   path drives Team Kitty / external / stub equivalently — there is **no** target-type
    conditional in this module (contract §4).
 3. **Record** (:func:`_record`) — map each :class:`DeliveryResult` to a WP05 ledger
    write. ``success``/``duplicate`` -> terminal-success; ``pending``/``rejected``/
@@ -286,7 +286,7 @@ def _post(
     """Deliver *events* through the active *receiver* (one path; contract §4).
 
     An empty selection short-circuits without calling the receiver. The receiver
-    owns the per-event result mapping (Teamspace / external / stub alike) — the
+    owns the per-event result mapping (Team Kitty / external / stub alike) — the
     dispatcher carries no target-type branch.
 
     Attribution is taken from the journal's **stored** ``project_uuid`` column,

--- a/src/specify_cli/delivery/interfaces.py
+++ b/src/specify_cli/delivery/interfaces.py
@@ -156,7 +156,7 @@ class DeliveryReceiver(Protocol):
     """One dispatch contract per delivery-target type (**WP06**, contract §4).
 
     Mirrors the contract §4 column semantics (endpoint, auth, gates, per-event
-    result mapping, retry). Teamspace, external-receiver, and stub all implement
+    result mapping, retry). Team Kitty, external-receiver, and stub all implement
     this single contract so the dispatcher carries no target-specific branches.
     """
 

--- a/src/specify_cli/delivery/receivers.py
+++ b/src/specify_cli/delivery/receivers.py
@@ -2,7 +2,7 @@
 
 This module is the load-bearing artifact of **FR-014** and the spec's
 **DeliveryReceiver** Key Entity. It defines *one* dispatch contract that every
-delivery-target type implements, plus the three concrete receivers (Teamspace,
+delivery-target type implements, plus the three concrete receivers (Team Kitty,
 external, stub). The WP07 dispatcher consumes **only** this contract — it must
 never branch on target type (``isinstance``), because every §4 aspect is modeled
 here as data the dispatcher reads uniformly.
@@ -10,11 +10,11 @@ here as data the dispatcher reads uniformly.
 Contract §4 interface matrix (the success boundary):
 
 ============  =================================  ====================  ==================
-Aspect        Teamspace                          External              Stub
+Aspect        Team Kitty                          External              Stub
 ============  =================================  ====================  ==================
 Endpoint      ``{server}/api/v1/events/batch/``  operator URL          localhost/in-proc
 Auth          ``Bearer <token>``                 operator-supplied/``{}``  none (``{}``)
-Gates         SaaS + Private-Teamspace + auth    endpoint-configured   none
+Gates         SaaS + private workspace + auth    endpoint-configured   none
 Results       success/duplicate/pending/         same mapping          same mapping
               rejected/terminal-failed/transient
 Retry         ledger attempt state               ledger attempt state  ledger attempt state
@@ -28,7 +28,7 @@ Three binding rules (§4):
 2. The stub is a **real** receiver implementing this same contract — not a test-only
    alternate dispatch path. It maps results through the **same** :func:`map_batch_response`
    helper as the wire receivers, so its ledger state is indistinguishable from a
-   Teamspace delivery for equivalent payloads (SC-005 / SC-007).
+   Team Kitty delivery for equivalent payloads (SC-005 / SC-007).
 3. Batch *wire* semantics stay compatible with ``contracts/batch-api-contract.md``;
    this mission only shifts the *local* event-row behaviour from delete-on-success to
    ledger-on-success (NFR-006, additive).
@@ -569,11 +569,11 @@ def map_batch_response(
     http_status: int,
     body: Mapping[str, Any] | None,
 ) -> list[DeliveryResult]:
-    """The single response→result mapper shared by Teamspace / external / stub.
+    """The single response→result mapper shared by Team Kitty / external / stub.
 
     Maps a batch HTTP response to one :class:`DeliveryResult` per event using the
     contract §4 vocabulary. Having one mapper (not three) is what makes the stub's
-    ledger state identical to Teamspace's for equivalent payloads (SC-007).
+    ledger state identical to Team Kitty's for equivalent payloads (SC-007).
     """
     if http_status == 200:
         return _map_ok_results(batch, body)
@@ -622,11 +622,11 @@ def _wp_id_of(event: OutboundEvent) -> Hashable:
     return event.event_id
 
 
-# -- The HTTP receivers (Teamspace + external share the transport) -------------
+# -- The HTTP receivers (Team Kitty + external share the transport) -------------
 
 
 class _HttpReceiver:
-    """Shared HTTP-batch transport + mapping for the wire receivers (Teamspace/external).
+    """Shared HTTP-batch transport + mapping for the wire receivers (Team Kitty/external).
 
     Subclasses declare :attr:`endpoint_url`, :meth:`auth_headers`, and :meth:`gates`;
     delivery (build → gzip → POST → map) is shared so the result-mapping logic is
@@ -742,7 +742,7 @@ class TeamspaceReceiver(_HttpReceiver):
 
     Endpoint is ``{resolved_server_url}/api/v1/events/batch/`` (the resolved URL comes
     from the WP04 target authority — never re-derived here, contract §1 / FR-016);
-    auth is ``Bearer <token>``; gates are SaaS-enabled + Private-Teamspace + auth.
+    auth is ``Bearer <token>``; gates are SaaS-enabled + private workspace + auth.
     """
 
     def __init__(
@@ -772,8 +772,8 @@ class ExternalReceiver(_HttpReceiver):
 
     Generalizes the target: it speaks the batch contract and reuses the shared
     mapper, so the stub is just a special case. Its only gate is
-    ``endpoint-configured`` — **no** Teamspace gating (no SaaS-enabled, no
-    Private-Teamspace, no Bearer requirement). Auth is operator-supplied or ``{}``.
+    ``endpoint-configured`` — **no** Team Kitty gating (no SaaS-enabled, no
+    private workspace, no Bearer requirement). Auth is operator-supplied or ``{}``.
     """
 
     def __init__(
@@ -805,8 +805,8 @@ class StubReceiver:
     test-only dispatch fork (§4 rule 2). It records received events for assertions
     and maps outcomes through the **same** :func:`map_batch_response` path as the
     wire receivers, so the ledger state it produces is indistinguishable from a
-    Teamspace delivery for equivalent payloads (SC-007). A repeat ``event_id`` maps
-    to ``duplicate``, mirroring Teamspace idempotency (NFR-003). The sink is guarded
+    Team Kitty delivery for equivalent payloads (SC-007). A repeat ``event_id`` maps
+    to ``duplicate``, mirroring Team Kitty idempotency (NFR-003). The sink is guarded
     by a lock so a daemon test exercising it concurrently cannot corrupt it.
     """
 

--- a/src/specify_cli/event_journal/journal.py
+++ b/src/specify_cli/event_journal/journal.py
@@ -14,7 +14,7 @@ payload store that does **not** know delivery state (FR-003, C-001):
 * :func:`capture_teamspace_bound` is the capture-first writer the emit layer
   calls: it records the fact (with a classified ``drain_blocked_reason``)
   *before* any delivery gate decides whether delivery may proceed (FR-017,
-  contract §2). It refuses to silently drop a Teamspace-bound family (C-008).
+  contract §2). It refuses to silently drop a Team Kitty-bound family (C-008).
 
 This module imports nothing from ``specify_cli.delivery`` (FR-003, C-001).
 """
@@ -593,16 +593,16 @@ def classify_drain_blocked_reason(gate: CaptureGateState) -> str | None:
 
 
 class TeamspaceBoundDropError(RuntimeError):
-    """Raised when a Teamspace-bound family is asked to skip the journal write.
+    """Raised when a Team Kitty-bound family is asked to skip the journal write.
 
     Enforces C-008: such a fact is never silently dropped. Full OPT_OUT/TRASH
-    classification (local-only vs Teamspace-bound vs discardable) is WP09's
-    responsibility; WP03 only guarantees the Teamspace-bound write happens.
+    classification (local-only vs Team Kitty-bound vs discardable) is WP09's
+    responsibility; WP03 only guarantees the Team Kitty-bound write happens.
     """
 
     def __init__(self, *, event_id: str) -> None:
         super().__init__(
-            f"Refusing to silently drop Teamspace-bound event {event_id!r}: "
+            f"Refusing to silently drop Team Kitty-bound event {event_id!r}: "
             "capture-first requires a durable journal write (C-008)."
         )
         self.event_id = event_id
@@ -624,12 +624,12 @@ def capture_teamspace_bound(
     project_slug: str | None = None,
     repo_slug: str | None = None,
 ) -> Event:
-    """Durably capture a Teamspace-bound fact *before* the delivery gates.
+    """Durably capture a Team Kitty-bound fact *before* the delivery gates.
 
     For every event that reaches this function the write is unconditional:
     ``gate`` decides only the recorded ``drain_blocked_reason`` (delivery
     eligibility), never whether the write happens (FR-017, contract §2). A
-    request to skip the write for a Teamspace-bound family fails loudly
+    request to skip the write for a Team Kitty-bound family fails loudly
     (C-008, T018).
 
     **Amended 2026-07-29 (#3030 NFR-005, operator decision).** "Unconditional"
@@ -640,15 +640,15 @@ def capture_teamspace_bound(
     Capture-first durability therefore applies to consenting projects only.
 
     This deliberately reverses the original contract, which held that a
-    Teamspace-bound fact must survive even when every gate blocks. The reason:
+    Team Kitty-bound fact must survive even when every gate blocks. The reason:
     that invariant made the journal a machine-global pool of every local
     project's payloads, and one consenting checkout shipped the lot (the
     2026-07-27 incident, 1,322 events from 5 never-opted-in projects). The
     invariant is preserved *within* a consenting project and abandoned across
     project boundaries.
 
-    Note the axis: consent, not Teamspace-boundedness. Nothing here decides an
-    event is not Teamspace-bound in order to skip it — ``TeamspaceBoundDropError``
+    Note the axis: consent, not Team Kitty-boundedness. Nothing here decides an
+    event is not Team Kitty-bound in order to skip it — ``TeamspaceBoundDropError``
     still fires for that, and the consent refusal happens before this function
     is ever called.
     """

--- a/src/specify_cli/merge/preflight.py
+++ b/src/specify_cli/merge/preflight.py
@@ -324,7 +324,7 @@ def _enforce_canonical_status_history(
     nothing but forced ``planned -> planned`` entries emitted by
     ``finalize-tasks``. When the mission carries work packages that
     must have advanced past planned for merge to make sense, the log
-    is an unreliable source of truth and downstream replay (TeamSpace
+    is an unreliable source of truth and downstream replay (Team Kitty
     rebuild, dashboard refresh) will reset every WP to planned. We
     fail loudly with a remediation hint rather than ship in that
     state. See https://github.com/Priivacy-ai/spec-kitty/issues/1069.

--- a/src/specify_cli/migration/envelope_seam.py
+++ b/src/specify_cli/migration/envelope_seam.py
@@ -1,6 +1,6 @@
 """The deliberate shared surface between migration replay and history import.
 
-``migration.mission_state`` owns the TeamSpace envelope machinery — the
+``migration.mission_state`` owns the Team Kitty envelope machinery — the
 canonical schema version, deterministic id minting, the envelope body
 checksum, the ``WPStatusChanged`` envelope builder, and the mission
 selection / fail-closed audit seams. Its ``__all__`` deliberately demoted

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -1,4 +1,4 @@
-"""Deterministic mission-state repair and TeamSpace dry-run helpers.
+"""Deterministic mission-state repair and Team Kitty dry-run helpers.
 
 This module is the mutating counterpart to ``specify_cli.audit``.  The audit
 package remains read-only; this module is only reached from
@@ -279,7 +279,7 @@ class MissionStateRepairError(RuntimeError):
 
 
 class MissionStateDryRunError(RuntimeError):
-    """Raised when TeamSpace dry-run validation cannot proceed."""
+    """Raised when Team Kitty dry-run validation cannot proceed."""
 
 
 @dataclass(frozen=True)
@@ -395,7 +395,7 @@ class RepairReport:
 
 @dataclass(frozen=True)
 class TeamspaceDryRunRowMapping:
-    """Mapping from one local status row to its synthesized TeamSpace event."""
+    """Mapping from one local status row to its synthesized Team Kitty event."""
 
     mission_slug: str
     artifact_path: str
@@ -487,7 +487,7 @@ def deterministic_ulid(seed: bytes | str) -> str:
 
 
 def envelope_sha256(envelope: Mapping[str, Any]) -> str:
-    """Canonical-JSON SHA-256 of a TeamSpace envelope (single recipe owner).
+    """Canonical-JSON SHA-256 of a Team Kitty envelope (single recipe owner).
 
     Both the migration dry-run's ``TeamspaceDryRunRowMapping.envelope_sha256``
     and the import-history provenance manifest (#2262, via
@@ -596,7 +596,7 @@ def teamspace_dry_run(
     scan_root: Path | None = None,
     mission: str | None = None,
 ) -> TeamspaceDryRunReport:
-    """Synthesize TeamSpace envelopes from local status logs and validate them."""
+    """Synthesize Team Kitty envelopes from local status logs and validate them."""
     event_cls, validate_event, package_version = _load_events_contract()
     mission_dirs = _select_mission_dirs(repo_root.resolve(), scan_root=scan_root, mission=mission)
     audit_errors = _teamspace_audit_blockers(repo_root.resolve(), scan_root=scan_root, mission_dirs=mission_dirs)
@@ -722,7 +722,7 @@ def _teamspace_audit_blockers(
     scan_root: Path | None,
     mission_dirs: Sequence[Path],
 ) -> list[dict[str, object]]:
-    """Return audit findings that must block TeamSpace historical import."""
+    """Return audit findings that must block Team Kitty historical import."""
     from specify_cli.audit import AuditOptions, run_audit
     from specify_cli.audit.models import is_teamspace_blocker
 
@@ -748,7 +748,7 @@ def _teamspace_audit_blockers(
                     "remediation": (
                         "Run `spec-kitty doctor mission-state --audit --fail-on "
                         "teamspace-blocker`, then `--fix`, then "
-                        "`--teamspace-dry-run` before TeamSpace import/sync."
+                        "`--teamspace-dry-run` before Team Kitty import/sync."
                     ),
                 }
             )
@@ -803,7 +803,7 @@ def _teamspace_context_warnings(repo_root: Path, project_uuid: uuid.UUID) -> lis
     warnings.append(
         {
             "code": "TEAMSPACE_TEAM_CONTEXT_NOT_VALIDATED",
-            "message": "Team/private TeamSpace membership is not checked by offline dry-run.",
+            "message": "Team/private workspace membership is not checked by offline dry-run.",
         }
     )
     return warnings
@@ -834,14 +834,14 @@ def _load_events_contract() -> tuple[type[Any], Any, str]:
     package_version = Version(spec_kitty_events.__version__)
     if package_version < REQUIRED_EVENTS_PACKAGE:
         raise MissionStateDryRunError(
-            "TeamSpace dry-run requires spec-kitty-events >= "
+            "Team Kitty dry-run requires spec-kitty-events >= "
             f"{REQUIRED_EVENTS_PACKAGE}; installed {package_version}."
         )
     return Event, validate_event, str(package_version)
 
 
 class _TeamspaceEnvelope(BaseModel):
-    """The SINGLE TeamSpace replay-envelope shape (#2891, CP001/CP002 #2884).
+    """The SINGLE Team Kitty replay-envelope shape (#2891, CP001/CP002 #2884).
 
     The migration ``WPStatusChanged`` builder and the history-import
     creation-prefix builder (``sync.history_import.synthesize._envelope``, via
@@ -901,7 +901,7 @@ def _build_teamspace_envelope(
     correlation_id: str,
     causation_id: str | None = None,
 ) -> _TeamspaceEnvelope:
-    """Construct the SINGLE TeamSpace replay-envelope shell (#2891).
+    """Construct the SINGLE Team Kitty replay-envelope shell (#2891).
 
     Callers that need the wire-format dict (JSONL rows, hashing, upload
     payloads) call ``.model_dump()`` at their own serialization boundary --
@@ -992,7 +992,7 @@ def _historical_teamspace_evidence(
     """Return deterministic evidence for historical approval/done rows.
 
     Older local status rows may have no evidence at all, or may have review
-    evidence without repo evidence. The TeamSpace 5.0.0 event contract requires
+    evidence without repo evidence. The Team Kitty 5.0.0 event contract requires
     evidence for both approved and done transitions, including at least one repo
     entry, so dry-run/import synthesis fills only the missing historical facts.
     """
@@ -1481,7 +1481,7 @@ def _rule_reject_non_status_event(
       emptied healthy mission logs.
     - Any other ``event_type`` / ``event_name`` row is QUARANTINED (its canonical
       state, if any, lives elsewhere). ``_scan_raw_status_rows`` flags the same
-      class before a TeamSpace dry-run.
+      class before a Team Kitty dry-run.
     """
     if _is_preserved_non_lane_row(row):
         return CanonicalStepResult(

--- a/src/specify_cli/migration/normalize_mission_lifecycle.py
+++ b/src/specify_cli/migration/normalize_mission_lifecycle.py
@@ -2,7 +2,7 @@
 
 The goal is not to rewrite historical repositories into a perfect new layout.
 It is to make old missions coherent enough that lifecycle derivation and
-Teamspace-facing projections can reason about them consistently.
+Team Kitty-facing projections can reason about them consistently.
 """
 
 from __future__ import annotations

--- a/src/specify_cli/readiness/auth.py
+++ b/src/specify_cli/readiness/auth.py
@@ -70,7 +70,7 @@ def probe_auth_status(
         if authenticated:
             return (AuthStatus.AUTHENTICATED, None)
 
-        # Step 2: logged-out — does the repo show a connected Teamspace?
+        # Step 2: logged-out — does the repo show a connected Team Kitty workspace?
         from specify_cli.cli.commands._auth_recovery import (  # noqa: PLC0415 — lazy
             detect_logged_out_with_connected_teamspace,
         )

--- a/src/specify_cli/readiness/coordinator.py
+++ b/src/specify_cli/readiness/coordinator.py
@@ -5,7 +5,7 @@ See data model: kitty-specs/cli-startup-readiness-coordinator-skeleton-01KS7JRV/
 See contracts: kitty-specs/cli-startup-readiness-coordinator-skeleton-01KS7JRV/contracts/readiness-api.md
 
 The coordinator's first gate is ``is_saas_sync_enabled()``. When hosted mode is
-disabled the coordinator returns a no-op result and emits no Teamspace-labeled
+disabled the coordinator returns a no-op result and emits no Team Kitty-labeled
 output. When hosted mode is enabled the coordinator composes (stubbed in this
 mission) feature-gate state, output policy, auth readiness, and upgrade
 readiness into a typed ``ReadinessResult`` cached on ``ctx.obj``.
@@ -48,7 +48,7 @@ class OutputPolicy(StrEnum):
 
 
 class AuthStatus(StrEnum):
-    """Coordinator's record of Teamspace-auth state.
+    """Coordinator's record of Team Kitty-auth state.
 
     Wave 1 (issue #1093) shipped ``NOT_CHECKED`` and ``DISABLED``. WS2
     (issue #1094) extends this enum with the authoritative values produced

--- a/src/specify_cli/readiness/render.py
+++ b/src/specify_cli/readiness/render.py
@@ -44,7 +44,7 @@ def _render_interactive_panel(teamspace: str, command_name: str) -> None:
     fails to import or render.
     """
     body = (
-        f"This repo is connected to Teamspace [cyan]{teamspace}[/cyan], "
+        f"This repo is connected to Team Kitty [cyan]{teamspace}[/cyan], "
         f"but you are not logged in.\n"
         f"Command: [dim]spec-kitty {command_name}[/dim]\n\n"
         f"Run: [bold]{_AUTH_LOGIN_REMEDIATION}[/bold] to re-authenticate."
@@ -57,7 +57,7 @@ def _render_interactive_panel(teamspace: str, command_name: str) -> None:
         console = Console(file=sys.stderr, force_terminal=False, highlight=False)
         panel = Panel(
             body,
-            title="Logged out on a connected Teamspace",
+            title="Logged out on a connected Team Kitty workspace",
             border_style="yellow",
             expand=False,
         )
@@ -71,8 +71,8 @@ def _render_interactive_panel(teamspace: str, command_name: str) -> None:
     # interactive test assertions hold.
     try:
         sys.stderr.write(
-            "Logged out on a connected Teamspace\n"
-            f"  Teamspace: {teamspace}\n"
+            "Logged out on a connected Team Kitty workspace\n"
+            f"  Team Kitty: {teamspace}\n"
             f"  Command:   spec-kitty {command_name}\n"
             f"  Run: {_AUTH_LOGIN_REMEDIATION} to re-authenticate.\n"
         )

--- a/src/specify_cli/saas/readiness.py
+++ b/src/specify_cli/saas/readiness.py
@@ -1,4 +1,4 @@
-"""Hosted-readiness evaluator for the Spec Kitty SaaS sync subsystem.
+"""Hosted-readiness evaluator for the Team Kitty sync subsystem.
 
 Stability contract: ``kitty-specs/082-stealth-gated-saas-sync-hardening/contracts/hosted_readiness.md``
 

--- a/src/specify_cli/saas_client/client.py
+++ b/src/specify_cli/saas_client/client.py
@@ -202,7 +202,7 @@ class SaasClient:
     def _resolve_team_slug(self, team_slug: str | None = None) -> str:
         slug = (team_slug or self._team_slug or "").strip()
         if not slug:
-            raise SaasAuthError("SaaS team_slug is required for Teamspace-scoped Decision Moment endpoints")
+            raise SaasAuthError("SaaS team_slug is required for Team Kitty-scoped Decision Moment endpoints")
         return slug
 
     def _team_path(self, team_slug: str | None, path: str) -> str:
@@ -217,7 +217,7 @@ class SaasClient:
 
         ``GET /a/{team_slug}/collaboration/missions/{id}/audience-default``
 
-        Returns Teamspace member dicts containing at least ``user_id`` and
+        Returns Team Kitty workspace member dicts containing at least ``user_id`` and
         ``display_name``. Legacy bare-string responses are tolerated for older
         test stubs by returning display-name-only member dicts.
 
@@ -259,7 +259,7 @@ class SaasClient:
 
         Args:
             decision_id: ULID of the decision point to widen.
-            invited: List of Teamspace user IDs to invite.
+            invited: List of Team Kitty member IDs to invite.
 
         Returns:
             :class:`~specify_cli.saas_client.endpoints.WidenResponse` with

--- a/src/specify_cli/saas_client/endpoints.py
+++ b/src/specify_cli/saas_client/endpoints.py
@@ -28,7 +28,7 @@ class WidenResponse(TypedDict):
 
 
 class AudienceMember(TypedDict, total=False):
-    """A Teamspace member returned by the audience-default endpoint."""
+    """A Team Kitty workspace member returned by the audience-default endpoint."""
 
     user_id: int
     display_name: str

--- a/src/specify_cli/saas_client/errors.py
+++ b/src/specify_cli/saas_client/errors.py
@@ -47,7 +47,7 @@ class SaasConsentError(SaasClientError):
 
     def __init__(self, reason: str) -> None:
         super().__init__(
-            f"Refusing to call Spec Kitty SaaS: {reason}",
+            f"Refusing to call Team Kitty: {reason}",
             status_code=None,
         )
         self.reason = reason

--- a/src/specify_cli/status/lifecycle.py
+++ b/src/specify_cli/status/lifecycle.py
@@ -1,4 +1,4 @@
-"""Canonical mission lifecycle derivation for local and Teamspace-facing surfaces.
+"""Canonical mission lifecycle derivation for local and Team Kitty-facing surfaces.
 
 This module intentionally sits above the WP lane model.  It translates
 authoritative mission status snapshots into a small set of product-facing

--- a/src/specify_cli/status/lifecycle_events.py
+++ b/src/specify_cli/status/lifecycle_events.py
@@ -4,7 +4,7 @@ This module is the durable, local-first writer for the canonical event
 stream that records project initialization, mission creation,
 spec/plan/tasks artifact lifecycle, and work-package creation. Lifecycle
 events land on disk synchronously *before* any best-effort SaaS outbox
-fan-out, so local dashboards and TeamSpace import always have a complete
+fan-out, so local dashboards and Team Kitty import always have a complete
 history even when the scoped sync boundary is unavailable.
 
 Two log targets exist:

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -203,7 +203,7 @@ def _lifecycle_saas_fanout_handler(**kwargs):  # type: ignore[no-untyped-def]
 
     Constructs the SaaS wire envelope from the local lifecycle event and
     queues it into the offline outbox when sync is enabled and a valid
-    Teamspace scope is available. Strict canonical-payload validation
+    Team Kitty scope is available. Strict canonical-payload validation
     runs here (see ``_validate_lifecycle_payload``) so schema-drift
     becomes an emit-time error, not an RC-canary failure
     (issues Priivacy-ai/spec-kitty#1198 / #1200).

--- a/src/specify_cli/sync/_team.py
+++ b/src/specify_cli/sync/_team.py
@@ -26,7 +26,7 @@ def resolve_private_team_id_for_ingress(
     *,
     endpoint: str,
 ) -> str | None:
-    """Return the Private Teamspace id for a direct-ingress request, else None. SYNC.
+    """Return the private workspace id for a direct-ingress request, else None. SYNC.
 
     Performs at most one /api/v1/me rehydrate per CLI process for shared-only sessions
     (single-flight + negative-cache enforced inside TokenManager). On a None return,
@@ -44,7 +44,7 @@ def resolve_private_team_id_for_ingress(
     Returns
     -------
     str | None
-        A Private Teamspace id when one is available, otherwise None.
+        A private workspace id when one is available, otherwise None.
     """
     if not is_saas_sync_enabled():
         return None

--- a/src/specify_cli/sync/batch.py
+++ b/src/specify_cli/sync/batch.py
@@ -79,7 +79,7 @@ CATEGORY_ACTIONS: dict[str, str] = {
     "schema_mismatch": "Run `spec-kitty sync diagnose` to inspect invalid events",
     "auth_expired": "Run `spec-kitty auth login` to refresh credentials",
     "unauthenticated": "Run `spec-kitty auth login` to authenticate",
-    CATEGORY_MISSING_PRIVATE_TEAM: ("Private Teamspace access is required for direct ingress"),
+    CATEGORY_MISSING_PRIVATE_TEAM: ("private workspace access is required for direct ingress"),
     "retryable_transport": "Retry later or check network connectivity",
     "server_error": "Retry later or check server status",
     "unknown": "Inspect the failure report for details: --report <file.json>",
@@ -116,8 +116,8 @@ HISTORICAL_MISSION_STATE_FORBIDDEN_KEYS = frozenset(
 def _current_team_slug() -> str | None:
     """Resolve the ingress team slug via the strict shared helper. SYNC.
 
-    Returns the user's Private Teamspace id, or ``None`` when no Private
-    Teamspace is available (in which case the helper has already emitted
+    Returns the user's private workspace id, or ``None`` when no private
+    workspace is available (in which case the helper has already emitted
     a structured warning and callers MUST NOT send the ingress request).
     """
     try:
@@ -269,7 +269,7 @@ def _historical_mission_state_rejection(events: list[dict]) -> BatchSyncResult |
     result.error_count = len(by_event)
     result.failed_ids = sorted(by_event)
     message = (
-        "Historical mission-state rows cannot be sent directly to TeamSpace. "
+        "Historical mission-state rows cannot be sent directly to Team Kitty. "
         "Run `spec-kitty doctor mission-state --audit --fail-on teamspace-blocker`, "
         "then `--fix`, then `--teamspace-dry-run` before sync/import."
     )
@@ -546,8 +546,8 @@ class BatchEventResult:
               **incremented**.
             * ``failed_transient`` -- batch-level failure where the server
               never evaluated individual events: HTTP 401/403/5xx, transport
-              timeouts/connection errors, or the pre-flight "no Private
-              Teamspace" skip. The queue row is **left untouched** (no DELETE,
+              timeouts/connection errors, or the pre-flight "no private
+              workspace" skip. The queue row is **left untouched** (no DELETE,
               no ``retry_count`` bump) so transient outages cannot poison the
               retry counter. See issue Priivacy-ai/spec-kitty#889.
 
@@ -1034,7 +1034,7 @@ def batch_sync(  # noqa: C901
         # structured ``logger.warning`` (with category, rehydrate_attempted,
         # ingress_sent, endpoint), which is the sole skip diagnostic. Skip the
         # ingress POST entirely and leave events in the durable queue for a
-        # future drain after the SaaS provisions a Private Teamspace for this
+        # future drain after the SaaS provisions a private workspace for this
         # user. FR-009 prohibits adding a stdout ``print`` here.
         #
         # Append a sentinel error message so ``sync_all_queued_events`` can
@@ -1050,7 +1050,7 @@ def batch_sync(  # noqa: C901
         _record_all_events_failed(
             result,
             events,
-            error="skipped: no Private Teamspace available for direct ingress",
+            error="skipped: no private workspace available for direct ingress",
             category=CATEGORY_MISSING_PRIVATE_TEAM,
             transient=True,
         )
@@ -1436,7 +1436,7 @@ def sync_all_queued_events(
         # Stop if no progress made. This covers two cases:
         #   1. All events in the batch failed (error_count > 0).
         #   2. The batch was skipped entirely because the strict private-team
-        #      resolver returned None (FR-002/FR-004 — no Private Teamspace
+        #      resolver returned None (FR-002/FR-004 — no private workspace
         #      means no direct ingress; the helper's structured warning is the
         #      sole stderr diagnostic). Without this, sync_all_queued_events
         #      would spin forever on a shared-only session because the queue
@@ -1485,5 +1485,5 @@ def _should_stop_sync_loop(result: BatchSyncResult, show_progress: bool) -> bool
         if result.error_count > 0:
             print("Stopping: No events successfully synced in this batch")
         else:
-            print("Stopping: Batch skipped (no Private Teamspace; see structured stderr diagnostic)")
+            print("Stopping: Batch skipped (no private workspace; see structured stderr diagnostic)")
     return True

--- a/src/specify_cli/sync/client.py
+++ b/src/specify_cli/sync/client.py
@@ -124,7 +124,7 @@ class WebSocketClient:
             self.status = ConnectionStatus.OFFLINE
             raise AuthenticationError(saas_sync_disabled_message())
 
-        # Resolve the Private Teamspace id via the strict shared helper.
+        # Resolve the private workspace id via the strict shared helper.
         # On None the helper has already emitted a structured warning, and the
         # local command MUST still succeed (FR-010), so we silently go OFFLINE
         # rather than raise.

--- a/src/specify_cli/sync/diagnostics.py
+++ b/src/specify_cli/sync/diagnostics.py
@@ -73,7 +73,7 @@ def classify_sync_error(error_text: str) -> SyncDiagnosticCode:
     Fallback to SERVER_AUTH_FAILURE for unrecognized signals.
     """
     lower = error_text.lower()
-    # A shared-only session that reaches ingress with no Private Teamspace is a
+    # A shared-only session that reaches ingress with no private workspace is a
     # benign skip (events stay durable and retry), NOT an auth failure. Classify
     # it before the auth/catch-all so the canonical
     # ``direct_ingress_missing_private_team`` category surfaces on the diagnostic

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -870,8 +870,8 @@ class EventEmitter:
     def _current_team_slug() -> str | None:
         """Resolve the ingress team slug via the strict shared helper. SYNC.
 
-        Returns the user's Private Teamspace id, or ``None`` when no Private
-        Teamspace is available. On ``None`` the shared helper has already
+        Returns the user's private workspace id, or ``None`` when no private
+        workspace is available. On ``None`` the shared helper has already
         emitted the structured warning and emission of any event that
         requires an ingress team-id MUST be skipped.
         """
@@ -1300,7 +1300,7 @@ class EventEmitter:
 
         The payload follows spec-kitty-events ``MissionClosedPayload`` exactly.
         Historical close details such as ``total_wps`` and close timestamps are
-        intentionally not emitted in the TeamSpace payload.
+        intentionally not emitted in the Team Kitty payload.
         """
         from spec_kitty_events.lifecycle import MissionClosedPayload
 
@@ -1872,7 +1872,7 @@ class EventEmitter:
     #                     project** has not consented to hosted sync (#3030 M1-1;
     #                     it used to mean "the checkout cwd happens to be in").
     # ``"no_auth"``       no authenticated session; drain cannot ship.
-    # ``"no_team"``       authenticated but the strict Private Teamspace
+    # ``"no_team"``       authenticated but the strict private workspace
     #                     resolver returned None (ingress safety).
     #
     # The flag is captured at emit time as a diagnostic. The drain loop
@@ -2061,7 +2061,7 @@ class EventEmitter:
     ) -> None:
         """Capture-first durable write to the producer-scoped event journal.
 
-        Runs before every delivery gate so a Teamspace-bound fact survives even
+        Runs before every delivery gate so a Team Kitty-bound fact survives even
         when all gates block (FR-017, contract §2; SC-009). Producer-scoped,
         never server-scoped (FR-003). A journal I/O error is warned but never
         propagated — capture-first must not make emission fail.
@@ -2166,7 +2166,7 @@ class EventEmitter:
 
             # Resolve identity, team_slug (may be None), and git metadata.
             # When the global SaaS feature flag is disabled, avoid even
-            # touching the direct-ingress Teamspace resolver; feature-disabled
+            # touching the direct-ingress Team Kitty resolver; feature-disabled
             # runs should not emit feature-specific warnings.
             identity = self._get_identity()
             team_slug = self._get_team_slug() if is_saas_sync_enabled() else None
@@ -2213,7 +2213,7 @@ class EventEmitter:
                 event.update(envelope_fields)
 
             # Capture-first (FR-017, contract §2; SC-009): durably record the
-            # Teamspace-bound fact in the producer-scoped event journal BEFORE
+            # Team Kitty-bound fact in the producer-scoped event journal BEFORE
             # any delivery gate (validation, contract gate, project routing,
             # WebSocket, drain) can decide whether to ship it.
             #
@@ -2271,8 +2271,8 @@ class EventEmitter:
     def _get_team_slug(self) -> str | None:
         """Get team_slug from the active TokenManager session.
 
-        Returns the user's Private Teamspace id, or ``None`` when no Private
-        Teamspace is available for direct ingress (FR-002/FR-007 of the
+        Returns the user's private workspace id, or ``None`` when no private
+        workspace is available for direct ingress (FR-002/FR-007 of the
         private-teamspace-ingress-safeguards mission). On ``None`` the
         caller MUST skip event emission rather than fall back to a shared
         or ``"local"`` team value.
@@ -2287,7 +2287,7 @@ class EventEmitter:
 
     @staticmethod
     def _get_cached_private_team_slug() -> str | None:
-        """Read Private Teamspace id from cached auth session without ingress I/O."""
+        """Read private workspace id from cached auth session without ingress I/O."""
         try:
             from specify_cli.auth import get_token_manager
             from specify_cli.auth.session import require_private_team_id

--- a/src/specify_cli/sync/history_import/pipeline.py
+++ b/src/specify_cli/sync/history_import/pipeline.py
@@ -32,7 +32,7 @@ from specify_cli.sync.history_import.upload import (
 
 
 class ImportAuditBlocked(RuntimeError):
-    """Raised when the fail-closed TeamSpace audit finds blocking findings.
+    """Raised when the fail-closed Team Kitty audit finds blocking findings.
 
     Carries the blocker records (each a dict with at least ``mission_slug`` and
     ``message``) so the caller can name them without re-running the audit.

--- a/src/specify_cli/sync/history_import/synthesize.py
+++ b/src/specify_cli/sync/history_import/synthesize.py
@@ -1,7 +1,7 @@
 """SYNTHESIZE stage for ``sync import-history`` (WP-Y3, #2262).
 
 Turns a :class:`~specify_cli.sync.history_import.scan.MissionScan` into the
-ordered TeamSpace envelope stream
+ordered Team Kitty envelope stream
 
     MissionCreated → WPCreated[] → WPStatusChanged[]
 
@@ -17,7 +17,7 @@ Reuse (spec §3.3 stage 5):
 * ``WPStatusChanged`` envelopes are built by the existing
   :func:`~specify_cli.migration.envelope_seam.status_event_to_teamspace_envelope`
   (via the deliberate ``migration.envelope_seam`` surface), so the lane
-  back-fill and the historical-evidence synthesis (required by the TeamSpace
+  back-fill and the historical-evidence synthesis (required by the Team Kitty
   5.0.0 contract on ``approved``/``done``) are not re-implemented here.
 * ``MissionCreated`` / ``WPCreated`` payloads are built by the canonical
   ``build_mission_created_payload`` and ``WPCreatedPayload`` so the wire shapes
@@ -247,7 +247,7 @@ def _envelope(
     lamport: int,
     identity: _EnvelopeIdentity,
 ) -> dict[str, Any]:
-    """Assemble the creation-prefix TeamSpace envelope via the shared shell.
+    """Assemble the creation-prefix Team Kitty envelope via the shared shell.
 
     The 15-key envelope shell is owned by ``build_teamspace_envelope`` (the same
     owner the migration ``WPStatusChanged`` builder uses, re-exported through

--- a/src/specify_cli/sync/lint_report_staging.py
+++ b/src/specify_cli/sync/lint_report_staging.py
@@ -4,7 +4,7 @@ The charter-lint engine writes a single repo-global report at
 ``<repo_root>/.kittify/lint-report.json`` (see
 ``specify_cli.charter_runtime.lint.findings.DecayReport``). The dossier
 indexer only scans a mission's ``feature_dir``, so the report has to be
-copied in before indexing for the downstream Teamspace SaaS dossier indexer
+copied in before indexing for the downstream Team Kitty SaaS dossier indexer
 to surface it (issue #2481, unblocks saas #392).
 
 Staging is scoped: the report is copied into the mission dossier only when it

--- a/src/specify_cli/sync/owner.py
+++ b/src/specify_cli/sync/owner.py
@@ -1032,7 +1032,7 @@ def build_record_for_current_process(
     plus the supplied PID/port/token and the current UTC timestamp.
 
     Daemon startup passes ``allow_network=False`` for the initial owner
-    record so TeamSpace membership rehydrate can never delay the first
+    record so Team Kitty membership rehydrate can never delay the first
     health response.
     """
     identity = compute_foreground_identity(allow_network=allow_network)

--- a/src/specify_cli/sync/preflight.py
+++ b/src/specify_cli/sync/preflight.py
@@ -423,14 +423,14 @@ def _read_queue_scope_local_only() -> str | None:
     ``resolve_private_team_id_for_ingress`` which can transitively invoke
     ``TokenManager.rehydrate_membership_if_needed()`` — and that issues a
     ``GET /api/v1/me`` HTTP request when the in-memory session lacks a
-    Private Teamspace. That violates the preflight contract
+    private workspace. That violates the preflight contract
     (``contracts/sync-boundary-preflight.md``: "The helper does not mutate
     state and does not call SaaS endpoints").
 
     This helper replicates the on-disk-only portion of that logic:
 
     1. Inspect the in-memory ``TokenManager`` session (no rehydrate). If
-       the session already exposes a Private Teamspace, derive the scope
+       the session already exposes a private workspace, derive the scope
        from it via the pure helper :func:`require_private_team_id`.
     2. Otherwise, fall back to reading credentials directly from disk via
        :func:`read_queue_scope_from_credentials`, which is a pure TOML
@@ -490,7 +490,7 @@ def _read_scope_identity_local_only() -> tuple[str, str] | None:
         # ``require_private_team_id`` is a pure function (no I/O, no
         # mutation) — see specify_cli.auth.session. It returns ``None``
         # without attempting any rehydrate when the in-memory session
-        # has no Private Teamspace, which is exactly the read-only
+        # has no private workspace, which is exactly the read-only
         # behaviour the preflight contract requires.
         team_id = require_private_team_id(session)
         if team_id is not None:
@@ -518,7 +518,7 @@ def _resolve_queue_db_path_readonly() -> Path:
     Additionally, ``read_queue_scope_from_session`` (which the prior
     cycle-2 fix used) can transitively reach
     ``TokenManager.rehydrate_membership_if_needed()`` → ``GET /api/v1/me``
-    when the in-memory session lacks a Private Teamspace, which would be a
+    when the in-memory session lacks a private workspace, which would be a
     SaaS round-trip from inside the preflight. Cycle-3 routes through
     :func:`_read_queue_scope_local_only` instead — strictly on-disk /
     in-memory reads, no SaaS.
@@ -568,7 +568,7 @@ def collect_foreground_identity(repo_root: Path) -> ForegroundIdentity:
     # through ``resolve_private_team_id_for_ingress`` →
     # ``TokenManager.rehydrate_membership_if_needed`` which can issue a
     # ``GET /api/v1/me`` HTTP request when the in-memory session lacks a
-    # Private Teamspace. The preflight contract forbids any SaaS
+    # private workspace. The preflight contract forbids any SaaS
     # round-trip. We use :func:`_read_queue_scope_local_only` instead —
     # strictly on-disk + pure-function reads.
     from specify_cli.sync.daemon import _get_package_version

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -475,8 +475,8 @@ def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None
     """Read queue scope from the real encrypted auth session store.
 
     Returns None when the session is missing, unreadable, or incomplete, or
-    when the session lacks a Private Teamspace (FR-002/FR-004 — direct ingress
-    requires a Private Teamspace; the shared helper emits the structured
+    when the session lacks a private workspace (FR-002/FR-004 — direct ingress
+    requires a private workspace; the shared helper emits the structured
     warning and the queue-scope path skips by returning ``None``).
     """
     # FR-002/FR-004/NFR-002 + NFR-001: ingress team-id derivation must go
@@ -511,7 +511,7 @@ def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None
     else:
         team_id = require_private_team_id(session)
     if team_id is None:
-        # Queue scope cannot be safely derived without a Private Teamspace;
+        # Queue scope cannot be safely derived without a private workspace;
         # leave events in any existing scoped queue and return None so
         # callers fall back to non-ingress paths.
         return None
@@ -1730,7 +1730,7 @@ class OfflineQueue:
           event and refused it.
         * ``failed_transient`` -> **no mutation**. Batch-level failures
           (HTTP 401/403/5xx, transport timeouts, connection errors, or the
-          pre-flight "no Private Teamspace" skip) never reach individual
+          pre-flight "no private workspace" skip) never reach individual
           events on the server, so per-event retry attribution is wrong.
           Leaving these rows untouched lets the daemon retry on its next
           tick without poisoning the retry counter. Issue #889.

--- a/src/specify_cli/sync/runtime_event_emitter.py
+++ b/src/specify_cli/sync/runtime_event_emitter.py
@@ -16,8 +16,8 @@ class SyncRuntimeEventEmitter:
     Capture-first (FR-017, contract §2) is inherited, not re-implemented here:
     every ``emit_*`` callback forwards to the canonical
     :class:`~specify_cli.sync.emitter.EventEmitter`, whose ``_emit`` writes the
-    Teamspace-bound fact to the producer-scoped event journal *before* any
-    SaaS/auth/team/Private-Teamspace/network gate is evaluated. These runtime
+    Team Kitty-bound fact to the producer-scoped event journal *before* any
+    SaaS/auth/team/private workspace/network gate is evaluated. These runtime
     mission/phase/decision facts are therefore durably captured even when sync
     is disabled or auth/team are missing (SC-009).
     """
@@ -137,15 +137,15 @@ class SyncRuntimeEventEmitter:
             )
 
     def emit_significance_evaluated(self, payload: Any) -> None:
-        # WP09: significance/timeout signals have no canonical Teamspace-bound
+        # WP09: significance/timeout signals have no canonical Team Kitty-bound
         # emit method yet, so they are intentionally not produced (and thus not
-        # journaled). Classifying which families are Teamspace-bound vs
+        # journaled). Classifying which families are Team Kitty-bound vs
         # local-only/discardable (the full OPT_OUT/TRASH policy) is WP09's
-        # responsibility; this is not a silent drop of a Teamspace-bound fact.
+        # responsibility; this is not a silent drop of a Team Kitty-bound fact.
         del payload
 
     def emit_decision_timeout_expired(self, payload: Any) -> None:
-        # WP09: see emit_significance_evaluated — no Teamspace-bound family is
+        # WP09: see emit_significance_evaluated — no Team Kitty-bound family is
         # produced here; family classification is deferred to WP09.
         del payload
 

--- a/src/specify_cli/tracker/saas_client.py
+++ b/src/specify_cli/tracker/saas_client.py
@@ -81,7 +81,7 @@ class TrackerEgressRefusedError(SaaSTrackerClientError):
 
     def __init__(self, reason: str) -> None:
         super().__init__(
-            f"Refusing to send tracker data to Spec Kitty SaaS: {reason}",
+            f"Refusing to send tracker data to Team Kitty: {reason}",
             error_code="project_consent_denied",
             status_code=None,
             details={"category": "project_consent_denied", "reason": reason},
@@ -362,12 +362,12 @@ class SaaSTrackerClient:
                 )
         except httpx.ConnectError as exc:
             raise SaaSTrackerClientError(
-                f"Cannot connect to Spec Kitty SaaS at {url}. "
+                f"Cannot connect to Team Kitty at {url}. "
                 "Check your network connection."
             ) from exc
         except httpx.TimeoutException as exc:
             raise SaaSTrackerClientError(
-                f"Cannot connect to Spec Kitty SaaS at {url}. "
+                f"Cannot connect to Team Kitty at {url}. "
                 "Check your network connection."
             ) from exc
 

--- a/src/specify_cli/upgrade/migrations/m_3_2_0a4_normalize_mission_lifecycle.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_0a4_normalize_mission_lifecycle.py
@@ -3,7 +3,7 @@
 This migration repairs historical ``kitty-specs`` missions enough that the
 canonical lifecycle model can classify them consistently. It backfills
 identity, rebuilds missing event logs from legacy state, and regenerates the
-status/progress/lifecycle projections consumed by the CLI and Teamspace.
+status/progress/lifecycle projections consumed by the CLI and Team Kitty.
 """
 
 from __future__ import annotations

--- a/src/specify_cli/widen/audience.py
+++ b/src/specify_cli/widen/audience.py
@@ -115,7 +115,7 @@ def run_audience_review(
         console: Rich Console for rendering output and prompting.
 
     Returns:
-        Confirmed display names and Teamspace user IDs to pass to SaaS, or
+        Confirmed display names and Team Kitty member IDs to pass to SaaS, or
         ``None`` if the user canceled or a SaaS error occurred.
     """
     # --- T020: Fetch audience from SaaS with typed error handling ---
@@ -182,7 +182,7 @@ def run_audience_review(
 
     if missing_ids:
         console.print(
-            "[red]Widen failed:[/red] SaaS audience entries are missing Teamspace user IDs for "
+            "[red]Widen failed:[/red] SaaS audience entries are missing Team Kitty member IDs for "
             f"{', '.join(missing_ids)}."
         )
         console.print("Returning to interview prompt.")

--- a/src/specify_cli/widen/models.py
+++ b/src/specify_cli/widen/models.py
@@ -45,7 +45,7 @@ class PrereqState:
     """
 
     teamspace_ok: bool
-    """User is a member of at least one Teamspace."""
+    """User is a member of at least one Team Kitty workspace."""
 
     slack_ok: bool
     """Team has Slack integration configured."""

--- a/src/specify_cli/widen/prereq.py
+++ b/src/specify_cli/widen/prereq.py
@@ -3,7 +3,7 @@
 Determines whether the ``[w]iden`` option is shown to the user by checking
 three conditions synchronously:
 
-1. Teamspace membership (token presence check)
+1. Team Kitty membership (token presence check)
 2. Slack integration (``GET /api/v1/teams/{slug}/integrations``)
 3. SaaS reachability (``GET /api/v1/health``)
 
@@ -48,10 +48,10 @@ def check_prereqs(saas_client: SaasClient, team_slug: str) -> PrereqState:
 
 
 def _check_teamspace(client: SaasClient) -> bool:
-    """Teamspace membership derived from token presence.
+    """Team Kitty membership derived from token presence.
 
     If a non-empty token is present and valid, the user is considered a
-    Teamspace member.  Returns ``False`` on ``SaasAuthError`` or any error.
+    Team Kitty member.  Returns ``False`` on ``SaasAuthError`` or any error.
     """
     try:
         # A non-empty token = token-authenticated = teamspace member

--- a/tests/agent/cli/commands/conftest.py
+++ b/tests/agent/cli/commands/conftest.py
@@ -2,7 +2,7 @@
 
 The M7 ``enforce_teamspace_mission_state_ready`` gate audits the local
 project root before any sync/tracker call path runs. In the test
-environment, spec-kitty's own ``.kittify/`` contains TeamSpace blockers
+environment, spec-kitty's own ``.kittify/`` contains Team Kitty blockers
 (FORBIDDEN_KEY) — so the gate raises ``typer.Exit(1)`` before the test's
 intended assertion can run.
 
@@ -17,7 +17,7 @@ Pattern mirrors the per-class fixture introduced for
 directory level here because the tracker test suite is module-level
 (no class scope to attach an autouse fixture to).
 
-Phase 6 (issue #1288) decoupled identity acquisition from TeamSpace
+Phase 6 (issue #1288) decoupled identity acquisition from Team Kitty
 mission-state readiness; the auth-login module no longer imports the
 gate and therefore is not stubbed here.
 """

--- a/tests/agent/cli/commands/test_sync.py
+++ b/tests/agent/cli/commands/test_sync.py
@@ -405,7 +405,7 @@ class TestSyncNowExitCodes:
         the FR-002 sync-now structural preflight.
 
         Both gates audit the local project root before any sync work. In the
-        spec-kitty checkout the gates surface TeamSpace / daemon-owner
+        spec-kitty checkout the gates surface Team Kitty / daemon-owner
         blockers that raise ``typer.Exit(1)`` or ``typer.Exit(2)`` before the
         sync exit-code semantics under test can be observed. Tests here
         exercise the post-gate contract, so both gates are stubbed at the

--- a/tests/architectural/test_team_kitty_product_name.py
+++ b/tests/architectural/test_team_kitty_product_name.py
@@ -1,0 +1,47 @@
+"""Keep active product language canonical while compatibility symbols migrate."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+SCANNED = (
+    ROOT / "src",
+    ROOT / "docs",
+    ROOT / "README.md",
+    ROOT / "MANUAL_TEST_PLAN.md",
+    ROOT / "AGENTS.md",
+)
+REJECTED_PRODUCT_LANGUAGE = re.compile(
+    r"\b(?:Team" + "Space|Team" + "space|Kitty" + "Space|Spec Kitty " + r"SaaS)\b"
+)
+
+
+def _active_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCANNED:
+        if root.is_file():
+            files.append(root)
+            continue
+        files.extend(
+            path
+            for path in root.rglob("*")
+            if path.suffix in {".py", ".md", ".json", ".yaml", ".yml", ".html"}
+            and "archive" not in path.parts
+        )
+    return files
+
+
+def test_active_product_language_names_team_kitty() -> None:
+    violations: list[str] = []
+
+    for path in _active_files():
+        for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+            if REJECTED_PRODUCT_LANGUAGE.search(line):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line_number}: {line.strip()}"
+                )
+
+    assert not violations, "Retired product name found:\n" + "\n".join(violations)

--- a/tests/audit/test_audit_cli.py
+++ b/tests/audit/test_audit_cli.py
@@ -54,7 +54,7 @@ def _make_corrupt_mission(parent: Path, slug: str = "corrupt-mission") -> Path:
 
 
 def _make_legacy_mission(parent: Path, slug: str = "legacy-mission") -> Path:
-    """Create a mission directory with a TeamSpace-blocking legacy warning."""
+    """Create a mission directory with a Team Kitty-blocking legacy warning."""
     mission_dir = parent / slug
     mission_dir.mkdir(parents=True, exist_ok=True)
     (mission_dir / "meta.json").write_text(

--- a/tests/auth/concurrency/test_machine_refresh_lock.py
+++ b/tests/auth/concurrency/test_machine_refresh_lock.py
@@ -105,7 +105,7 @@ class _CountingRefreshFlow:
             email=session.email,
             name=session.name,
             # The refresh-lock contract is about single-flight refresh, not
-            # post-refresh membership rehydrate. Return a Private Teamspace so
+            # post-refresh membership rehydrate. Return a private workspace so
             # TokenManager's membership hook is a no-op in this suite.
             teams=[_private_teamspace()],
             default_team_id="t-private",

--- a/tests/auth/concurrency/test_single_flight_refresh.py
+++ b/tests/auth/concurrency/test_single_flight_refresh.py
@@ -118,7 +118,7 @@ class _FakeRefreshFlow:
             email=session.email,
             name=session.name,
             # This suite validates refresh single-flight behavior, not
-            # membership rehydrate. Return a Private Teamspace so the
+            # membership rehydrate. Return a private workspace so the
             # post-refresh hook remains a no-op and the test stays hermetic.
             teams=[_private_teamspace()],
             default_team_id="t-private",

--- a/tests/auth/concurrency/test_stale_grant_preservation.py
+++ b/tests/auth/concurrency/test_stale_grant_preservation.py
@@ -123,7 +123,7 @@ class _RotateOnceFlow:
                 email=session.email,
                 name=session.name,
                 # This suite validates refresh reconciliation, not membership
-                # rehydrate. Return a Private Teamspace so TokenManager's
+                # rehydrate. Return a private workspace so TokenManager's
                 # post-refresh hook remains a no-op.
                 teams=[_private_teamspace()],
                 default_team_id="t-private",

--- a/tests/auth/test_authorization_code_flow.py
+++ b/tests/auth/test_authorization_code_flow.py
@@ -270,7 +270,7 @@ class TestBuildSession:
         me = _me_response(
             teams=[
                 {"id": "t-shared", "name": "Shared Team", "role": "member", "is_private_teamspace": False},
-                {"id": "t-private", "name": "Private Teamspace", "role": "owner", "is_private_teamspace": True},
+                {"id": "t-private", "name": "private workspace", "role": "owner", "is_private_teamspace": True},
             ]
         )
 

--- a/tests/auth/test_device_code_flow.py
+++ b/tests/auth/test_device_code_flow.py
@@ -416,7 +416,7 @@ class TestBuildSession:
         me = _me_response(
             teams=[
                 {"id": "tm_shared", "name": "Shared", "role": "member", "is_private_teamspace": False},
-                {"id": "tm_private", "name": "Private Teamspace", "role": "admin", "is_private_teamspace": True},
+                {"id": "tm_private", "name": "private workspace", "role": "admin", "is_private_teamspace": True},
             ]
         )
 

--- a/tests/auth/test_refresh_flow.py
+++ b/tests/auth/test_refresh_flow.py
@@ -570,7 +570,7 @@ def token_manager_with_expired_private_session(
     _isolate_refresh_hook_lock: Path,
     _refresh_hook_saas_url: None,
 ) -> TokenManager:
-    """A ``TokenManager`` with an expired access token whose session already has a Private Teamspace."""
+    """A ``TokenManager`` with an expired access token whose session already has a private workspace."""
     storage = _RefreshHookFakeStorage()
     session = _make_expired_session_with_teams(
         [
@@ -593,7 +593,7 @@ def token_manager_with_expired_private_session(
 async def test_refresh_force_rehydrates_when_adopted_session_lacks_private_team(
     token_manager_with_expired_shared_only_session: TokenManager,
 ) -> None:
-    """A refresh whose adopted session lacks a Private Teamspace must trigger
+    """A refresh whose adopted session lacks a private workspace must trigger
     ``rehydrate_membership_if_needed(force=True)`` and end with a private session."""
     # OAuth refresh response (PublicHttpClient → httpx.AsyncClient)
     respx.post(f"{_REFRESH_HOOK_SAAS_BASE_URL}/oauth/token").mock(
@@ -607,7 +607,7 @@ async def test_refresh_force_rehydrates_when_adopted_session_lacks_private_team(
             },
         )
     )
-    # /api/v1/me — provides the Private Teamspace
+    # /api/v1/me — provides the private workspace
     me_route = respx.get(f"{_REFRESH_HOOK_SAAS_BASE_URL}/api/v1/me").mock(
         return_value=httpx.Response(
             200,

--- a/tests/auth/test_session.py
+++ b/tests/auth/test_session.py
@@ -284,7 +284,7 @@ def test_require_private_team_id_never_returns_first_team_fallback() -> None:
 
 def test_require_private_team_id_wins_over_drifting_default() -> None:
     """Regression for spec NFR-004: when default_team_id points at a shared team
-    but the team list contains a Private Teamspace, return the private id."""
+    but the team list contains a private workspace, return the private id."""
     session = _make_session_with_teams(
         default_team_id="t-shared-default",
         teams=[

--- a/tests/auth/test_token_manager.py
+++ b/tests/auth/test_token_manager.py
@@ -66,7 +66,7 @@ def _make_session(
         user_id="user-1",
         email="a@b.com",
         name="A B",
-        # WP02: include a Private Teamspace so the post-refresh hook in
+        # WP02: include a private workspace so the post-refresh hook in
         # ``refresh_if_needed`` short-circuits (no synthetic /api/v1/me HTTP).
         teams=[Team(id="t1", name="T1", role="owner", is_private_teamspace=True)],
         default_team_id="t1",
@@ -916,7 +916,7 @@ def _make_session_with_teams(teams: list[Team]) -> StoredSession:
 
 @pytest.fixture
 def token_manager_with_private_session() -> TokenManager:
-    """A ``TokenManager`` whose loaded session already has a Private Teamspace."""
+    """A ``TokenManager`` whose loaded session already has a private workspace."""
     storage = FakeStorage()
     tm = TokenManager(storage, saas_base_url=_SAAS_BASE_URL)
     tm._session = _make_session_with_teams(
@@ -957,7 +957,7 @@ def token_manager_with_shared_only_session() -> TokenManager:
 def test_rehydrate_early_returns_when_session_already_has_private(
     token_manager_with_private_session: TokenManager,
 ) -> None:
-    """Branch (a): existing Private Teamspace short-circuits — no HTTP issued."""
+    """Branch (a): existing private workspace short-circuits — no HTTP issued."""
     route = respx.get(f"{_SAAS_BASE_URL}/api/v1/me").mock(
         return_value=httpx.Response(200, json={})
     )
@@ -1005,7 +1005,7 @@ def test_rehydrate_fetches_persists_and_recomputes_default_team_id(
     updated = tm.get_current_session()
     assert updated is not None
     assert any(t.is_private_teamspace for t in updated.teams)
-    # pick_default_team_id prefers the Private Teamspace.
+    # pick_default_team_id prefers the private workspace.
     assert updated.default_team_id == "t-private"
 
 

--- a/tests/cli/commands/test_auth_login.py
+++ b/tests/cli/commands/test_auth_login.py
@@ -107,7 +107,7 @@ class TestAuthLoginHelp:
 class TestAuthLoginDispatch:
     def test_login_no_longer_calls_teamspace_mission_state_gate(self):
         """Phase 6 (issue #1288): identity acquisition is decoupled from
-        TeamSpace mission-state readiness. The gate symbol must not be
+        Team Kitty mission-state readiness. The gate symbol must not be
         imported into the auth-login module and the command must not
         consult it. Sync / tracker / connect commands continue to gate
         themselves — that's their job, not auth's."""
@@ -128,7 +128,7 @@ class TestAuthLoginDispatch:
 
         with patch(
             "specify_cli.cli.commands._teamspace_mission_state_gate.enforce_teamspace_mission_state_ready",
-            side_effect=AssertionError("auth login must not invoke the TeamSpace gate"),
+            side_effect=AssertionError("auth login must not invoke the Team Kitty gate"),
         ), patch(
             "specify_cli.cli.commands._auth_login._run_browser_flow",
             new=AsyncMock(side_effect=_noop_browser_flow),

--- a/tests/cli/commands/test_sync_commands.py
+++ b/tests/cli/commands/test_sync_commands.py
@@ -8,7 +8,7 @@ state — never the internal call order or which domain function fired when.
 The wiring is THIN: every piece of logic lives in a domain module (WP07
 dispatcher, WP09 config, WP11 status-report/retention, WP01 target authority).
 A localhost :class:`StubReceiver` (WP06) stands in for the network so the suite
-needs no Teamspace credentials (SC-005).
+needs no Team Kitty credentials (SC-005).
 """
 
 from __future__ import annotations

--- a/tests/cli/commands/test_sync_import_history.py
+++ b/tests/cli/commands/test_sync_import_history.py
@@ -1,6 +1,6 @@
 """Tests for ``spec-kitty sync import-history`` — WP-Y1 (#2262).
 
-WP-Y1 is the command surface + mission selection + the fail-closed TeamSpace
+WP-Y1 is the command surface + mission selection + the fail-closed Team Kitty
 audit gate. It reuses ``migration.mission_state`` helpers rather than
 re-deriving them; envelope synthesis and the §3.6b pre-sync log re-drain land
 in later slices, so ``--apply`` is an honest non-zero stub here (it must never
@@ -8,7 +8,7 @@ claim a materialize it cannot perform).
 
 These tests drive the CLI wrapper only. The selection/audit authority stays in
 ``migration.mission_state`` and is monkeypatched at its seams, so the suite
-needs no on-disk repo, no dossier, and no TeamSpace credentials.
+needs no on-disk repo, no dossier, and no Team Kitty credentials.
 """
 
 from __future__ import annotations
@@ -313,7 +313,7 @@ def test_apply_proceeds_when_persisted_mode_is_teamspace(tmp_path, monkeypatch):
 def _wire_apply_seams_real_gates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, saas_enabled: bool, team_slug: str
 ) -> None:
-    """Like ``_wire_apply_seams`` but the receiver declares the real Teamspace
+    """Like ``_wire_apply_seams`` but the receiver declares the real Team Kitty
     gate tuple, so ``evaluate_gates`` genuinely evaluates saas/private/auth."""
     monkeypatch.setattr(sync_command, "_event_sync_access_token", lambda: "tok")
     target = SimpleNamespace(resolved_server_url="http://x", team_slug=team_slug)
@@ -340,7 +340,7 @@ def _wire_apply_seams_real_gates(
 
 def test_apply_fails_closed_when_real_gates_are_unsatisfied(tmp_path, monkeypatch):
     """A GateContext short on saas_enabled and private_teamspace genuinely blocks
-    through the real Teamspace gate tuple, naming both unsatisfied gates."""
+    through the real Team Kitty gate tuple, naming both unsatisfied gates."""
     _wire_apply_seams_real_gates(monkeypatch, tmp_path, saas_enabled=False, team_slug="")
     result = runner.invoke(app, ["import-history", "--apply"])
     assert result.exit_code == 1

--- a/tests/cli/commands/test_sync_now_empty_selection_t005.py
+++ b/tests/cli/commands/test_sync_now_empty_selection_t005.py
@@ -23,7 +23,7 @@ reachable from `sync now` any more. That message lives in `sync_all_queued_event
 the legacy queue drain FR-012 retired — `sync/__init__.py` deliberately stops
 re-exporting it and `sync now` calls `_run_event_sync_dispatch` instead. And
 `dispatcher._post` already returns early on an empty batch, so no empty POST is
-issued. Measured before writing this file: the no-Private-Teamspace string does not
+issued. Measured before writing this file: the no-private-workspace string does not
 appear in `sync now`'s output, the receiver records zero POSTs, and the exit code is
 already 0. What was genuinely missing is the *cause*, which is what these tests pin.
 """
@@ -225,7 +225,7 @@ def test_sync_now_does_not_claim_a_cause_it_cannot_prove(
     report cannot distinguish "already delivered" from "terminally drain-blocked"
     without ledger state, so the message must state what is known and stop. Naming
     consent here would be the same wrong-and-actionable diagnosis that the
-    no-Private-Teamspace message was.
+    no-private-workspace message was.
     """
     from specify_cli.sync.consent import set_project_consent
 

--- a/tests/cli/commands/test_sync_routes.py
+++ b/tests/cli/commands/test_sync_routes.py
@@ -51,7 +51,7 @@ def _session() -> StoredSession:
         email="robert@example.com",
         name="Robert",
         teams=[
-            Team(id="private-team", name="Robert Private Teamspace", role="owner", is_private_teamspace=True),
+            Team(id="private-team", name="Robert private workspace", role="owner", is_private_teamspace=True),
             Team(id="product-team", name="Product Team", role="member"),
         ],
         default_team_id="private-team",
@@ -104,7 +104,7 @@ def test_routes_command_renders_share_state(monkeypatch: pytest.MonkeyPatch) -> 
     result = runner.invoke(sync_module.app, ["routes"])
 
     assert result.exit_code == 0, result.stdout
-    assert "Spec Kitty Teamspace Routing" in result.stdout
+    assert "Team Kitty Workspace Routing" in result.stdout
     assert "acme/spec-kitty" in result.stdout
     assert "Product Team" in result.stdout
     assert "shared" in result.stdout
@@ -311,7 +311,7 @@ def test_unshare_command_stops_sharing_for_one_team(monkeypatch: pytest.MonkeyPa
 
     assert result.exit_code == 0, result.stdout
     assert "Stopped sharing" in result.stdout
-    assert "Private Teamspace data was kept intact" in result.stdout
+    assert "private workspace data was kept intact" in result.stdout
 
 
 def test_opt_out_command_can_delete_private_remote_data(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/commands/test_sync_status_drain_blockers.py
+++ b/tests/cli/commands/test_sync_status_drain_blockers.py
@@ -52,7 +52,7 @@ def test_format_queue_health_renders_drain_blocker_table(tmp_path: Path):
     # Remediation hints reference the canonical recovery commands so the
     # operator can act without guessing.
     assert "spec-kitty auth login" in output
-    assert "Private Teamspace" in output
+    assert "private workspace" in output
 
 
 def test_drain_blocked_counts_zero_when_all_ready():

--- a/tests/delivery/test_config.py
+++ b/tests/delivery/test_config.py
@@ -9,9 +9,9 @@ never by call order:
   *journals* rows on disk but *never posts*; the retained events become drainable
   once a delivery mode is selected later (US2 acceptance scenario 2).
 * ``EXTERNAL_RECEIVER``  — same resolution branch as the localhost stub; a delivery
-  records ledger state with **no** Teamspace credentials present (SC-005, US3).
+  records ledger state with **no** Team Kitty credentials present (SC-005, US3).
 * ``OPT_OUT``/``TRASH``  — local-only families neither journal nor post; a
-  Teamspace-bound discard is **refused or audit-recorded** through a durable
+  Team Kitty-bound discard is **refused or audit-recorded** through a durable
   source, never silently dropped (C-008); unknown families fail closed.
 """
 from __future__ import annotations
@@ -159,7 +159,7 @@ def test_axes_are_independent_local_retention_vs_opt_out() -> None:
 
 def test_config_carries_no_teamspace_target_url() -> None:
     # The config models policy, not target authority (FR-016/C-007): it has no
-    # Teamspace server-URL field at all.
+    # Team Kitty server-URL field at all.
     field_names = set(EventSyncConfig.__dataclass_fields__)
     assert "resolved_server_url" not in field_names
     assert "server_url" not in field_names
@@ -267,7 +267,7 @@ def test_external_receiver_records_ledger_without_teamspace_credentials() -> Non
 
     assert policy.retain is True
     assert policy.receiver is stub
-    # No Teamspace credentials leak into the external/stub path (SC-005 hygiene).
+    # No Team Kitty credentials leak into the external/stub path (SC-005 hygiene).
     assert policy.receiver.auth_headers() == {}
 
     ledger = _make_ledger()
@@ -340,7 +340,7 @@ def test_opt_out_explicitly_discardable_family_is_allowed() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# US2 acceptance scenario 5 — Teamspace-bound discard is never silent (C-008)
+# US2 acceptance scenario 5 — Team Kitty-bound discard is never silent (C-008)
 # --------------------------------------------------------------------------- #
 
 
@@ -351,7 +351,7 @@ def test_teamspace_bound_discard_is_refused_without_durable_sink() -> None:
     assert decision.kind is DiscardDecisionKind.REFUSED
     assert decision.refused is True
     assert decision.dropped is False  # NOT silently dropped
-    assert "teamspace" in decision.reason.lower()
+    assert "team kitty" in decision.reason.lower()
     assert decision.reason.strip()  # human-readable, audit-visible reason
 
 
@@ -374,7 +374,7 @@ def test_teamspace_bound_discard_is_audit_recorded_to_durable_source(tmp_path: P
 
 
 def test_unknown_family_fails_closed_non_discardable() -> None:
-    # Fail-closed: an unclassified family is treated as potentially Teamspace-bound.
+    # Fail-closed: an unclassified family is treated as potentially Team Kitty-bound.
     decision = discard_decision("mystery", classification=FamilyClassification.UNKNOWN)
     assert decision.kind is DiscardDecisionKind.REFUSED
     assert decision.dropped is False

--- a/tests/delivery/test_poison_batch_2736.py
+++ b/tests/delivery/test_poison_batch_2736.py
@@ -14,7 +14,7 @@ reason that had nothing to do with them.
 The receiver now **bisects** a whole-batch 400 (split → re-POST both halves →
 recurse to singletons), isolating the culprit and delivering every innocent. This
 module guards that fix through the receiver delivery entry point
-(:meth:`ExternalReceiver.deliver`, the same batch-post path the Teamspace receiver
+(:meth:`ExternalReceiver.deliver`, the same batch-post path the Team Kitty receiver
 uses), with a content-aware fake poster standing in for the all-or-nothing server.
 No network, deterministic.
 """

--- a/tests/delivery/test_receivers.py
+++ b/tests/delivery/test_receivers.py
@@ -6,13 +6,13 @@ order. They lock the contract §4 behaviours:
 * one :class:`DeliveryReceiver` protocol covers all five §4 aspects and every
   concrete receiver implements it (**FR-014**, §4 rule 1);
 * :class:`StubReceiver` is a *real* receiver in the production module that records
-  events with **no Teamspace credentials present** (**SC-005**, §4 required test 1);
-* the Teamspace and stub receivers produce the **same** per-event outcome sequence
+  events with **no Team Kitty credentials present** (**SC-005**, §4 required test 1);
+* the Team Kitty and stub receivers produce the **same** per-event outcome sequence
   for equivalent payloads (**SC-007**, §4 required test 2);
 * the full §4 result vocabulary is exercised (success / duplicate / pending /
   rejected / transient / terminal-failed) — NFR-002 — and a batch-level transient
   failure never poisons per-event retry state;
-* :class:`ExternalReceiver` applies **no** Teamspace gating (**FR-007**);
+* :class:`ExternalReceiver` applies **no** Team Kitty gating (**FR-007**);
 * gate evaluation is per-receiver data driven by a shared helper — no target-type
   ``if`` (FR-014).
 """
@@ -130,7 +130,7 @@ def test_all_three_receivers_implement_the_one_protocol() -> None:
         assert isinstance(receiver.gates(), tuple)
 
 
-# -- SC-005: stub with NO Teamspace credentials --------------------------------
+# -- SC-005: stub with NO Team Kitty credentials --------------------------------
 
 
 def test_stub_records_events_with_no_teamspace_credentials(
@@ -157,12 +157,12 @@ def test_stub_records_events_with_no_teamspace_credentials(
     )
 
 
-# -- SC-007: stub and Teamspace produce the SAME ledger state ------------------
+# -- SC-007: stub and Team Kitty produce the SAME ledger state ------------------
 
 
 def test_stub_and_teamspace_produce_identical_outcomes_for_equivalent_payloads() -> None:
     batch = [_event("01JMBY0000000000000000000A"), _event("01JMBY0000000000000000000B")]
-    # Teamspace faked transport reports success for both events.
+    # Team Kitty faked transport reports success for both events.
     poster = _FakePoster(
         _FakeResponse(
             200,
@@ -229,7 +229,7 @@ def test_teamspace_posts_to_resolved_endpoint_with_bearer_header() -> None:
     assert call["headers"]["Content-Encoding"] == "gzip"
 
 
-# -- ExternalReceiver: FR-007, no Teamspace gating -----------------------------
+# -- ExternalReceiver: FR-007, no Team Kitty gating -----------------------------
 
 
 def test_external_applies_only_endpoint_configured_gate() -> None:
@@ -242,7 +242,7 @@ def test_external_applies_only_endpoint_configured_gate() -> None:
 
 def test_external_delivers_with_no_credentials_when_endpoint_configured() -> None:
     external = ExternalReceiver(endpoint_url="https://ops.example/ingest/")
-    # No Teamspace creds anywhere; only an endpoint-configured context is needed.
+    # No Team Kitty creds anywhere; only an endpoint-configured context is needed.
     decision = evaluate_gates(external, GateContext(endpoint_configured=True))
     assert decision.satisfied is True
     assert external.auth_headers() == {}

--- a/tests/event_journal/test_capture_first.py
+++ b/tests/event_journal/test_capture_first.py
@@ -1,7 +1,7 @@
 """Capture-first durability tests (WP03 / T016-T019, contract §2 + SC-009).
 
 Observable acceptance (NFR-001): with sync disabled or missing auth/team, a
-Teamspace-bound fact is durably journaled with a ``drain_blocked_reason`` and
+Team Kitty-bound fact is durably journaled with a ``drain_blocked_reason`` and
 no delivery is attempted. We assert the *result* (a row exists even though the
 gate blocked), never the internal call order.
 """

--- a/tests/integration/migration/test_lifecycle_events_preserved.py
+++ b/tests/integration/migration/test_lifecycle_events_preserved.py
@@ -299,7 +299,7 @@ def test_annotation_row_is_preserved(tmp_path: Path) -> None:
     falls through ``_rule_reject_non_status_event``'s passthrough, and reaches
     ``_rule_require_to_lane`` — which hard-errors with "missing required to_lane"
     on a row that carries no lane fields by construction. The whole mission
-    repair then aborts, so the TeamSpace gate can never clear.
+    repair then aborts, so the Team Kitty gate can never clear.
 
     Preserve is the only correct disposition: annotations are load-bearing
     (the reducer folds them into runtime slots), so quarantining them would

--- a/tests/merge/test_merge_bootstrap_history_gate.py
+++ b/tests/merge/test_merge_bootstrap_history_gate.py
@@ -3,7 +3,7 @@
 Regression coverage for issue #1069: a mission whose
 ``status.events.jsonl`` contains nothing but forced ``planned -> planned``
 events cannot be merged, even when WP frontmatter or the dashboard
-looks done, because TeamSpace replay would silently collapse every WP
+looks done, because Team Kitty replay would silently collapse every WP
 back to planned.
 """
 

--- a/tests/migration/test_mission_state_repair.py
+++ b/tests/migration/test_mission_state_repair.py
@@ -300,7 +300,7 @@ def test_deterministic_repair_ids_follow_fork_seed_material(tmp_path: Path) -> N
 
 def test_teamspace_dry_run_fails_when_status_rows_still_contain_legacy_keys(tmp_path: Path) -> None:
     if not _has_events_5():
-        pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
+        pytest.skip("Team Kitty dry-run validation requires spec-kitty-events >= 5.0.0")
 
     repo = tmp_path
     mission = repo / "kitty-specs" / "001-needs-repair"
@@ -359,7 +359,7 @@ def test_teamspace_dry_run_fails_when_status_rows_still_contain_legacy_keys(tmp_
 
 def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tmp_path: Path) -> None:
     if not _has_events_5():
-        pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
+        pytest.skip("Team Kitty dry-run validation requires spec-kitty-events >= 5.0.0")
 
     repo = tmp_path
     mission = repo / "kitty-specs" / "001-historical-done"
@@ -418,7 +418,7 @@ def test_teamspace_dry_run_synthesizes_repo_evidence_for_historical_done_rows(tm
 
 def test_teamspace_dry_run_synthesizes_missing_historical_approval_evidence(tmp_path: Path) -> None:
     if not _has_events_5():
-        pytest.skip("TeamSpace dry-run validation requires spec-kitty-events >= 5.0.0")
+        pytest.skip("Team Kitty dry-run validation requires spec-kitty-events >= 5.0.0")
 
     repo = tmp_path
     mission = repo / "kitty-specs" / "001-historical-approval"

--- a/tests/migration/test_teamspace_migration_rehearsal.py
+++ b/tests/migration/test_teamspace_migration_rehearsal.py
@@ -1,4 +1,4 @@
-"""Cross-repo TeamSpace mission-state migration rehearsal."""
+"""Cross-repo Team Kitty mission-state migration rehearsal."""
 
 from __future__ import annotations
 
@@ -160,7 +160,7 @@ def _find_forbidden_keys(value: Any) -> list[str]:
     return findings
 
 
-@pytest.mark.skipif(not _has_events_5(), reason="TeamSpace rehearsal requires spec-kitty-events >= 5.0.0")
+@pytest.mark.skipif(not _has_events_5(), reason="Team Kitty rehearsal requires spec-kitty-events >= 5.0.0")
 def test_teamspace_mission_state_rehearsal_is_deterministic_across_clones(tmp_path: Path) -> None:
     """Exercise the #932 launch rehearsal path on two cloned historical repos."""
     from spec_kitty_events import Event

--- a/tests/readiness/test_auth_coordinator_matrix.py
+++ b/tests/readiness/test_auth_coordinator_matrix.py
@@ -99,7 +99,7 @@ MATRIX: list[AuthMatrixRow] = [
         stdout_assert=_empty,
         stderr_assert=_stderr_no_teamspace,
     ),
-    # Scenario 3 — hosted ON, logged-out, connected Teamspace, TTY:
+    # Scenario 3 — hosted ON, logged-out, connected Team Kitty workspace, TTY:
     # interactive multiline panel.
     AuthMatrixRow(
         name="hosted_on_logged_out_tty",
@@ -126,7 +126,7 @@ MATRIX: list[AuthMatrixRow] = [
         stdout_assert=_empty,
         stderr_assert=_stderr_is_canonical_line,
     ),
-    # Scenario 5 — hosted ON, logged-out, no Teamspace markers: silent.
+    # Scenario 5 — hosted ON, logged-out, no Team Kitty markers: silent.
     AuthMatrixRow(
         name="hosted_on_not_in_teamspace_tty",
         argv=[],

--- a/tests/readiness/test_coordinator_suppression_matrix.py
+++ b/tests/readiness/test_coordinator_suppression_matrix.py
@@ -1,6 +1,6 @@
 """Suppression matrix tests for the readiness coordinator.
 
-Asserts FR-011 (no Teamspace leakage when hosted mode is disabled, across the
+Asserts FR-011 (no Team Kitty leakage when hosted mode is disabled, across the
 full suppression matrix) and FR-004 (output policy derivation).
 
 Mission: cli-startup-readiness-coordinator-skeleton-01KS7JRV
@@ -102,7 +102,7 @@ MATRIX_ROWS: list[MatrixRow] = [
         expected_policy=OutputPolicy.NON_INTERACTIVE,
         expected_enabled=False,
     ),
-    # Hosted-mode-enabled row: still no Teamspace leakage because the auth probe
+    # Hosted-mode-enabled row: still no Team Kitty leakage because the auth probe
     # is not exercised in this mission.
     MatrixRow(
         name="hosted_enabled_interactive",
@@ -152,7 +152,7 @@ def test_suppression_matrix_no_teamspace_leakage(
     monkeypatch.setattr(coord_module, "_invoke_nag", lambda ctx: None)
 
     # WS2 (issue #1094): the readiness auth probe now runs on the
-    # hosted-enabled path. Stub it to a Teamspace-free verdict so this
+    # hosted-enabled path. Stub it to a Team Kitty-free verdict so this
     # Wave 1 suppression matrix continues to assert the "no leakage"
     # invariant deterministically — independent of any local repo state.
     from specify_cli.readiness import auth as auth_module
@@ -197,11 +197,11 @@ def test_suppression_matrix_no_teamspace_leakage(
         ), f"row={row.name}: disabled rows expect DISABLED"
         assert result.ran is False
 
-    # Assert: no Teamspace leakage
+    # Assert: no Team Kitty leakage
     captured = capsys.readouterr()
     assert "teamspace" not in captured.out.lower(), (
-        f"row={row.name}: Teamspace leaked to stdout: {captured.out!r}"
+        f"row={row.name}: Team Kitty leaked to stdout: {captured.out!r}"
     )
     assert "teamspace" not in captured.err.lower(), (
-        f"row={row.name}: Teamspace leaked to stderr: {captured.err!r}"
+        f"row={row.name}: Team Kitty leaked to stderr: {captured.err!r}"
     )

--- a/tests/regression/test_birth_cutover.py
+++ b/tests/regression/test_birth_cutover.py
@@ -251,7 +251,7 @@ def _bootstrap_born_mission(
     # in this bare fixture, so an un-ignored ``git add -A`` would sweep its own
     # files in) and ``.kittify/sync-state.json`` (the offline-queue's local
     # fallback file, touched by every status-emit call in this sandboxed
-    # fixture — no real Teamspace project_uuid is configured) are pure
+    # fixture — no real Team Kitty project_uuid is configured) are pure
     # test-harness churn, orthogonal to the birth-cutover behavior under test;
     # ignore both so neither trips the merge's dirty-tree guard.
     (repo / ".gitignore").write_text(".worktrees/\n.kittify/sync-state.json\n", encoding="utf-8")

--- a/tests/specify_cli/audit/test_detectors_row_family.py
+++ b/tests/specify_cli/audit/test_detectors_row_family.py
@@ -261,7 +261,7 @@ class TestDetectForbiddenKeysRowFamily:
         This is the regression-guard half of the contract: malformed
         pre-migration rows that carry ``event_type`` without the lifecycle
         aggregate marker must still surface as ``FORBIDDEN_KEY`` findings,
-        otherwise the TeamSpace blocker rule loses its teeth.
+        otherwise the Team Kitty blocker rule loses its teeth.
         """
         row: dict[str, object] = {"event_type": "Foo"}
         findings = detect_forbidden_keys(row, "status.events.jsonl")
@@ -335,7 +335,7 @@ class TestDetectForbiddenKeysRowFamily:
         """Issue #1142: ``WorkPackage`` lifecycle rows skip the FORBIDDEN_KEYS rule.
 
         Pre-fix the audit raised ``FORBIDDEN_KEY`` against this legitimate row
-        shape, blocking the canary's scenarios 1 + 2 with a TeamSpace gate.
+        shape, blocking the canary's scenarios 1 + 2 with a Team Kitty gate.
         """
         row: dict[str, object] = {
             "aggregate_type": "WorkPackage",

--- a/tests/specify_cli/cli/commands/test_charter_prereq_suppression.py
+++ b/tests/specify_cli/cli/commands/test_charter_prereq_suppression.py
@@ -122,7 +122,7 @@ class TestPrereqSuppression:
         assert "[w]iden" not in result.output
 
     def test_no_widen_when_no_teamspace(self, tmp_path: Path) -> None:
-        """User not in any Teamspace → [w]iden suppressed (FR-003)."""
+        """User not in any Team Kitty → [w]iden suppressed (FR-003)."""
         _setup_repo(tmp_path)
         prereq = PrereqState(teamspace_ok=False, slack_ok=False, saas_reachable=True)
         result = _invoke_with_prereqs(tmp_path, prereq, self._default_inputs())

--- a/tests/specify_cli/cli/commands/test_doctor_cli_surface_golden.py
+++ b/tests/specify_cli/cli/commands/test_doctor_cli_surface_golden.py
@@ -337,11 +337,11 @@ EXPECTED_HELP: dict[str, list[str]] = {
     ],
     'mission-state': [
         'Usage: doctor mission-state [OPTIONS]',
-        'Audit, repair, or TeamSpace-validate mission-state shapes.',
+        'Audit, repair, or Team Kitty-validate mission-state shapes.',
         'Options',
         '--audit Run mission-state audit (required to proceed)',
         '--fix Repair mission-state artifacts in place and write a migration manifest',
-        '--teamspace-dry-run Synthesize canonical TeamSpace envelopes from local state and validate them',
+        '--teamspace-dry-run Synthesize canonical Team Kitty envelopes from local state and validate them',
         '--json Emit JSON report to stdout',
         '--mission TEXT Scope to a single mission handle',
         '--fail-on TEXT Exit 1 if findings meet a gate (error|warning|info|teamspace-blocker)',

--- a/tests/specify_cli/core/test_mission_creation_specify_started.py
+++ b/tests/specify_cli/core/test_mission_creation_specify_started.py
@@ -6,7 +6,7 @@ already scaffolds ``spec.md`` from mission configuration and opens the specify p
 that is the canonical moment to emit ``SpecifyStarted``. Without it, a
 fresh mission's ``status.events.jsonl`` skips straight from
 ``MissionCreated`` to ``SpecifyCompleted`` (emitted at setup-plan time),
-leaving TeamSpace and the local dashboard blind to the in-progress
+leaving Team Kitty and the local dashboard blind to the in-progress
 specify state.
 
 This regression test was missing when #1067 was first closed; the

--- a/tests/specify_cli/skills/test_installer.py
+++ b/tests/specify_cli/skills/test_installer.py
@@ -273,7 +273,7 @@ class TestInstallSharedRootAgent:
         upsun_body = (
             "---\n"
             f"name: {RETIRED_UPSUN_SKILL}\n"
-            "description: Point a local Spec Kitty CLI at Spec Kitty SaaS on Upsun.\n"
+            "description: Point a local Spec Kitty CLI at Team Kitty on Upsun.\n"
             "---\n"
             "# Upsun CLI sync\n\nInternal kittyfooding helper.\n"
         )

--- a/tests/specify_cli/widen/test_audience.py
+++ b/tests/specify_cli/widen/test_audience.py
@@ -209,7 +209,7 @@ class TestRunAudienceReview:
         assert result is None
         assert "Note:" in output
         assert "Eve Newcomer" in output
-        assert "missing Teamspace user IDs" in output
+        assert "missing Team Kitty member IDs" in output
 
     def test_cancel_keyword_returns_none(self) -> None:
         result, _ = self._run("cancel")

--- a/tests/sync/test_batch_400_no_details_poison_2736.py
+++ b/tests/sync/test_batch_400_no_details_poison_2736.py
@@ -39,7 +39,7 @@ pytestmark = pytest.mark.fast
 
 @pytest.fixture(autouse=True)
 def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default TokenManager exposing a Private Teamspace for the pre-flight."""
+    """Default TokenManager exposing a private workspace for the pre-flight."""
     now = datetime.now(UTC)
     fake_session = StoredSession(
         user_id="user-default",

--- a/tests/sync/test_batch_error_surfacing.py
+++ b/tests/sync/test_batch_error_surfacing.py
@@ -791,12 +791,12 @@ class TestBatchSyncEventResults:
     def test_http_403_missing_private_team_preserves_direct_ingress_category(
         self, mock_post, small_queue
     ):
-        """Issue #889: direct-ingress missing Private Teamspace is not server_error."""
+        """Issue #889: direct-ingress missing private workspace is not server_error."""
         mock_response = Mock()
         mock_response.status_code = 403
         mock_response.json.return_value = {
             "category": CATEGORY_MISSING_PRIVATE_TEAM,
-            "message": "Private Teamspace is required for direct ingress.",
+            "message": "private workspace is required for direct ingress.",
         }
         mock_post.return_value = mock_response
 

--- a/tests/sync/test_batch_retry_hygiene.py
+++ b/tests/sync/test_batch_retry_hygiene.py
@@ -1,8 +1,8 @@
 """Regression tests for Mission 5 / issue Priivacy-ai/spec-kitty#889.
 
 When a batch POST fails at the batch level (HTTP 401, 403, 5xx, transport
-timeout/connection error) or the pre-flight skips because no Private
-Teamspace is available, ``OfflineQueue.process_batch_results`` MUST NOT
+timeout/connection error) or the pre-flight skips because no private
+workspace is available, ``OfflineQueue.process_batch_results`` MUST NOT
 increment ``retry_count`` for the drained queue rows. The server never
 adjudicated those events individually, so a per-event retry attribution is
 wrong and eventually poisons the queue.
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.fast
 
 @pytest.fixture(autouse=True)
 def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default TokenManager exposing a Private Teamspace.
+    """Default TokenManager exposing a private workspace.
 
     Mirrors the fixture in ``test_batch_sync.py`` so the pre-flight
     ``_current_team_slug`` resolution succeeds for the tests that exercise

--- a/tests/sync/test_batch_sync.py
+++ b/tests/sync/test_batch_sync.py
@@ -34,13 +34,13 @@ _INGRESS_SAAS_BASE_URL = "https://saas.example"
 
 @pytest.fixture(autouse=True)
 def _default_private_team_token_manager(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default TokenManager fixture exposing a Private Teamspace.
+    """Default TokenManager fixture exposing a private workspace.
 
-    WP04 (private-teamspace-ingress-safeguards) makes Private Teamspace a hard
+    WP04 (private-teamspace-ingress-safeguards) makes private workspace a hard
     precondition for direct ingress. Pre-existing batch tests in this module
     don't bother with TokenManager state — they rely on ``requests.post`` being
     patched. To preserve their semantics without changing each one, install an
-    autouse default that surfaces a Private Teamspace. Individual tests that
+    autouse default that surfaces a private workspace. Individual tests that
     need a different session re-patch ``get_token_manager`` themselves; the
     later monkeypatch wins.
     """
@@ -167,7 +167,7 @@ class TestSaasFeatureFlag:
 
 
 class TestHistoricalMissionStateGuard:
-    """TeamSpace import guard for historical mission-state rows."""
+    """Team Kitty import guard for historical mission-state rows."""
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_rejects_legacy_status_row_before_network(
@@ -783,7 +783,7 @@ class TestBatchSyncSuccess:
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_sends_private_team_slug_header(self, mock_post, populated_queue, monkeypatch):
-        """Batch sync should target Private Teamspace for ingress when available."""
+        """Batch sync should target private workspace for ingress when available."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"results": []}
@@ -796,7 +796,7 @@ class TestBatchSyncSuccess:
             email="robert@example.com",
             name="Robert",
             teams=[
-                Team(id="private-team", name="Robert Private Teamspace", role="owner", is_private_teamspace=True),
+                Team(id="private-team", name="Robert private workspace", role="owner", is_private_teamspace=True),
                 Team(id="product-team", name="Product Team", role="member"),
             ],
             default_team_id="private-team",
@@ -826,7 +826,7 @@ class TestBatchSyncSuccess:
 
     @patch("specify_cli.sync.batch.requests.post")
     def test_batch_sync_prefers_private_team_over_shared_default(self, mock_post, populated_queue, monkeypatch):
-        """Ingress must keep routing to Private Teamspace even if session default drifts."""
+        """Ingress must keep routing to private workspace even if session default drifts."""
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"results": []}
@@ -840,7 +840,7 @@ class TestBatchSyncSuccess:
             name="Robert",
             teams=[
                 Team(id="product-team", name="Product Team", role="member"),
-                Team(id="private-team", name="Robert Private Teamspace", role="owner", is_private_teamspace=True),
+                Team(id="private-team", name="Robert private workspace", role="owner", is_private_teamspace=True),
             ],
             default_team_id="product-team",
             access_token="access",
@@ -1249,7 +1249,7 @@ def token_manager_with_shared_only_session() -> TokenManager:
 
 @pytest.fixture
 def token_manager_with_private_session() -> TokenManager:
-    """A ``TokenManager`` whose loaded session already has a Private Teamspace."""
+    """A ``TokenManager`` whose loaded session already has a private workspace."""
     storage = _IngressFakeStorage()
     tm = TokenManager(storage, saas_base_url=_INGRESS_SAAS_BASE_URL)
     tm._session = _build_ingress_session(
@@ -1479,11 +1479,11 @@ def test_sync_all_queued_events_terminates_on_no_private_team(
             )
 
         # Loop terminated — events stayed queued for a future drain after
-        # the SaaS provisions a Private Teamspace.
+        # the SaaS provisions a private workspace.
         assert queue.size() == 5, "events must stay queued (no destructive skip)"
         # The skip path issued no batch POST.
         assert mock_post.call_count == 0
         # The skip-path sentinel surfaces on the result for operator-visible
         # diagnostics (also goes to stderr via the helper's structured
         # logger.warning, but operators reading the result get a hint too).
-        assert any("Private Teamspace" in m for m in result.error_messages), f"expected skip-sentinel in error_messages, got {result.error_messages!r}"
+        assert any("private workspace" in m for m in result.error_messages), f"expected skip-sentinel in error_messages, got {result.error_messages!r}"

--- a/tests/sync/test_body_transport.py
+++ b/tests/sync/test_body_transport.py
@@ -147,7 +147,7 @@ class TestClassifyResponse:
             403,
             {
                 "category": "direct_ingress_missing_private_team",
-                "message": "Private Teamspace is required.",
+                "message": "private workspace is required.",
             },
         )
         outcome = _classify_response(task, resp)

--- a/tests/sync/test_client_integration.py
+++ b/tests/sync/test_client_integration.py
@@ -186,7 +186,7 @@ def test_normalize_ws_url_rejects_insecure_remote_plaintext():
 #
 #   - shared-only session that rehydrates to a private team via /api/v1/me
 #   - shared-only session whose rehydrate still surfaces no private team
-#   - healthy session that already carries a Private Teamspace and skips /me
+#   - healthy session that already carries a private workspace and skips /me
 #
 # We patch ``websockets.connect`` so the WS upgrade never opens a real socket;
 # the assertions are about the HTTP traffic ``provision_ws_token`` produces

--- a/tests/sync/test_edge_cases.py
+++ b/tests/sync/test_edge_cases.py
@@ -346,8 +346,8 @@ class TestNonBlockingEmission:
         raises, the strict ingress resolver returns ``None``. The emitter
         must NOT drop the event — instead it queues with ``team_slug =
         None`` and ``drain_blocked_reason in {"no_auth", "no_team"}``. The
-        drain layer re-checks on every tick and only POSTs when a Private
-        Teamspace is resolvable, preserving FR-002/FR-007 of the
+        drain layer re-checks on every tick and only POSTs when a private
+        workspace is resolvable, preserving FR-002/FR-007 of the
         private-teamspace-ingress-safeguards mission.
         """
         queue = OfflineQueue(db_path=tmp_path / "q.db")

--- a/tests/sync/test_event_emission.py
+++ b/tests/sync/test_event_emission.py
@@ -560,7 +560,7 @@ class TestNoDuplicateEmissions:
 
 
 class TestPolicyMetadataPassthrough:
-    """Verify policy_metadata is kept out of the canonical TeamSpace payload."""
+    """Verify policy_metadata is kept out of the canonical Team Kitty payload."""
 
     def test_policy_metadata_included_in_payload(self, emitter: EventEmitter, temp_queue: OfflineQueue):
         """policy_metadata is accepted for compatibility but not emitted."""

--- a/tests/sync/test_events.py
+++ b/tests/sync/test_events.py
@@ -123,7 +123,7 @@ class TestEventEnvelope:
     def test_team_slug_unresolvable_queues_event_locally(
         self, temp_queue, temp_clock, mock_config, monkeypatch
     ):
-        """Emitter queues events durably even when no Private Teamspace exists.
+        """Emitter queues events durably even when no private workspace exists.
 
         FR-1 / issue #1072 of the teamspace-local-first-outbox mission: local
         durability is unconditional. When the strict ingress resolver returns
@@ -325,7 +325,7 @@ class TestWPStatusChanged:
         assert "mission_id" not in event["payload"]
 
     def test_transition_metadata_passes_through(self, emitter: EventEmitter, temp_queue):
-        """WPStatusChanged carries the canonical status event metadata TeamSpace projects."""
+        """WPStatusChanged carries the canonical status event metadata Team Kitty projects."""
         evidence = {"review": {"reviewer": "alice", "verdict": "approved", "reference": "PR#1"}}
         event = emitter.emit_wp_status_changed(
             "WP01",

--- a/tests/sync/test_final_sync_diagnostics.py
+++ b/tests/sync/test_final_sync_diagnostics.py
@@ -144,7 +144,7 @@ def test_classify_server_auth_failure() -> None:
 
 
 def test_classify_direct_ingress_missing_private_team() -> None:
-    """A benign 'no Private Teamspace' ingress skip is NOT a server auth failure.
+    """A benign 'no private workspace' ingress skip is NOT a server auth failure.
 
     Regression for #2254: the catch-all previously misclassified this skip as
     ``sync.server_auth_failure``, which wrongly tells the operator to re-auth.
@@ -152,7 +152,7 @@ def test_classify_direct_ingress_missing_private_team() -> None:
     category, and must be classified before the auth/catch-all branches.
     """
     assert (
-        classify_sync_error("skipped: no Private Teamspace available for direct ingress")
+        classify_sync_error("skipped: no private workspace available for direct ingress")
         == SyncDiagnosticCode.DIRECT_INGRESS_MISSING_PRIVATE_TEAM
     )
     # Matches on the canonical signals regardless of surrounding prose.

--- a/tests/sync/test_history_import_upload.py
+++ b/tests/sync/test_history_import_upload.py
@@ -36,7 +36,7 @@ def _env(
     event_id: str, event_type: str = "WPStatusChanged"
 ) -> dict[
     str, Any
-]:  # canonical-event-exempt(exception-flow): the TeamSpace wire envelope is not a *Payload model; a raw fixture is the transport's unit-under-test input
+]:  # canonical-event-exempt(exception-flow): the Team Kitty wire envelope is not a *Payload model; a raw fixture is the transport's unit-under-test input
     # canonical-event-exempt(exception-flow): minimal wire envelope fed into the upload transport under test
     return {
         "event_id": event_id,

--- a/tests/sync/test_lifecycle_readiness.py
+++ b/tests/sync/test_lifecycle_readiness.py
@@ -1,11 +1,11 @@
-"""Teamspace MVP readiness tests.
+"""Team Kitty MVP readiness tests.
 
 Covers the local-first / eventually-consistent contract from
 ``kitty-specs/teamspace-local-first-outbox/`` (Priivacy-ai/spec-kitty
 issues #1072, #1073, #1074, #1075, #1076):
 
 - Lifecycle events are locally durable regardless of sync feature flag,
-  auth state, Private Teamspace resolution, or git-remote availability.
+  auth state, private workspace resolution, or git-remote availability.
 - ``BuildRegistered`` / ``BuildHeartbeat`` no longer require ``repo_slug``.
 - ``spec-kitty init`` registers a project-init lifecycle event in the
   durable outbox.

--- a/tests/sync/test_offline_queue.py
+++ b/tests/sync/test_offline_queue.py
@@ -266,7 +266,7 @@ class TestOfflineQueueDefaultPath:
             teams=[
                 Team(
                     id=team_id,
-                    name="Private Teamspace",
+                    name="private workspace",
                     role="owner",
                     is_private_teamspace=True,
                 )

--- a/tests/sync/test_reconnection.py
+++ b/tests/sync/test_reconnection.py
@@ -314,7 +314,7 @@ class TestClientLifecycle:
 
         # Patch the authenticated-session accessor used by the strict ingress
         # resolver in ``connect()`` so the WS provisioning path does not skip
-        # the ws-token POST. The team must be a Private Teamspace because WP05
+        # the ws-token POST. The team must be a private workspace because WP05
         # forbids posting a shared team id to /api/v1/ws-token.
         class _Team:
             id = "team-42"
@@ -330,7 +330,7 @@ class TestClientLifecycle:
 
             def rehydrate_membership_if_needed(self, *, force: bool = False) -> bool:
                 # Never invoked when the session already exposes a Private
-                # Teamspace, but the resolver protocol requires the method.
+                # Team Kitty, but the resolver protocol requires the method.
                 return True
 
         monkeypatch.setattr("specify_cli.sync.client.get_token_manager", lambda: _TM())

--- a/tests/sync/test_strict_json_stdout.py
+++ b/tests/sync/test_strict_json_stdout.py
@@ -45,7 +45,7 @@ The cycle-2 fix in this file:
   team into an isolated ``HOME`` via the production
   ``FileFallbackStorage``. The sync layer then sees an authenticated
   session, calls ``resolve_private_team_id_for_ingress``, finds no
-  Private Teamspace, attempts a rehydrate against an unreachable SaaS
+  private workspace, attempts a rehydrate against an unreachable SaaS
   URL (``http://localhost:1``), fails, and emits ``direct ingress
   skipped`` to stderr via the module logger -- the exact path AC-006
   guards against leaking onto stdout.
@@ -255,7 +255,7 @@ def _seed_shared_only_session(auth_dir: pathlib.Path) -> None:
     The session deliberately has only a non-Private team so the
     ingress-resolver path inside the CLI:
 
-      1. finds no Private Teamspace via ``require_private_team_id``;
+      1. finds no private workspace via ``require_private_team_id``;
       2. attempts a rehydrate via
          ``TokenManager.rehydrate_membership_if_needed``;
       3. fails because ``SPEC_KITTY_SAAS_URL`` points at an unreachable

--- a/tests/sync/test_sync_boundary_preflight.py
+++ b/tests/sync/test_sync_boundary_preflight.py
@@ -715,10 +715,10 @@ def test_run_preflight_never_calls_rehydrate_membership(
     ``specify_cli.sync.queue.read_queue_scope_from_session`` →
     ``resolve_private_team_id_for_ingress`` →
     ``TokenManager.rehydrate_membership_if_needed`` → ``GET /api/v1/me``
-    whenever the current session lacked a Private Teamspace in memory.
+    whenever the current session lacked a private workspace in memory.
     That violates the contract.
 
-    This test installs an in-memory session WITHOUT a Private Teamspace
+    This test installs an in-memory session WITHOUT a private workspace
     (so the legacy code path would have fired the rehydrate), monkeypatches
     ``TokenManager.rehydrate_membership_if_needed`` to raise, and asserts
     that ``run_preflight`` produces a result without invoking it.
@@ -733,7 +733,7 @@ def test_run_preflight_never_calls_rehydrate_membership(
     from specify_cli.auth.token_manager import TokenManager
     from datetime import datetime, UTC
 
-    # Build a session whose teams list has NO Private Teamspace. The legacy
+    # Build a session whose teams list has NO private workspace. The legacy
     # ``read_queue_scope_from_session`` path would call
     # ``resolve_private_team_id_for_ingress`` here, which would then call
     # ``rehydrate_membership_if_needed`` to fetch ``/api/v1/me``.
@@ -748,7 +748,7 @@ def test_run_preflight_never_calls_rehydrate_membership(
         user_id="u-1",
         email="tester@example.com",
         name="Test User",
-        teams=[shared_team],  # no Private Teamspace
+        teams=[shared_team],  # no private workspace
         default_team_id="shared-team",
         access_token="tok-access",
         refresh_token="tok-refresh",

--- a/tests/sync/test_sync_consent_capture_gap_3031.py
+++ b/tests/sync/test_sync_consent_capture_gap_3031.py
@@ -56,20 +56,20 @@ outcome. A fix that disables capture wholesale would also fail the
 consenting half of this test.
 
 Doctrinal tension, named rather than resolved here: ``event_journal/journal.py``
-documents the journal write as deliberately unconditional for Teamspace-bound
+documents the journal write as deliberately unconditional for Team Kitty-bound
 families — FR-017 / C-008, enforced by ``TeamspaceBoundDropError`` so a
-Teamspace-bound fact is never silently dropped
+Team Kitty-bound fact is never silently dropped
 (``capture_teamspace_bound``'s docstring: "The journal write is unconditional
-for Teamspace-bound families; ``gate`` only decides the recorded
+for Team Kitty-bound families; ``gate`` only decides the recorded
 ``drain_blocked_reason`` ... never whether the write happens"). #3031 Defect 3
 asks for the opposite outcome for *non-consenting* projects: no write at all.
-Reconciling "unconditional durable write for Teamspace-bound facts" with "a
+Reconciling "unconditional durable write for Team Kitty-bound facts" with "a
 non-consenting project's events must never reach the journal" is an
-architecture question (which axis wins, and whether "Teamspace-bound" and
+architecture question (which axis wins, and whether "Team Kitty-bound" and
 "consenting" turn out to be the same predicate) being filed separately. This
 test pins only what #3031 explicitly asks for; it does not adjudicate the
 tension, and the fix that satisfies it must not do so by quietly deciding
-every event is not Teamspace-bound.
+every event is not Team Kitty-bound.
 """
 from __future__ import annotations
 

--- a/tests/sync/test_sync_logged_out_recovery.py
+++ b/tests/sync/test_sync_logged_out_recovery.py
@@ -112,7 +112,7 @@ class TestSyncNowRecovery:
 
         Same rationale as ``TestSyncNowExitCodes._stub_teamspace_gate`` in
         ``tests/agent/cli/commands/test_sync.py``: spec-kitty's own
-        ``.kittify/`` contains TeamSpace blockers in the test environment,
+        ``.kittify/`` contains Team Kitty blockers in the test environment,
         which raises ``typer.Exit(1)`` before the recovery contract can be
         evaluated. These tests assert on the recovery layer specifically,
         so the gate is stubbed at the call-site in ``sync.py``.

--- a/tests/sync/test_team_ingress_resolver.py
+++ b/tests/sync/test_team_ingress_resolver.py
@@ -174,7 +174,7 @@ def test_queue_scope_local_only_skips_rehydrate(
     token_manager_with_shared_only_session: TokenManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local-only scope reads must not call TeamSpace membership rehydrate."""
+    """Local-only scope reads must not call Team Kitty membership rehydrate."""
     me_route = respx.get(f"{_SAAS_BASE_URL}/api/v1/me").mock(
         return_value=httpx.Response(
             200,
@@ -205,7 +205,7 @@ def test_default_queue_db_path_local_only_skips_rehydrate(
     token_manager_with_shared_only_session: TokenManager,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Local-only queue path resolution must not call TeamSpace membership rehydrate."""
+    """Local-only queue path resolution must not call Team Kitty membership rehydrate."""
     me_route = respx.get(f"{_SAAS_BASE_URL}/api/v1/me").mock(
         return_value=httpx.Response(
             200,

--- a/tests/sync/test_ws_publish_consent_3030.py
+++ b/tests/sync/test_ws_publish_consent_3030.py
@@ -97,7 +97,7 @@ def _usable_event_loop():
 
 @pytest.fixture(autouse=True)
 def _authenticated(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An authenticated session with a resolvable Private Teamspace.
+    """An authenticated session with a resolvable private workspace.
 
     Both are preconditions of the publish branch, not the subject: without them
     ``_route_event`` never reaches the client and every assertion below would pass

--- a/tests/sync/tracker/test_tracker_discovery_integration.py
+++ b/tests/sync/tracker/test_tracker_discovery_integration.py
@@ -179,7 +179,7 @@ def test_scenario_7b_host_unavailable_propagates_without_changing_config(
     mock_client: MagicMock,
 ) -> None:
     mock_client.bind_resolve.side_effect = SaaSTrackerClientError(
-        "Cannot connect to Spec Kitty SaaS at https://saas.example.com.",
+        "Cannot connect to Team Kitty at https://saas.example.com.",
     )
 
     with (

--- a/tests/upgrade/test_upgrade_auto_commit_unit.py
+++ b/tests/upgrade/test_upgrade_auto_commit_unit.py
@@ -882,7 +882,7 @@ def test_upgrade_no_migrations_surfaces_teamspace_mission_state_prompt(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """A normal upgrade run checks TeamSpace mission-state readiness even when up to date."""
+    """A normal upgrade run checks Team Kitty mission-state readiness even when up to date."""
     project_path = _setup_upgrade_project(tmp_path)
     monkeypatch.setattr(Path, "cwd", lambda: project_path)
     monkeypatch.setattr(autocommit, "git_status_paths", lambda _rp: set())


### PR DESCRIPTION
## Summary

- replaces the retired product wording in active CLI messages, errors, help, docstrings, tests, workflow descriptions, and current documentation
- uses `private workspace` for the personal container and `Team Kitty` for the product
- deliberately preserves persisted tokens, public/internal compatibility symbols, CLI flags, telemetry keys, historical mission slugs, and redirect URLs for a separate versioned migration
- adds an architectural regression test that rejects the retired standalone product names while allowing compound compatibility symbols such as the current receiver class

Canonical naming decision: Priivacy-ai/spec-kitty-saas#704.
Shared event-contract migration: Priivacy-ai/spec-kitty-events#46.

## Verification

- canonical product-language guard plus existing legacy terminology guard — 11 passed
- all changed test modules — 1,169 passed, 1 skipped before two tail results; the nomenclature assertion failure was corrected and its focused test now passes
- new architectural test Ruff check — passed
- `git diff --check` — passed

## Existing environment-sensitive test

`tests/sync/test_strict_json_stdout.py::test_mission_create_json_strict_when_sync_skips_ingress` remains red with empty stderr in this local backend-less environment. The product-language diff changes only prose in that file/path and does not alter the diagnostic branch; the test itself documents the backend/environment split (#2782). No behavior change is being claimed for that path.

## Follow-up contract migration

The remaining lowercase/CamelCase occurrences are machine-facing compatibility contracts, including `Mode.TEAMSPACE`, `TeamspaceReceiver`, `--teamspace-dry-run`, persisted auth fields, metrics/diagnostic keys, module paths, and stable redirects. They need explicit dual-read/old-token migration before removal, not a blind rename.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788263554&installation_model_id=427282&pr_number=3153&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3153&signature=97e4d156d5065c1abd76cadaf6a4f23466f2983232773453235f6a39e9626283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->