### PR TITLE
fix(#3086): flatten coordination metadata when merge deletes the coord branch

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -312,6 +312,11 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **Commands run on a merged coordination mission no longer crash (`#3086`).**
+  Once a coordination mission was merged, later commands against it — creating a
+  retrospective, resuming implementation, or checking its status — failed
+  outright, and this hit every merged coordination mission. Merging now
+  finalizes the mission cleanly, so it stays usable afterward.
 - **`decision widen` no longer lets one mission's decision travel under
   another mission's identity (mission `egress-refusal-consolidation-3110`;
   `#3111`).** Previously, ownership was resolved from whatever the decision

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -1243,6 +1243,70 @@ def _phase_push(run: _MergeRunState) -> None:
     console.print(f"[green]✓[/green] Pushed {lanes_manifest.target_branch} to origin")
 
 
+def _flatten_coordination_metadata_after_branch_delete(run: _MergeRunState) -> None:
+    """issue #3086: clear the coordination marker once the coord branch is gone.
+
+    ``spec-kitty merge --delete-branch`` (the default) deletes a Mission's
+    coordination branch (``kitty/mission-<slug>``) from git but, before this fix,
+    left the paired ``coordination_branch`` key in
+    ``kitty-specs/<slug>/meta.json``. Every later command routing through
+    ``resolve_status_surface_with_anchor`` then hit ``CoordState.DELETED`` and
+    raised ``CoordinationBranchDeleted`` — the deliberate #1848 data-loss
+    hard-fail — a 100% crash on merged coord missions.
+
+    This mirrors the canonical flatten already performed by
+    ``spec-kitty mission close --discard`` and ``doctor coordination --fix``:
+    :func:`~specify_cli.mission_metadata.clear_coordination_metadata` + pop the
+    now-stale ``topology`` + record ``flattened=True``. It reuses those existing
+    primitives rather than inventing a new mechanism.
+
+    Ordering matters. This runs AFTER the lane/mission branches were merged into
+    the target: the spec-kitty-meta merge driver treats ``coordination_branch``
+    as a *theirs-authoritative* planning key (``merge/merge_driver.py``), so any
+    earlier clear would be re-populated by driver reconciliation. Running here
+    makes this clear the last writer, so it wins. The edit is persisted through
+    the same protected-flow bookkeeping-commit seam the merge uses for its other
+    meta.json mutations, so the merged target branch is not left dirty.
+
+    A non-coord Mission (``SINGLE_BRANCH`` / ``LANES``) or an already-flattened
+    one carries no ``coordination_branch`` key, so this is an idempotent no-op
+    that leaves ``topology`` / ``flattened`` untouched.
+    """
+    from specify_cli.mission_metadata import (
+        clear_coordination_metadata,
+        load_meta_or_empty,
+        write_meta,
+    )
+
+    feature_dir = run.target_feature_dir
+    meta = load_meta_or_empty(feature_dir)
+    if "coordination_branch" not in meta:
+        return
+
+    # Canonical three-mutation flatten (parity with ``doctor coordination --fix``
+    # / ``mission close --discard``); ``coordination_branch`` presence above means
+    # meta.json exists, so ``clear_coordination_metadata`` cannot raise here.
+    clear_coordination_metadata(feature_dir)
+    meta = load_meta_or_empty(feature_dir)
+    meta.pop("topology", None)
+    meta["flattened"] = True
+    write_meta(feature_dir, meta, validate=False)
+
+    meta_path = feature_dir / "meta.json"
+    if _paths_have_status_changes(run.main_repo, [meta_path]):
+        commit_merge_bookkeeping(
+            repo_root=run.main_repo,
+            worktree_root=run.main_repo,
+            mission_slug=run.mission_slug,
+            branch=run.lanes_manifest.target_branch,
+            message=(
+                f"chore({run.mission_slug}): flatten coordination metadata "
+                f"after branch deletion (#3086)"
+            ),
+            paths=(meta_path,),
+        )
+
+
 def _phase_cleanup_worktrees_and_branches(run: _MergeRunState) -> None:
     """Worktree removal + lane/mission branch deletion + coordination teardown."""
     from specify_cli.lanes.branch_naming import lane_branch_name, worktree_dir_name, worktree_path
