### PR TITLE
fix(doctrine): slug-hub directive normalization + regression-gate reliability (bulk red follow-ons)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -363,6 +363,15 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
 
 ### 🐛 Fixed
 
+- **Activating a slug-named hub directive (e.g. `use-c4-model-techniques`) in a
+  charter now resolves to the real doctrine node instead of a dangling
+  identifier (`#3009`, `#3298`).** The directive-id normalizer folded numbered
+  slugs (`024-...` → `DIRECTIVE_024`) but left slug-named directives hyphenated
+  and uppercased (`use-c4-model-techniques` → `USE-C4-MODEL-TECHNIQUES`), which
+  is not the artifact's canonical node id (`USE_C4_MODEL_TECHNIQUES`). So
+  activating or referencing such a directive by its slug silently pointed at
+  nothing. The normalizer now folds hyphens to underscores, matching the
+  canonical node id — so slug-hub directives activate and cascade like any other.
 - **`spec-kitty tracker sync publish` on a local (`beads`/`fp`) binding now
   prints a clear error instead of crashing with a Python traceback (`#3168`).**
   Local providers have no snapshot-publish transport, but the command delegated

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -8259,6 +8259,7 @@ pages:
     - {slug: "the-30-rescued-artefacts-by-prior-mission-family-attribution", text: "The 30 rescued artefacts, by prior-mission family attribution", level: 3}
     - {slug: "deferred-set-neither-channel-48-20", text: "Deferred set (neither channel) — 48 → 20", level: 3}
     - {slug: "reconciliation-note-the-50-vs-60-39-39-stale-prose-wp03-d19", text: "Reconciliation note — the \"50 vs 60\" / \"39→39\" stale prose (WP03, D19)", level: 3}
+    - {slug: "writing-comms-diagramming-activation-commit-9a99801f1-3009-profile-channel-rescues-6", text: "Writing-comms/diagramming activation (commit `9a99801f1`, #3009) — profile-channel rescues +6", level: 3}
     - {slug: "composition-ledger-nfr-004-counts-this-wp-moves", text: "Composition ledger (NFR-004) — counts this WP moves", level: 2}
     - {slug: "composition-ledger-nfr-004-family-a-3063-ddd-family", text: "Composition ledger (NFR-004) — Family A (#3063 DDD family)", level: 2}
     - {slug: "family-b-3063-refactoring-family-operator-interview-outcome-inert-composition-only", text: "Family B (#3063 REFACTORING family) — operator interview outcome, INERT (composition-only)", level: 2}

--- a/docs/plans/doctrine/delivery-reachability-wiring-table.md
+++ b/docs/plans/doctrine/delivery-reachability-wiring-table.md
@@ -465,6 +465,34 @@ cuts both ways — including *not* moving a correct one to match a stale premise
   gate for the pins; a reviewer should verify each of the 30 rescued members and
   the 20 remaining against the measured diff.
 
+### Writing-comms/diagramming activation (commit `9a99801f1`, #3009) — profile-channel rescues +6
+
+The dogfooding activation of the writing-comms/diagramming doctrine set (commit
+`9a99801f1`) added seventeen artefacts to the action-channel unreachable sets
+(`_ACTION_UNREACHABLE_D1`/`D2`). Seven of the seventeen are **rescued by the
+profile channel** — action-`d=2`-unreachable yet delivered by an activated
+writing-comms profile — so `_PROFILE_RESCUES` moves **30 → 37**. Each delivering
+edge is traced from the built-in graph via `profile_channel_reachable` (C-001, no
+hand-rolled walk):
+
+- `directive:DIRECTIVE_047` — `agent_profile:scribe-sally` requires it directly.
+- `directive:DIRECTIVE_048` — `agent_profile:scribe-sally` requires it directly.
+- `directive:DIRECTIVE_049` — `agent_profile:minutes-maker-mahad` requires it directly.
+- `directive:DIRECTIVE_050` — `agent_profile:minutes-maker-mahad` requires it directly.
+- `directive:USE_C4_MODEL_TECHNIQUES` — `agent_profile:diagram-daisy` requires it
+  directly (the slug-hub directive; its store slug `use-c4-model-techniques` now
+  normalizes to this node URN via the `id_normalizer` hyphen→underscore fix).
+- `styleguide:quadruple-a-test-format` — via `agent_profile:generic-agent` →
+  `directive:DIRECTIVE_041` --`suggests`--> the styleguide.
+- `tactic:writing-audience-catalog` — `agent_profile:comms-cleo` reaches it directly.
+
+The other ten of the seventeen are unreachable from **both** channels and are
+recorded as tracked #3009 debt (added to `_PROFILE_UNREACHABLE`), to be wired with
+real inbound edges by the deferred orphan-wiring doctrine mission — they are NOT
+rescues and carry no ledger row here. (`directive:RECONCILE_CHANGE_SCOPE_TENSIONS`
+is one of the ten: it is wired only by hand-authored `reconciles_tension` overlay
+edges the profile channel does not walk.)
+
 ## Composition ledger (NFR-004) — counts this WP moves
 
 The single authored edge moves these counts. Each is recorded so no golden

--- a/src/charter/profile_resolution.py
+++ b/src/charter/profile_resolution.py
@@ -204,6 +204,12 @@ def _normalize_directive_id(raw: str) -> str:
     """Normalise a directive slug like '024-locality-of-change' -> 'DIRECTIVE_024'.
 
     If the raw value already looks like DIRECTIVE_NNN, return as-is.
+
+    Kept in lock-step with ``doctrine.drg.migration.id_normalizer.normalize_directive_id``
+    (a separate copy for a documented import-cycle reason): the fallback folds
+    hyphens to underscores so slug-named hub directives
+    (``use-c4-model-techniques`` -> ``USE_C4_MODEL_TECHNIQUES``) resolve to their
+    canonical node id rather than a dangling hyphenated form (#3009).
     """
     if re.match(r"^DIRECTIVE_\d+$", raw):
         return raw
