### PR TITLE
fix(commit): failing git commit must not be reported as an empty changeset

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -347,6 +347,16 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **A spec commit that genuinely FAILS is no longer silently reported as
+  "unchanged" (`#3269`).** When a `git commit` failed for a real reason — a
+  rejecting pre-commit hook, a lock error — `safe_commit` collapsed every
+  non-zero exit onto the same "nothing to commit" path, so `spec-commit` printed
+  _"Spec artifact(s) unchanged, no commit needed"_ and the spec silently never
+  landed. Emptiness is now decided by the **staged tree** (`git diff --cached`),
+  not by matching git's output text: a genuine no-op is still reported as
+  unchanged, while a real failure surfaces as an error carrying git's own
+  diagnostic — even when a failing hook prints its own "nothing to
+  commit"-shaped message.
 - **`spec-kitty` no longer crashes when an arbiter override lands on a
   conflict-marked review-cycle file (mission `verdict-seam-boundary-hardening`;
   `#3244`).** An arbiter override written against a `review-cycle-N.md` that

--- a/src/specify_cli/coordination/commit_router.py
+++ b/src/specify_cli/coordination/commit_router.py
@@ -911,7 +911,11 @@ def _any_path_absent(paths: tuple[Path, ...]) -> bool:
 
 
 def _is_empty_changeset_error(exc: RuntimeError) -> bool:
