### PR TITLE
Release 3.2.6rc1: internal Release Candidate (prerelease, not official)

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.6
+  version: 3.2.6rc1
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,9 +13,35 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 3.2.6
+## [Unreleased]
 
-_The 3.2.6 development cycle is open. Entries land here as missions merge._
+_The next development cycle is open. Entries land here as missions merge._
+
+## [3.2.6rc1] - 2026-08-12
+
+> [!WARNING]
+> **`3.2.6rc1` is a Release Candidate — an internal, delta build published for validation, NOT an official `3.2.6` release.** It ships as a GitHub _prerelease_ and to PyPI as a PEP 440 prerelease, so ordinary installers skip it unless you explicitly opt in with `--pre`. Do **not** use it for production or general rollout. The last official release remains `v3.2.5`; when `3.2.6` is finalized its changelog section supersedes this one.
+
+**Install for testing (opt-in only):**
+
+```bash
+pipx install --pre spec-kitty-cli==3.2.6rc1
+# or, inside an existing environment:
+pip install --pre spec-kitty-cli==3.2.6rc1
+```
+
+**Highlights since `v3.2.5`** — the operator-facing changes worth exercising in this candidate:
+
+- **Breaking — built-in doctrine content relocated to `packs/built-in/` with no compatibility shim** (mission `relocate-builtin-doctrine-packs`). Repoint any reference that still targets the old `src/doctrine/<kind>/built-in/` path.
+- **Breaking — local `beads`/`fp` tracker sync now requires a recorded egress decision** (mission `tracker-egress-refusal-3108`). A binding that never recorded hosted-sync consent stops syncing on upgrade until you record `tracker.egress: permitted` or `sync.enabled: true`.
+- **Breaking — the `rtk-search-tooling` toolguide is removed**, and the `3.2.6_retire_rtk_search_tooling` upgrade migration strips it from projects that had it activated (it runs automatically on `spec-kitty upgrade` and is safe to re-run).
+- **Breaking — org packs with an unrecognised agent-profile or DRG key now fail to load** (mission `doctrine-silence-guards`). Run `spec-kitty doctor doctrine --json` and check `skipped_profiles` before you upgrade.
+- **`charter synthesize` is now non-destructive** — it preserves backed governance content by default, with `--prune` as the explicit opt-in and `--dry-run` to preview (mission `charter-synthesize-reconciliation`; `#3270` P0, folds `#2777` / `#3052`). The `implement` / `next` boundary no longer hard-blocks until you resynthesize.
+- **Approving a work package after a rejection now sticks with no override flag required** (mission `review-verdict-write-integrity`; `#3044`) — the reject → fix → approve cycle no longer forces `--skip-review-artifact-check`.
+- **Timestamps Spec Kitty writes into your project are now correct aware-UTC** instead of local time mislabelled as UTC (mission `kernel-clock-single-door`; `#3305`, closes `#3289`).
+- **CLI UX: shell autocompletion, a `-h` short-help alias, and alphabetical command listing** (`#2232`, `#2234`, `#2235`) — additive, with no behavior change to existing commands.
+
+The complete, factual list of changes for this candidate follows in the entries below.
 
 ### ✨ Added
 

