### PR TITLE
test(docs): declare pytestmark on test_guards.py (green main after #3268)

### DIFF
--- a/tests/docs/test_guards.py
+++ b/tests/docs/test_guards.py
@@ -15,6 +15,8 @@ import pytest
 
 from scripts.docs._guards import assert_examined_floor
 
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
 
 def test_below_floor_raises_with_expected_substrings() -> None:
     """A count under the minimum raises, and the message carries the shape


### PR DESCRIPTION
Greens `main`: `tests/docs/test_guards.py` (merged in #3268) lacked a module-level `pytestmark`, so the architectural marker-convention gate `test_every_test_file_declares_a_pytestmark_marker` fails on `main` and would red the next PR's arch shard.

Fix adds `pytestmark = [pytest.mark.unit, pytest.mark.fast]`, matching sibling docs unit tests (e.g. `tests/docs/test_published_pages.py`).

Local verification:
- `PYTHONPATH=. uv run pytest tests/architectural/test_pytest_marker_convention.py tests/docs/test_guards.py -q` → 8 passed
- `PYTHONPATH=. uv run ruff check tests/docs/test_guards.py` → All checks passed!

Follow-up to #3268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788853213&installation_model_id=427282&pr_number=3274&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3274&signature=e8fa3406960c82f0b2e9e3325b96b04056a2940fb37c349012fe213dbcdff553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->