### PR TITLE
fix(auth): point SaaS URL guidance to hosted app

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -363,6 +363,15 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **`spec-kitty auth login` (and any caller of the SaaS URL helper) now points
+  you at the real hosted service when `SPEC_KITTY_SAAS_URL` is unset, not a fake
+  placeholder (`#3297`, closes `#3296`).** Previously, running the command
+  without that variable set told you to `Set it to your spec-kitty-saas instance
+  URL (e.g. https://api.spec-kitty.example.com)` — a `.example.com` placeholder
+  that does not resolve, so a first-time user who copied it got a dead URL. The
+  guidance now names the actual hosted URL, `https://app.spec-kitty.ai`, so the
+  example is copy-paste-usable; self-hosted instances still override via the env
+  var exactly as before.
 - **Timestamps that Spec Kitty writes into your project no longer record local
   time while labelling it UTC (mission `kernel-clock-single-door`; `#3305`,
   closes `#3289`, owns the closed `#3288`).** Roughly twenty places across the

--- a/kitty-ops/01KZNHXGBDN8FR13TJEAJFHWCD.jsonl
+++ b/kitty-ops/01KZNHXGBDN8FR13TJEAJFHWCD.jsonl
@@ -1,0 +1,6 @@
+{"event": "started", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "profile_id": "python-pedro", "action": "implement", "request_text": "Fix https://github.com/Priivacy-ai/spec-kitty/issues/3296 and submit a PR", "actor": "operator", "mode_of_work": "task_execution", "governance_context_hash": "ea5cb0e0ae22da74", "governance_context_available": true, "router_confidence": "canonical_verb", "started_at": "2026-08-10T10:01:32.212497+00:00", "model_id": "claude-sonnet-5"}
+{"event": "completed", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "completed_at": "2026-08-10T10:15:07.516231+00:00", "outcome": "done", "closed_by": "agent"}
+{"event": "artifact_link", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "at": "2026-08-10T10:15:07.517093+00:00", "kind": "artifact", "ref": "src/specify_cli/auth/config.py"}
+{"event": "artifact_link", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "at": "2026-08-10T10:15:07.517321+00:00", "kind": "artifact", "ref": "tests/auth/test_config.py"}
+{"event": "artifact_link", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "at": "2026-08-10T10:15:07.517524+00:00", "kind": "artifact", "ref": "tests/cli/commands/test_auth_login.py"}
+{"event": "commit_link", "invocation_id": "01KZNHXGBDN8FR13TJEAJFHWCD", "at": "2026-08-10T10:15:07.517657+00:00", "sha": "1f0457b73"}

--- a/src/specify_cli/auth/config.py
+++ b/src/specify_cli/auth/config.py
@@ -36,8 +36,8 @@ def get_saas_base_url() -> str:
 
     Raises:
         ConfigurationError: If the env var is not set or is empty. There is NO
-            fallback to a hardcoded domain — fly.io deployments use generated
-            hostnames and there is no stable production domain.
+            fallback to a hardcoded domain; callers must explicitly opt in to
+            either the hosted service or a self-hosted instance.
 
     Returns:
         The SaaS base URL with any trailing slashes stripped.
@@ -47,6 +47,6 @@ def get_saas_base_url() -> str:
         raise ConfigurationError(
             f"{_ENV_VAR} environment variable is not set. "
             f"Set it to your spec-kitty-saas instance URL (e.g. "
-            f"https://api.spec-kitty.example.com) and try again."
+            f"https://app.spec-kitty.ai) and try again."
         )
     return url.rstrip("/")

--- a/tests/auth/test_config.py
+++ b/tests/auth/test_config.py
@@ -31,7 +31,7 @@ def test_get_saas_base_url_raises_when_unset(monkeypatch):
         get_saas_base_url()
     message = str(excinfo.value)
     assert "SPEC_KITTY_SAAS_URL" in message
-    assert "https://app.spec-kitty.ai" in message
+    assert "https://app.spec-kitty.ai) and try again." in message
 
 
 def test_get_saas_base_url_raises_when_empty(monkeypatch):

--- a/tests/auth/test_config.py
+++ b/tests/auth/test_config.py
@@ -29,7 +29,9 @@ def test_get_saas_base_url_raises_when_unset(monkeypatch):
     monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
     with pytest.raises(ConfigurationError) as excinfo:
         get_saas_base_url()
-    assert "SPEC_KITTY_SAAS_URL" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "SPEC_KITTY_SAAS_URL" in message
+    assert "https://app.spec-kitty.ai" in message
 
 
 def test_get_saas_base_url_raises_when_empty(monkeypatch):

--- a/tests/cli/commands/test_auth_login.py
+++ b/tests/cli/commands/test_auth_login.py
@@ -191,7 +191,7 @@ class TestAuthLoginConfigErrors:
 
         assert result.exit_code != 0
         assert "SPEC_KITTY_SAAS_URL" in result.stdout
-        assert "https://app.spec-kitty.ai" in result.stdout
+        assert "https://app.spec-kitty.ai) and try again." in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/commands/test_auth_login.py
+++ b/tests/cli/commands/test_auth_login.py
@@ -191,6 +191,7 @@ class TestAuthLoginConfigErrors:
 
         assert result.exit_code != 0
         assert "SPEC_KITTY_SAAS_URL" in result.stdout
+        assert "https://app.spec-kitty.ai" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changes for you

Running `spec-kitty auth login` (or anything that reads the SaaS base URL) with
`SPEC_KITTY_SAAS_URL` unset used to tell you:

> Set it to your spec-kitty-saas instance URL (e.g. `https://api.spec-kitty.example.com`)

That `.example.com` address is a placeholder that doesn't resolve — a first-time
user who copied it got a dead URL. The guidance now names the **real hosted
service**, `https://app.spec-kitty.ai`, so the example is copy-paste-usable.
Self-hosted instances still override via the env var exactly as before.

Fixes #3296.

## The fix

- `src/specify_cli/auth/config.py`: the `ConfigurationError` example now points to
  `https://app.spec-kitty.ai`, and the accessor docstring drops the obsolete
  "no stable production domain" rationale (a stable hosted URL now exists) while
  keeping the explicit-opt-in, no-hardcoded-fallback semantics.

## Tests

- `tests/auth/test_config.py` — helper error-path assertion on the new URL.
- `tests/cli/commands/test_auth_login.py` — user-visible `spec-kitty auth login`
  path asserts the new URL in stdout.
- Red-first verified during landing: with the pre-fix `config.py` swapped back in,
  both assertions fail; with the fix they pass.

## Landing notes

Rebased onto current `upstream/main`. Two maintainer folds:

- `chore(op)` — the contributor's Op-record commit used commit type `op`, which
  is not in the repo's commitlint `type-enum` and would fail the gate; reworded
  to `chore` (authorship preserved).
- `docs(landing)` — added the missing `[Unreleased] → Fixed` entry in
  `docs/changelog/CHANGELOG.md` (the canonical changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