@@ -1323,6 +1387,13 @@ def _phase_cleanup_worktrees_and_branches(run: _MergeRunState) -> None:
         else:
             logger.debug("Mission branch %s does not exist, skipping deletion", lanes_manifest.mission_branch)
         console.print(f"  Cleaned up {len(lanes_manifest.lanes)} lane branch(es) + mission branch")
+
+        # issue #3086: the coordination branch is now gone from git; flatten the
+        # mission's meta.json in the SAME gate so we can never delete the branch
+        # yet strand the paired ``coordination_branch`` marker (the 100%-hit-rate
+        # ``CoordinationBranchDeleted`` crash on every later resolve). Decoupled
+        # from the ``remove_worktree`` gate below on purpose.
+        _flatten_coordination_metadata_after_branch_delete(run)
 
     # -- WP07 / FR-016 / SC-10: Coordination worktree teardown --
     #

--- a/src/specify_cli/merge/executor.py
+++ b/src/specify_cli/merge/executor.py
@@ -1260,13 +1260,26 @@ def _flatten_coordination_metadata_after_branch_delete(run: _MergeRunState) -> N
     now-stale ``topology`` + record ``flattened=True``. It reuses those existing
     primitives rather than inventing a new mechanism.
 
-    Ordering matters. This runs AFTER the lane/mission branches were merged into
-    the target: the spec-kitty-meta merge driver treats ``coordination_branch``
-    as a *theirs-authoritative* planning key (``merge/merge_driver.py``), so any
-    earlier clear would be re-populated by driver reconciliation. Running here
-    makes this clear the last writer, so it wins. The edit is persisted through
-    the same protected-flow bookkeeping-commit seam the merge uses for its other
-    meta.json mutations, so the merged target branch is not left dirty.
+    Placement & ordering. This lives in the ``delete_branch`` gate, co-located
+    with the branch deletion, so the marker is cleared **iff** the branch it
+    names is deleted — the two mutations stay atomic. It is deliberately NOT
+    folded into the earlier, unconditional ``_phase_commit_and_assert``: doing so
+    would (a) require duplicating this gate's ``delete_branch`` guard into a phase
+    that must stay unconditional, and (b) clear the marker *before* the branch is
+    deleted, so a failed deletion would strand the inverse inconsistency (a
+    cleared marker with a still-live branch). It still runs after the lane->target
+    merge-driver reconciliation (which treats ``coordination_branch`` as a
+    *theirs-authoritative* planning key, ``merge/merge_driver.py``), so the clear
+    is the last writer regardless.
+
+    The edit is persisted through the same protected-flow bookkeeping-commit seam
+    the merge uses for its other meta.json mutations. A commit failure here is
+    logged and swallowed (fail-open), never raised: this runs in the post-push
+    cleanup phase, the on-disk flatten has already cleared ``coordination_branch``
+    (so #3086 stays fixed), and aborting an otherwise-complete merge — or
+    restoring the pre-flatten snapshot, which would re-strand the marker — is
+    worse than a locally-dirty meta.json (recoverable via
+    ``spec-kitty doctor coordination --fix``).
 
     A non-coord Mission (``SINGLE_BRANCH`` / ``LANES``) or an already-flattened
     one carries no ``coordination_branch`` key, so this is an idempotent no-op
@@ -1293,7 +1306,15 @@ def _flatten_coordination_metadata_after_branch_delete(run: _MergeRunState) -> N
     write_meta(feature_dir, meta, validate=False)
 
     meta_path = feature_dir / "meta.json"
-    if _paths_have_status_changes(run.main_repo, [meta_path]):
+    if not _paths_have_status_changes(run.main_repo, [meta_path]):
+        return
+
+    # Fail-open, unlike ``_phase_commit_and_assert``'s restore-and-reraise: the
+    # on-disk flatten already cleared ``coordination_branch`` (so #3086 stays
+    # fixed even if the commit does not land), and restoring the pre-flatten
+    # snapshot would re-strand the marker. A recovered commit (``commit_sha`` set)
+    # actually landed and is a success; every other failure is logged, not raised.
+    try:
         commit_merge_bookkeeping(
             repo_root=run.main_repo,
             worktree_root=run.main_repo,
@@ -1304,6 +1325,24 @@ def _flatten_coordination_metadata_after_branch_delete(run: _MergeRunState) -> N
                 f"after branch deletion (#3086)"
             ),
             paths=(meta_path,),
+        )
+    except SafeCommitRecoveryFailed as exc:
+        if exc.commit_sha is None:
+            logger.warning(
+                "Flatten bookkeeping commit did not land for %s (%s); meta.json is "
+                "flattened on disk but may be uncommitted — recover with "
+                "`spec-kitty doctor coordination --fix`",
+                run.mission_slug,
+                exc,
+            )
+    except Exception as exc:
+        # Fail-open: never abort a completed merge for a bookkeeping-commit failure.
+        logger.warning(
+            "Flatten bookkeeping commit failed for %s (%s); meta.json is flattened "
+            "on disk but may be uncommitted — recover with "
+            "`spec-kitty doctor coordination --fix`",
+            run.mission_slug,
+            exc,
         )
 
 

