### PR TITLE
docs(auth): scope D-5 to the hosted-SaaS opt-in gate, not every domain literal

### DIFF
--- a/src/specify_cli/auth/config.py
+++ b/src/specify_cli/auth/config.py
@@ -1,8 +1,17 @@
 """Configuration helpers for the spec-kitty auth subsystem (feature 080).
 
-Single source of truth for the SaaS base URL. Per architectural decision D-5,
-there is NO hardcoded SaaS domain anywhere in the codebase — callers must set
-``SPEC_KITTY_SAAS_URL`` in the environment.
+Single source of truth for the *hosted SaaS opt-in* base URL. Per
+architectural decision D-5, :func:`get_saas_base_url` never falls back to a
+default — callers must set ``SPEC_KITTY_SAAS_URL`` in the environment to opt
+a machine into hosted SaaS sync (mirrored by the "D-5 opt-in gate" in
+:func:`specify_cli.saas.readiness._probe_host_config`).
+
+D-5 scopes this opt-in gate, not every SaaS-domain literal in the codebase:
+:data:`specify_cli.sync.target_authority.DEFAULT_SERVER_URL` is a separate,
+documented default used only for local/descriptive resolution (queue-scope
+derivation, diagnostics) when neither the env var nor ``config.toml``
+supplies a target. That default never opens a network connection and never
+bypasses this function's opt-in gate for hosted activation.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Doc-only fix for question 1 in #2911.

`auth/config.py` said D-5 means "there is NO hardcoded SaaS domain anywhere in the codebase". That is contradicted by `DEFAULT_SERVER_URL = "https://spec-kitty-dev.fly.dev"` in `sync/target_authority.py`, mirrored in `sync/config.py` and `sync/queue.py`. The fallback is intentional: `tests/sync/test_target_authority.py` asserts `resolved_server_url == DEFAULT_SERVER_URL` when the env var is unset.

I reworded the module docstring in `auth/config.py` to say what D-5 actually guarantees: `get_saas_base_url()` never falls back, so hosted SaaS sync only activates when `SPEC_KITTY_SAAS_URL` is explicitly set. `saas/readiness.py::_probe_host_config` already calls this the "D-5 opt-in gate", so I reused that framing and cross-referenced `DEFAULT_SERVER_URL` as a separate, documented default for local/descriptive resolution (queue-scope derivation, diagnostics) that never opens a network connection and never bypasses the opt-in gate.

No behavior change, no new tests needed (docstring only). `ruff check` passes on the file.

## What this does not answer

Questions 2 and 3 from #2911 are still open and are product decisions, not doc fixes:
- Should there be a warning at sync-enable time when `SPEC_KITTY_SAAS_URL` is unset and the resolver falls back to the dev host?
- Should `spec-kitty-dev.fly.dev` stay the default for self-hosting adopters, or should it become a neutral placeholder?

Happy to follow up on either once there is a preferred direction.

## Test plan

- [x] `ruff check src/specify_cli/auth/config.py` passes
- [x] Verified the module still parses and imports (`python -c "from specify_cli.auth.config import get_saas_base_url"`)
- [ ] Full `pytest tests/auth/test_config.py` could not run in my local environment (pre-existing venv-creation permission error unrelated to this change); the change is docstring-only so I don't expect it to affect test outcomes

Refs #2911 (answers question 1; questions 2 and 3 stay open).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788648731&installation_model_id=427282&pr_number=3249&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3249&signature=b11032941bc20854c5f0611fd268abf9271da4624b3f801aa11ed5d69613ad0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->