@@ -211,4 +217,4 @@ def _normalize_directive_id(raw: str) -> str:
     if match:
         number = match.group(1).zfill(3)
         return f"DIRECTIVE_{number}"
-    return raw.upper()
+    return raw.upper().replace("-", "_")

--- a/src/doctrine/drg/migration/id_normalizer.py
+++ b/src/doctrine/drg/migration/id_normalizer.py
@@ -16,7 +16,11 @@ def normalize_directive_id(raw: str) -> str:
     - ``"DIRECTIVE_024"`` -- returned as-is.
     - ``"024-locality-of-change"`` -- leading digits extracted, zero-padded to 3.
     - ``"3-short"`` -- single digit padded to ``DIRECTIVE_003``.
-    - Anything else -- uppercased as a best-effort fallback.
+    - ``"use-c4-model-techniques"`` -- a deliberately slug-named hub directive;
+      uppercased with hyphens folded to underscores so it matches the artifact's
+      own ``id:`` (``USE_C4_MODEL_TECHNIQUES``) and therefore its DRG node URN.
+    - Anything else -- uppercased (hyphens -> underscores) as a best-effort
+      fallback.
     """
     if re.match(r"^DIRECTIVE_\d+$", raw):
         return raw
@@ -24,7 +28,13 @@ def normalize_directive_id(raw: str) -> str:
     if match:
         number = match.group(1).zfill(3)
         return f"DIRECTIVE_{number}"
-    return raw.upper()
+    # Slug-named hub directives (e.g. ``use-c4-model-techniques``) declare an
+    # UPPER_SNAKE ``id:`` (``USE_C4_MODEL_TECHNIQUES``). A bare ``.upper()`` kept
+    # the hyphens (``USE-C4-MODEL-TECHNIQUES``), a form that is NOT the node URN,
+    # so slug-form references and activations dangled / mis-normalized (#3009).
+    # Fold hyphens to underscores to converge on the canonical node id, matching
+    # ``charter.kind_vocabulary.resolve_artifact_urn``.
+    return raw.upper().replace("-", "_")
 
 
 def directive_to_urn(raw: str) -> str:

--- a/tests/architectural/test_docs_cli_reference_parity.py
+++ b/tests/architectural/test_docs_cli_reference_parity.py
@@ -44,7 +44,9 @@ import typer
 
 # CRITICAL: env flags MUST be set before importing specify_cli so that
 # the tracker / issue-search subtree is registered.
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is now set collection-wide in tests/conftest.py
+# pytest_configure (#3213), before any module import, so the gate decision is
+# selection-invariant; only the non-gate NO_UPGRADE flag remains per-module.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 # Ensure scripts/docs is importable (matches tests/docs/conftest.py).

--- a/tests/architectural/test_saas_sync_gate_selection_invariance.py
+++ b/tests/architectural/test_saas_sync_gate_selection_invariance.py
@@ -32,8 +32,11 @@ pytestmark = [pytest.mark.architectural, pytest.mark.unit]
 
 _FLAG = "SPEC_KITTY_ENABLE_SAAS_SYNC"
 _TESTS_ROOT = Path(__file__).resolve().parents[1]
-#: The single sanctioned authority that sets the flag collection-wide.
-_ALLOWED = {"conftest.py"}
+#: The single sanctioned authority that sets the flag collection-wide: the ROOT
+#: tests/conftest.py only. A NESTED conftest.py writing the flag would apply to
+#: its subtree alone -- reintroducing the exact selection-dependence this guards
+#: against -- so it is NOT exempt.
+_ALLOWED_RELPATHS = {Path("conftest.py")}
 
 
 def test_flag_is_set_at_collection_time() -> None:
@@ -55,7 +58,7 @@ def _module_level_flag_writers() -> list[str]:
     """
     offenders: list[str] = []
     for path in _TESTS_ROOT.rglob("*.py"):
-        if path.name in _ALLOWED:
+        if path.relative_to(_TESTS_ROOT) in _ALLOWED_RELPATHS:
             continue
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"))

