### PR TITLE
refactor(clock): route remaining specify_cli now-stamps onto now_utc_iso() + full-tree AST gate (#2496)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1258,6 +1258,14 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   (create-if-absent); an existing curated companion is left byte-for-byte untouched,
   preserving the #2772 never-clobber invariant. `charter.md` remains display-only, never a
   resolving input. ADR 2026-07-18-1 amended.
+- **Internal: remaining `specify_cli` datetime stamp sites consolidated onto
+  `now_utc_iso()` (#2496).** Follow-up to #2494's clock-consolidation sweep; routes the
+  remaining byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in
+  `specify_cli` (14 sites, 11 files) onto the single canonical `now_utc_iso()` helper.
+  Behaviour-preserving: the `UTC` / `timezone.utc` spellings serialize byte-identically
+  under `requires-python >=3.11`. Boundary packages (`charter`/`glossary`, blocked by the
+  architectural layer contract) and non-`now` sites (`timespec=`, naive, subprocess-string)
+  are left as-is by design.
 - **Internal: the coord-authority trio is decomposed into ports + pure cores
   (#2464, #2465).** The three coord-authority god-modules are restructured
   behaviour-preservingly into the shipped Typer-shell + request-dataclass + pure-cores

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1261,17 +1261,18 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 - **Internal: the `specify_cli` aware-UTC clock contract is now enforced structurally
   (#2496).** Follow-up to #2494's clock-consolidation sweep. Routes the remaining
   byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in `specify_cli`
-  onto the single canonical `now_utc_iso()` helper, so that helper is the sole permitted
-  producer of the form. Behaviour-preserving: the `UTC` / `timezone.utc` spellings
-  serialize byte-identically under `requires-python >=3.11`. Adds an **AST negative
-  gate** over the whole `src/specify_cli` tree
-  (`tests/specify_cli/test_clock_consolidation.py`), alongside the pre-existing
-  owned-file inventory, so a module added later is covered the moment it lands rather
-  than silently regressing while the suite stays green; the gate ships a self-mutant
-  non-vacuity test and a stale-exemption check.
-  Distinct contracts are deliberately out of scope and are not flagged: the
-  second-precision `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`,
-  naive `now()`, and the datetime-returning family.
+  onto the single canonical `now_utc_iso()` helper, the canonical producer of that form.
+  Behaviour-preserving: the `UTC` / `timezone.utc` spellings serialize byte-identically
+  under `requires-python >=3.11`. Adds an **AST negative gate** over the whole
+  `src/specify_cli` tree (`tests/specify_cli/test_clock_consolidation.py`), alongside
+  the pre-existing owned-file inventory, so a module added later is covered the moment it
+  lands rather than silently regressing while the suite stays green; the gate ships a
+  self-mutant non-vacuity test and a stale-exemption check. It targets the fluent
+  single-expression `<x>.now(<aware-UTC>).isoformat()` idiom (import aliases resolved);
+  distinct contracts are deliberately out of scope and not flagged: the second-precision
+  `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`, naive `now()`, the
+  datetime-returning family, and non-fluent forms (a variable-split or a space-separated
+  `str()` of an aware instant).
 - **Internal: the coord-authority trio is decomposed into ports + pure cores
   (#2464, #2465).** The three coord-authority god-modules are restructured
   behaviour-preservingly into the shipped Typer-shell + request-dataclass + pure-cores

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1263,11 +1263,12 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in `specify_cli`
   onto the single canonical `now_utc_iso()` helper, so that helper is the sole permitted
   producer of the form. Behaviour-preserving: the `UTC` / `timezone.utc` spellings
-  serialize byte-identically under `requires-python >=3.11`. Replaces the previous
-  owned-file inventory with an **AST negative gate** over the whole `src/specify_cli`
-  tree (`tests/specify_cli/test_clock_consolidation.py`), so a module added later is
-  covered the moment it lands rather than silently regressing while the suite stays
-  green; the gate ships a self-mutant non-vacuity test and a stale-exemption check.
+  serialize byte-identically under `requires-python >=3.11`. Adds an **AST negative
+  gate** over the whole `src/specify_cli` tree
+  (`tests/specify_cli/test_clock_consolidation.py`), alongside the pre-existing
+  owned-file inventory, so a module added later is covered the moment it lands rather
+  than silently regressing while the suite stays green; the gate ships a self-mutant
+  non-vacuity test and a stale-exemption check.
   Distinct contracts are deliberately out of scope and are not flagged: the
   second-precision `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`,
   naive `now()`, and the datetime-returning family.

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1258,14 +1258,19 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   (create-if-absent); an existing curated companion is left byte-for-byte untouched,
   preserving the #2772 never-clobber invariant. `charter.md` remains display-only, never a
   resolving input. ADR 2026-07-18-1 amended.
-- **Internal: remaining `specify_cli` datetime stamp sites consolidated onto
-  `now_utc_iso()` (#2496).** Follow-up to #2494's clock-consolidation sweep; routes the
-  remaining byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in
-  `specify_cli` (14 sites, 11 files) onto the single canonical `now_utc_iso()` helper.
-  Behaviour-preserving: the `UTC` / `timezone.utc` spellings serialize byte-identically
-  under `requires-python >=3.11`. Boundary packages (`charter`/`glossary`, blocked by the
-  architectural layer contract) and non-`now` sites (`timespec=`, naive, subprocess-string)
-  are left as-is by design.
+- **Internal: the `specify_cli` aware-UTC clock contract is now enforced structurally
+  (#2496).** Follow-up to #2494's clock-consolidation sweep. Routes the remaining
+  byte-identical `datetime.now(UTC).isoformat()` "now"-stamp call sites in `specify_cli`
+  onto the single canonical `now_utc_iso()` helper, so that helper is the sole permitted
+  producer of the form. Behaviour-preserving: the `UTC` / `timezone.utc` spellings
+  serialize byte-identically under `requires-python >=3.11`. Replaces the previous
+  owned-file inventory with an **AST negative gate** over the whole `src/specify_cli`
+  tree (`tests/specify_cli/test_clock_consolidation.py`), so a module added later is
+  covered the moment it lands rather than silently regressing while the suite stays
+  green; the gate ships a self-mutant non-vacuity test and a stale-exemption check.
+  Distinct contracts are deliberately out of scope and are not flagged: the
+  second-precision `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`,
+  naive `now()`, and the datetime-returning family.
 - **Internal: the coord-authority trio is decomposed into ports + pure cores
   (#2464, #2465).** The three coord-authority god-modules are restructured
   behaviour-preservingly into the shipped Typer-shell + request-dataclass + pure-cores

--- a/src/specify_cli/charter_runtime/lint/engine.py
+++ b/src/specify_cli/charter_runtime/lint/engine.py
@@ -13,10 +13,11 @@ Zero LLM calls.  All checks are pure graph traversal.
 
 from __future__ import annotations
 
-import datetime
 import logging
 import time
 from pathlib import Path
+
+from specify_cli.core.time_utils import now_utc_iso
 
 from .findings import DecayReport, GraphState, LintFinding
 from .checks.orphan import OrphanChecker
@@ -106,7 +107,7 @@ class LintEngine:
             )
             empty = DecayReport(
                 findings=[],
-                scanned_at=datetime.datetime.now(datetime.UTC).isoformat(),
+                scanned_at=now_utc_iso(),
                 feature_scope=feature_scope,
                 duration_seconds=0.0,
                 drg_node_count=0,
@@ -139,7 +140,7 @@ class LintEngine:
 
         report = DecayReport(
             findings=all_findings,
-            scanned_at=datetime.datetime.now(datetime.UTC).isoformat(),
+            scanned_at=now_utc_iso(),
             feature_scope=feature_scope,
             duration_seconds=round(duration, 3),
             drg_node_count=len(list(getattr(drg, "nodes", []))),

--- a/src/specify_cli/cli/commands/agent/acceptance_verdict.py
+++ b/src/specify_cli/cli/commands/agent/acceptance_verdict.py
@@ -39,7 +39,6 @@ enforce_negative_invariants` engine (never reimplemented here), recording its
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -57,6 +56,7 @@ from specify_cli.acceptance.matrix import (
 from specify_cli.agent_tasks_ports import RealRender
 from specify_cli.cli.console import console
 from specify_cli.cli.selector_resolution import resolve_mission_handle
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.task_utils import TaskCliError, find_repo_root
 
 if TYPE_CHECKING:
@@ -124,7 +124,7 @@ def _resolve_criterion_update(
         return existing
     return replace(
         candidate,
-        verified_at=datetime.now(UTC).isoformat(),
+        verified_at=now_utc_iso(),
     )
 
 

--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -27,6 +26,7 @@ from typing_extensions import Annotated
 from specify_cli.context.mission_resolver import AmbiguousHandleError, MissionNotFoundError, ResolvedMission, resolve_mission
 from specify_cli.coordination.surface_resolver import resolve_status_surface
 from specify_cli.core.paths import locate_project_root
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.doctrine_synthesizer import (
     SynthesisResult,
     apply_proposals,
@@ -178,7 +178,7 @@ def _build_json_envelope(
     envelope: dict[str, object] = {
         "schema_version": "1",
         "command": "agent.retrospect.synthesize",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": now_utc_iso(),
         "dry_run": dry_run,
         "status": status,
         "outcome": outcome,
@@ -280,7 +280,7 @@ def _create_empty_retrospective_record(
         gen_record directly without re-reading the YAML via the Pydantic reader.
     """
     del feature_dir
-    now = datetime.now(timezone.utc).isoformat()
+    now = now_utc_iso()
     gen_actor = GenActor(kind=actor.kind, id=actor.id)
     record = GenRetrospectiveRecord(
         schema_version=1,

--- a/src/specify_cli/cli/commands/charter/lint.py
+++ b/src/specify_cli/cli/commands/charter/lint.py
@@ -9,6 +9,7 @@ from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import charter_app, console
 from specify_cli.cli.commands.charter._common import _emit_error
+from specify_cli.core.time_utils import now_utc_iso
 
 # Test-patch shim — see ``synthesize.py``.
 import specify_cli.cli.commands.charter as _charter_pkg
@@ -154,8 +155,6 @@ def charter_lint(
     # existing graph load remains authoritative for findings — but the
     # call enforces FR-005 hard-fails as a lint gate.
     if org_fragments:
-        import datetime as _dt
-
         from charter.drg import (
             DRGGraph,
             OrgDRGConflict,
@@ -165,7 +164,7 @@ def charter_lint(
 
         empty_built_in = DRGGraph(
             schema_version="1.0",
-            generated_at=_dt.datetime.now(_dt.UTC).isoformat(),
+            generated_at=now_utc_iso(),
             generated_by="charter-lint",
             nodes=[],
             edges=[],

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -13,6 +13,7 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -920,7 +921,7 @@ def _annotation_for_request(
         request.wp_id,
         request.annotation_delta,
         actor=request.actor,
-        at=at or datetime.now(UTC).isoformat(),
+        at=at or now_utc_iso(),
         event_id=_emit._generate_ulid(),
     )
 

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -13,7 +13,6 @@ import logging
 import re
 import shutil
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +26,7 @@ from specify_cli.core.mission_payload import (
     default_mission_purpose_context,
 )
 from specify_cli.core.paths import is_worktree_context, locate_project_root
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.git import safe_commit
 from specify_cli.lanes.branch_naming import mission_dir_name, resolve_mid8
 from specify_cli.mission_metadata import load_meta_or_empty, validate_purpose_summary
@@ -458,7 +458,7 @@ def create_mission_core(
     meta.setdefault("purpose_context", normalized_purpose_context)
     meta.setdefault(_META_KEY_MISSION_TYPE, mission or "software-dev")
     meta.setdefault("target_branch", planning_branch)
-    meta.setdefault(_META_KEY_CREATED_AT, datetime.now(timezone.utc).isoformat())  # noqa: UP017
+    meta.setdefault(_META_KEY_CREATED_AT, now_utc_iso())
 
     # ------------------------------------------------------------------
     # 6.5 Coordination branch (WP03 / issue #1348, #2218)

--- a/src/specify_cli/core/time_utils.py
+++ b/src/specify_cli/core/time_utils.py
@@ -1,8 +1,23 @@
 """Canonical clock helper for ISO-8601 UTC timestamps.
 
-This module hosts the single canonical `now_utc_iso()` helper that replaces
-12 byte-identical `datetime.now(UTC).isoformat()` copies scattered across
-`event_journal/`, `status/`, `retrospective/`, `delivery/`, and `dossier/`.
+This module hosts the single canonical `now_utc_iso()` helper.
+
+**The semantic clock contract**: every "now"-stamp in `specify_cli` that
+serializes an *aware-UTC* instant at `isoformat()`'s native precision routes
+through this helper. `now_utc_iso()` is the sole permitted producer of that
+form; a local `datetime.now(UTC).isoformat()` copy is a contract violation.
+This is enforced structurally rather than by inventory: an AST gate
+(`tests/specify_cli/test_clock_consolidation.py`) scans the whole
+`src/specify_cli` tree for the raw form and fails on any occurrence outside
+the exception families below, so a newly added module is covered the moment
+it lands. (A count of migrated copies is deliberately NOT recorded here — it
+decays on every migration.)
+
+Allowed exception families (each a genuinely *distinct contract*, not an
+escape hatch):
+
+- **This module itself** — the canonical implementation.
+- The **stamp** family and the **datetime-returning** family, below.
 
 Two distinct-contract families are deliberately NOT folded into this helper
 (see mission-resolver-port-01KX1C05 research.md D-04, NFR-004):
@@ -29,10 +44,11 @@ from datetime import UTC, datetime
 def now_utc_iso() -> str:
     """Return the current UTC time as an ISO 8601 string.
 
-    Canonical replacement for the 12 byte-identical
-    ``datetime.now(UTC).isoformat()`` copies. Do not use this for the
-    second-precision ``%Y-%m-%dT%H:%M:%SZ`` stamp format (see
-    ``task_utils.support.now_utc``) or for callers that need a ``datetime``
-    object back.
+    The canonical producer of the aware-UTC ``isoformat()`` form: a local
+    ``datetime.now(UTC).isoformat()`` copy anywhere in ``specify_cli`` is a
+    violation of the module's clock contract and is caught by the AST gate.
+    Do not use this for the second-precision ``%Y-%m-%dT%H:%M:%SZ`` stamp
+    format (see ``task_utils.support.now_utc``) or for callers that need a
+    ``datetime`` object back.
     """
     return datetime.now(UTC).isoformat()

--- a/src/specify_cli/core/time_utils.py
+++ b/src/specify_cli/core/time_utils.py
@@ -3,15 +3,19 @@
 This module hosts the single canonical `now_utc_iso()` helper.
 
 **The semantic clock contract**: every "now"-stamp in `specify_cli` that
-serializes an *aware-UTC* instant at `isoformat()`'s native precision routes
-through this helper. `now_utc_iso()` is the sole permitted producer of that
-form; a local `datetime.now(UTC).isoformat()` copy is a contract violation.
-This is enforced structurally rather than by inventory: an AST gate
+serializes an *aware-UTC* instant at `isoformat()`'s native precision should
+route through this helper — it is the canonical producer of that form, and a
+local `datetime.now(UTC).isoformat()` copy is a contract violation. This is
+enforced structurally rather than by inventory: an AST gate
 (`tests/specify_cli/test_clock_consolidation.py`) scans the whole
-`src/specify_cli` tree for the raw form and fails on any occurrence outside
-the exception families below, so a newly added module is covered the moment
-it lands. (A count of migrated copies is deliberately NOT recorded here — it
-decays on every migration.)
+`src/specify_cli` tree and fails on the **fluent single-expression idiom**
+`<x>.now(<aware-UTC>).isoformat()` (import aliases resolved) outside the
+exception families below, so a newly added module is covered the moment it
+lands. The gate is precise, not total: a variable-split
+(`d = datetime.now(UTC)` then `d.isoformat()`) or a `str()` of an aware
+instant (a distinct, space-separated string) is not the fluent idiom and is
+out of scope by design — see the gate's own docstring. (A count of migrated
+copies is deliberately NOT recorded here — it decays on every migration.)
 
 Allowed exception families (each a genuinely *distinct contract*, not an
 escape hatch):
@@ -46,9 +50,9 @@ def now_utc_iso() -> str:
 
     The canonical producer of the aware-UTC ``isoformat()`` form: a local
     ``datetime.now(UTC).isoformat()`` copy anywhere in ``specify_cli`` is a
-    violation of the module's clock contract and is caught by the AST gate.
-    Do not use this for the second-precision ``%Y-%m-%dT%H:%M:%SZ`` stamp
-    format (see ``task_utils.support.now_utc``) or for callers that need a
-    ``datetime`` object back.
+    violation of the module's clock contract, and the AST gate catches that
+    fluent idiom. Do not use this for the second-precision
+    ``%Y-%m-%dT%H:%M:%SZ`` stamp format (see ``task_utils.support.now_utc``)
+    or for callers that need a ``datetime`` object back.
     """
     return datetime.now(UTC).isoformat()

--- a/src/specify_cli/invocation/executor.py
+++ b/src/specify_cli/invocation/executor.py
@@ -10,7 +10,6 @@ The invocation executor must NEVER claim a first-load token.
 from __future__ import annotations
 
 import dataclasses
-import datetime
 import hashlib
 import json as _json_mod
 import logging
@@ -31,6 +30,7 @@ import ulid as _ulid_mod  # matches codebase pattern: status/emit.py, core/missi
 from charter.context import build_charter_context
 from mission_runtime import CommitTarget
 from specify_cli.core.commit_guard import GuardCapability
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.git import safe_commit
 from specify_cli.invocation.empty_charter import resolve_generic_fallback
 from specify_cli.invocation.errors import (
@@ -384,7 +384,7 @@ class ProfileInvocationExecutor:
             bundle = GlossaryObservationBundle(matched_urns=(), high_severity=(), all_conflicts=(), tokens_checked=0, duration_ms=0.0, error_msg=repr(_exc))
 
         # 3. Write started record (raises InvocationWriteError on fs failure)
-        started_at = datetime.datetime.now(datetime.UTC).isoformat()
+        started_at = now_utc_iso()
         record = OpStartedEvent(
             invocation_id=invocation_id,
             profile_id=profile.profile_id,
@@ -475,7 +475,7 @@ class ProfileInvocationExecutor:
         # Step 3: Append completed event (existing behaviour).
         completed = OpCompletedEvent(
             invocation_id=invocation_id,
-            completed_at=datetime.datetime.now(datetime.UTC).isoformat(),
+            completed_at=now_utc_iso(),
             outcome=outcome,
             closed_by=closed_by,
             evidence_ref=evidence_ref,

--- a/src/specify_cli/invocation/propagator.py
+++ b/src/specify_cli/invocation/propagator.py
@@ -34,6 +34,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.invocation.adapters import get_saas_client as _get_saas_client_from_seam
 from specify_cli.invocation.adapters import resolve_egress_consent
 from specify_cli.invocation.projection_policy import EventKind, ModeOfWork, resolve_projection
@@ -275,15 +276,13 @@ def _log_propagation_error(
 ) -> None:
     """Append propagation failure to the local error log.  Never raises."""
     try:
-        import datetime  # noqa: PLC0415
-
         error_log = repo_root / PROPAGATION_ERRORS_PATH
         error_log.parent.mkdir(parents=True, exist_ok=True)
         entry = {
             "invocation_id": record.invocation_id,
             "event": record.event,
             "error": error,
-            "at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "at": now_utc_iso(),
         }
         with error_log.open("a", encoding="utf-8") as f:
             f.write(json.dumps(entry) + "\n")

--- a/src/specify_cli/invocation/writer.py
+++ b/src/specify_cli/invocation/writer.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import contextlib
-import datetime
 import json
 import os
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.core.utils import ensure_within_any
 from specify_cli.invocation.errors import AlreadyClosedError, InvocationError, InvocationWriteError
 from specify_cli.invocation.record import (
@@ -240,7 +240,7 @@ class InvocationWriter:
         if (ref is None) == (sha is None):
             raise ValueError("Exactly one of ref or sha must be provided")
         path = self.invocation_path(invocation_id)
-        at_ts = at or datetime.datetime.now(datetime.UTC).isoformat()
+        at_ts = at or now_utc_iso()
         entry: dict[str, object] = {
             "event": "artifact_link" if ref is not None else "commit_link",
             "invocation_id": invocation_id,

--- a/src/specify_cli/migration/rewrite_opposed_by.py
+++ b/src/specify_cli/migration/rewrite_opposed_by.py
@@ -90,7 +90,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any
 
@@ -333,7 +333,7 @@ def _load_graph(pack_root: Path, artifact_type: str) -> DRGGraph:
     if not path.exists():
         return DRGGraph(
             schema_version="1.0",
-            generated_at=datetime.now(UTC).isoformat(),
+            generated_at=now_utc_iso(),
             generated_by=_GENERATED_BY,
             nodes=[],
             edges=[],

--- a/src/specify_cli/mission_metadata.py
+++ b/src/specify_cli/mission_metadata.py
@@ -15,7 +15,6 @@ always either the old version or the new version, never a partial write.
 
 from __future__ import annotations
 
-import datetime as _dt
 import json
 import re
 from dataclasses import dataclass
@@ -24,6 +23,7 @@ from typing import Any, Literal, TypedDict
 
 from specify_cli.core.atomic import atomic_write
 from specify_cli.core.paths import safe_mission_slug
+from specify_cli.core.time_utils import now_utc_iso
 
 # Hoisted S1192 literals (campsite #1970) -- the meta.json filename and the two
 # decode encodings appear across this module and the legacy contracts it absorbs.
@@ -123,7 +123,7 @@ class MissionIdentity:
 
 def _now_iso() -> str:
     """Current UTC time in ISO 8601."""
-    return _dt.datetime.now(_dt.UTC).isoformat()
+    return now_utc_iso()
 
 
 def mission_number_from_slug(mission_slug: str) -> int | None:

--- a/src/specify_cli/missions/_archive.py
+++ b/src/specify_cli/missions/_archive.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 from typing import Any
 
@@ -130,7 +130,7 @@ class DeferralDisposition:
 
 
 def _utc_now_iso() -> str:
-    return datetime.now(UTC).isoformat()
+    return now_utc_iso()
 
 
 # ---------------------------------------------------------------------------

--- a/src/specify_cli/retrospective/cli.py
+++ b/src/specify_cli/retrospective/cli.py
@@ -13,9 +13,10 @@ Source-of-truth:
 from __future__ import annotations
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.time_utils import now_utc_iso
 import json
 import sys
-from datetime import date, datetime, timezone
+from datetime import date
 from pathlib import Path
 from typing import Optional
 
@@ -56,7 +57,7 @@ def _build_json_envelope(snapshot: SummarySnapshot) -> dict[str, object]:
     return {
         "schema_version": "1",
         "command": "retrospect.summary",
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": now_utc_iso(),
         "result": snapshot.model_dump(),
     }
 

--- a/src/specify_cli/retrospective/generator.py
+++ b/src/specify_cli/retrospective/generator.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.core.git_ops import resolve_primary_branch
 from specify_cli.core.paths import read_target_branch_from_meta
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.lanes.branch_naming import resolve_mid8
 import contextlib
-import datetime
 import json
 import logging
 import re
@@ -1207,7 +1207,7 @@ def generate_retrospective(
         RecordValidationError: If the generator produces an invalid record (indicates a bug).
     """
     if invoked_at is None:
-        invoked_at = datetime.datetime.now(datetime.UTC).isoformat()
+        invoked_at = now_utc_iso()
 
     if actor is None:
         actor = GenActor(kind="runtime", id="spec-kitty-generator", display="Spec Kitty Generator")

--- a/src/specify_cli/retrospective/summary.py
+++ b/src/specify_cli/retrospective/summary.py
@@ -17,6 +17,7 @@ WP03 addition (T017):
 from __future__ import annotations
 
 from specify_cli.core.constants import RETROSPECTIVE_FILENAME
+from specify_cli.core.time_utils import now_utc_iso
 from specify_cli.core.utils import safe_is_dir
 from specify_cli.mission_metadata import load_meta_or_empty
 from specify_cli.missions._read_path_resolver import candidate_feature_dir_for_mission
@@ -351,7 +352,7 @@ def build_summary(
         A :class:`SummarySnapshot` (always — never raises on malformed
         records; they appear in ``snapshot.malformed``).
     """
-    generated_at = datetime.now(timezone.utc).isoformat()
+    generated_at = now_utc_iso()
 
     # Mutable accumulator state
     mission_count = 0

--- a/src/specify_cli/session_presence/upgrade_check.py
+++ b/src/specify_cli/session_presence/upgrade_check.py
@@ -16,7 +16,8 @@ import json
 import os
 import subprocess
 import sys
-from datetime import UTC, datetime
+from datetime import datetime
+from specify_cli.core.time_utils import now_utc_iso
 from pathlib import Path
 
 from specify_cli.core.env import is_truthy
@@ -68,7 +69,7 @@ def refresh_cache_once() -> None:
         tmp.write_text(
             json.dumps(
                 {
-                    "checked_at": datetime.now(UTC).isoformat(),
+                    "checked_at": now_utc_iso(),
                     "latest_version": latest,
                 }
             ),

--- a/tests/_factories/test_make_mission_parity.py
+++ b/tests/_factories/test_make_mission_parity.py
@@ -61,21 +61,23 @@ def _read_meta_bytes(repo_root: Path, mission_slug_prefix: str) -> bytes:
 
 @pytest.fixture
 def _frozen_mint(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Freeze the ULID mint and wall-clock inside ``mission_creation`` so two
-    independent ``create_mission_core()`` calls made under this fixture mint
-    the identical ``mission_id`` / ``created_at`` -- the only two per-call
+    """Freeze the ULID mint and the clock seam inside ``mission_creation`` so
+    two independent ``create_mission_core()`` calls made under this fixture
+    mint the identical ``mission_id`` / ``created_at`` -- the only two per-call
     non-deterministic fields in the schema (the ``mid8`` embedded in
     ``slug``/``mission_slug`` derives from ``mission_id``, so freezing it also
     pins those fields).
+
+    The ``created_at`` stamp routes through the canonical
+    :func:`specify_cli.core.time_utils.now_utc_iso` helper (#2496), imported
+    into ``mission_creation`` as a module-level name. Freezing that name is the
+    supported seam; there is deliberately no module-local ``datetime`` copy
+    left to patch.
     """
-
-    class _FrozenDatetime(datetime):
-        @classmethod
-        def now(cls, tz: object | None = None) -> _FrozenDatetime:  # noqa: ARG003
-            return cls.fromtimestamp(_FROZEN_NOW.timestamp(), tz=UTC)
-
     monkeypatch.setattr(mission_creation_module, "ULID", _FrozenULID)
-    monkeypatch.setattr(mission_creation_module, "datetime", _FrozenDatetime)
+    monkeypatch.setattr(
+        mission_creation_module, "now_utc_iso", lambda: _FROZEN_NOW.isoformat()
+    )
 
 
 def test_make_mission_meta_is_byte_identical_to_direct_core_call(

--- a/tests/specify_cli/test_clock_consolidation.py
+++ b/tests/specify_cli/test_clock_consolidation.py
@@ -204,15 +204,49 @@ _RAW_FORM_EXEMPT: dict[str, str] = {
 
 
 def _is_utc_alias(node: ast.expr) -> bool:
-    """``UTC`` / ``datetime.UTC`` / ``timezone.utc`` - the aware-UTC spellings."""
+    """Every aware-UTC spelling, including module-aliased imports.
+
+    Covers ``UTC`` / ``<mod>.UTC`` / ``timezone.utc`` / ``<mod>.timezone.utc``.
+    The module segment is matched by *shape*, not by the literal name
+    ``datetime``, so an ``import datetime as _dt`` alias (``_dt.UTC`` /
+    ``_dt.timezone.utc``) is caught too -- the exact idiom two of this PR's
+    own migrated modules used before migration. An attribute chain ending in
+    ``.UTC`` or ``.timezone.utc`` passed to a bare ``.now(...)`` is, in
+    practice, always stdlib datetime.
+    """
     if isinstance(node, ast.Name):
         return node.id == "UTC"
     if isinstance(node, ast.Attribute):
         base = node.value
-        if node.attr == "UTC" and isinstance(base, ast.Name) and base.id == "datetime":
+        # <mod>.UTC  (datetime.UTC, _dt.UTC)
+        if node.attr == "UTC" and isinstance(base, ast.Name):
             return True
-        if node.attr == "utc" and isinstance(base, ast.Name) and base.id == "timezone":
-            return True
+        if node.attr == "utc":
+            # timezone.utc  (bare, or aliased to a bare name)
+            if isinstance(base, ast.Name) and base.id == "timezone":
+                return True
+            # <mod>.timezone.utc  (datetime.timezone.utc, _dt.timezone.utc)
+            if (
+                isinstance(base, ast.Attribute)
+                and base.attr == "timezone"
+                and isinstance(base.value, ast.Name)
+            ):
+                return True
+    return False
+
+
+def _now_call_passes_utc(call: ast.Call) -> bool:
+    """True for ``<x>.now(<aware-UTC>)`` where the timezone is passed either
+    positionally (``now(UTC)``) or by the ``tz=`` keyword (``now(tz=UTC)``) -
+    the two spellings serialize byte-identically.
+    """
+    if not (isinstance(call.func, ast.Attribute) and call.func.attr == "now"):
+        return False
+    if len(call.args) == 1 and not call.keywords:  # now(UTC)
+        return _is_utc_alias(call.args[0])
+    if not call.args and len(call.keywords) == 1:  # now(tz=UTC)
+        kw = call.keywords[0]
+        return kw.arg == "tz" and _is_utc_alias(kw.value)
     return False
 
 
@@ -224,8 +258,9 @@ def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
 
     - ``.isoformat()`` must take NO arguments. ``isoformat(timespec=...)`` is a
       different serialization (a distinct contract), not a violation.
-    - the ``now()`` argument must be an aware-UTC alias. A naive ``now()`` and
-      ``now(some_tz)`` are different contracts too.
+    - the ``now()`` timezone must be an aware-UTC alias, passed positionally
+      (``now(UTC)``) or by the ``tz=`` keyword (``now(tz=UTC)``). A naive
+      ``now()`` and ``now(some_other_tz)`` are different contracts too.
     """
     hits: list[int] = []
     for node in ast.walk(tree):
@@ -237,11 +272,7 @@ def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
         if node.args or node.keywords:
             continue  # timespec= etc. -> a distinct serialization contract
         inner = outer.value
-        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
-            continue
-        if inner.func.attr != "now" or len(inner.args) != 1 or inner.keywords:
-            continue
-        if _is_utc_alias(inner.args[0]):
+        if isinstance(inner, ast.Call) and _now_call_passes_utc(inner):
             hits.append(node.lineno)
     return hits
 
@@ -280,6 +311,14 @@ def test_the_ratchet_is_non_vacuous() -> None:
         "import datetime\nx = datetime.datetime.now(datetime.UTC).isoformat()\n",
         "from datetime import UTC, datetime\nx = datetime.now(UTC).isoformat()\n",
         "from datetime import datetime, timezone\nx = datetime.now(timezone.utc).isoformat()\n",
+        # the ``tz=`` keyword spelling -- byte-identical to positional now(UTC)
+        "from datetime import UTC, datetime\nx = datetime.now(tz=UTC).isoformat()\n",
+        # the fully-qualified ``datetime.timezone.utc`` alias
+        "import datetime\nx = datetime.datetime.now(datetime.timezone.utc).isoformat()\n",
+        # module-aliased import (``import datetime as _dt``) - the idiom two of
+        # this PR's own migrated modules used before migration
+        "import datetime as _dt\nx = _dt.datetime.now(_dt.UTC).isoformat()\n",
+        "import datetime as _dt\nx = _dt.datetime.now(_dt.timezone.utc).isoformat()\n",
     )
     for src in violations:
         assert _raw_utc_isoformat_lines(ast.parse(src)), f"detector MISSED a violation:\n{src}"

--- a/tests/specify_cli/test_clock_consolidation.py
+++ b/tests/specify_cli/test_clock_consolidation.py
@@ -203,27 +203,50 @@ _RAW_FORM_EXEMPT: dict[str, str] = {
 }
 
 
-def _is_utc_alias(node: ast.expr) -> bool:
-    """Every aware-UTC spelling, including module-aliased imports.
+def _utc_alias_names(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Local names that resolve to aware-UTC, honouring ``import ... as``.
 
-    Covers ``UTC`` / ``<mod>.UTC`` / ``timezone.utc`` / ``<mod>.timezone.utc``.
-    The module segment is matched by *shape*, not by the literal name
-    ``datetime``, so an ``import datetime as _dt`` alias (``_dt.UTC`` /
-    ``_dt.timezone.utc``) is caught too -- the exact idiom two of this PR's
-    own migrated modules used before migration. An attribute chain ending in
-    ``.UTC`` or ``.timezone.utc`` passed to a bare ``.now(...)`` is, in
-    practice, always stdlib datetime.
+    Returns ``(utc_names, timezone_names)`` -- the names bound to
+    ``datetime.UTC`` and to the ``datetime.timezone`` class respectively,
+    including alias spellings (``from datetime import UTC as U`` /
+    ``timezone as tz2``). Without this, ``datetime.now(U).isoformat()`` and
+    ``datetime.now(tz2.utc).isoformat()`` -- byte-identical to the banned
+    form -- would sail past the gate.
+    """
+    utc_names = {"UTC"}
+    timezone_names = {"timezone"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "datetime":
+            for alias in node.names:
+                if alias.name == "UTC":
+                    utc_names.add(alias.asname or alias.name)
+                elif alias.name == "timezone":
+                    timezone_names.add(alias.asname or alias.name)
+    return utc_names, timezone_names
+
+
+def _is_utc_alias(node: ast.expr, utc_names: set[str], timezone_names: set[str]) -> bool:
+    """Every aware-UTC spelling, including module- and name-aliased imports.
+
+    Covers ``UTC`` / ``<mod>.UTC`` / ``timezone.utc`` / ``<mod>.timezone.utc``
+    plus their ``import ... as`` aliases (``U``, ``tz2`` ...) resolved by
+    :func:`_utc_alias_names`. The module segment of an attribute chain is
+    matched by *shape*, not the literal name ``datetime``, so
+    ``import datetime as _dt`` (``_dt.UTC`` / ``_dt.timezone.utc``) is caught
+    too -- the exact idiom two of this PR's own migrated modules used before
+    migration. An attribute chain ending in ``.UTC`` / ``.timezone.utc``
+    passed to a bare ``.now(...)`` is, in practice, always stdlib datetime.
     """
     if isinstance(node, ast.Name):
-        return node.id == "UTC"
+        return node.id in utc_names
     if isinstance(node, ast.Attribute):
         base = node.value
         # <mod>.UTC  (datetime.UTC, _dt.UTC)
         if node.attr == "UTC" and isinstance(base, ast.Name):
             return True
         if node.attr == "utc":
-            # timezone.utc  (bare, or aliased to a bare name)
-            if isinstance(base, ast.Name) and base.id == "timezone":
+            # timezone.utc  (bare or name-aliased)
+            if isinstance(base, ast.Name) and base.id in timezone_names:
                 return True
             # <mod>.timezone.utc  (datetime.timezone.utc, _dt.timezone.utc)
             if (
@@ -235,7 +258,7 @@ def _is_utc_alias(node: ast.expr) -> bool:
     return False
 
 
-def _now_call_passes_utc(call: ast.Call) -> bool:
+def _now_call_passes_utc(call: ast.Call, utc_names: set[str], timezone_names: set[str]) -> bool:
     """True for ``<x>.now(<aware-UTC>)`` where the timezone is passed either
     positionally (``now(UTC)``) or by the ``tz=`` keyword (``now(tz=UTC)``) -
     the two spellings serialize byte-identically.
@@ -243,25 +266,36 @@ def _now_call_passes_utc(call: ast.Call) -> bool:
     if not (isinstance(call.func, ast.Attribute) and call.func.attr == "now"):
         return False
     if len(call.args) == 1 and not call.keywords:  # now(UTC)
-        return _is_utc_alias(call.args[0])
+        return _is_utc_alias(call.args[0], utc_names, timezone_names)
     if not call.args and len(call.keywords) == 1:  # now(tz=UTC)
         kw = call.keywords[0]
-        return kw.arg == "tz" and _is_utc_alias(kw.value)
+        return kw.arg == "tz" and _is_utc_alias(kw.value, utc_names, timezone_names)
     return False
 
 
 def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
-    """Line numbers of every raw ``datetime.now(<aware-UTC>).isoformat()``.
+    """Line numbers of the fluent ``<x>.now(<aware-UTC>).isoformat()`` idiom.
 
-    Deliberately NARROW - it flags only the byte-identical form that
-    ``now_utc_iso()`` replaces:
+    Enforces exactly ONE spelling: the single-expression fluent idiom -- the
+    byte-identical form ``now_utc_iso()`` replaces. ``import ... as`` aliases
+    of ``UTC``/``timezone`` ARE resolved (see :func:`_utc_alias_names`), so
+    ``now(U)`` / ``now(tz2.utc)`` are caught.
 
-    - ``.isoformat()`` must take NO arguments. ``isoformat(timespec=...)`` is a
-      different serialization (a distinct contract), not a violation.
-    - the ``now()`` timezone must be an aware-UTC alias, passed positionally
-      (``now(UTC)``) or by the ``tz=`` keyword (``now(tz=UTC)``). A naive
-      ``now()`` and ``now(some_other_tz)`` are different contracts too.
+    It deliberately does NOT match the following -- each is either a distinct
+    serialization or needs dataflow to detect and has no live instance in-tree
+    (documented so a future reader does not over-trust the ratchet):
+
+    - ``.isoformat(timespec=...)`` -- a different serialization.
+    - a naive ``now()`` or ``now(<non-UTC tz>)`` -- different contracts.
+    - a two-statement split (``d = datetime.now(UTC)`` then ``d.isoformat()``):
+      needs intra-function taint analysis. The only such site, ``decisions/
+      emit.py``, is the *datetime-returning* family -- a genuinely distinct
+      contract, not this stamp.
+    - ``str(<aware now()>)`` -- uses a space separator, not ``T`` (e.g.
+      ``2026-01-01 00:00:00+00:00``), so it is NOT byte-identical to
+      ``isoformat()`` and is a different string entirely.
     """
+    utc_names, timezone_names = _utc_alias_names(tree)
     hits: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -272,16 +306,20 @@ def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
         if node.args or node.keywords:
             continue  # timespec= etc. -> a distinct serialization contract
         inner = outer.value
-        if isinstance(inner, ast.Call) and _now_call_passes_utc(inner):
+        if isinstance(inner, ast.Call) and _now_call_passes_utc(inner, utc_names, timezone_names):
             hits.append(node.lineno)
     return hits
 
 
 def test_no_raw_aware_utc_isoformat_outside_the_canonical_helper() -> None:
-    """THE RATCHET: no module may mint the raw form locally.
+    """THE RATCHET: no module mints the fluent raw idiom locally.
 
     Structural, not inventory-based - a module added after this test was
-    written is covered automatically.
+    written is covered automatically. Scope is precise, not total: this
+    enforces the single-expression ``<x>.now(<aware-UTC>).isoformat()`` idiom
+    (alias-resolved), which is the form ``now_utc_iso()`` replaces. See
+    :func:`_raw_utc_isoformat_lines` for the forms deliberately left out of
+    scope (variable-split, ``str()``, the datetime-returning family).
     """
     offenders: list[str] = []
     scanned = 0
@@ -319,6 +357,10 @@ def test_the_ratchet_is_non_vacuous() -> None:
         # this PR's own migrated modules used before migration
         "import datetime as _dt\nx = _dt.datetime.now(_dt.UTC).isoformat()\n",
         "import datetime as _dt\nx = _dt.datetime.now(_dt.timezone.utc).isoformat()\n",
+        # name-aliased imports (``from datetime import UTC as U`` /
+        # ``timezone as tz2``) - resolved via _utc_alias_names
+        "from datetime import UTC as U, datetime\nx = datetime.now(U).isoformat()\n",
+        "from datetime import datetime, timezone as tz2\nx = datetime.now(tz2.utc).isoformat()\n",
     )
     for src in violations:
         assert _raw_utc_isoformat_lines(ast.parse(src)), f"detector MISSED a violation:\n{src}"

--- a/tests/specify_cli/test_clock_consolidation.py
+++ b/tests/specify_cli/test_clock_consolidation.py
@@ -183,3 +183,126 @@ class TestStampFamilyPreserved:
         assert stamp_value.endswith("Z")
         assert "." in iso_value  # microseconds retained
         assert "." not in stamp_value  # microseconds dropped (second precision)
+
+
+# ---------------------------------------------------------------------------
+# The structural ratchet (review #2611): a full-tree AST negative gate.
+#
+# The owned-file inventory above protects only the ORIGINAL 12 files, so every
+# newly migrated module could regress while this suite stayed green. That is an
+# inventory, not a gate. The scan below walks the WHOLE src/specify_cli tree for
+# the raw aware-UTC ``.isoformat()`` form, so a module added tomorrow is covered
+# the moment it lands -- no list to remember to update.
+# ---------------------------------------------------------------------------
+
+# Justified exceptions. Each is a genuinely DISTINCT CONTRACT, not an escape
+# hatch; anything added here needs the same standard.
+_RAW_FORM_EXEMPT: dict[str, str] = {
+    # The canonical implementation itself -- this IS the one permitted producer.
+    "specify_cli/core/time_utils.py": "hosts now_utc_iso(); the single canonical call site",
+}
+
+
+def _is_utc_alias(node: ast.expr) -> bool:
+    """``UTC`` / ``datetime.UTC`` / ``timezone.utc`` - the aware-UTC spellings."""
+    if isinstance(node, ast.Name):
+        return node.id == "UTC"
+    if isinstance(node, ast.Attribute):
+        base = node.value
+        if node.attr == "UTC" and isinstance(base, ast.Name) and base.id == "datetime":
+            return True
+        if node.attr == "utc" and isinstance(base, ast.Name) and base.id == "timezone":
+            return True
+    return False
+
+
+def _raw_utc_isoformat_lines(tree: ast.AST) -> list[int]:
+    """Line numbers of every raw ``datetime.now(<aware-UTC>).isoformat()``.
+
+    Deliberately NARROW - it flags only the byte-identical form that
+    ``now_utc_iso()`` replaces:
+
+    - ``.isoformat()`` must take NO arguments. ``isoformat(timespec=...)`` is a
+      different serialization (a distinct contract), not a violation.
+    - the ``now()`` argument must be an aware-UTC alias. A naive ``now()`` and
+      ``now(some_tz)`` are different contracts too.
+    """
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        outer = node.func
+        if not (isinstance(outer, ast.Attribute) and outer.attr == "isoformat"):
+            continue
+        if node.args or node.keywords:
+            continue  # timespec= etc. -> a distinct serialization contract
+        inner = outer.value
+        if not (isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute)):
+            continue
+        if inner.func.attr != "now" or len(inner.args) != 1 or inner.keywords:
+            continue
+        if _is_utc_alias(inner.args[0]):
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_raw_aware_utc_isoformat_outside_the_canonical_helper() -> None:
+    """THE RATCHET: no module may mint the raw form locally.
+
+    Structural, not inventory-based - a module added after this test was
+    written is covered automatically.
+    """
+    offenders: list[str] = []
+    scanned = 0
+    for path in sorted((_SRC / "specify_cli").rglob("*.py")):
+        rel = path.relative_to(_SRC).as_posix()
+        if rel in _RAW_FORM_EXEMPT:
+            continue
+        scanned += 1
+        for lineno in _raw_utc_isoformat_lines(ast.parse(path.read_text(encoding="utf-8"))):
+            offenders.append(f"{rel}:{lineno}")
+
+    assert scanned > 100, f"the scan must actually cover the tree (only {scanned} files seen)"
+    assert not offenders, (
+        "raw aware-UTC isoformat() found outside the canonical helper - route these "
+        "onto specify_cli.core.time_utils.now_utc_iso():\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_ratchet_is_non_vacuous() -> None:
+    """SELF-MUTANT: prove the detector FIRES on a planted violation.
+
+    A gate that never exercised its failure path is theatre. This drives the
+    SAME detector the tree scan uses, so a future refactor that silently breaks
+    the matcher turns this red instead of passing an empty scan.
+    """
+    violations = (
+        "import datetime\nx = datetime.datetime.now(datetime.UTC).isoformat()\n",
+        "from datetime import UTC, datetime\nx = datetime.now(UTC).isoformat()\n",
+        "from datetime import datetime, timezone\nx = datetime.now(timezone.utc).isoformat()\n",
+    )
+    for src in violations:
+        assert _raw_utc_isoformat_lines(ast.parse(src)), f"detector MISSED a violation:\n{src}"
+
+    # ...and does NOT fire on the distinct contracts it must leave alone.
+    allowed = (
+        "from specify_cli.core.time_utils import now_utc_iso\nx = now_utc_iso()\n",
+        # a different serialization: second precision via timespec
+        "from datetime import UTC, datetime\nx = datetime.now(UTC).isoformat(timespec='seconds')\n",
+        # the datetime-returning family
+        "from datetime import UTC, datetime\nx = datetime.now(UTC)\n",
+        # naive now() - a different contract
+        "from datetime import datetime\nx = datetime.now().isoformat()\n",
+    )
+    for src in allowed:
+        assert not _raw_utc_isoformat_lines(ast.parse(src)), f"detector FALSE-POSITIVED on:\n{src}"
+
+
+def test_every_exemption_is_real_and_still_needed() -> None:
+    """No stale exemptions: each exempt file must exist AND still contain the form."""
+    for rel, why in _RAW_FORM_EXEMPT.items():
+        path = _SRC / rel
+        assert path.exists(), f"exempt file no longer exists, drop it: {rel}"
+        assert _raw_utc_isoformat_lines(ast.parse(path.read_text(encoding="utf-8"))), (
+            f"exemption is stale (file no longer contains the raw form) - remove it: {rel} ({why})"
+        )


### PR DESCRIPTION
## What changes

Timestamps written across `specify_cli` now come from one place, and a structural test stops that from quietly drifting again.

Every "now"-stamp that serializes an aware-UTC instant (`datetime.now(UTC).isoformat()`) is routed onto the single canonical helper `now_utc_iso()` — the last raw copies in `specify_cli` are gone. A full-tree AST gate then fails CI if any module reintroduces the raw form, so a file added next month is covered the moment it lands instead of silently regressing while the "clock consolidation" suite stays green.

**No behaviour change.** On supported Python (`>=3.11`) `datetime.UTC is timezone.utc`, so every substitution serializes byte-identically — same precision, same `+00:00` offset.

## Why it matters

Before: ~14 byte-identical `datetime.now(UTC).isoformat()` copies scattered across 15 files, each free to drift (naive vs aware, precision, offset spelling), and a "consolidation" test that only watched the original 12 files — so any new copy regressed unseen. After: one helper, one contract, one gate that watches the whole tree.

## The fix (for reviewers)

- Routes the remaining raw sites onto `now_utc_iso()` (`core/time_utils.py`).
- Adds a full-tree AST negative gate (`tests/specify_cli/test_clock_consolidation.py`) with a self-mutant non-vacuity test and a stale-exemption check.
- Deliberately out of scope (distinct contracts, not flagged): the second-precision `%Y-%m-%dT%H:%M:%SZ` stamp family, `isoformat(timespec=...)`, naive `now()`, and the datetime-returning family.

## Landing notes

This supersedes #2611 by @shashankcm95 — maintainer edits were disabled on the source fork (`maintainerCanModify=false`), so the rebase + folds could not be pushed there. **The two original contributor commits are carried unchanged, with their authorship preserved.**

Rebased onto current `upstream/main` (branch was ~615 commits behind). Landing folds on top, each single-purpose:

- `refactor(landing)`: routed one **new** raw site (`acceptance_verdict.py`) that landed on main after the branch was cut — surfaced by this PR's own gate.
- `test(landing)`: restored the mission-parity determinism seam — main's `test_make_mission_parity.py` froze the clock by patching a module-local `datetime` symbol the refactor removed; it now freezes the canonical `now_utc_iso` seam (adversarial-squad HIGH).
- `test(landing)`: closed three byte-identical detector bypasses — the `tz=` keyword form, the fully-qualified `datetime.timezone.utc` alias, and the `import datetime as _dt` module-aliased idiom (the exact spelling two migrated modules used pre-migration) — proven red-first (adversarial-squad HIGH).
- `docs(landing)`: corrected the changelog claim (the gate is added *alongside* the owned-file inventory, not replacing it).

**Adversarial squad** (paula-patterns SSOT/duplication + reviewer-renata correctness, profile-loaded): **APPROVE, no MAJOR.** All 16 substitutions confirmed byte-identical; the parity seam is sound; the detector is false-positive-safe. Deferred MINOR/NOTE items tracked in a single follow-up issue.

**Pre-existing reds** (reproduce on `upstream/main`, not caused here): `tests/architectural/test_verdict_name_truthfulness.py` (2 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788924752&installation_model_id=427282&pr_number=3288&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3288&signature=d6cd95f319b167cb680ed29fb473dd1dccd7641d548348550efebd08091495b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->