### PR TITLE
Fix LICENSE copyright holder to Spec Kitty, Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright GitHub, Inc.
+Copyright (c) 2026 Spec Kitty, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What
Updates the copyright line in `LICENSE` to `Copyright (c) 2026 Spec Kitty, Inc.`

## Why
Org-wide license audit (Aug 2026) found the MIT license body text was already correct across our public repos, but the copyright holder line was inconsistent — some repos said "Copyright GitHub, Inc." (a template leftover from however the file was originally generated), others said "Spec Kitty Contributors" (a placeholder that predates the settled legal entity name). This standardizes the copyright holder to the actual legal entity, Spec Kitty, Inc., across every public/published repo.

No change to license terms — the MIT permissions grant and warranty disclaimer are byte-for-byte unchanged, verified against the canonical MIT License text (choosealicense.com / OSI).

Part of a batch cleanup across 16 repos — see other open PRs from this branch name for the companion changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789083219&installation_model_id=427282&pr_number=3344&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3344&signature=801867cea12d3592263ec0b813e7cf1715b5244a7ab19d0f73402357e2089702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->