-    return str(exc).startswith("safe_commit: git commit failed")
+    # Match ONLY the genuine empty-changeset signal safe_commit now raises with a
+    # distinct message. A generic "safe_commit: git commit failed …" (a rejecting
+    # pre-commit hook, a lock error, etc.) must fall through to a real error,
+    # never be silently reported as "unchanged".
+    return "safe_commit: nothing to commit" in str(exc)
 
 
 def _try_advance_ref(

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -801,13 +801,47 @@ _EMPTY_CHANGESET_MARKERS = (
 def _commit_output_is_empty_changeset(output: str) -> bool:
     """True iff git's own output says the commit was a genuine empty changeset.
 
-    Distinguishes a benign no-op (staged content already matches HEAD) from a
-    real failure (a rejecting pre-commit hook, a lock error, etc.). Without this
-    distinction every non-zero ``git commit`` exit looked identical to callers
-    and a real failure was silently reported as "unchanged".
+    Secondary signal only — see :func:`_staged_tree_is_empty` for the
+    authoritative check. Output-text matching alone is unsound: a failing
+    pre-commit hook can print one of these markers to its own stdout/stderr
+    while rejecting a real staged change, which would misclassify a genuine
+    failure as a benign no-op (audit finding, PR #3269). Kept as a fallback
+    for callers that only have the combined text and no repo to probe.
     """
     low = output.lower()
     return any(marker in low for marker in _EMPTY_CHANGESET_MARKERS)
+
+
+def _staged_tree_is_empty(repo_path: Path) -> bool:
+    """True iff the index matches HEAD, i.e. there is genuinely nothing staged.
+
+    This is the AUTHORITY for the empty-vs-failure decision after a failed
+    ``git commit`` (audit BLOCK_MATERIAL, PR #3269): git's own combined
+    stdout+stderr text is not a reliable signal, because a pre-commit hook
+    that REJECTS a real staged change can still print a "nothing to commit"
+    -shaped message on its own account. A hook failure always leaves the
+    rejected files staged, so the index still differs from HEAD regardless of
+    what strings the hook printed -- while a true no-op leaves the index
+    identical to HEAD. Keying off staged state instead of output text makes
+    the distinction structural rather than textual.
+
+    Runs ``git diff --cached --quiet`` in ``repo_path``: exit code 0 means the
+    staged tree matches HEAD (nothing to commit); exit code 1 means staged
+    content differs from HEAD (a real, non-empty change is sitting in the
+    index). Any other exit code is treated as "not empty" (fail closed --
+    do not mask a genuine failure as a benign no-op just because the probe
+    itself misbehaved).
+    """
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return result.returncode == 0
 
 
 def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> tuple[str | None, str]:
@@ -1098,7 +1132,15 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
             new_sha, commit_output = _run_commit_capture_sha(worktree_root, message)
             commit_created = new_sha is not None
             if not commit_created:
-                if _commit_output_is_empty_changeset(commit_output):
+                # AUTHORITY: staged state, not git's output text (audit
+                # BLOCK_MATERIAL, PR #3269). A rejecting pre-commit hook can
+                # print a "nothing to commit"-shaped message on its own
+                # account while leaving a real staged change in the index --
+                # `_commit_output_is_empty_changeset` alone would misclassify
+                # that as a benign no-op. `_staged_tree_is_empty` cannot be
+                # fooled by hook output: it is only True when the index
+                # genuinely matches HEAD.
+                if _staged_tree_is_empty(worktree_root):
                     # Benign no-op: staged content already matches HEAD. The
                     # commit router maps this distinct message to "unchanged".
                     raise RuntimeError(

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -791,8 +791,33 @@ def _restore_staged_patch(
         )
 
 
-def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> str | None:
-    """Run ``git commit`` and return the new commit SHA, or ``None`` on failure."""
+_EMPTY_CHANGESET_MARKERS = (
+    "nothing to commit",
+    "nothing added to commit",
+    "no changes added to commit",
+)
+
+
+def _commit_output_is_empty_changeset(output: str) -> bool:
+    """True iff git's own output says the commit was a genuine empty changeset.
+
+    Distinguishes a benign no-op (staged content already matches HEAD) from a
+    real failure (a rejecting pre-commit hook, a lock error, etc.). Without this
+    distinction every non-zero ``git commit`` exit looked identical to callers
+    and a real failure was silently reported as "unchanged".
+    """
+    low = output.lower()
+    return any(marker in low for marker in _EMPTY_CHANGESET_MARKERS)
+
+
+def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> tuple[str | None, str]:
+    """Run ``git commit``.
+
+    Returns ``(new SHA, "")`` on success, or ``(None, combined_output)`` on
+    failure — where ``combined_output`` carries git's stdout+stderr so the
+    caller can tell an empty changeset apart from a genuine commit failure
+    (e.g. a failing pre-commit hook) instead of collapsing both to ``None``.
+    """
     commit_result = subprocess.run(
         ["git", "-c", "commit.gpgsign=false", "commit", "-m", commit_message],
         cwd=repo_path,
@@ -803,9 +828,10 @@ def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> str | None:
         check=False,
     )
     if commit_result.returncode != 0:
-        return None
+        combined = f"{commit_result.stdout}\n{commit_result.stderr}".strip()
+        return None, combined
     sha = _run_git_text(repo_path, ["rev-parse", "HEAD"])
-    return sha
+    return sha, ""
 
 
 def _derive_mission_id(paths: list[str]) -> str:
@@ -1069,12 +1095,22 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
         except SafeCommitBackstopError as exc:
             backstop_error = exc
         else:
-            new_sha = _run_commit_capture_sha(worktree_root, message)
+            new_sha, commit_output = _run_commit_capture_sha(worktree_root, message)
             commit_created = new_sha is not None
             if not commit_created:
+                if _commit_output_is_empty_changeset(commit_output):
+                    # Benign no-op: staged content already matches HEAD. The
+                    # commit router maps this distinct message to "unchanged".
+                    raise RuntimeError(
+                        f"safe_commit: nothing to commit for "
+                        f"destination_ref={destination_ref!r} (empty changeset)"
+                    )
+                # Genuine failure (rejecting pre-commit hook, lock, etc.) — carry
+                # git's own output so it is NOT mistaken for an empty changeset.
+                detail = f": {commit_output}" if commit_output else ""
                 raise RuntimeError(
                     f"safe_commit: git commit failed in {worktree_root} for "
-                    f"destination_ref={destination_ref!r}"
+                    f"destination_ref={destination_ref!r}{detail}"
                 )
     finally:
         recovery_messages: list[str] = []

--- a/tests/git_ops/test_safe_commit_commit_failure_classification.py
+++ b/tests/git_ops/test_safe_commit_commit_failure_classification.py
@@ -1,0 +1,121 @@
+"""Regression: safe_commit must distinguish a genuine empty changeset from a
+real commit failure (e.g. a failing pre-commit hook).
+
+Before this fix, ``_run_commit_capture_sha`` collapsed *every* non-zero
+``git commit`` exit to ``None`` and ``safe_commit`` raised a single
+``"safe_commit: git commit failed"`` RuntimeError for all of them. The commit
+router's ``_is_empty_changeset_error`` matched that message by prefix, so a
+commit that FAILED for a non-empty reason (a broken pre-commit hook, a rejected
+commit, etc.) was silently reported as ``status="unchanged"`` / ``committed=False``
+— masking the real failure. This surfaced live as ``spec-commit`` reporting
+"Spec artifact(s) unchanged, no commit needed" for a fresh mission whose
+pre-commit hook pointed at a since-deleted interpreter.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.coordination.commit_router import _is_empty_changeset_error
+from specify_cli.git.commit_helpers import safe_commit
+
+pytestmark = pytest.mark.git_repo
+
+_UNPROTECTED_BRANCH = "kitty/mission-test-01ABCDEF"
+
+
+def _init_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=root, check=True)
+    (root / "README.md").write_text("# seed\n")
+    subprocess.run(["git", "add", "README.md"], cwd=root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=root, check=True, capture_output=True)
+    subprocess.run(["git", "branch", "-M", _UNPROTECTED_BRANCH], cwd=root, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _init_repo(root)
+    return root
+
+
+def _new_spec(root: Path) -> Path:
+    spec = root / "kitty-specs" / "demo-mission" / "spec.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# Spec\n\n| FR-001 | a real requirement | High | Open |\n")
+    return spec
+
+
+def test_hook_failure_is_not_classified_as_empty_changeset(repo: Path) -> None:
+    """A failing pre-commit hook must surface as a real failure, never 'unchanged'."""
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\necho 'pre-commit boom' >&2\nexit 1\n")
+    hook.chmod(0o755)
+
+    spec = _new_spec(repo)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref=_UNPROTECTED_BRANCH,
+            message="Add spec",
+            paths=(spec,),
+        )
+
+    # The load-bearing assertion: the router must NOT treat this as a benign
+    # empty changeset (which it would render as status="unchanged").
+    assert not _is_empty_changeset_error(excinfo.value), (
+        "hook failure was misclassified as an empty changeset -> would surface "
+        f"as 'unchanged, no commit needed'. message={excinfo.value!r}"
+    )
+    # And the failure must carry git's own output so the operator can diagnose it.
+    assert "pre-commit boom" in str(excinfo.value)
+    # The commit genuinely did not land.
+    head_files = subprocess.run(
+        ["git", "ls-files", "kitty-specs/demo-mission/spec.md"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head_files == "", "hook aborted the commit, so the spec must not be tracked"
+
+
+def test_genuine_empty_changeset_is_still_classified_as_empty(repo: Path) -> None:
+    """A true no-op (staged content identical to HEAD) stays 'unchanged'."""
+    spec = _new_spec(repo)
+    # First commit lands.
+    safe_commit(
+        repo_root=repo, worktree_root=repo, destination_ref=_UNPROTECTED_BRANCH,
+        message="Add spec", paths=(spec,),
+    )
+    # Re-committing identical content is a genuine empty changeset.
+    with pytest.raises(RuntimeError) as excinfo:
+        safe_commit(
+            repo_root=repo, worktree_root=repo, destination_ref=_UNPROTECTED_BRANCH,
+            message="Add spec again", paths=(spec,),
+        )
+    assert _is_empty_changeset_error(excinfo.value), (
+        "a genuine empty changeset must still classify as empty (-> 'unchanged'); "
+        f"message={excinfo.value!r}"
+    )
+
+
+def test_fresh_untracked_file_commits_cleanly(repo: Path) -> None:
+    """Control: with no broken hook, a brand-new untracked spec commits (guards the
+    first-spec-of-a-fresh-mission path that originally looked broken)."""
+    spec = _new_spec(repo)
+    result = safe_commit(
+        repo_root=repo, worktree_root=repo, destination_ref=_UNPROTECTED_BRANCH,
+        message="Add spec", paths=(spec,),
+    )
+    assert result is not None and result.sha
+    tracked = subprocess.run(
+        ["git", "ls-files", "kitty-specs/demo-mission/spec.md"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert tracked == "kitty-specs/demo-mission/spec.md"

--- a/tests/git_ops/test_safe_commit_commit_failure_classification.py
+++ b/tests/git_ops/test_safe_commit_commit_failure_classification.py
@@ -105,6 +105,48 @@ def test_genuine_empty_changeset_is_still_classified_as_empty(repo: Path) -> Non
     )
 
 
+def test_hook_failure_that_prints_nothing_to_commit_is_not_classified_as_empty(repo: Path) -> None:
+    """Adversarial case (audit BLOCK_MATERIAL): a pre-commit hook that FAILS
+    while also printing a "nothing to commit" marker in its own stdout/stderr
+    must still surface as a real failure, not as a benign empty changeset.
+
+    Output-string matching alone cannot distinguish this from a genuine no-op,
+    since git's own output and the hook's output are combined. The staged tree
+    is the authority: a real (rejected) staged change differs from HEAD, so
+    the classification must key off that, not off what strings appear in the
+    combined output.
+    """
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\necho 'nothing to commit, working tree clean'\nexit 1\n")
+    hook.chmod(0o755)
+
+    spec = _new_spec(repo)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        safe_commit(
+            repo_root=repo,
+            worktree_root=repo,
+            destination_ref=_UNPROTECTED_BRANCH,
+            message="Add spec",
+            paths=(spec,),
+        )
+
+    # The load-bearing assertion: a real staged change rejected by a failing
+    # hook must NEVER classify as an empty changeset, even though the hook's
+    # own output contains the "nothing to commit" marker.
+    assert not _is_empty_changeset_error(excinfo.value), (
+        "hook failure that prints a 'nothing to commit' marker was "
+        "misclassified as an empty changeset -> would surface as "
+        f"'unchanged, no commit needed'. message={excinfo.value!r}"
+    )
+    # The commit genuinely did not land.
+    head_files = subprocess.run(
+        ["git", "ls-files", "kitty-specs/demo-mission/spec.md"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head_files == "", "hook aborted the commit, so the spec must not be tracked"
+
+
 def test_fresh_untracked_file_commits_cleanly(repo: Path) -> None:
     """Control: with no broken hook, a brand-new untracked spec commits (guards the
     first-spec-of-a-fresh-mission path that originally looked broken)."""


### PR DESCRIPTION
## Problem

A spec commit that genuinely **failed** was silently reported as **"unchanged"**, so the spec never landed. `safe_commit` collapsed *every* non-zero `git commit` exit onto the same "nothing to commit" path, so `spec-commit` printed _"Spec artifact(s) unchanged, no commit needed"_ even when the commit had actually failed.

Observed live: a fresh mission whose `.git/hooks/pre-commit` pointed at a since-deleted agent-worktree interpreter — the commit failed, but the spec silently never landed.

## Fix — decide emptiness from **staged state**, not git's output text

- New `_staged_tree_is_empty(repo_path)` runs `git diff --cached --quiet`: exit 0 ⟹ the index matches HEAD (genuinely nothing to commit); exit 1 ⟹ a real staged change is sitting in the index. A rejecting pre-commit hook **always leaves the rejected files staged**, so a real failure stays distinguishable from a true no-op regardless of what the hook printed. Unexpected exit codes are treated as **not empty (fail-closed)** — a misbehaving probe never masks a genuine failure.
- In `safe_commit`'s commit-failure branch this probe is now the **sole authority**. The prior output-string helper (`_commit_output_is_empty_changeset`) is retained only as a documented secondary fallback and can no longer override a non-empty staged tree into "empty".
- Net: a benign no-op is still `unchanged`; a genuine failure surfaces as an **error carrying git's own diagnostic** — even when a failing hook emits its own "nothing to commit"-shaped message.

## Tests (red-first)

`tests/git_ops/test_safe_commit_commit_failure_classification.py`:

- **A hook that fails while printing "nothing to commit" with a real staged change → classified as FAILURE, not empty** (the adversarial case — red against the output-string logic, green after the staged-state fix; commit does not land);
- broken hook → failure; genuine empty changeset (`staged == HEAD`) → unchanged; fresh untracked file (no hook) → clean commit.

Verified on the rebased tip: classification + integration **20 passed**; `test_commit_router` + siblings **51 passed**; `tests/git_ops/` + `tests/coordination/` sweep **402 passed**; `ruff` clean; commitlint clean. The one `no-any-return` mypy finding at `commit_helpers.py:494` is pre-existing (identical on `main`).

## Changelog

Consumer-focused Unreleased/Fixed entry added in `docs/changelog/CHANGELOG.md`.

## Landing notes

Rebased onto current `main`. The initial output-string classifier was hardened to key off staged state after an adversarial audit's `BLOCK_MATERIAL` finding (a failing hook emitting the "nothing to commit" marker would otherwise still be mis-read as benign-empty). Remaining CI reds are the by-design `regression tests (blocking)` (**#2782**, reproduces on `main`) and its `quality-gate` aggregate — unrelated to this diff. One dead-code residual flagged for separate cleanup: `commit_router.py:313` matches "nothing to commit" on a `CalledProcessError` that `safe_commit` never raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