--- a/docs/changelog/release-notes-3.2.6rc1.md
+++ b/docs/changelog/release-notes-3.2.6rc1.md
@@ -1,0 +1,45 @@
+---
+title: Release notes — 3.2.6rc1 (internal Release Candidate)
+description: 'Internal Release Candidate notes for spec-kitty-cli 3.2.6rc1: an opt-in prerelease build for maintainer validation, not an official 3.2.6 release.'
+doc_status: active
+type: reference
+audience: docs/context/audience/internal/maintainer.md
+updated: '2026-08-12'
+related:
+- docs/changelog/CHANGELOG.md
+- docs/changelog/index.md
+- docs/changelog/release-goals.md
+---
+# Release notes — `3.2.6rc1` (internal Release Candidate)
+
+_For the existing Spec Kitty operator/maintainer deciding whether to pull this candidate into a test environment._
+
+> [!WARNING]
+> **`3.2.6rc1` is a Release Candidate — an internal, delta build published for validation, NOT an official `3.2.6` release.** It ships as a GitHub _prerelease_ and to PyPI as a PEP 440 prerelease, so ordinary installers skip it unless you explicitly opt in with `--pre`. Do **not** use it for production or general rollout. The last official release remains `v3.2.5`; when `3.2.6` is finalized its changelog section supersedes this candidate.
+
+## Install for testing
+
+This candidate is opt-in. Standard installs will not pick it up without `--pre`.
+
+```bash
+pipx install --pre spec-kitty-cli==3.2.6rc1
+# or, inside an existing environment:
+pip install --pre spec-kitty-cli==3.2.6rc1
+```
+
+## Highlights since `v3.2.5`
+
+The operator-facing changes worth exercising in this candidate:
+
+- **Breaking — built-in doctrine content relocated to `packs/built-in/` with no compatibility shim** (mission `relocate-builtin-doctrine-packs`). Repoint any reference that still targets the old `src/doctrine/<kind>/built-in/` path.
+- **Breaking — local `beads`/`fp` tracker sync now requires a recorded egress decision** (mission `tracker-egress-refusal-3108`). A binding that never recorded hosted-sync consent stops syncing on upgrade until you record `tracker.egress: permitted` or `sync.enabled: true`.
+- **Breaking — the `rtk-search-tooling` toolguide is removed**, and the `3.2.6_retire_rtk_search_tooling` upgrade migration strips it from projects that had it activated (it runs automatically on `spec-kitty upgrade` and is safe to re-run).
+- **Breaking — org packs with an unrecognised agent-profile or DRG key now fail to load** (mission `doctrine-silence-guards`). Run `spec-kitty doctor doctrine --json` and check `skipped_profiles` before you upgrade.
+- **`charter synthesize` is now non-destructive** — it preserves backed governance content by default, with `--prune` as the explicit opt-in and `--dry-run` to preview (mission `charter-synthesize-reconciliation`; `#3270` P0, folds `#2777` / `#3052`). The `implement` / `next` boundary no longer hard-blocks until you resynthesize.
+- **Approving a work package after a rejection now sticks with no override flag required** (mission `review-verdict-write-integrity`; `#3044`) — the reject → fix → approve cycle no longer forces `--skip-review-artifact-check`.
+- **Timestamps Spec Kitty writes into your project are now correct aware-UTC** instead of local time mislabelled as UTC (mission `kernel-clock-single-door`; `#3305`, closes `#3289`).
+- **CLI UX: shell autocompletion, a `-h` short-help alias, and alphabetical command listing** (`#2232`, `#2234`, `#2235`) — additive, with no behavior change to existing commands.
+
+## Full changelog
+
+These highlights are a curated subset. For the complete, factual list of everything in this candidate — every Added, Fixed, Changed, and Breaking Changes entry — see the `[3.2.6rc1]` section of the [canonical changelog](CHANGELOG.md).

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -4987,7 +4987,8 @@ pages:
     divio_type: "none"
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
-    - {slug: "unreleased-3-2-6", text: "[Unreleased] - 3.2.6", level: 2}
+    - {slug: "unreleased", text: "[Unreleased]", level: 2}
+    - {slug: "3-2-6rc1-2026-08-12", text: "[3.2.6rc1] - 2026-08-12", level: 2}
     - {slug: "added", text: "✨ Added", level: 3}
     - {slug: "fixed", text: "🐛 Fixed", level: 3}
     - {slug: "changed", text: "♻️ Changed", level: 3}
