### PR TITLE
fix(#3168): tracker sync publish on a local binding fails cleanly instead of a traceback

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -347,6 +347,13 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **`spec-kitty tracker sync publish` on a local (`beads`/`fp`) binding now
+  prints a clear error instead of crashing with a Python traceback (`#3168`).**
+  Local providers have no snapshot-publish transport, but the command delegated
+  to the backend unconditionally and hit an uncaught `AttributeError`, which the
+  CLI let escape as a raw traceback. It now exits with a clean
+  "not supported for local providers — use `tracker sync push` instead" message.
+
 - **A spec commit that genuinely FAILS is no longer silently reported as
   "unchanged" (`#3269`).** When a `git commit` failed for a real reason — a
   rejecting pre-commit hook, a lock error — `safe_commit` collapsed every

--- a/src/specify_cli/tracker/local_service.py
+++ b/src/specify_cli/tracker/local_service.py
@@ -86,7 +86,7 @@ def _render_refusal(verdict: TrackerEgressVerdict) -> str:
     them; it is not a path-local message string (FR-012).
     """
     if not verdict.remedies:
-        return verdict.message
+        return cast("str", verdict.message)
     remedy_lines = "\n".join(f"  - {remedy}" for remedy in verdict.remedies)
     return f"{verdict.message}\nRemedies:\n{remedy_lines}"
 
@@ -271,6 +271,19 @@ class LocalTrackerService:
             return self._sync_result(result, connector.name)
 
         return cast(dict[str, Any], self._run_async(_run()))
+
+    def sync_publish(self, **_kwargs: Any) -> dict[str, Any]:
+        # #3168: local providers (beads/fp) have no snapshot-publish transport.
+        # TrackerService.sync_publish delegates unconditionally to the backend,
+        # so without this method a local binding hits AttributeError, which the
+        # CLI's _run_or_exit does not catch (it catches RuntimeError/ValueError)
+        # -- the operator saw a raw traceback. Raise LocalTrackerServiceError (a
+        # RuntimeError subclass) instead, so the CLI renders a clean message and
+        # exit 1, matching the command's documented contract for local providers.
+        raise LocalTrackerServiceError(
+            "Snapshot publish is not supported for local providers (beads/fp). "
+            "Use 'spec-kitty tracker sync push' instead."
+        )
 
     # ------------------------------------------------------------------
     # mapping operations

--- a/tests/sync/tracker/test_local_service.py
+++ b/tests/sync/tracker/test_local_service.py
@@ -641,6 +641,35 @@ class TestLoadRuntime:
             svc._load_runtime()
 
 
+class TestLocalSyncPublishUnsupported:
+    """#3168: local providers (beads/fp) have no snapshot-publish transport.
+
+    ``TrackerService.sync_publish`` delegates unconditionally to the backend, so
+    a local binding used to hit ``AttributeError: 'LocalTrackerService' object has
+    no attribute 'sync_publish'`` -- which the CLI's ``_run_or_exit`` does NOT catch
+    (it catches ``RuntimeError``/``ValueError``), so the operator saw a raw traceback.
+    It must surface a clean ``LocalTrackerServiceError`` (a ``RuntimeError`` subclass).
+    """
+
+    def test_local_sync_publish_raises_local_tracker_service_error(self, repo: Path) -> None:
+        svc = _make_service(repo)
+        with pytest.raises(LocalTrackerServiceError, match="not supported for local providers"):
+            svc.sync_publish()
+
+    def test_facade_sync_publish_on_local_binding_raises_cleanly_not_attributeerror(
+        self, repo: Path
+    ) -> None:
+        # The real regression path: the CLI calls TrackerService.sync_publish, which
+        # delegates to the resolved (local) backend. Before #3168 this raised
+        # AttributeError; it must be a RuntimeError-family error the CLI can render.
+        svc = _make_service(repo)
+        with patch.object(TrackerService, "_resolve_backend", return_value=svc):
+            with pytest.raises(LocalTrackerServiceError):
+                TrackerService(repo).sync_publish()
+        # RuntimeError subclass == caught by the CLI's _run_or_exit (exit 1, clean message).
+        assert issubclass(LocalTrackerServiceError, RuntimeError)
+
+
 # ---------------------------------------------------------------------------
 # No SaaS imports
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes, for an operator

If you have a local `beads`/`fp` tracker binding, `spec-kitty tracker sync publish` crashed with a raw Python `AttributeError` traceback. Local providers have no snapshot-publish transport, but the command delegated to the backend unconditionally, and the CLI's error handler (`_run_or_exit`) catches only `RuntimeError`/`ValueError` — so the `AttributeError` escaped as a traceback.

**After this change** it exits cleanly: *"Snapshot publish is not supported for local providers (beads/fp). Use `spec-kitty tracker sync push` instead."*

## The fix

Add a `sync_publish` to `LocalTrackerService` that raises `LocalTrackerServiceError` (a `RuntimeError` subclass, so `_run_or_exit` renders it as a clean exit 1) — matching the contract the command already documents for local providers.

## Tests

- **Red-first:** `TestLocalSyncPublishUnsupported` (direct call + the real `TrackerService` facade-delegation path) raises `AttributeError` against the pre-fix backend and `LocalTrackerServiceError` after.
- Full `tests/sync/tracker/test_local_service.py` green (31 passed); `ruff` / `mypy --strict` / `commitlint` clean.
- Also carries a boundary cast for a pre-existing touched-file strict-mypy `Any`-return (`_format_local_refusal`, present verbatim on `main`).

Closes #3168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788938417&installation_model_id=427282&pr_number=3294&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3294&signature=95c6d8203abe6a097c0834de27ca46f84acfc1709cca255b1fd9c712dd9c1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->