### PR TITLE
ci(docs-pages): fix Pages deploy — add src to PYTHONPATH so kernel.clock import resolves

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -36,6 +36,15 @@ concurrency:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # The docs scripts import first-party src-layout packages: seo_postprocess.py
+    # imports `kernel.clock` (src/kernel/), and glossary_linker.py / seo_verify.py
+    # import `scripts.docs.*` (seo_verify transitively pulls in seo_postprocess ->
+    # kernel.clock too). This job runs raw `python3 scripts/docs/*.py` without
+    # installing the package, so both roots must be on PYTHONPATH or the Build and
+    # Verify steps die with `ModuleNotFoundError: No module named 'kernel'`. Mirrors
+    # docs-build-pr.yml's `PYTHONPATH: .`, extended with `src` for the kernel import.
+    env:
+      PYTHONPATH: .:src
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## What breaks for users

**The documentation site has not republished for ~2 days.** Every GitHub Pages deploy since 2026-08-10 has failed, so `docs/` changes merged to `main` — including the whole recent landing run — are not live on the docsite. The symptom: the "Deploy Docs to GitHub Pages" workflow is red on every push to `main`, and the `deploy` job never runs.

## Root cause

The `build` job's **"Build documentation"** step runs `python3 scripts/docs/seo_postprocess.py`. Since the kernel-clock refactor (`944bf3581`, 2026-08-10) that script imports `from kernel.clock import now_utc`. `kernel` is a **src-layout package** (`src/kernel/`), but this workflow runs raw `python3` — it sets no `PYTHONPATH` and never installs the package — so the step dies:

```
File "scripts/docs/seo_postprocess.py", line 10, in <module>
    from kernel.clock import now_utc
ModuleNotFoundError: No module named 'kernel'
```

DocFX itself renders cleanly (`0 error(s)`); it's the Python post-step that fails, which skips the whole `deploy` job.

## The fix

Set job-level `PYTHONPATH: .:src` on the `build` job so both first-party roots resolve — `kernel` from `src/`, `scripts.docs.*` from the repo root. This is scoped to the job (not one step) on purpose: `seo_verify.py` (a later step) transitively imports `seo_postprocess` → `kernel.clock`, so it needs the same path. Mirrors the existing `PYTHONPATH: .` in the sibling `docs-build-pr.yml`, extended with `src`.

## Verification

`docs-pages.yml` has no `pull_request` trigger (push-to-`main`/`2.x` + `workflow_dispatch` only), so this PR's own checks don't exercise it. Verified instead by dispatching the workflow on this branch (build-only; the `deploy` job is gated on `refs/heads/main`, so it stays skipped): **see the run linked in a comment below.** Locally, `PYTHONPATH=.:src python3 -c "from kernel.clock import now_utc"` resolves.

Once merged, the change touches a trigger path, so the deploy re-runs on `main` and republishes the current docs. Downstream gates in the same job (redirect-coverage, `seo_verify --strict`) have never been reached because the build died at import; if any of them surface a further issue, that's a separate follow-up — this PR unblocks the import wall that has kept the site dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789117008&installation_model_id=427282&pr_number=3349&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3349&signature=9fbdf0b7936d07d3e5576a89c3c0c18e4f8bdf7a2dde7023f48859a0267fdf55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->