### PR TITLE
fix(release): pin hatchling build backend to 1.31.0 (Metadata-Version 2.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,13 @@ lint = [
 spec-kitty = "specify_cli:main"
 
 [build-system]
-requires = ["hatchling"]
+# Pin the build backend to the uv.lock-recorded hatchling. Unpinned, the
+# isolated build pulls whatever hatchling is newest on PyPI, and post-1.31
+# releases emit `Metadata-Version: 2.5`, which the release pipeline's pinned
+# `twine==6.*` (pkginfo) rejects as "not a valid metadata version" — failing
+# `twine check` before publish. hatchling 1.31.0 emits the widely-accepted
+# `2.4`. Keep this in lockstep with uv.lock's hatchling entry.
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.metadata]


### PR DESCRIPTION
## Summary

Second pre-existing release-toolchain failure blocking `v3.2.6rc1`. After the doctrine-count gate fix (#3360), the release run got to **build-release → "Check distributions"** and failed:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

PyPI publish + downstream were **skipped** — nothing published.

## Root cause

`[build-system].requires` was unpinned (`"hatchling"`), so the isolated `python -m build` pulls the newest hatchling from PyPI. Post-1.31 hatchling emits `Metadata-Version: 2.5`, but the release pipeline pins `twine==6.*`, whose validator rejects 2.5. Pure toolchain drift — surfaces on the first release build since `v3.2.5`.

Empirically (constrained isolated builds in this repo):

| hatchling | Metadata-Version |
|-----------|------------------|
| 1.31.0 (uv.lock) | **2.4** ✅ |
| newest (unpinned) | 2.5 ❌ |

## Fix

Pin the build backend to the `uv.lock`-recorded `hatchling==1.31.0`, which emits the widely-accepted `2.4`. Building with locked deps is the correct behavior for a release anyway.

**Verified locally end-to-end:** build with the pinned backend → `Metadata-Version: 2.4` → `twine==6.2.0 check` **PASSED**. No runtime/wheel-content change; the shipped code is unaffected.

## Follow-up

Once merged, `v3.2.6rc1` is re-tagged at the fixed `main` tip and the release re-run. A later cleanup could modernize the pipeline to accept 2.5 metadata (upgrade `twine`/`packaging`) once PyPI 2.5 acceptance is confirmed — pinning the backend is the low-risk fix for now. Also unblocks the eventual `3.2.6` final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789143114&installation_model_id=427282&pr_number=3361&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3361&signature=9a5e845c874192cc1fd3b8acb04d61109de2ba10aa5b334a3d7baa6d433252f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->