@@ -5604,6 +5605,14 @@ pages:
     - {slug: "three-surfaces-one-goal-and-how-they-connect", text: "Three surfaces, one goal — and how they connect", level: 2}
     - {slug: "authoring-a-new-cycle", text: "Authoring a new cycle", level: 2}
     - {slug: "declared-cycles", text: "Declared cycles", level: 2}
+  - path: "docs/changelog/release-notes-3.2.6rc1.md"
+    title: "Release notes — 3.2.6rc1 (internal Release Candidate)"
+    divio_type: "reference"
+    abstract: "Internal Release Candidate notes for spec-kitty-cli 3.2.6rc1: an opt-in prerelease build for maintainer validation, not an official 3.2.6 release."
+    anchors:
+    - {slug: "install-for-testing", text: "Install for testing", level: 2}
+    - {slug: "highlights-since-v3-2-5", text: "Highlights since `v3.2.5`", level: 2}
+    - {slug: "full-changelog", text: "Full changelog", level: 2}
   - path: "docs/configuration/index.md"
     title: "Configuration"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1706,6 +1706,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/changelog/release-notes-3.2.6rc1.md
+  tag: current
+  divio_type: reference
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/configuration/index.md
   tag: current
   divio_type: none

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.6"
+version = "3.2.6rc1"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_decisions_event_log_merge_driver.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_decisions_event_log_merge_driver.py
@@ -41,6 +41,6 @@ class DecisionsEventLogMergeDriverMigration(MergeDriverSeedingMigration):
 
     migration_id = "3.2.6_decisions_event_log_merge_driver"
     description = "Install a semantic git merge driver for decisions.events.jsonl"
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     drivers = _DRIVERS
     dry_run_summary = "Would install the decisions.events.jsonl merge driver and .gitattributes entry"

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_gate_artifact_merge_drivers.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_gate_artifact_merge_drivers.py
@@ -40,6 +40,6 @@ class GateArtifactMergeDriverMigration(MergeDriverSeedingMigration):
 
     migration_id = "3.2.6_gate_artifact_merge_drivers"
     description = "Install semantic git merge drivers for acceptance-matrix.json and issue-matrix.md"
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     drivers = _DRIVERS
     dry_run_summary = "Would install gate-artifact merge drivers and .gitattributes entries"

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_issue_matrix_driver_repoint.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_issue_matrix_driver_repoint.py
@@ -15,11 +15,12 @@ and its ``issue-matrix.md`` line is now simply inert (no file matches it since
 WP05 shipped). Mutating a historical migration in place would rewrite already-
 applied history; a fresh migration is the correct additive fix (DIRECTIVE_044).
 
-``target_version`` is ``"3.2.6"``, tied with the sibling merge-driver
+``target_version`` is ``"3.2.6rc1"``, tied with the sibling merge-driver
 migrations (``m_3_2_6_gate_artifact_merge_drivers``,
 ``m_3_2_6_meta_traces_merge_drivers``,
 ``m_3_2_6_decisions_event_log_merge_driver``), not the unreleased ``3.2.7``:
-the installed package on this branch is still ``3.2.6``
+the installed package on this branch is ``3.2.6rc1`` -- the release-candidate
+build that ships this cycle's migrations
 (``test_discovered_migration_targets_do_not_exceed_package_version``), and
 ``spec-kitty upgrade`` skips any migration whose ``target_version`` exceeds
 the installed package version -- targeting an unreleased future version means
