### PR TITLE
Allow mission creation from caller-owned linked worktrees

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -384,6 +384,11 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   return contradictory verdicts on the same file — is also unified into a single
   authority.
 
+- **`agent mission create --start-branch` now works from a caller-owned linked
+  worktree without touching the primary checkout (`#2739`).** Mission creation
+  keeps its scaffold and first metadata commit on the already-selected planning
+  branch, while Spec Kitty coordination and lane worktrees remain blocked from
+  spawning nested missions.
 - **Two blocking CI gates now reflect what a PR actually changed (mission
   `ci-scoping-gate-reliability`; `#3008`, `#3147`).** _Corpus data no longer ships
   unguarded (`#3008`):_ a PR that changed only non-source corpus data — shipped

--- a/src/specify_cli/cli/commands/agent/mission_create.py
+++ b/src/specify_cli/cli/commands/agent/mission_create.py
@@ -32,6 +32,7 @@ import typer
 
 from specify_cli.cli.selector_resolution import resolve_selector
 from specify_cli.core.constants import MISSION_TYPE_DOCUMENTATION
+from specify_cli.core.paths import resolve_mission_creation_root
 from specify_cli.diagnostics import mark_invocation_succeeded
 
 from specify_cli.cli.commands.agent.mission_branch_context import (
@@ -471,7 +472,7 @@ def create_mission(
     # ``mission._switch_to_start_branch`` patch targets the tests rely on.
     from specify_cli.cli.commands.agent import mission as _mission
 
-    repo_root = _mission.locate_project_root()
+    repo_root = resolve_mission_creation_root(_mission.locate_project_root())
 
     _resolve_start_branch_phase(
         repo_root=repo_root,

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -7,7 +7,7 @@ command ``create()`` is a thin wrapper around this function.
 
 from __future__ import annotations
 
-from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.constants import KITTY_SPECS_DIR, WORKTREES_DIR
 import contextlib
 import logging
 import re
@@ -18,17 +18,31 @@ from typing import Any
 
 from ulid import ULID
 
-from mission_runtime import MissionArtifactKind, MissionTopology, placement_seam
+from mission_runtime import (
+    MissionArtifactKind,
+    MissionTopology,
+    resolve_write_target_or_degrade,
+)
 from specify_cli.core.commit_guard import GuardCapability
 from specify_cli.core.git_ops import get_current_branch, is_git_repo
 from specify_cli.core.mission_payload import (
     default_mission_display_name,
     default_mission_purpose_context,
 )
-from specify_cli.core.paths import is_worktree_context, locate_project_root
+from specify_cli.core.paths import (
+    get_main_repo_root,
+    is_worktree_context,
+    locate_project_root,
+    resolve_mission_creation_root,
+)
 from kernel.clock import now_utc_iso
 from specify_cli.git import safe_commit
-from specify_cli.lanes.branch_naming import mission_dir_name, resolve_mid8
+from specify_cli.lanes.branch_naming import (
+    is_lane_branch,
+    is_mission_branch,
+    mission_dir_name,
+    resolve_mid8,
+)
 from specify_cli.mission_metadata import load_meta_or_empty, validate_purpose_summary
 
 logger = logging.getLogger(__name__)
@@ -157,6 +171,7 @@ def _commit_feature_file(
     mission_slug: str,
     artifact_type: str,
     repo_root: Path,
+    planning_branch: str,
 ) -> None:
     """Commit a single planning artifact to its seam-resolved primary home.
 
@@ -165,7 +180,7 @@ def _commit_feature_file(
     when there is nothing to commit.
 
     coord-primary-partition-lock WP02 (T007 / C-001 / C-006): the commit
-    destination is derived from ``placement_seam(...).write_target(SPEC)``,
+    destination is derived from the shared placement/degrade authority,
     NOT from the operator's current checkout. Pre-fix this constructed
     ``CommitTarget(ref=current_branch)`` directly, which is the create-time
     split-brain root (research.md D5) -- under a coord-routing mission whose
@@ -187,7 +202,18 @@ def _commit_feature_file(
     # plans on a protected branch, WP05's placement projection routes the
     # commit; this caller does not duplicate that decision (T010).
     commit_msg = f"Add {artifact_type} for feature {mission_slug}"
-    seam_target = placement_seam(repo_root, mission_slug).write_target(MissionArtifactKind.SPEC)
+    # A mission created in a caller-owned linked worktree is not visible from
+    # the canonical primary checkout until its first commit.  Resolve against
+    # that primary surface so the shared bootstrap-window helper degrades to
+    # the explicit planning branch instead of silently falling back to the
+    # repository's default branch.  Once metadata is visible on the primary
+    # surface, the same helper delegates to the normal placement authority.
+    seam_target = resolve_write_target_or_degrade(
+        get_main_repo_root(repo_root),
+        mission_slug,
+        MissionArtifactKind.SPEC,
+        degrade_ref=planning_branch,
+    )
     safe_commit(
         repo_root=repo_root,
         worktree_root=repo_root,
@@ -201,6 +227,26 @@ def _commit_feature_file(
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def _is_safe_external_creation_worktree(
+    cwd: Path,
+    resolved_root: Path,
+    current_branch: str,
+) -> bool:
+    """Return whether ``cwd`` is a caller-owned, non-mission worktree.
+
+    Spec Kitty coordination and lane worktrees remain invalid creation
+    contexts: their branch and directory conventions prove that they already
+    belong to another mission.  A linked worktree on an ordinary branch is a
+    safe planning checkout when the resolved write root is that same checkout.
+    """
+    checkout_root = resolved_root.resolve()
+    if cwd != checkout_root and checkout_root not in cwd.parents:
+        return False
+    if WORKTREES_DIR in checkout_root.parts:
+        return False
+    return not (is_lane_branch(current_branch) or is_mission_branch(current_branch))
 
 
 def create_mission_core(
@@ -310,14 +356,22 @@ def create_mission_core(
     # 2. Context guards
     # ------------------------------------------------------------------
     cwd = Path.cwd().resolve()
-    if not allow_worktree_context and is_worktree_context(cwd):
-        raise MissionCreationError("Cannot create missions from inside a worktree. Run from the project root checkout.")
-
-    resolved_root = repo_root
-    if resolved_root is None:
-        resolved_root = locate_project_root()
+    project_root = repo_root if repo_root is not None else locate_project_root()
+    resolved_root = resolve_mission_creation_root(project_root, cwd)
     if resolved_root is None:
         raise MissionCreationError("Could not locate project root. Run from within spec-kitty repository.")
+
+    in_worktree = is_worktree_context(cwd)
+    checkout_root = resolved_root.resolve()
+    if (
+        not allow_worktree_context
+        and in_worktree
+        and cwd != checkout_root
+        and checkout_root not in cwd.parents
+    ):
+        raise MissionCreationError(
+            "Cannot create missions from inside a worktree. Run from the project root checkout."
+        )
 
     if not is_git_repo(resolved_root):
         raise MissionCreationError("Not in a git repository. Mission creation requires git.")
@@ -325,6 +379,14 @@ def create_mission_core(
     current_branch = get_current_branch(resolved_root)
     if not current_branch or current_branch == "HEAD":
         raise MissionCreationError("Must be on a branch to create missions (detached HEAD detected).")
+    if (
+        not allow_worktree_context
+        and in_worktree
+        and not _is_safe_external_creation_worktree(cwd, resolved_root, current_branch)
+    ):
+        raise MissionCreationError(
+            "Cannot create missions from inside a worktree. Run from the project root checkout."
+        )
 
     # ------------------------------------------------------------------
     # 3. Resolve planning branch
@@ -518,7 +580,13 @@ def create_mission_core(
 
     write_meta(feature_dir, meta)
     with contextlib.suppress(Exception):
-        _commit_feature_file(meta_file, mission_slug_formatted, "meta", resolved_root)
+        _commit_feature_file(
+            meta_file,
+            mission_slug_formatted,
+            "meta",
+            resolved_root,
+            planning_branch,
+        )
 
     # ------------------------------------------------------------------
     # 7. Documentation state (if applicable)
@@ -536,7 +604,13 @@ def create_mission_core(
             }
             set_documentation_state(feature_dir, doc_state)
         with contextlib.suppress(Exception):
-            _commit_feature_file(meta_file, mission_slug_formatted, "meta", resolved_root)
+            _commit_feature_file(
+                meta_file,
+                mission_slug_formatted,
+                "meta",
+                resolved_root,
+                planning_branch,
+            )
 
     # ------------------------------------------------------------------
     # 8. Event emission

--- a/src/specify_cli/core/paths.py
+++ b/src/specify_cli/core/paths.py
@@ -328,6 +328,52 @@ def is_worktree_context(path: Path) -> bool:
     return False
 
 
+def _nearest_checkout_root(path: Path) -> Path | None:
+    """Return the nearest Git checkout root without following worktree pointers."""
+    resolved = path.resolve()
+    for candidate in [resolved, *resolved.parents]:
+        git_path = candidate / ".git"
+        if git_path.is_file() or git_path.is_dir():
+            return candidate
+    return None
+
+
+def resolve_mission_creation_root(
+    project_root: Path | None,
+    start: Path | None = None,
+) -> Path | None:
+    """Resolve the checkout that should receive a new mission scaffold.
+
+    ``locate_project_root`` deliberately follows a linked-worktree ``.git``
+    pointer to the repository root checkout because most lifecycle reads need
+    that canonical anchor.  Mission creation is different: a caller that has
+    already selected an isolated external worktree must write and commit the
+    scaffold in that checkout, leaving the repository root checkout untouched.
+
+    The current checkout is selected only when it belongs to the same Git
+    repository as ``project_root`` and carries the project's ``.kittify``
+    marker.  An explicit unrelated root therefore remains authoritative for
+    programmatic callers and test factories.
+    """
+    if project_root is None:
+        return None
+
+    resolved_project_root = project_root.resolve()
+    if not (resolved_project_root / KITTIFY_DIR).is_dir():
+        return resolved_project_root
+    current_checkout = _nearest_checkout_root(start or Path.cwd())
+    if current_checkout is None or not is_worktree_context(current_checkout):
+        return resolved_project_root
+    if not (current_checkout / KITTIFY_DIR).is_dir():
+        return resolved_project_root
+
+    project_main_root = get_main_repo_root(resolved_project_root).resolve()
+    checkout_main_root = get_main_repo_root(current_checkout).resolve()
+    if checkout_main_root != project_main_root:
+        return resolved_project_root
+    return current_checkout
+
+
 def resolve_with_context(start: Path | None = None) -> tuple[Path | None, bool]:
     """
     Resolve project root and detect worktree context in one call.
@@ -918,6 +964,7 @@ __all__ = [
     "locate_project_root",
     "lint_report_path",
     "is_worktree_context",
+    "resolve_mission_creation_root",
     "resolve_with_context",
     "check_broken_symlink",
     "get_main_repo_root",

--- a/tests/runtime/test_paths_unit.py
+++ b/tests/runtime/test_paths_unit.py
@@ -11,6 +11,7 @@ from specify_cli.core.paths import (
     get_main_repo_root,
     locate_project_root,
     is_worktree_context,
+    resolve_mission_creation_root,
     resolve_with_context,
     check_broken_symlink,
     require_explicit_feature,
@@ -143,6 +144,53 @@ def test_locate_project_root_from_external_worktree_pointer(tmp_path: Path) -> N
     )
 
     assert locate_project_root(external_wt) == main_repo
+
+
+def test_resolve_mission_creation_root_selects_related_external_worktree(
+    tmp_path: Path,
+) -> None:
+    """Mission creation writes to the caller's related linked checkout."""
+    main_repo = tmp_path / "main-repo"
+    gitdir = main_repo / ".git" / "worktrees" / "external-wt"
+    gitdir.mkdir(parents=True)
+    (main_repo / ".kittify").mkdir()
+
+    external_wt = tmp_path / "external-wt"
+    nested = external_wt / "src" / "nested"
+    nested.mkdir(parents=True)
+    (external_wt / ".kittify").mkdir()
+    (external_wt / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    assert resolve_mission_creation_root(main_repo, nested) == external_wt
+
+
+def test_resolve_mission_creation_root_keeps_unrelated_explicit_root(
+    tmp_path: Path,
+) -> None:
+    """A programmatic root is not replaced by an unrelated process checkout."""
+    explicit_root = tmp_path / "explicit-repo"
+    (explicit_root / ".git").mkdir(parents=True)
+    (explicit_root / ".kittify").mkdir()
+
+    other_main = tmp_path / "other-repo"
+    other_gitdir = other_main / ".git" / "worktrees" / "other-wt"
+    other_gitdir.mkdir(parents=True)
+    (other_main / ".kittify").mkdir()
+    other_wt = tmp_path / "other-wt"
+    other_wt.mkdir()
+    (other_wt / ".kittify").mkdir()
+    (other_wt / ".git").write_text(f"gitdir: {other_gitdir}\n", encoding="utf-8")
+
+    assert resolve_mission_creation_root(explicit_root, other_wt) == explicit_root
+
+
+def test_resolve_mission_creation_root_keeps_unprovisioned_explicit_root(
+    tmp_path: Path,
+) -> None:
+    """A missing project marker must not trigger ambient checkout discovery."""
+    explicit_root = tmp_path / "unprovisioned-repo"
+
+    assert resolve_mission_creation_root(explicit_root, Path.cwd()) == explicit_root.resolve()
 
 
 def test_get_main_repo_root_ignores_non_worktree_git_file(tmp_path: Path) -> None:

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -486,6 +486,40 @@ def test_create_from_external_worktree_keeps_primary_checkout_untouched(
     assert _git(repo, "show", f"{task_branch}:{mission_rel}/meta.json").stdout
 
 
+def test_create_from_managed_lane_worktree_remains_forbidden(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The external-worktree allowance must not admit Spec Kitty lane worktrees."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _commit_project_scaffold(repo)
+
+    lane_worktree = repo / ".worktrees" / "existing-lane"
+    lane_worktree.parent.mkdir()
+    lane_branch = "kitty/mission-existing-01KZRABC-lane-a"
+    _git(repo, "worktree", "add", "-b", lane_branch, str(lane_worktree), "main")
+
+    monkeypatch.chdir(lane_worktree)
+    monkeypatch.setenv("SPECIFY_REPO_ROOT", str(lane_worktree))
+    runner = CliRunner()
+    result = runner.invoke(
+        mission_app,
+        [
+            "create",
+            "nested-mission",
+            "--json",
+            *_mission_summary_args("Nested Mission"),
+        ],
+    )
+
+    assert result.exit_code != 0
+    payload = _json_payload_from_output(result.output)
+    assert "Cannot create missions from inside a worktree" in str(payload["error"])
+    assert not list((lane_worktree / "kitty-specs").glob("nested-mission-*"))
+
+
 def test_create_on_primary_branch_still_defaults_to_coord(tmp_path: Path) -> None:
     """Non-regression: a primary-branch create with no ``--topology`` still gets ``coord``."""
     _init_repo(tmp_path)

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -138,6 +138,12 @@ def _branch_sha(repo: Path, branch: str) -> str:
     return _git(repo, "rev-parse", branch).stdout.strip()
 
 
+def _commit_project_scaffold(repo: Path) -> None:
+    """Commit the minimal project files needed by real safe-commit tests."""
+    _git(repo, "add", ".kittify/config.yaml")
+    _git(repo, "commit", "-m", "configure project")
+
+
 def _json_payload_from_output(output: str) -> dict[str, Any]:
     """Return the first JSON object emitted by the CLI."""
     for line in output.splitlines():
@@ -422,6 +428,62 @@ def test_create_on_non_primary_branch_without_pr_bound_defaults_to_single_branch
     assert payload["topology"] == "single_branch", payload
     assert payload.get("coordination_branch") is None, payload
     assert payload.get("coordination_branch_created") is False, payload
+
+
+def test_create_from_external_worktree_keeps_primary_checkout_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-owned linked worktree is a valid mission-planning checkout.
+
+    Regression for the protected-primary dead end in #2739: the operator has
+    already created an isolated branch/worktree, but ``locate_project_root``
+    follows the gitdir pointer back to the repository root checkout.  The CLI
+    then tries to switch that checkout to ``--start-branch`` even though the
+    branch is already checked out in the linked worktree, so mission creation
+    fails before writing the scaffold.
+
+    The observable contract is deliberately black-box: the command succeeds,
+    the mission exists and is committed on the external worktree branch, and
+    the protected primary branch and its checkout remain unchanged.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    _commit_project_scaffold(repo)
+    primary_head = _branch_sha(repo, "main")
+
+    worktree = tmp_path / "external-worktree"
+    task_branch = "fix/worktree-mission-create"
+    _git(repo, "worktree", "add", "-b", task_branch, str(worktree), "main")
+
+    monkeypatch.chdir(worktree)
+    monkeypatch.setenv("SPECIFY_REPO_ROOT", str(worktree))
+    runner = CliRunner()
+    with patch("specify_cli.status.fire_dossier_sync"):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "external-worktree-create",
+                "--json",
+                "--start-branch",
+                task_branch,
+                *_mission_summary_args("External Worktree Create"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = _json_payload_from_output(result.output)
+    mission_dir = Path(str(payload["feature_dir"]))
+    mission_rel = mission_dir.relative_to(worktree).as_posix()
+
+    assert mission_dir.parent == worktree / "kitty-specs"
+    assert not (repo / mission_dir.relative_to(worktree)).exists()
+    assert _branch_sha(repo, "main") == primary_head
+    assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+    assert _branch_sha(repo, task_branch) != primary_head
+    assert _git(repo, "show", f"{task_branch}:{mission_rel}/meta.json").stdout
 
 
 def test_create_on_primary_branch_still_defaults_to_coord(tmp_path: Path) -> None:


### PR DESCRIPTION
> [!IMPORTANT]
> ## ⛔ Recommended for CLOSE — superseded by #3346 (maintainer landing triage + adversarial squad)
>
> **The bug this PR fixes — `mission create --start-branch` failing with `START_BRANCH_FAILED` from a caller-owned linked worktree — was independently fixed on `main` by #3346, merged 2026-08-13 (two days after this PR was authored).** Use it today:
> ```
> spec-kitty agent mission create --start-branch <branch> --owned-checkout <worktree-path>
> ```
> This PR's distinct approach — **implicitly auto-detecting** the current worktree as the write root — is the alternative that Accepted ADR [`2026-08-12-1`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/adr/3.x/2026-08-12-1-checkout-ownership-for-mission-create-and-next.md) **explicitly Rejects** ("Infer the owned root from ambient project discovery — Rejected"), and a two-lens adversarial squad found it fails *open* where the canonical `checkout_ownership` seam fails *closed*, duplicates that ownership authority, and bypasses the unified `kernel.git_topology` primitive. Even the bootstrap write-target fix is already on `main` (`resolve_create_time_write_target(planning_branch)`). Full evidence in the review comments below.
>
> **The ergonomic intent — making it work without typing the flag — is worth keeping**, tracked as **#3443** (under #2739): do it *through* `resolve_ownership_claim`, fail-closed. Thank you, @rusliksu.
>
> ---
> _Original PR description follows._

## Summary

- Allows `spec-kitty agent mission create --start-branch` to run from a caller-owned linked worktree.
- Keeps the primary checkout and primary branch unchanged.
- Preserves the existing refusal for Spec Kitty coordination and lane worktrees.

## Why Now

The current root resolver follows a linked-worktree `.git` pointer back to the primary checkout. Mission creation then tries to switch the primary checkout to a branch that is already checked out in the linked worktree, producing `START_BRANCH_FAILED`. This is a focused B02/create-time slice of #2739.

## What This PR Does

- Resolves a mission-creation write root to the current linked checkout only when it belongs to the same repository and carries the project marker.
- Keeps explicit unrelated roots authoritative.
- Uses the existing bootstrap write-target degrade seam for the first metadata commit, with the explicit planning branch as the fallback rather than the repository default branch.
- Rejects `.worktrees` paths and `kitty/mission-*`/lane branches so a managed mission worktree cannot spawn a nested mission.
- Adds a black-box RED/GREEN regression that creates a real external Git worktree and invokes the real CLI.

## Effect on Existing Projects

- Runtime / compatibility: existing primary-checkout and explicit-target behavior is unchanged; caller-owned linked worktrees now work.
- Upgrade / migration: none.
- Operator / reviewer impact: operators can keep the primary checkout clean while creating a mission from an isolated task worktree.

## Validation

- [x] 72 targeted tests pass, including mission creation, path resolution, placement routing, and the production worktree guard.
- [x] `ruff check` passes for every changed Python file.
- [x] `py_compile` passes for every changed Python module.
- [x] `git diff --check` passes.
- [x] Backward compatibility impact considered: primary checkout and managed-lane scenarios are explicitly regression-tested.

The broader Windows-only audit also exposed two pre-existing path-separator assertions and two pre-existing `/nonexistent` mock failures outside this change. No affected production or test lines overlap those failures; hosted Linux CI remains the authoritative full gate.

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| #2739 | Focused B02/create-time worktree dead-end fix; does not close the full bundled issue |

## Mission Artifacts

- Spec: N/A — the bug prevents the dogfooded mission-creation path itself; implemented through the repository's isolated fallback workflow.
- Plan: N/A
- Research: #2739 and the existing placement/bootstrap contracts in code.
- Review: local self-review complete; hosted CI and maintainer review pending.
- PR summary: this body.

## Follow-ups

- None for this focused worktree failure; the remaining #2739 commit-router facets stay open.

## AI assistance disclosure

This contribution was implemented with OpenAI Codex assistance. Ruslan authorized the scope; Codex performed the repository analysis, RED/GREEN implementation, and local validation. The resulting commits and evidence were reviewed in the task before submission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056106&installation_model_id=427282&pr_number=3332&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3332&signature=ee508df7627dfe2de244693a01432b8af200074998ec518ab7006015da2fbba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->