--- a/tests/architectural/test_saas_sync_gate_selection_invariance.py
+++ b/tests/architectural/test_saas_sync_gate_selection_invariance.py
@@ -1,0 +1,133 @@
+"""#3213 — the SaaS-sync feature flag is a single collection-time authority.
+
+Import-time ``@pytest.mark.skipif(not os.environ.get("SPEC_KITTY_ENABLE_SAAS_SYNC"))``
+gates (e.g. the #2782 regression) are evaluated at *collection*. If any test
+module sets that flag at import via its own module-level
+``os.environ.setdefault(...)``, the gate's decision depends on whether that
+module happens to be collected in the current selection — so the SAME node
+skips under ``pytest tests/regression`` but runs under ``pytest tests/ -m
+regression``. That selection-dependence is the #3213 defect.
+
+The fix makes ``tests/conftest.py``'s ``pytest_configure`` the single authority
+that sets the flag once, collection-wide, before any module import. These two
+guards pin that authority:
+
+1. the flag IS set at collection time (so import-time gates see a stable value);
+2. NO test module re-introduces a module-level write of the flag (which would
+   restore the selection-dependence).
+
+Note: with the flag consistently set, the known-open #2782 P0 red runs (and is
+red) under ``pytest tests/regression`` too — that is the intended, honest
+effect, not a new regression.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.architectural, pytest.mark.unit]
+
+_FLAG = "SPEC_KITTY_ENABLE_SAAS_SYNC"
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+#: The single sanctioned authority that sets the flag collection-wide.
+_ALLOWED = {"conftest.py"}
+
+
+def test_flag_is_set_at_collection_time() -> None:
+    """``pytest_configure`` set the flag before any module import (#3213)."""
+    import os
+
+    assert os.environ.get(_FLAG) == "1", (
+        f"{_FLAG} must be set collection-wide by tests/conftest.py "
+        "pytest_configure so import-time skipif gates are selection-invariant."
+    )
+
+
+def _module_level_flag_writers() -> list[str]:
+    """Test files that write ``SPEC_KITTY_ENABLE_SAAS_SYNC`` at module scope.
+
+    AST-based (not a text grep) so comments and string literals mentioning the
+    flag do not count — only real module-level ``os.environ[...] = ...`` /
+    ``os.environ.setdefault(...)`` statements do.
+    """
+    offenders: list[str] = []
+    for path in _TESTS_ROOT.rglob("*.py"):
+        if path.name in _ALLOWED:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        for node in tree.body:  # module scope only — nested (in-test) writes are fine
+            if _statement_writes_flag(node):
+                offenders.append(str(path.relative_to(_TESTS_ROOT)))
+                break
+    return offenders
+
+
+def _statement_writes_flag(node: ast.stmt) -> bool:
+    if isinstance(node, ast.Assign):
+        return any(_is_environ_subscript_of_flag(t) for t in node.targets)
+    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+        return _is_environ_setdefault_of_flag(node.value)
+    return False
+
+
+def _is_environ_subscript_of_flag(target: ast.expr) -> bool:
+    # os.environ["SPEC_KITTY_ENABLE_SAAS_SYNC"] = ...
+    return (
+        isinstance(target, ast.Subscript)
+        and _is_os_environ(target.value)
+        and _is_flag_constant(target.slice)
+    )
+
+
+def _is_environ_setdefault_of_flag(call: ast.Call) -> bool:
+    # os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", ...)
+    func = call.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "setdefault"
+        and _is_os_environ(func.value)
+        and bool(call.args)
+        and _is_flag_constant(call.args[0])
+    )
+
+
+def _is_os_environ(expr: ast.expr) -> bool:
+    return (
+        isinstance(expr, ast.Attribute)
+        and expr.attr == "environ"
+        and isinstance(expr.value, ast.Name)
+        and expr.value.id == "os"
+    )
+
+
+def _is_flag_constant(expr: ast.expr) -> bool:
+    return isinstance(expr, ast.Constant) and expr.value == _FLAG
+
+
+def test_no_test_module_sets_the_flag_at_import_time() -> None:
+    """Only tests/conftest.py may set the flag; module-level writes bring back
+    the #3213 selection-dependence."""
+    offenders = _module_level_flag_writers()
+    assert not offenders, (
+        f"These test modules set {_FLAG} at import time, which makes import-time "
+        "skipif gates depend on the current selection (#3213). Remove the "
+        "module-level write; the flag is set collection-wide in "
+        "tests/conftest.py pytest_configure:\n"
+        + "\n".join(f"    - {o}" for o in sorted(offenders))
+    )
+
+
+def test_scan_is_not_vacuous() -> None:
+    """The AST scan actually detects a module-level flag write (bite proof)."""
+    sample = f'import os\nos.environ.setdefault("{_FLAG}", "1")\n'
+    tree = ast.parse(sample)
+    assert any(_statement_writes_flag(node) for node in tree.body)
+    # ...and does NOT flag a nested (in-function) write or a mere mention.
+    nested = f'import os\ndef f():\n    os.environ["{_FLAG}"] = "1"\n'
+    assert not any(_statement_writes_flag(node) for node in ast.parse(nested).body)

--- a/tests/architectural/test_status_command_guidance.py
+++ b/tests/architectural/test_status_command_guidance.py
@@ -38,7 +38,8 @@ import pytest
 import typer
 import typer.main
 
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is set collection-wide in tests/conftest.py
+# pytest_configure (#3213), not per-module.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 #: ``architectural`` is what the always-on ``arch-adversarial`` CI pole selects

--- a/tests/charter/test_config_stem_parity.py
+++ b/tests/charter/test_config_stem_parity.py
@@ -14,17 +14,20 @@ This module:
   ``UnknownArtifactIdError``) — no new resolver logic is introduced here; this
   is a reuse-and-pin, not a reimplementation (see module docstring history in
   ``kind_vocabulary.py``).
-- **T003**: a data-driven fixture that round-trips *every one* of the 25
+- **T003**: a data-driven fixture that round-trips *every one* of the
   ``activated_directives`` slug-stems declared in this repository's own
-  ``.kittify/config.yaml`` against the real built-in doctrine tree, plus a
+  activation store against the real built-in doctrine tree, plus a
   spot-check of one activated entry from each of the other five activatable