@@ -57,6 +58,6 @@ class IssueMatrixDriverRepointMigration(MergeDriverSeedingMigration):
 
     migration_id = "3.2.6_issue_matrix_driver_repoint"
     description = "Repoint the issue-matrix merge driver to issue-matrix.json"
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     drivers = _DRIVERS
     dry_run_summary = "Would repoint the issue-matrix merge driver to issue-matrix.json"

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_meta_traces_merge_drivers.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_meta_traces_merge_drivers.py
@@ -50,6 +50,6 @@ class MetaTracesMergeDriverMigration(MergeDriverSeedingMigration):
 
     migration_id = "3.2.6_meta_traces_merge_drivers"
     description = "Install semantic git merge drivers for meta.json and traces/*.md"
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     drivers = _DRIVERS
     dry_run_summary = "Would install meta.json + traces/*.md merge drivers and .gitattributes entries"

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_retire_rtk_search_tooling.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_retire_rtk_search_tooling.py
@@ -185,7 +185,7 @@ class RetireRtkSearchToolingMigration(BaseMigration):
         ".kittify/config.yaml and the compiled .kittify/charter/ blocks so "
         "charter compilation stops failing on the deleted artefact."
     )
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
 
     def detect(self, project_path: Path) -> bool:
         """Return True when any project surface still names the retired toolguide."""

