### PR TITLE
chore(release): open 3.2.6rc2 candidate cycle (post-rc1 version bump)

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.6rc1
+  version: 3.2.6rc2
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,9 +13,9 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] - 3.2.6rc2
 
-_The next development cycle is open. Entries land here as missions merge._
+_The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land here as missions merge._
 
 ## [3.2.6rc1] - 2026-08-12
 

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -4987,7 +4987,7 @@ pages:
     divio_type: "none"
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
-    - {slug: "unreleased", text: "[Unreleased]", level: 2}
+    - {slug: "unreleased-3-2-6rc2", text: "[Unreleased] - 3.2.6rc2", level: 2}
     - {slug: "3-2-6rc1-2026-08-12", text: "[3.2.6rc1] - 2026-08-12", level: 2}
     - {slug: "added", text: "✨ Added", level: 3}
     - {slug: "fixed", text: "🐛 Fixed", level: 3}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.6rc1"
+version = "3.2.6rc2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2261,7 +2261,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.6rc1"
+version = "3.2.6rc2"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
## Summary

Post-release version bump. `v3.2.6rc1` shipped 2026-08-12 (GitHub prerelease + PyPI `--pre`), so main should be stamped ahead of it.

- Bump `3.2.6rc1` → `3.2.6rc2` in `pyproject.toml`, `uv.lock`, `.kittify/metadata.yaml`.
- Declare the next candidate cycle: `## [Unreleased] - 3.2.6rc2` in the changelog.
- The 11 cycle migrations keep `target_version=3.2.6rc1` — `rc1 <= rc2`, so the package-version guard (`test_discovered_migration_targets_do_not_exceed_package_version`) still fires them; **no migration retarget needed**.

## Validation

- `scripts/release/validate_release.py --mode branch` → **all checks passed**.
- `tests/upgrade/test_auto_discovery.py` + `tests/doctrine/test_versioning.py` → 79 passed.

## Landing notes

Renaming the changelog `## [Unreleased]` heading to `## [Unreleased] - 3.2.6rc2` shifts its anchor slug (`unreleased` → `unreleased-3-2-6rc2`), which drifted the committed docs retrieval index and red-lit the `docs-freshness` CI gate (`DOCS-INDEX-DRIFT`). Landing fold `docs(landing): regen docs retrieval index for rc2 changelog heading` regenerates `docs/development/3-2-docs-retrieval-index.yaml` (via `scripts/docs/docs_index.py --write --strict`, 730 rows, drift=0). No docs link to the old `#unreleased` anchor. The `## [Unreleased] - X.Y.Z` pending-cycle heading is a first-class form supported by `scripts/release/validate_release.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa
