### PR TITLE
fix(release): exclude dormant wheel-scaffolding from doctrine-count gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,13 @@ jobs:
 
           # Count tracked doctrine files in source. Release tests can mutate the
           # checkout, so use the tracked tree as the source of truth here too.
-          SOURCE_DOCTRINE_COUNT=$(git ls-files src/doctrine | wc -l | tr -d ' ')
+          # Apply the SAME exclusions the wheel build applies (pyproject.toml
+          # [tool.hatch.build.targets.wheel].exclude): src/doctrine/hatch_build.py
+          # and the nested src/doctrine/pyproject.toml are dormant standalone-wheel
+          # build scaffolding (#3163, ADR 2026-08-02-1), deliberately NOT shipped in
+          # the runtime wheel -- counting them as doctrine payload falsely fails this
+          # gate (they are tracked, so appear in `git ls-files`, but never in the wheel).
+          SOURCE_DOCTRINE_COUNT=$(git ls-files src/doctrine ':!src/doctrine/hatch_build.py' ':!src/doctrine/pyproject.toml' | wc -l | tr -d ' ')
           echo "Source doctrine file count: $SOURCE_DOCTRINE_COUNT"
 
           WHEEL_DOCTRINE_COUNT=$(find /tmp/wheel_check/doctrine -type f 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## Summary

The `v3.2.6rc1` release run failed at **build-release → "Verify wheel contents"** with:

```
Doctrine file count mismatch! Source: 250, Wheel: 248
```

**PyPI publish and everything downstream were skipped — nothing was published.** This is a pre-existing gate bug, not an artifact problem.

## Root cause

The check counts `git ls-files src/doctrine` (250) as shippable doctrine payload and compares it to the wheel's `doctrine/` tree (248). The two-file gap is:

- `src/doctrine/hatch_build.py`
- `src/doctrine/pyproject.toml`

These are **dormant standalone-wheel build scaffolding** (`#3163`, ADR `2026-08-02-1`) that the wheel build *deliberately excludes* via `[tool.hatch.build.targets.wheel].exclude` (`src/doctrine/hatch_build.py`, `src/*/pyproject.toml`) — shipping them would be "packaging pollution for every consumer of `spec-kitty-cli`" (their words, in `pyproject.toml`). The wheel is correct; the **gate over-counts**.

They were added `2026-08-03` (commit `f0397a973`), *after* `v3.2.5` — the last release that actually built a wheel — which is why this only surfaces now.

## Fix

Apply the same exclusions to the source count so it matches the wheel:

```bash
git ls-files src/doctrine ':!src/doctrine/hatch_build.py' ':!src/doctrine/pyproject.toml'   # -> 248
```

No runtime/wheel content changes — the shipped artifact is byte-identical. Verified locally: corrected source count `248` == wheel `248`.

## Follow-up

Once merged, `v3.2.6rc1` is re-tagged at the fixed `main` tip and the release re-run (the built wheel is unchanged; only the gate math is corrected). Affects the eventual `3.2.6` final release too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789141976&installation_model_id=427282&pr_number=3360&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3360&signature=0550a1289fb8b22a067bf722a42aafb1da70e017673257dafddaf3c63dd12ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->