--- a/src/specify_cli/upgrade/migrations/m_3_2_7_review_cycle_merge_driver.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_7_review_cycle_merge_driver.py
@@ -8,15 +8,15 @@ clones, the same way those two migrations registered ``spec-kitty-event-log``.
 
 **Module name vs. ``target_version`` (deliberately not the same number).**
 This module is named ``m_3_2_7_...`` (the WP's prescribed filename/id), but
-``target_version`` below is pinned to ``"3.2.6"`` -- the same reasoning
+``target_version`` below is pinned to ``"3.2.6rc1"`` -- the same reasoning
 ``m_3_2_6_issue_matrix_driver_repoint.py`` documents: the installed package
-on this branch is still ``3.2.6`` (``pyproject.toml``,
-``CHANGELOG.md``'s still-open "Unreleased - 3.2.6" section), and
+on this branch is ``3.2.6rc1`` (``pyproject.toml``, the release-candidate
+build that ships this cycle's migrations), and
 ``spec-kitty upgrade``/``test_discovered_migration_targets_do_not_exceed_
 package_version`` skip/flag any migration whose ``target_version`` exceeds
-the installed package version -- targeting the unreleased ``3.2.7`` would
-mean this migration silently never runs for a user upgrading to the current
-release.
+the installed package version -- targeting the unreleased ``3.2.7`` (or even
+the not-yet-final ``3.2.6``) would mean this migration silently never runs
+for a user upgrading to the current release candidate.
 
 Unlike its siblings, the driver this migration seeds does NOT union or
 field-merge -- ``merge_driver_review_cycle`` (see that function's docstring
@@ -68,6 +68,6 @@ class ReviewCycleMergeDriverMigration(MergeDriverSeedingMigration):
 
     migration_id = "3.2.7_review_cycle_merge_driver"
     description = "Install a fail-closed git merge driver for review-cycle-*.md"
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     drivers = _DRIVERS
     dry_run_summary = "Would install the review-cycle-*.md merge driver and .gitattributes entry"

--- a/src/specify_cli/upgrade/migrations/m_3_2_x_normalize_activation_absence.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_x_normalize_activation_absence.py
@@ -27,11 +27,11 @@ Reconciliation of the two prior migrations (WP07/T041)
 Two migrations already fought over this surface, in opposite directions, and the
 config-embedded ``activated_*`` mirror survived both:
 
-1. ``m_unify_charter_activation.py`` (``target_version = "3.2.6"``) made
+1. ``m_unify_charter_activation.py`` (``target_version = "3.2.6rc1"``) made
    ``config.activated_<kind>`` the single activation authority — it *wrote*
    activation INTO ``config.yaml``.
 2. ``m_unify_charter_activation_finalize.py``
-   (``consolidate_charter_bundle_fold``, ``target_version = "3.2.6"``) reversed
+   (``consolidate_charter_bundle_fold``, ``target_version = "3.2.6rc1"``) reversed
    that: it folded activation into a git-tracked ``charter.yaml`` and minted the
    ``config.yaml`` ``charter:`` pointer, then stripped the ``activated_*`` keys
    from ``config.yaml``.
@@ -49,7 +49,7 @@ Why the finalize pass did not take (the mirror is still present on checkouts):
   migration only when ``from_version < target_version <= to_version``, or when
   ``target_version == from_version`` *and* ``detect()`` is true on an explicit
   upgrade run. A project already stamped at the finalize migration's own
-  ``3.2.6`` target (e.g. via the seed migration that shares that version, or via
+  ``3.2.6rc1`` target (e.g. via the seed migration that shares that version, or via
   hand-authored dogfood config) reaches ``3.2.6`` with no ``from < to`` window,
   so the mirror-removal (``_rewrite_config``) only fires if an upgrade is
   explicitly invoked at that exact version. That timing gap left a
@@ -122,7 +122,7 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 MIGRATION_ID = "normalize_activation_absence"
-TARGET_VERSION = "3.2.6"
+TARGET_VERSION = "3.2.6rc1"
 
 _KITTIFY_DIRNAME = ".kittify"
 _CONFIG_FILENAME = "config.yaml"

--- a/src/specify_cli/upgrade/migrations/m_unify_charter_activation.py
+++ b/src/specify_cli/upgrade/migrations/m_unify_charter_activation.py
@@ -210,7 +210,7 @@ class UnifyCharterActivationMigration(BaseMigration):
         "so config-authority derivation never silently drops an artefact "
         "recorded only in the charter interview (FR-006)."
     )
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
 
     def detect(self, project_path: Path) -> bool:
         """Return True when at least one answers-only selection is promotable."""

--- a/src/specify_cli/upgrade/migrations/m_unify_charter_activation_finalize.py
+++ b/src/specify_cli/upgrade/migrations/m_unify_charter_activation_finalize.py
@@ -23,7 +23,7 @@ stay import-cheap).
 
 Ordering (MG6 -- paula MAJOR-3): sequenced strictly AFTER the existing
 activation-seed migrations that write ``activated_*`` INTO ``config.yaml``:
-``m_unify_charter_activation.py`` (``target_version = "3.2.6"``, whose
+``m_unify_charter_activation.py`` (``target_version = "3.2.6rc1"``, whose
 "config is the activation authority" invariant is now REVERSED by this
 migration -- see the docstring note on that class) and the rc35 pair
 (``m_3_2_0rc35_default_charter_pack.py`` /
@@ -33,7 +33,7 @@ carries ``activated_*``) is this migration's pre-state; this migration
 relocates those keys into ``charter.yaml`` and then removes them from
 ``config.yaml``.
 
-``target_version`` is ``"3.2.6"`` -- tied with ``m_unify_charter_activation``.
+``target_version`` is ``"3.2.6rc1"`` -- tied with ``m_unify_charter_activation``.
 ``3.2.6`` is unreleased, so this fold ships within the same cycle rather than
 advancing the package version (a migration whose ``target_version`` exceeds
 the installed package is skipped by ``spec-kitty upgrade``; targeting an
@@ -65,7 +65,7 @@ from ..registry import MigrationRegistry
 from .base import BaseMigration, MigrationResult
 
 MIGRATION_ID = "consolidate_charter_bundle_fold"
-TARGET_VERSION = "3.2.6"
+TARGET_VERSION = "3.2.6rc1"
 
 _KITTIFY_DIRNAME = ".kittify"
 _CHARTER_DIRNAME = "charter"

--- a/src/specify_cli/upgrade/migrations/m_zz_runtime_state_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_zz_runtime_state_backfill.py
@@ -35,16 +35,16 @@ order**, which is **alphabetical module-discovery order**
 imports them -- verified empirically). FR-010 requires this migration to run
 strictly **after** the charter-fold migrations
 (``m_unify_charter_activation.py`` / ``m_unify_charter_activation_finalize.py``,
-both ``target_version = "3.2.6"``). Two ways to get this wrong:
+both ``target_version = "3.2.6rc1"``). Two ways to get this wrong:
 
-1. **A ``target_version`` above ``"3.2.6"``** (e.g. ``"3.3.1"``, matching the
+1. **A ``target_version`` above ``"3.2.6rc1"``** (e.g. ``"3.3.1"``, matching the
    pre-flight brief's original filename): the installed/unreleased package
    version is ``3.2.6`` (see ``pyproject.toml``), and
    ``MigrationRegistry.get_applicable()`` only includes a migration when
    ``target <= to_version`` -- a higher ``target_version`` is **silently
    skipped** by real upgrades, and separately HARD-FAILs
    ``tests/architectural/test_migration_chain_integrity.py`` (chain end ahead of
-   ``pyproject.toml``). Fix: tie the version at ``"3.2.6"``, shipping within the
+   ``pyproject.toml``). Fix: tie the version at ``"3.2.6rc1"``, shipping within the
    same, still-unreleased cycle as the charter folds and
    ``m_3_2_6_meta_traces_merge_drivers.py``.
 2. **A numeric-prefix filename at the tied version** (e.g.
@@ -264,7 +264,7 @@ class RuntimeStateBackfillMigration(BaseMigration):
         "flip), aborting the whole step on the first mission whose verify "
         "fails (FR-010, NFR-005)."
     )
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     runs_on_worktrees = False
 
     def detect(self, project_path: Path) -> bool:

--- a/src/specify_cli/upgrade/migrations/m_zz_verdict_provenance_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_zz_verdict_provenance_backfill.py
@@ -38,7 +38,7 @@ nothing (``appended_count == 0`` for every mission) -- ``detect()`` returns
 
 Version-key ordering
 --------------------
-``target_version = "3.2.6"`` -- tied to the installed package version
+``target_version = "3.2.6rc1"`` -- tied to the installed package version
 (``pyproject.toml``), the same still-unreleased cycle as the sibling
 ``m_zz_runtime_state_backfill.py``. The ``m_zz_`` filename prefix keeps this
 module importing (and registering) after the ``m_unify_charter_activation*``
@@ -97,7 +97,7 @@ class VerdictProvenanceBackfillMigration(BaseMigration):
         "review_result event, so the event authority is complete after the "
         "verdict-reader collapse (FR-012, SC-008). Idempotent."
     )
-    target_version = "3.2.6"
+    target_version = "3.2.6rc1"
     runs_on_worktrees = False
 
     def detect(self, project_path: Path) -> bool:

--- a/tests/architectural/test_no_dead_modules.py
+++ b/tests/architectural/test_no_dead_modules.py
@@ -278,7 +278,7 @@ _CATEGORY_1_AUTO_DISCOVERED_MIGRATIONS: frozenset[str] = frozenset(
         # pkgutil.iter_modules + @MigrationRegistry.register; never statically
         # imported by runtime code. Named m_zz_* (not a numeric-prefix name) so it
         # sorts alphabetically AFTER the m_unify_charter_activation* folds at the
-        # same tied target_version="3.2.6" (see the module docstring).
+        # same tied target_version="3.2.6rc1" (see the module docstring).
         "specify_cli.upgrade.migrations.m_zz_runtime_state_backfill",
         # verdict-seam-write-unification-01KZ9Q35 pre-merge remediation (#3236,
         # FR-012/SC-008): auto-discovered upgrade migration that backfills each
@@ -286,7 +286,7 @@ _CATEGORY_1_AUTO_DISCOVERED_MIGRATIONS: frozenset[str] = frozenset(
         # status.events.jsonl. Auto-discovered via pkgutil.iter_modules +
         # @MigrationRegistry.register; never statically imported by runtime code.
         # Named m_zz_* (same ordering rationale as the runtime-state sibling
-        # above) at the tied target_version="3.2.6".
+        # above) at the tied target_version="3.2.6rc1".
         "specify_cli.upgrade.migrations.m_zz_verdict_provenance_backfill",
         # review-cycle-verdict-seam-rebuild-01KZ2W7W WP18/T079 (T017): installs
         # the review-cycle-*.md fail-closed merge driver for already-init'd

--- a/tests/specify_cli/upgrade/test_runtime_state_backfill_migration.py
+++ b/tests/specify_cli/upgrade/test_runtime_state_backfill_migration.py
@@ -405,4 +405,4 @@ def test_migration_is_auto_discovered_and_sorts_after_charter_folds() -> None:
 def test_target_version_ties_with_charter_folds_not_higher() -> None:
     """Regression guard: a target_version above 3.2.6 is silently skipped by
     ``get_applicable()`` and HARD-FAILs ``test_migration_chain_integrity.py``."""
-    assert RuntimeStateBackfillMigration.target_version == "3.2.6"
+    assert RuntimeStateBackfillMigration.target_version == "3.2.6rc1"

--- a/tests/specify_cli/upgrade/test_verdict_provenance_backfill_migration.py
+++ b/tests/specify_cli/upgrade/test_verdict_provenance_backfill_migration.py
@@ -169,5 +169,5 @@ def test_migration_is_auto_discovered_and_registered() -> None:
     assert migration is not None, (
         "verdict_provenance_backfill must be auto-discovered and registered"
     )
-    assert migration.target_version == "3.2.6"
+    assert migration.target_version == "3.2.6rc1"
     assert migration.runs_on_worktrees is False

--- a/uv.lock
+++ b/uv.lock
@@ -2261,7 +2261,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.6"
+version = "3.2.6rc1"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Cuts **`3.2.6rc1`** — an **internal Release Candidate / delta build for validation, NOT an official `3.2.6` release**. It publishes as a GitHub _prerelease_ and to PyPI as a PEP 440 prerelease, so installers only pick it up with `--pre`. Once merged, `v3.2.6rc1` is tagged from `main` to trigger the prerelease workflow.

## What's in this PR

- **Version bump `3.2.6` → `3.2.6rc1`** across `pyproject.toml`, `uv.lock`, and `.kittify/metadata.yaml`.
- **Retarget the 11 open 3.2.6-cycle upgrade migrations to `target_version=3.2.6rc1`.** Under PEP 440 `3.2.6rc1 < 3.2.6`, so the package-version guard (`test_discovered_migration_targets_do_not_exceed_package_version`) would otherwise skip the *entire* cycle on RC installs — testers would not exercise the migrations this delta ships. This matches the `3.2.0rcNN` precedent (each rc's migrations targeted the rc it shipped in). Final `3.2.6` still fires them for `3.2.5 → 3.2.6` upgraders. Tied rationale docstrings, the two hard target-version test assertions, and the dead-module ledger comments are updated to match.
- **Release notes (authored by Cleo / comms profile):** the `CHANGELOG.md` `[3.2.6rc1]` section is finalized with an RC / not-official banner and opt-in `--pre` install guidance; a standalone `docs/changelog/release-notes-3.2.6rc1.md` is added. The RC disclaimer leads the extracted GitHub release body.

## Validation

- `scripts/release/validate_release.py --mode branch` → **all checks passed**.
- `extract_changelog.py 3.2.6rc1` → release body leads with the "NOT an official 3.2.6 release" banner.
- Targeted + broad upgrade suites green: `tests/upgrade/`, `tests/specify_cli/upgrade/`, `test_no_dead_modules.py`, versioning, validator tests (**923 passed, 5 skipped** + 132 targeted). `ruff check` clean; terminology guard green.

## Merge & release plan

1. Operator reviews and merges this PR into `main` (per no-direct-push doctrine).
2. Tag `v3.2.6rc1` from `main`; push to trigger `release.yml` (auto-marks prerelease).
3. Verify the GitHub prerelease + PyPI `--pre` availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789139344&installation_model_id=427282&pr_number=3359&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3359&signature=05b7ac4defcf63ddf3be8ccf3e16800206ad26408329fad300ae7ccc4c454414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->