### PR TITLE
test: restore charter/packs provisioning in fixtures regressed by PACKS_ROOT unification

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -312,6 +312,17 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **Restored green CI on two suites that regressed after the single-`PACKS_ROOT`
+  / charter-activation unification (mission `resolution-activation-foundation`).**
+  `tests/review/test_pre_review_gate_integration.py` and
+  `tests/merge/test_profile_charter_e2e.py` still built bare fixtures that never
+  provisioned the default charter / mission-type activations, so once resolution
+  moved to a single fail-closed `SPEC_KITTY_PACKS_ROOT` read the pre-review gate
+  degraded to `no_coverage` (never blocking) and mission-template resolution
+  raised `MissionsRootNotFound`. The fixtures now seed the default activations
+  via the production provisioner and mirror the built-in `missions` leaf under
+  the packs root. Test-harness only — no product behaviour changed; the
+  fail-closed resolution the sibling mission introduced is intentional.
 - **Commands run on a merged coordination mission no longer crash (`#3086`).**
   Once a coordination mission was merged, later commands against it — creating a
   retrospective, resuming implementation, or checking its status — failed

--- a/tests/merge/test_profile_charter_e2e.py
+++ b/tests/merge/test_profile_charter_e2e.py
@@ -130,6 +130,20 @@ def test_profile_aware_charter_compilation_resolves_transitive_references(
             "description": "Software development mission.",
         },
     )
+    # Post `resolution-activation-foundation` (unified single-PACKS_ROOT read):
+    # ``MissionTemplateRepository.default_missions_root()`` now resolves the
+    # ``missions`` leaf from ``SPEC_KITTY_PACKS_ROOT`` (``packs/built-in/missions``),
+    # not the patched ``resolve_doctrine_root``. ``default_interview`` below reads
+    # it before the ``resolve_doctrine_root`` patch is even applied, so mirror the
+    # mission template under the packs root or it fails closed with
+    # ``MissionsRootNotFound``.
+    _write_yaml(
+        packs_root / "built-in" / "missions" / "software-dev" / "mission.yaml",
+        {
+            "name": "software-dev",
+            "description": "Software development mission.",
+        },
+    )
     # Post-WP03: the DRG graph is the sole authority for transitive
     # reference chains. Materialize a synthetic graph.yaml that mirrors the
     # pre-WP02 inline topology (REVIEW_FIRST -> review-tactic; review-tactic

--- a/tests/review/test_pre_review_gate_integration.py
+++ b/tests/review/test_pre_review_gate_integration.py
@@ -83,6 +83,7 @@ from specify_cli.status.store import append_event
 from specify_cli.status.reducer import materialize
 from specify_cli.status.store import read_events
 from specify_cli.workspace.context import ResolvedWorkspace
+from tests._factories import provision_test_charter
 from tests.mocked_env import setup_mocked_env
 from tests.specify_cli.cli.commands.agent.test_tasks_ports import (
     FakeFsReader,
@@ -216,6 +217,12 @@ def _build_wp_file(
     tasks_dir = feature_dir / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
     (tmp_path / ".kittify").mkdir(exist_ok=True)
+    # Post `resolution-activation-foundation`: the pre-review gate resolves its
+    # owning `mission_step_contract:software-dev/review` via charter activation.
+    # A bare project has no activations, so the gate degrades to `no_coverage`
+    # (never blocks). Seed the default activations via the production provisioner
+    # so the gate has real coverage to enforce.
+    provision_test_charter(tmp_path)
     wp_file = tasks_dir / f"{wp_id}-test.md"
     wp_file.write_text(
         f"---\n"
@@ -255,7 +262,13 @@ def _write_config_yaml(main_repo_root: Path, *, block: bool = False, test_comman
         lines.append("  fail_on_pre_review_regression: true")
     if test_command:
         lines.append(f'  pre_review_test_command: "{test_command}"')
-    (main_repo_root / ".kittify" / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # Append (don't clobber): `_build_wp_file` may have already provisioned the
+    # default `mission_type_activations` the gate needs to resolve its contract.
+    (main_repo_root / ".kittify").mkdir(exist_ok=True)
+    config_path = main_repo_root / ".kittify" / "config.yaml"
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    prefix = existing if existing.endswith("\n") or not existing else existing + "\n"
+    config_path.write_text(prefix + "\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _seed_baseline(


### PR DESCRIPTION
## Restore green CI on two suites regressed by the single-`PACKS_ROOT` unification

**Impact:** `main` went red on `integration-tests-review` and `integration-tests-merge` after mission `resolution-activation-foundation` merged (`bccb4b4b5`). Both are **stale test fixtures**, not product defects — this PR restores them. No product behaviour changes.

### Root cause
`resolution-activation-foundation` unified mission-template/doctrine resolution onto a single **fail-closed** `SPEC_KITTY_PACKS_ROOT` read and made charter activation the sole authority for what is active. Its landing pass provisioned the default charter in most affected fixtures but **missed two**:

- **`tests/review/test_pre_review_gate_integration.py`** (7 tests) — the pre-review gate now resolves its owning `mission_step_contract:software-dev/review` via charter activation. The bare fixtures never activated it, so the gate degraded to `no_coverage` and never blocked (`DID NOT RAISE`).
- **`tests/merge/test_profile_charter_e2e.py`** — `default_interview` → `MissionTemplateRepository.default_missions_root()` now reads the `missions` leaf from `SPEC_KITTY_PACKS_ROOT`, not the patched `resolve_doctrine_root`, so it failed closed with `MissionsRootNotFound`.

### Fix (test-harness only)
- Provision the default activations in `_build_wp_file` via the production `provision_test_charter` helper (the same helper the sibling landing used elsewhere), and make `_write_config_yaml` **append** rather than clobber them.
- Mirror the synthetic `software-dev` mission template under `packs/built-in/missions/` in the charter-e2e fixture.

The fail-closed resolution the sibling mission introduced is **intentional and untouched** — only the missed fixtures are brought in line with it.

### Verification
- Locally green: `test_profile_aware_charter_compilation_resolves_transitive_references` (1 passed), and `test_block_mode_blocks_without_force` + `test_consumer_repo_missing_gate_authority_degrades_to_calm_warn` (2 passed — confirms both the coverage-expecting **and** degradation paths).
- The remaining 5 pre-review-gate tests share the identical root cause + fix; the full suites are left to CI.
- `ruff` clean, `commitlint` clean, `docs-freshness --ci` exit 0, terminology guard 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788759909&installation_model_id=427282&pr_number=3257&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3257&signature=aedfd0990789bbb77e1bb1c9f49f8b0ba3f3a89f7e26b479fdba827f247d1c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->