-  kinds (tactic, toolguide, procedure, paradigm, styleguide).
+  kinds (tactic, toolguide, procedure, paradigm, styleguide). Both numbered
+  (``DIRECTIVE_NNN``) and slug-hub (``USE_C4_MODEL_TECHNIQUES``) canonical id
+  forms are accepted.
 - **T004**: non-vacuity — a deliberately malformed/unresolvable stem is
   rejected (proves the guard actually bites and is not inert).
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -122,7 +125,7 @@ def test_resolve_artifact_urn_is_reject_not_drop_on_unresolvable_stem(
 
 
 # --------------------------------------------------------------------------- #
-# T003 — full 25-directive parity fixture, driven by this repo's own
+# T003 — full activated-directive parity fixture, driven by this repo's own
 # .kittify/config.yaml (production-shaped data, not placeholders).
 # --------------------------------------------------------------------------- #
 
@@ -130,10 +133,13 @@ def test_resolve_artifact_urn_is_reject_not_drop_on_unresolvable_stem(
 def test_config_declares_exactly_the_expected_directive_count(
     activated_directive_stems: list[str],
 ) -> None:
-    # Pins the observed count from spec.md (Context & Motivation: "25 vs 24
-    # directives observed") so a silent addition/removal in config.yaml is
-    # visible as an intentional test update, not an invisible drift.
-    assert len(activated_directive_stems) == 25  # golden-count: cardinality-is-contract
+    # Pins the observed activated-directive count so a silent addition/removal
+    # in the activation store is visible as an intentional test update, not an
+    # invisible drift. Bumped 25 -> 31 for the writing-comms/diagramming
+    # doctrine activation (commit 9a99801f1): numbered directives 046-050 plus
+    # the two deliberately slug-named hub directives
+    # (use-c4-model-techniques, reconcile-change-scope-tensions).
+    assert len(activated_directive_stems) == 31  # golden-count: cardinality-is-contract
 
 
 def _directive_stems_for_parametrize() -> list[str]:
@@ -142,7 +148,7 @@ def _directive_stems_for_parametrize() -> list[str]:
     ``pytest.mark.parametrize`` needs its argument list at collection time,
     before fixtures run, so this re-reads the same config file the
     ``activated_directive_stems`` fixture reads. Both routes must produce the
-    same 25 stems; :func:`test_config_declares_exactly_the_expected_directive_count`
+    same stems; :func:`test_config_declares_exactly_the_expected_directive_count`
     pins the count so drift between the two reads would show up as a count
     mismatch, not silently.
     """
@@ -159,11 +165,23 @@ def test_every_activated_directive_stem_round_trips_to_canonical_urn(
     """Every real ``config.activated_directives`` stem resolves and round-trips.
 
     Exercises the exact mapping the live derivation (WP02) must reproduce:
-    stem → canonical URN (``directive:DIRECTIVE_NNN``) → back to the same
-    stem, with no manual answers.yaml involvement.
+    stem -> canonical directive URN -> back to the same stem, with no manual
+    answers.yaml involvement.
+
+    The canonical id is *whatever form the directive artifact declares*: the
+    numbered ``directive:DIRECTIVE_NNN`` form, or the UPPER_SNAKE slug form used
+    by deliberately-named extensible hub directives (e.g.
+    ``directive:USE_C4_MODEL_TECHNIQUES``,
+    ``directive:RECONCILE_CHANGE_SCOPE_TENSIONS`` — the same established
+    convention as ``DISCIPLINED_REFACTORING`` / ``USE_MUTATION_TESTING`` already
+    in the graph). The round-trip below is the real bite; the URN shape check
+    only pins that a *canonical* directive URN came back, not a particular id
+    spelling.
     """
     urn = resolve_artifact_urn(ArtifactKind.DIRECTIVE, stem, doctrine_root=doctrine_root)
-    assert urn.startswith("directive:DIRECTIVE_")
+    assert re.fullmatch(
+        r"directive:[A-Z][A-Z0-9_]+", urn
+    ), f"expected a canonical directive URN, got {urn!r}"
     assert resolve_config_id(urn, doctrine_root=doctrine_root) == stem
 
 

--- a/tests/charter/test_context_service_seams.py
+++ b/tests/charter/test_context_service_seams.py
@@ -205,8 +205,11 @@ class TestNormalizeDirectiveId:
     def test_canonical_form_passes_through(self) -> None:
         assert _normalize_directive_id("DIRECTIVE_024") == "DIRECTIVE_024"
 
-    def test_non_numeric_uppercases(self) -> None:
-        assert _normalize_directive_id("some-slug") == "SOME-SLUG"
+    def test_non_numeric_uppercases_and_folds_hyphens(self) -> None:
+        # Slug-named hub directives normalize to their UPPER_SNAKE node id, so the
+        # fallback folds hyphens to underscores (#3009) -- matching id_normalizer.
+        assert _normalize_directive_id("some-slug") == "SOME_SLUG"
+        assert _normalize_directive_id("use-c4-model-techniques") == "USE_C4_MODEL_TECHNIQUES"
 
 
 class TestExistingOrgRoots:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,21 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     os.environ.setdefault(_REAL_HOME_ENV_VAR, str(Path.home()))
 
+    # #3213: set the SaaS-sync feature flag ONCE, collection-wide, before any test
+    # module is imported. Import-time ``@pytest.mark.skipif(not
+    # os.environ.get("SPEC_KITTY_ENABLE_SAAS_SYNC"))`` gates (e.g. the #2782
+    # regression) are evaluated at collection, which the per-test autouse
+    # ``_enable_saas_sync_feature_flag`` fixture (a setup-time monkeypatch) is too
+    # late to satisfy. Previously six docs/architectural modules set it at import
+    # via their own ``os.environ.setdefault``, so whether the gate fired depended
+    # on whether one of those modules happened to be collected — ``pytest
+    # tests/ -m regression`` enforced it, ``pytest tests/regression`` did not.
+    # Setting it here is the single collection-time authority, so a given node's
+    # skip/run decision is the same under every selection. (This correctly
+    # re-exposes the known-open #2782 P0 red under ``pytest tests/regression`` —
+    # intended, not a new regression.)
+    os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+
     # WP04: isolate this worker's home BEFORE collection so modules that bind a
     # home-derived path at import time (e.g. ``daemon.SPEC_KITTY_DIR`` at
     # ``daemon.py:94``) resolve into the per-worker isolated home, never the

--- a/tests/docs/test_build_cli_reference.py
+++ b/tests/docs/test_build_cli_reference.py
@@ -21,7 +21,9 @@ import pytest
 import typer
 
 # Ensure the env flags exist before importing the build module.
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is set collection-wide in tests/conftest.py
+# pytest_configure (#3213) — not per-module, which made the gate selection-
+# dependent.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 from scripts.docs import build_cli_reference as build

--- a/tests/docs/test_check_cli_reference_freshness.py
+++ b/tests/docs/test_check_cli_reference_freshness.py
@@ -14,7 +14,8 @@ from pathlib import Path
 import pytest
 import typer
 
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is set collection-wide in tests/conftest.py
+# pytest_configure (#3213), not per-module.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 from scripts.docs import check_cli_reference_freshness as freshness

--- a/tests/docs/test_check_docs_freshness.py
+++ b/tests/docs/test_check_docs_freshness.py
@@ -17,7 +17,8 @@ from pathlib import Path
 
 import pytest
 
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is set collection-wide in tests/conftest.py
+# pytest_configure (#3213), not per-module.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/docs/test_docs_index_freshness.py
+++ b/tests/docs/test_docs_index_freshness.py
@@ -19,7 +19,8 @@ from pathlib import Path
 
 import pytest
 
-os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+# SPEC_KITTY_ENABLE_SAAS_SYNC is set collection-wide in tests/conftest.py
+# pytest_configure (#3213), not per-module.
 os.environ.setdefault("SPEC_KITTY_NO_UPGRADE_CHECK", "1")
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/doctrine/drg/migration/test_extractor_projection.py
+++ b/tests/doctrine/drg/migration/test_extractor_projection.py
@@ -630,11 +630,6 @@ _AWAITING_REFERENCES: frozenset[str] = frozenset(
         # pack layer by ADR 2026-07-26-2, which made it a node for the first
         # time. Nothing references it yet.
         "toolguide:powershell-syntax",
-        # Ledger (doctrine-tension-edges-01KY1WPC WP03): a plain built-in
-        # directive whose only edges are the hand-authored
-        # ``reconciles_tension`` ones the extractor cannot mint. Wired by the
-        # overlay -- see _ORPHANS_RESOLVED_BY_OVERLAY.
-        "directive:RECONCILE_CHANGE_SCOPE_TENSIONS",
         # Ledger (10) #3063 family-B: the new disciplined-refactoring hub
         # directive. It carries no inline references, so a pure ``generate_graph``
         # mints its node but no edge; its only edges are the hand-authored
@@ -654,11 +649,16 @@ _AWAITING_REFERENCES: frozenset[str] = frozenset(
         # node but no edge; every one is wired only by the hand-authored family-D
         # ``suggests`` edges. Wired by the overlay -- see
         # _ORPHANS_RESOLVED_BY_OVERLAY.
+        #
+        # Ledger (writing-comms/diagramming activation, commit 9a99801f1, #3009):
+        # four of the five family-D artefacts -- quadruple-a-test-format,
+        # given-when-then-authoring, sonar, gherkin -- became charter-ACTIVATED. An
+        # activated pure orphan is a tracked #3009 defect, so they graduate to
+        # _ACTIVATED_BUT_ORPHANED (the floor guard demands it, and the orphan
+        # partition keeps each URN in exactly one bucket). Only
+        # ``USE_MUTATION_TESTING_TO_VALIDATE_TEST_QUALITY`` -- which is NOT activated
+        # -- stays here as a plain awaiting-references orphan.
         "directive:USE_MUTATION_TESTING_TO_VALIDATE_TEST_QUALITY",
-        "styleguide:quadruple-a-test-format",
-        "styleguide:given-when-then-authoring",
-        "toolguide:sonar",
-        "toolguide:gherkin",
     }
 )
 
@@ -700,7 +700,9 @@ _NOT_A_TRAVERSAL_TARGET: frozenset[str] = frozenset({"agent_profile:human-in-cha
 #: WIRED via ``_CURATED_ARTIFACT_EDGES`` (ledger entry 7) -- seven targets plus
 #: ``directive:DIRECTIVE_035``, which leaves this set by becoming an edge SOURCE
 #: rather than by gaining an inbound edge.
-#: ``styleguide:deployable-skill-authoring`` is the only survivor.
+#: ``styleguide:deployable-skill-authoring`` was the only survivor of ledger
+#: entry 7; the writing-comms/diagramming activation (commit 9a99801f1, #3009)
+#: later adds four more activated pure orphans -- see the set body.
 #:
 #: The first pass had ``paradigm:atomic-design`` here instead, claiming no
 #: defensible source existed. Review refuted that from the corpus:
@@ -717,11 +719,33 @@ _NOT_A_TRAVERSAL_TARGET: frozenset[str] = frozenset({"agent_profile:human-in-cha
 _ACTIVATED_BUT_ORPHANED: frozenset[str] = frozenset(
     {
         "styleguide:deployable-skill-authoring",
+        # Ledger (writing-comms/diagramming activation, commit 9a99801f1, #3009):
+        # the four family-D BDD/testing artefacts the writing-comms charter set
+        # activated. Each is still wired only by the family-D overlay (they stay in
+        # _ORPHANS_RESOLVED_BY_OVERLAY) yet remain unreachable from any action or
+        # profile traversal root -- activating them cascades to nothing. Tracked as
+        # #3009 debt until real inbound edges are authored (the deferred A2
+        # orphan-wiring doctrine mission), NOT green-washed away here.
+        "styleguide:quadruple-a-test-format",
+        "styleguide:given-when-then-authoring",
+        "toolguide:sonar",
+        "toolguide:gherkin",
+        # Ledger (writing-comms/diagramming activation, commit 9a99801f1, #3009):
+        # the reconcile-change-scope-tensions hub directive. Its only edges are the
+        # hand-authored ``reconciles_tension`` overlay edges (still in
+        # _ORPHANS_RESOLVED_BY_OVERLAY); it became charter-ACTIVATED, and once
+        # id_normalizer folds its slug to the node URN it is detected as an
+        # activated pure orphan -- so it graduates here from _AWAITING_REFERENCES.
+        "directive:RECONCILE_CHANGE_SCOPE_TENSIONS",
     }
 )
 
 #: Every node a PURE ``generate_graph`` run leaves incident to no edge.
-#: 17 + 10 + 1 + 1 = 29 (``_AWAITING_REFERENCES`` shrank to 10 with ledger entry (15)'s
+#: 17 + 5 + 1 + 6 = 29 (``_AWAITING_REFERENCES`` shrank 10 -> 5 when the
+#: writing-comms/diagramming activation (commit 9a99801f1, #3009) graduated four
+#: family-D artefacts plus the reconcile-change-scope-tensions hub directive into
+#: ``_ACTIVATED_BUT_ORPHANED`` 1 -> 6; the union is unchanged. It had earlier
+#: shrunk to 10 with ledger entry (15)'s
 #: rehome-writing-comms-doctrine, which gives ``directive:USE_C4_MODEL_TECHNIQUES`` a
 #: real extractor edge via ``agent_profile:diagram-daisy`` -- it had grown to 11 with
 #: ledger entry (12)'s five new family-D artefacts, atop entry (11)'s

--- a/tests/doctrine/drg/test_reachability.py
+++ b/tests/doctrine/drg/test_reachability.py
@@ -957,9 +957,14 @@ class TestProfileRescuesHaveLedgerCoverage:
 
 @pytest.mark.doctrine
 class TestC009NormalizationSwingExcluded:
-    """The 25-slug store->node reconciliation is declared, and never banked."""
+    """The store->node slug reconciliation is declared, and never banked.
 
-    def test_normalization_delta_is_the_declared_25_swing(self, graph: DRGGraph) -> None:
+    The swing size is pinned by ``_NORMALIZATION_DELTA`` (31 as of the
+    writing-comms/diagramming activation) rather than baked into names here, so a
+    later count change touches only the constant.
+    """
+
+    def test_normalization_delta_is_the_declared_swing(self, graph: DRGGraph) -> None:
         node_urns = graph.node_urns()
         reachable = action_channel_reachable(graph, action_seed_urns(graph), _ACTION_D1_DEPTH)
         partition = partition_activated_unreachable(_raw_activated_map(), node_urns, reachable)

--- a/tests/doctrine/drg/test_reachability.py
+++ b/tests/doctrine/drg/test_reachability.py
@@ -69,10 +69,16 @@ _REPO_ROOT: Path = Path(__file__).resolve().parents[3]
 _ACTION_D1_DEPTH = 1
 _ACTION_D2_DEPTH = 2
 
-#: The C-009 normalization swing (WP06): 25 activated directive slugs whose
-#: STORE form is not a graph node while their NORMALIZED form is. Reconciling
-#: the form is not reachability progress and is excluded from SC-005.
-_NORMALIZATION_DELTA = 25
+#: The C-009 normalization swing (WP06): activated directive slugs whose STORE
+#: form is not a graph node while their NORMALIZED form is. Reconciling the form
+#: is not reachability progress and is excluded from SC-005. Bumped 25 -> 31 for
+#: the writing-comms/diagramming activation (commit 9a99801f1, #3009): six more
+#: activated directives whose store slug is not a node while their normalized form
+#: is -- the four numbered 047-050 (``NNN-...`` -> ``DIRECTIVE_NNN``) and the two
+#: slug hubs use-c4-model-techniques / reconcile-change-scope-tensions
+#: (``slug`` -> ``USE_C4_MODEL_TECHNIQUES`` / ``RECONCILE_CHANGE_SCOPE_TENSIONS``,
+#: now that id_normalizer folds hyphens to underscores).
+_NORMALIZATION_DELTA = 31
 
 #: The measured d=1 <-> d=2 action-channel spread (R-2): d=2 (bootstrap) reaches
 #: exactly 10 more nodes than d=1 (compact), so d=2's unreachable set is d=1's
@@ -319,6 +325,33 @@ _ACTION_UNREACHABLE_D1: frozenset[str] = frozenset(
         "toolguide:python-review-checks",
         "toolguide:terminology-guard",
         "toolguide:typescript-mutation-tools",
+        # Writing-comms/diagramming activation (commit 9a99801f1, #3009): these
+        # seventeen newly-activated artefacts are reached by no action-channel
+        # traversal at this depth. All are in canonical DRG node form (the two
+        # slug-hub directives normalize to their UPPER_SNAKE node id, not the old
+        # hyphenated store slug -- see the id_normalizer fix). Seven of them
+        # (DIRECTIVE_047-050, quadruple-a-test-format, writing-audience-catalog,
+        # USE_C4_MODEL_TECHNIQUES) ARE rescued by the profile channel (see
+        # _PROFILE_RESCUES); the other ten are unreachable from BOTH channels and
+        # are the tracked #3009 debt the deferred A2 orphan-wiring doctrine mission
+        # will wire with real inbound edges.
+        "directive:DIRECTIVE_047",
+        "directive:DIRECTIVE_048",
+        "directive:DIRECTIVE_049",
+        "directive:DIRECTIVE_050",
+        "directive:RECONCILE_CHANGE_SCOPE_TENSIONS",
+        "directive:USE_C4_MODEL_TECHNIQUES",
+        "procedure:glossary-maintenance-workflow",
+        "styleguide:divio-type-discipline",
+        "styleguide:docs-accessibility",
+        "styleguide:docs-freshness-sla",
+        "styleguide:plain-language",
+        "styleguide:professional-communications",
+        "styleguide:publication-authority",
+        "styleguide:quadruple-a-test-format",
+        "styleguide:research-citation-discipline",
+        "tactic:dialectic-research",
+        "tactic:writing-audience-catalog",
     }
 )
 
@@ -376,6 +409,28 @@ _ACTION_UNREACHABLE_D2: frozenset[str] = frozenset(
         "toolguide:python-mutation-tools",
         "toolguide:terminology-guard",
         "toolguide:typescript-mutation-tools",
+        # Writing-comms/diagramming activation (commit 9a99801f1, #3009): the same
+        # seventeen additions as _ACTION_UNREACHABLE_D1 (canonical node form) -- all
+        # seventeen remain action-unreachable at d=2 too, so the d1<->d2 spread is
+        # unchanged (10) and D2 stays a subset of D1. See the D1 block for the
+        # debt/rescue split.
+        "directive:DIRECTIVE_047",
+        "directive:DIRECTIVE_048",
+        "directive:DIRECTIVE_049",
+        "directive:DIRECTIVE_050",
+        "directive:RECONCILE_CHANGE_SCOPE_TENSIONS",
+        "directive:USE_C4_MODEL_TECHNIQUES",
+        "procedure:glossary-maintenance-workflow",
+        "styleguide:divio-type-discipline",
+        "styleguide:docs-accessibility",
+        "styleguide:docs-freshness-sla",
+        "styleguide:plain-language",
+        "styleguide:professional-communications",
+        "styleguide:publication-authority",
+        "styleguide:quadruple-a-test-format",
+        "styleguide:research-citation-discipline",
+        "tactic:dialectic-research",
+        "tactic:writing-audience-catalog",
     }
 )
 
@@ -492,6 +547,24 @@ _PROFILE_UNREACHABLE: frozenset[str] = frozenset(
         "tactic:testing-select-appropriate-level",
         "toolguide:git-agent-commit-signing",
         "toolguide:maven-review-checks",
+        # Writing-comms/diagramming activation (commit 9a99801f1, #3009): ten of
+        # the seventeen newly-activated artefacts are unreachable from the profile
+        # channel too. These ten (action-d2-unreachable AND profile-unreachable)
+        # are the true "activating cascades to nothing" #3009 debt the deferred A2
+        # orphan-wiring mission will wire. The other seven action-d2-unreachable
+        # additions ARE profile-reachable and appear in _PROFILE_RESCUES instead
+        # (USE_C4_MODEL_TECHNIQUES is one of them -- diagram-daisy requires it -- so
+        # it is NOT listed here).
+        "directive:RECONCILE_CHANGE_SCOPE_TENSIONS",
+        "procedure:glossary-maintenance-workflow",
+        "styleguide:divio-type-discipline",
+        "styleguide:docs-accessibility",
+        "styleguide:docs-freshness-sla",
+        "styleguide:plain-language",
+        "styleguide:professional-communications",
+        "styleguide:publication-authority",
+        "styleguide:research-citation-discipline",
+        "tactic:dialectic-research",
     }
 )
 
@@ -511,6 +584,13 @@ _PROFILE_UNREACHABLE: frozenset[str] = frozenset(
 #: table flagged for the "fast-follow walk-update mission" (this mission). Every
 #: member here is covered by a wiring-table ledger row — enforced by
 #: ``test_profile_rescues_have_ledger_coverage`` below.
+#:
+#: Writing-comms/diagramming activation (commit 9a99801f1, #3009): 30 → 37. Seven
+#: newly-activated artefacts are action-d2-unreachable but profile-rescued
+#: (DIRECTIVE_047-050, USE_C4_MODEL_TECHNIQUES, quadruple-a-test-format,
+#: writing-audience-catalog); their delivering profile edges and ledger rows are
+#: recorded in the set body and the wiring table's profile-channel walk-activation
+#: ledger.
 _PROFILE_RESCUES: frozenset[str] = frozenset(
     {
         "directive:DIRECTIVE_044",
@@ -543,6 +623,23 @@ _PROFILE_RESCUES: frozenset[str] = frozenset(
         "toolguide:python-mutation-tools",
         "toolguide:terminology-guard",
         "toolguide:typescript-mutation-tools",
+        # Writing-comms/diagramming activation (commit 9a99801f1, #3009): seven of
+        # the seventeen newly-activated artefacts are rescued by the profile channel
+        # -- action-d2-unreachable yet delivered by an activated writing-comms
+        # profile. Delivering edges (traced from the built-in graph; ledger rows
+        # below):
+        #   DIRECTIVE_047, DIRECTIVE_048  <- agent_profile:scribe-sally
+        #   DIRECTIVE_049, DIRECTIVE_050  <- agent_profile:minutes-maker-mahad
+        #   quadruple-a-test-format       <- generic-agent -> DIRECTIVE_041 (suggests)
+        #   writing-audience-catalog      <- agent_profile:comms-cleo
+        #   USE_C4_MODEL_TECHNIQUES       <- agent_profile:diagram-daisy (requires)
+        "directive:DIRECTIVE_047",
+        "directive:DIRECTIVE_048",
+        "directive:DIRECTIVE_049",
+        "directive:DIRECTIVE_050",
+        "directive:USE_C4_MODEL_TECHNIQUES",
+        "styleguide:quadruple-a-test-format",
+        "tactic:writing-audience-catalog",
     }
 )
 


### PR DESCRIPTION
**BLUF —** A charter author who activated a slug-named hub directive (like
`use-c4-model-techniques`) got *silent nothing*: the directive resolved to a
dangling id and cascaded to no doctrine, with no error to explain why. This PR
makes those slug-hub directives activate and cascade correctly. It also fixes a
test gate that silently changed its mind — depending only on *how* you selected
tests — about whether a known regression even runs, and re-pins the doctrine
guards to the intended activation state. Net: three CI reds clear; one
known-open P0 (`#2782`) is honestly *un*masked (see the intended-side-effect
note below), not introduced.

## What this fixes

A bulk pass over open red / follow-on issues. Three of them share one root — a
July charter dogfooding activation (`9a99801f1`) that outran its guards — and one
is an independent test-gate reliability bug. Together they clear three CI reds and
close a class of silent misbehaviour.

### 1. Slug-named hub directives now activate correctly (`#3298`, and the root of `#3009`)

**Before:** activating a slug-named hub directive such as `use-c4-model-techniques`
in a charter silently pointed at nothing. The directive-id normalizer folded
*numbered* slugs (`024-locality-of-change` → `DIRECTIVE_024`) but left slug-named
ones hyphenated and uppercased (`use-c4-model-techniques` → `USE-C4-MODEL-TECHNIQUES`),
which is **not** the artifact's canonical node id (`USE_C4_MODEL_TECHNIQUES`). So
the activation — and any slug-form reference — resolved to a dangling identifier
that cascaded to nothing.

**After:** the normalizer folds hyphens to underscores in its fallback, converging
on the canonical node id that the other resolver (`resolve_artifact_urn`) already
produced. Slug-hub directives now activate and cascade like any other. Both copies
of the normalizer (`id_normalizer` and its `profile_resolution` twin, kept separate
for a documented import-cycle reason) were aligned so they can't drift again.

The `test_config_stem_parity` round-trip guard is relaxed to accept the canonical
UPPER_SNAKE slug-hub id form (the same convention as `DISCIPLINED_REFACTORING` /
`USE_MUTATION_TESTING` already in the graph) rather than renumbering two deliberate
hub directives into `DIRECTIVE_NNN` — a semantically-lossy ~20-file bulk-edit that
would fight the design. Activated-directive count re-pinned 25 → 31.

### 2. DRG orphan/reachability guards re-pinned to the intentional activation (`#3009` red tests)

The writing-comms/diagramming activation added 17 artefacts the DRG reachability
and orphan guards had not been told about, red-maining `fast-tests-doctrine`. The
guards are re-pinned to the deliberate new state — **not** green-washed: the tests
explicitly offer this enroll path and the genuine edge-wiring (making each
activated artefact actually cascade) is tracked as deferred debt for a follow-on
doctrine mission. Every re-pin is measured, not pasted: the 7 profile-rescued
artefacts each carry a traced delivering edge and a wiring-table ledger row; the 10
neither-channel orphans are recorded as the real `#3009` debt.

### 3. Regression gate no longer flips on test selection (`#3213`)

**Before:** the `#2782` regression's import-time
`skipif(not os.environ.get("SPEC_KITTY_ENABLE_SAAS_SYNC"))` was decided at
collection, but the flag was set at import by six unrelated docs/architectural
modules. So whether the gate fired depended on which modules happened to be
collected — `pytest tests/ -m regression` (CI) enforced it, `pytest tests/regression`
(a developer) silently skipped it. Same node, different decision.

**After:** `tests/conftest.py` `pytest_configure` is the single collection-time
authority — it sets the flag once, before any module import. The six per-module
leaks are removed (intentional per-test overrides kept), and a new architectural
guard pins both halves (flag set at collection; no module may re-add a
module-level write, AST-scanned with a non-vacuity proof).

> ⚠️ **Intended side effect:** with the flag consistently set, the **known-open
> `#2782` P0 red now runs (and is red) under `pytest tests/regression` too**,
> instead of hiding under that selection. That is the correct, honest effect of a
> consistent gate — not a new regression introduced here.

## Also closed in this pass (already fixed on `main`, issues left open)

Verified green at the PR base and closed with evidence — zero code, they were
already resolved by earlier missions: `#3159`, `#3160`, `#3092` (golden re-pins),
`#3138` (#2804 marker relocation + FR-008), `#3266` (mission-create fixture),
`#3157` (test-rot + CI decoupling).

## Tests

- `tests/charter/test_config_stem_parity.py`, `tests/doctrine/drg/test_reachability.py`,
  `tests/doctrine/drg/migration/test_extractor_projection.py` — all green.
- New guard `tests/architectural/test_saas_sync_gate_selection_invariance.py`
  (declares `pytestmark`, auto-sharded; marker/shard completeness gates pass).
- Terminology guard, docs-freshness (`errors=0`), ruff, and mypy (on changed code)
  all clean.

## Landing notes

- Base is `upstream/main` (`6bec17d11`); each fix is its own commit.
- `#3009` is **not** closed by this PR — only its red guards are re-pinned. The
  genuine orphan edge-wiring is a deferred follow-on doctrine mission (tracked with
  `#1923`).
- Any remaining red checks are inherited pre-existing `main` breakage per
  [ADR 2026-07-17-1](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md),
  plus the intended `#2782` unmask above.

Closes #3298
Closes #3213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788961872&installation_model_id=427282&pr_number=3301&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3301&signature=4a4e8ecd1d74eb215ed8c169cf20e83c2de50ba95ab7cc97eddca32ba0047428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
