### PR TITLE
docs(pr-landing): fold squad MINOR/NOTE findings by default, file only as the exception

### DIFF
--- a/docs/development/how-to/pr-landing.md
+++ b/docs/development/how-to/pr-landing.md
@@ -302,9 +302,21 @@ review lenses in parallel — for example `architect-alphonso` for design and
 contract adherence, `paula-patterns` for SSOT and duplication — with
 read-only access to the landing worktree.
 
-- Fold their MAJOR findings ([step 5](#5-folds-remediation-commits-on-the-contributor-branch)).
-- File their MINORs and NOTEs as **one** follow-up issue, parented under the
-  relevant functional epic.
+- **Fold their findings — MAJOR, MINOR, and NOTE alike** ([step 5](#5-folds-remediation-commits-on-the-contributor-branch)).
+  The default is to fix everything the squad surfaces, in this PR, while the
+  branch is open and the context is loaded. A MINOR or NOTE is cheap to fold now
+  and expensive to rediscover later; deferring it to a "someday" issue is how
+  easy fixes rot on a backlog and how the same finding gets re-raised on the next
+  pass. Do not triage-by-severity into fold-vs-defer — fold by default.
+- **File a follow-up issue only as the exception**, when folding is genuinely the
+  wrong call for one of two reasons: (a) the finding's **scope is too large** to
+  fold cleanly into this PR (wide blast radius, many files, a refactor that would
+  swamp the review), or (b) its **impact is severe enough that the remediation
+  needs its own mission or design pass** — a spec, an ADR, or an operator
+  decision before any code moves. In those cases file the issue, parent it under
+  the relevant functional epic, and say in the remediation summary why it was not
+  folded. Severity alone never justifies deferral; only unfoldable scope or a
+  required design pass does.
 
 ### Delegate remediation to subagents
 
@@ -422,10 +434,13 @@ deliverable is:
 
 ## 12. Follow-up hygiene
 
-Everything discovered but out of scope gets a tracked home **the same day**:
-filed, labeled, and parented under a functional epic (never a meta rollup).
-New issues get processed by a triage pass immediately, so the next landing
-pass starts from a clean queue.
+Most of what a landing pass discovers should be **folded, not filed** — see the
+fold-first default in [step 8](#8-adversarial-squad-for-architectural-or-api-surface-prs).
+What genuinely cannot be folded — a finding whose scope is too large for this PR,
+or whose impact needs its own mission or design pass — gets a tracked home **the
+same day**: filed, labeled, and parented under a functional epic (never a meta
+rollup). New issues get processed by a triage pass immediately, so the next
+landing pass starts from a clean queue.
 
 ## Gotchas
 


### PR DESCRIPTION
## What changes for maintainers

The contributor-PR **landing runbook** told maintainers to fold only **MAJOR** adversarial-squad findings and defer every **MINOR/NOTE** to a single follow-up issue. This flips that default. A squad finding is cheapest to fix while the branch is open and the context is loaded; a deferred MINOR/NOTE is how easy fixes rot on a backlog and get re-raised on the next pass.

## The rule now

**Fold squad findings of every severity — MAJOR, MINOR, and NOTE — into the PR by default.** Filing a follow-up issue is the explicit *exception*, justified only when:

- the finding's **scope is too large** to fold cleanly into the PR (wide blast radius, a refactor that would swamp the review), or
- its **impact needs its own mission or design pass** (a spec, an ADR, an operator decision before any code moves).

Severity alone never justifies deferral. Step 8 (adversarial squad) and step 12 (follow-up hygiene) are updated to the same fold-first default.

## Why now

Surfaced during the #3321 landing pass: applying the corrected rule turned up real, foldable findings the old "defer MINOR/NOTE" default would have shelved — a one-directional facade-identity gate (a public symbol could silently drift to a wrapper) and a 0%-coverage blind spot on a critical path. Both were cheap to fold in-context and expensive to rediscover later.

## Scope

Docs-only, single file (`docs/development/how-to/pr-landing.md`). markdownlint, terminology guard, and `check_docs_freshness --ci` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Knte7cwenfNTtyT33Ujemg

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789042134&installation_model_id=427282&pr_number=3327&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3327&signature=98f977f3b17e68a3b18d09555d77e71e3198ca11eda1c19dc8ba0cce46feac63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->