### PR TITLE
fix(charter): raise governance BUDGET_DEFAULT 32k→40k (regression from 3bcdda344)

### DIFF
--- a/src/charter/context_renderers/token_budget.py
+++ b/src/charter/context_renderers/token_budget.py
@@ -60,8 +60,21 @@ __all__ = [
 ]
 
 
-BUDGET_DEFAULT: int = 32_000
-"""Default character budget — NFR-001 pin (~8000 tokens at 4 chars/token)."""
+BUDGET_DEFAULT: int = 40_000
+"""Default character budget — NFR-001 pin (~10000 tokens at 4 chars/token).
+
+Raised 32_000 -> 40_000 (2026-08-12) after commit 3bcdda344 wired the
+software-dev doctrine cascade (mutation-testing, disciplined-refactoring,
+change-scope reconciliation) into action reachability. That legitimately grew
+the essential Action Doctrine payload past the old 32k pin, tripping the
+governance-contract guard (``tests/specify_cli/next/
+test_wp_prompt_governance_contract.py``) by compacting away the anti-drift
+anchors (DIRECTIVE_032, glossary path, ADR path). 40k gives the now-larger
+essential cascade headroom without dropping either delivery contract.
+
+NOTE: real charter payloads run ~65k pre-compaction, so this default is not a
+production ceiling — the deeper work of keeping the anti-drift anchors
+always-delivered under prod-scale compaction is tracked separately."""
 
 _PROFILE_INLINE_BODY_LIMIT_CHARS = 2_400
 """Per-entry inline-body character ceiling (WP03/WP12): a profile-cited

--- a/tests/charter/test_context_parity.py
+++ b/tests/charter/test_context_parity.py
@@ -63,7 +63,7 @@ _LONG_BODY_NEEDLE = "PARITY-FIXTURE-LONG-BODY-MARKER-78321"
 _LONG_BODY = (
     f"Canonical term line reinforcing prose consistency ({_LONG_BODY_NEEDLE}).\n"
     * 700
-)  # ~48,000 chars — comfortably over BUDGET_DEFAULT (32,000).
+)  # ~48,000 chars — comfortably over BUDGET_DEFAULT (40,000).
 
 _GHOST_DIRECTIVE_CODE = "998"
 

--- a/tests/charter/test_context_token_budget.py
+++ b/tests/charter/test_context_token_budget.py
@@ -463,8 +463,12 @@ class TestEdgeCases:
         assert joined == ""
         assert notes == []
 
-    def test_default_budget_is_32k(self) -> None:
-        assert BUDGET_DEFAULT == 32_000
+    def test_default_budget_is_40k(self) -> None:
+        # Raised 32_000 -> 40_000 (2026-08-12) so the software-dev doctrine
+        # cascade wired by 3bcdda344 fits without compacting away the
+        # anti-drift anchors (DIRECTIVE_032, glossary, ADR). See
+        # BUDGET_DEFAULT's docstring in token_budget.py.
+        assert BUDGET_DEFAULT == 40_000
 
     def test_non_positive_budget_is_noop(self) -> None:
         sections = [_make_section("a", "x" * 100)]


### PR DESCRIPTION
## What & why

Fixes the `integration-tests-next (next_shard_3)` red on `main` — 3 governance-contract tests in `test_wp_prompt_governance_contract.py` (the WP prompt must surface `DIRECTIVE_032`, the glossary path, and an ADR pointer).

**Root cause:** same-day commit `3bcdda344` wired the software-dev doctrine cascade (mutation-testing, disciplined-refactoring, change-scope reconciliation) into action reachability via new `suggests` edges. Those entries render as compact fetch stanzas in the Action Doctrine block, adding **~2,495 chars** and tipping the governance-contract fixture (calibrated at **31,772 / 32,000**) over the NFR-001 character budget. Over budget, the enforcer compacts away the **anti-drift anchors** (`DIRECTIVE_032`, `docs/context/`, ADR path).

The added doctrine is legitimate, and the entries are already minimal fetch stanzas (nothing left to compact) — the essential cascade simply no longer fits 32k. So the fix is a **budget recalibration**: `BUDGET_DEFAULT` 32,000 → 40,000.

## Scope / honesty note

This recalibrates the **synthetic** budget guard. It does **not** close the production gap: real charter payloads run **~65k pre-compaction**, so in prod these anchors are still compacted away today. The deeper fix (always-deliver the anti-drift anchors as compact pointers, non-substitutable even at prod scale) is tracked in **#3356**.

Two other approaches were rejected: making the Action Doctrine block budget-substitutable (breaks `test_every_load_delivery` — drops `DIRECTIVE_001` / `Styleguides`), and re-typing the wired edges (they're already `suggests`, already minimal stanzas — nothing to reclaim).

## Changes
- `src/charter/context_renderers/token_budget.py` — `BUDGET_DEFAULT` 32_000 → 40_000 (+ docstring rationale).
- `tests/charter/test_context_token_budget.py` — pin updated (`test_default_budget_is_40k`); the explicit `budget=32_000` behavior tests are unchanged.
- `tests/charter/test_context_parity.py` — stale comment updated (fixture still ~48k, still over budget).

## Validation (all green)
- `test_wp_prompt_governance_contract.py` — **26 passed** (was 3 failed / 23)
- `test_every_load_delivery.py` — **10 passed** (no over-compaction)
- `test_context_token_budget.py` — **22 passed** · `test_context_parity.py`, `test_reachability.py` — green
- ruff + mypy clean

Refs #3356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8yE9Cvx8sjWyZT32XiwcH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789134325&installation_model_id=427282&pr_number=3357&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3357&signature=49f4ad30254802045aee950b6bdfb3fb72c2665d504fc0bf443affa37c76bc52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->