### PR TITLE
docs(changelog): fix MD049 emphasis style in the #3324 entry

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1336,7 +1336,7 @@ _The 3.2.6 development cycle is open. Entries land here as missions merge._
   is an internal architecture boundary only — no CLI command, output, or runtime
   behavior changes — and it unblocks the `#3101` doctrine wheel cutover.
 - **The contributor planning surface (`docs/plans/`) gains durable, version-spanning
-  *domain plans* and a curated index (`#3324`).** Two domain throughlines — SaaS & hosted sync,
+  _domain plans_ and a curated index (`#3324`).** Two domain throughlines — SaaS & hosted sync,
   and doctrine & charter — now hold the standing strategy and invariants for their
   surface across releases, distinct from the release-scoped `3.2.x` plans that retire
   once distilled. The plans index is reorganized into domain throughlines, portfolio &


### PR DESCRIPTION
**What you'd notice:** nothing at runtime — this is a one-line docs-hygiene fix. The #3324 changelog entry rendered its `_domain plans_` phrase with asterisk emphasis (`*domain plans*`) while every other entry in the file uses underscore, leaving the changelog with a single style-inconsistent line and the file's only `markdownlint` MD049 finding.

**Fix:** switch `*domain plans*` → `_domain plans_`. That clears the finding (`markdownlint-cli2@0.18.1`: 0 errors on the file).

**Context:** markdownlint runs `continue-on-error` in CI, so this never blocked a gate — it surfaced during the #3331/#3333 landing pass (any PR touching the changelog gets the whole file linted). Fixing it at the source per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789108496&installation_model_id=427282&pr_number=3348&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3348&signature=62acda52c6d5c827d534f3890ebaf85d266d3270bbb75467dbe785b9dca6977b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->