--- a/tests/merge/test_coordination_flatten_on_branch_delete.py
+++ b/tests/merge/test_coordination_flatten_on_branch_delete.py
@@ -1,28 +1,28 @@
-"""Red-first reproduction for issue #3086.
+"""Regression guard for issue #3086 (fixed): merge flattens coordination metadata.
 
 ``spec-kitty merge --delete-branch`` (the default) deletes a Mission's
 coordination branch (``kitty/mission-<slug>``) from git inside
-``_phase_cleanup_worktrees_and_branches``, but never clears the paired
-``coordination_branch`` key from that Mission's ``kitty-specs/<slug>/meta.json``.
-Every successfully-merged Mission is therefore left permanently divergent:
-``meta.json`` declares a ``coordination_branch`` that git no longer has. Any
-later command routing through ``resolve_status_surface_with_anchor``
-(``coordination/surface_resolver.py``) then hits ``CoordState.DELETED`` and
-raises ``CoordinationBranchDeleted`` — confirmed hard-crash on
-``retrospect create --update``, ``agent retrospect`` and ``implement``.
+``_phase_cleanup_worktrees_and_branches``. Before the #3086 fix it left the
+paired ``coordination_branch`` key in that Mission's
+``kitty-specs/<slug>/meta.json``, so every merged coordination Mission was left
+divergent — ``meta.json`` named a ``coordination_branch`` git no longer had —
+and any later command routing through ``resolve_status_surface_with_anchor``
+(``coordination/surface_resolver.py``) hit ``CoordState.DELETED`` and raised
+``CoordinationBranchDeleted`` (``retrospect create --update``, ``agent
+retrospect``, ``implement``).
 
-Red-first note: on current ``main`` this test FAILS. After the branch-deletion
-phase runs, ``meta.json`` still contains ``coordination_branch`` (and
-``flattened`` is still ``False``, ``topology`` still present). It goes green
-only when merge's teardown mirrors the canonical *flatten* already performed by
-``spec-kitty mission close --discard`` and ``spec-kitty doctor coordination
---fix``: ``clear_coordination_metadata`` (``mission_metadata.py``) + pop
-``topology`` + set ``flattened=True`` (see ``_coordination_doctor.py``).
+The fix makes the branch-delete gate mirror the canonical flatten already
+performed by ``spec-kitty mission close --discard`` and ``spec-kitty doctor
+coordination --fix``: clear ``coordination_branch`` + pop ``topology`` + set
+``flattened=True``. These tests are the permanent guard that the flatten stays
+wired; they graduated out of ``tests/regression/`` when the fix landed.
 
-The anchor assertion is the *absence of* ``coordination_branch`` — the invariant
-``surface_resolver`` actually keys the ``CoordState.DELETED`` hard-fail on — so
-this repro cannot be greened by a downstream point-guard (e.g. adding an
-``except`` to ``retrospect.py``) while the root-cause divergence remains.
+The primary case anchors on the *absence of* ``coordination_branch`` — the
+invariant ``surface_resolver`` keys its ``CoordState.DELETED`` hard-fail on — so
+it cannot be satisfied by a downstream point-guard while the root-cause
+divergence remains, and it asserts the flatten is committed (clean tree), not
+merely written to the working tree. The companion case pins the idempotent
+no-op for a non-coord Mission.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ from specify_cli.merge import executor as ex
 from specify_cli.merge.state import MergeState
 from specify_cli.mission_metadata import load_meta
 
-pytestmark = [pytest.mark.regression, pytest.mark.git_repo]
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
 # Production-shaped identity (26-char ULID); ``mid8`` is the branch/worktree
 # disambiguator, slug is ``<human>-<mid8>`` per the mission-identity model.
@@ -159,10 +159,10 @@ def test_issue_3086_merge_delete_branch_flattens_coordination_metadata(
         "cleanup did not delete the coordination branch — fixture/wiring error"
     )
 
-    # ANCHOR (red on current main): after deleting the coordination branch from
-    # git, merge MUST clear ``coordination_branch`` from meta.json so the Mission
-    # is flattened and later status-surface resolves route to primary instead of
-    # raising CoordinationBranchDeleted. Read fresh from disk.
+    # ANCHOR: after deleting the coordination branch from git, merge MUST clear
+    # ``coordination_branch`` from meta.json so the Mission is flattened and later
+    # status-surface resolves route to primary instead of raising
+    # CoordinationBranchDeleted. Read fresh from disk.
     meta = load_meta(feature_dir)
     assert meta is not None
     assert "coordination_branch" not in meta, (

--- a/tests/regression/test_issue_3086_merge_delete_branch_flattens_coordination_metadata.py
+++ b/tests/regression/test_issue_3086_merge_delete_branch_flattens_coordination_metadata.py
@@ -180,3 +180,92 @@ def test_issue_3086_merge_delete_branch_flattens_coordination_metadata(
     assert "topology" not in meta, (
         "issue #3086: flatten must pop the stale 'topology' key"
     )
+
+    # PR #3218 landing fold: the flatten must be COMMITTED, not merely written to
+    # the working tree — otherwise a merged coord Mission leaves the target branch
+    # dirty (the docstring's "not left dirty" contract). The assertions above read
+    # on-disk content, which ``write_meta`` produces *before* the bookkeeping
+    # commit is reached; a regression that dropped only the commit would pass them
+    # silently. Asserting a clean tree closes that gap.
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain", "--", "kitty-specs"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert porcelain == "", (
+        "issue #3086: the coordination-metadata flatten was written but not "
+        f"committed — merged target left dirty: {porcelain!r}"
+    )
+
+
+def test_issue_3086_flatten_is_noop_for_non_coord_mission(tmp_path: Path) -> None:
+    """The flatten guard leaves a non-coord Mission untouched (PR #3218 fold).
+
+    A ``SINGLE_BRANCH`` / ``LANES`` (or already-flattened) Mission carries no
+    ``coordination_branch`` key, so there is nothing to strand: the helper must
+    early-return before mutating ``meta.json`` or attempting a bookkeeping commit.
+    Covers the guard branch the coord repro above does not exercise.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Spec Kitty Test")
+    (repo / "README.md").write_text("seed\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "seed")
+
+    slug = "non-coord-repro-01jqanar"
+    feature_dir = repo / "kitty-specs" / slug
+    feature_dir.mkdir(parents=True)
+    original = {
+        "mission_id": _MISSION_ID,
+        "mid8": _MISSION_ID[:8],
+        "mission_slug": slug,
+        "topology": "single_branch",
+    }
+    (feature_dir / "meta.json").write_text(json.dumps(original, indent=2) + "\n")
+
+    run = ex._MergeRunState(
+        main_repo=repo,
+        mission_slug=slug,
+        canonical_id=_MISSION_ID,
+        canonical_mission_id=_MISSION_ID,
+        feature_dir=feature_dir,
+        target_feature_dir=feature_dir,
+        lanes_manifest=SimpleNamespace(
+            target_branch="main",
+            mission_branch=f"kitty/mission-{slug}",
+            lanes=[SimpleNamespace(lane_id="lane-a", wp_ids=["WP01"])],
+        ),
+        all_wp_ids=["WP01"],
+        push=False,
+        delete_branch=True,
+        remove_worktree=False,
+        strategy=ex.MergeStrategy.SQUASH,
+        assume_yes=True,
+        planning_artifact_only=False,
+        state=MergeState(
+            mission_id=_MISSION_ID,
+            mission_slug=slug,
+            target_branch="main",
+            wp_order=["WP01"],
+        ),
+        is_resume=False,
+        baseline_mission_id=_MISSION_ID,
+    )
+
+    ex._flatten_coordination_metadata_after_branch_delete(run)
+
+    meta = load_meta(feature_dir)
+    assert meta is not None
+    # Untouched: no coordination_branch to clear, so the guard adds no
+    # ``flattened`` provenance and leaves the authored ``topology`` in place.
+    assert "coordination_branch" not in meta
+    assert "flattened" not in meta, (
+        "issue #3086: a non-coord mission must not be marked flattened"
+    )
+    assert meta.get("topology") == "single_branch", (
+        "issue #3086: the no-op path must not pop a non-coord mission's topology"
+    )


### PR DESCRIPTION
## What changes for you

Commands you run against a **merged coordination mission** no longer crash. Previously, once you merged a mission that ran with a coordination branch, the next thing you did with it — create a retrospective, resume implementation, or check its status — failed outright with a data-loss safety error. It hit **every** merged coordination mission (100%: 45/45 in this repo already carry the problem). After this change, merging finalizes the mission cleanly, so it keeps working afterward — no manual recovery step needed.

## What was going wrong

Merging removes the mission's coordination branch, but it used to leave behind a stale pointer to that branch in the mission's own records. Every later command read that pointer, saw a branch that no longer existed, and stopped rather than act on inconsistent state. The only prior workaround was to run `spec-kitty doctor coordination --fix` by hand on each merged mission.

---

## For reviewers

**Root cause.** `_phase_cleanup_worktrees_and_branches` (`src/specify_cli/merge/executor.py`) had two decoupled gates — branch deletion under `delete_branch`, and the only meta-clearing path folded into the `remove_worktree` teardown seam. So a `--delete-branch` merge deleted the coordination branch and stranded `coordination_branch` in `kitty-specs/<slug>/meta.json`, tripping the #1848 `CoordinationBranchDeleted` fail-closed on every later `resolve_status_surface_with_anchor`.

**Fix.** Add the canonical three-mutation flatten (`clear_coordination_metadata` + pop `topology` + set `flattened=True`) — the same one `mission close --discard` and `doctor coordination --fix` use — to the branch-delete gate, decoupled from `remove_worktree`. It runs after lane→target merge-driver reconciliation (`coordination_branch` is a theirs-authoritative planning key), so it is the last writer; it persists through the existing bookkeeping-commit seam, **fail-open** — a commit failure never aborts an otherwise-complete merge, and never restores the pre-flatten snapshot (that would re-strand the marker). Reuses existing primitives; no new mechanism.

**Testing.** Permanent guard `tests/merge/test_coordination_flatten_on_branch_delete.py` (graduated out of `tests/regression/` when this fix greened its red-first pin): red-first verified, asserts the flatten is **committed** (clean tree), plus an idempotent-no-op case for non-coord missions. Targeted merge + coordination suites: **985 passed**. `ruff` clean; `mypy` adds no new errors (2 pre-existing at lines 153/1092, tracked under epic #1928). `commitlint` passes every commit.

**Landing review.** A 4-lens read-only adversarial squad (architect / reviewer / debugger / patterns) ran on the rebased tip — all APPROVE-WITH-FOLDS. Folds landed: fail-open commit handling + docstring correction; commit-persistence + no-op test coverage. The SSOT cleanup (unify the flatten primitive across its three call sites, and fix the `mission close --discard` partial-flatten) is deferred to #3219 as its own scoped mission — out of this P0's blast radius.

**Scope.** Standalone campsite fix — not part of, and not sequenced behind, the review-cycle verdict-seam unification (#2804 / #3216 / #3217 belong to that mission). PR-only to `main`; the operator merges.

Closes #3086
Refs #3219

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788551368&installation_model_id=427282&pr_number=3218&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3218&signature=dad2d3edcebc9e729d7c4b2c39c305514ec8ff58570a7a705fa1faf43f05ed30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
