### PR TITLE
test(regression): red-first P0 reproductions for #3231 #3307 #3311 #3320 #3334

### DIFF
--- a/tests/regression/test_issue_3231_scaffold_pending_poisons_acceptance.py
+++ b/tests/regression/test_issue_3231_scaffold_pending_poisons_acceptance.py
@@ -1,0 +1,87 @@
+"""Red-first reproduction of #3231 — a leftover finalize-tasks scaffold row
+makes the acceptance aggregate ``pending`` and blocks acceptance.
+
+Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3231
+
+Root cause (both lines verified against current source):
+
+* ``AcceptanceMatrix.overall_verdict`` (``src/specify_cli/acceptance/matrix.py``)
+  makes ``pending`` DOMINATE — one ``pending`` row outvotes any number of
+  ``pass`` rows (``if any(v == "pending" ...): return "pending"``).
+* The row-union reconciler ``reconcile_acceptance_matrix_documents``
+  (``src/specify_cli/cli/commands/merge_driver.py``) admits BOTH sides' rows on
+  an add/add divergence (``#3076`` FR-008), so after a mission→target squash
+  merge the merged document legitimately contains the ``finalize-tasks``
+  placeholder row (``AC-001``, ``pass_fail="pending"``, ``notes=SCAFFOLD_TODO_MARKER``)
+  alongside the real, all-``pass`` criteria — and that one scaffold row poisons
+  the whole verdict, blocking acceptance even though every real criterion passes.
+
+This drives the REAL production reconciler exactly as the issue measured it
+(FILLED as *ours*, the scaffold PLACEHOLDER as *theirs*, empty base — the add/add
+divergence).
+
+Desired post-fix outcome (either resolution turns this green): a mission whose
+real acceptance criteria all ``pass`` must NOT be blocked by a leftover
+``finalize-tasks`` scaffold placeholder — the aggregate is admissible (not
+``pending``). Whether the reconciler suppresses the scaffold row or the verdict
+computation becomes scaffold-aware is a product decision (issue #3231); this test
+pins the observable behavioural contract, not the mechanism.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.acceptance.matrix import SCAFFOLD_TODO_MARKER
+from specify_cli.cli.commands.merge_driver import reconcile_acceptance_matrix_documents
+
+pytestmark = pytest.mark.regression
+
+
+def _pass_criterion(criterion_id: str) -> dict[str, object]:
+    return {
+        "criterion_id": criterion_id,
+        "description": f"Verify {criterion_id} is satisfied",
+        "proof_type": "automated_test",
+        "pass_fail": "pass",
+        "evidence": f"tests/test_{criterion_id.lower()}.py::test_it",
+    }
+
+
+def _scaffold_placeholder_row() -> dict[str, object]:
+    # Exactly what `finalize-tasks` writes for an un-authored matrix
+    # (src/specify_cli/acceptance/matrix.py scaffold builder).
+    return {
+        "criterion_id": "AC-001",
+        "description": SCAFFOLD_TODO_MARKER,
+        "proof_type": "automated_test",
+        "pass_fail": "pending",
+        "notes": SCAFFOLD_TODO_MARKER,
+    }
+
+
+def test_scaffold_pending_row_does_not_poison_acceptance_verdict() -> None:
+    ours_filled = {
+        "mission_slug": "example-mission",
+        "criteria": [_pass_criterion("FR-001"), _pass_criterion("FR-003")],
+    }
+    theirs_scaffold = {
+        "mission_slug": "example-mission",
+        "criteria": [_scaffold_placeholder_row()],
+    }
+    # Empty base == the add/add divergence the row-union authority model faces.
+    merged = reconcile_acceptance_matrix_documents({}, ours_filled, theirs_scaffold)
+
+    real_criteria = [c for c in merged["criteria"] if c["criterion_id"] != "AC-001"]
+    assert real_criteria, "sanity: the real, filled criteria survived the merge"
+    assert all(c["pass_fail"] == "pass" for c in real_criteria), (
+        "sanity: every real criterion is 'pass'; only the scaffold placeholder is 'pending'"
+    )
+
+    # RED today: a single admitted scaffold placeholder makes the aggregate
+    # 'pending', blocking acceptance despite every real criterion passing.
+    assert merged["overall_verdict"] != "pending", (
+        "a leftover finalize-tasks scaffold placeholder row must not poison the "
+        f"acceptance aggregate; got overall_verdict={merged['overall_verdict']!r} "
+        f"with rows={[(c['criterion_id'], c['pass_fail']) for c in merged['criteria']]}"
+    )

--- a/tests/regression/test_issue_3307_cli_emits_contract_invalid_unforced_rollback.py
+++ b/tests/regression/test_issue_3307_cli_emits_contract_invalid_unforced_rollback.py
@@ -1,0 +1,118 @@
+"""Red-first reproduction of #3307 — the CLI emits ``force=False`` for
+review-rejection rollbacks that the vendored ``spec-kitty-events`` contract
+declares invalid without ``force=True``.
+
+Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3307
+
+Root cause: two independently-authored ``validate_transition`` functions with the
+same name and opposite answers.
+
+* ``build_transition_plan`` (``src/specify_cli/cli/commands/agent/tasks_transition_core.py``)
+  asks the CLI-LOCAL FSM (``specify_cli.status``) whether a backward review-rejection
+  edge is legal force-free given the evidence carried at the plan layer, and emits
+  ``emit_force=False`` when it is.
+* The SHARED, vendored ``spec_kitty_events.validate_transition`` — the contract
+  package both this repo and ``spec-kitty-saas`` pin (``spec-kitty-events==6.1.0``)
+  — declares exactly these "review-rejection family" backward edges invalid unless
+  ``force=True``. The CLI emit path never calls the shared validator, so
+  contract-invalid events are produced and queued silently and are only rejected
+  later at sync time (10 real ``in_review -> planned`` events were rejected by the
+  SaaS ingestion endpoint in the reported case).
+
+This drives the REAL emit-decision function (``build_transition_plan``) and then
+validates the wire payload it would emit against the REAL shared contract
+validator — proving the CLI emits events its own vendored dependency rejects.
+
+Desired post-fix outcome (either maintainer resolution turns this green): every
+event ``build_transition_plan`` emits for these edges must be accepted by the
+shared ``spec_kitty_events`` contract — whether by emitting ``force=True`` (make
+the CLI conform) or by amending the shared contract to carry a wire-representable
+evidence exemption and having the CLI emit that evidence (issue #3307 options a/b).
+This test pins the conformance contract, not the chosen mechanism.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.cli.commands.agent.tasks_transition_core import build_transition_plan
+from specify_cli.status import ReviewResult
+from spec_kitty_events import validate_transition as shared_validate_transition
+from spec_kitty_events.status import StatusTransitionPayload
+
+pytestmark = pytest.mark.regression
+
+_REVIEW_RESULT = ReviewResult(
+    reviewer="claude",
+    verdict="rejected",
+    reference="review-cycle-1.md",
+    feedback_path="review-cycle-1.md",
+)
+
+# The four "review-rejection family" backward edges that spec-kitty-events==6.1.0
+# declares force-required, each with the plan-layer evidence that makes the
+# CLI-local FSM resolve them force-free today.
+_REVIEW_REJECTION_EDGES = [
+    (
+        "in_review",
+        "planned",
+        {"review_feedback_pointer": "review-cycle-1.md", "review_result": _REVIEW_RESULT},
+    ),
+    (
+        "in_progress",
+        "planned",
+        {"note_text": "rework needed"},
+    ),
+    (
+        "approved",
+        "planned",
+        {"review_feedback_pointer": "review-cycle-1.md", "arb_review_ref": "review-cycle-1.md"},
+    ),
+    (
+        "in_review",
+        "in_progress",
+        {"review_result": _REVIEW_RESULT},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("old_lane", "target_lane", "evidence"),
+    _REVIEW_REJECTION_EDGES,
+    ids=[f"{o}->{n}" for o, n, _ in _REVIEW_REJECTION_EDGES],
+)
+def test_cli_emit_conforms_to_shared_events_contract(
+    old_lane: str, target_lane: str, evidence: dict[str, object]
+) -> None:
+    kwargs: dict[str, object] = {
+        "review_feedback_pointer": None,
+        "arb_review_ref": None,
+        "note_text": None,
+        "review_result": None,
+    }
+    kwargs.update(evidence)
+
+    plan = build_transition_plan(
+        old_lane=old_lane, target_lane=target_lane, force=False, **kwargs
+    )
+
+    payload = StatusTransitionPayload(
+        mission_slug="example-mission",
+        wp_id="WP01",
+        from_lane=old_lane,
+        to_lane=target_lane,
+        actor="claude",
+        force=plan.emit_force,
+        reason=plan.emit_reason,
+        execution_mode="worktree",
+        review_ref=plan.emit_review_ref,
+        evidence=None,
+    )
+    result = shared_validate_transition(payload)
+
+    # RED today: the CLI emits force=False and the shared contract rejects it.
+    assert result.valid, (
+        f"CLI's build_transition_plan emitted force={plan.emit_force} for "
+        f"{old_lane} -> {target_lane}, which the vendored spec-kitty-events "
+        f"contract rejects: {result.violations}"
+    )

--- a/tests/regression/test_issue_3311_finalize_rewrites_active_lanes.py
+++ b/tests/regression/test_issue_3311_finalize_rewrites_active_lanes.py
@@ -84,8 +84,9 @@ def test_ownership_only_amendment_preserves_established_lanes_and_provenance(
     _run_finalize(mission_slug, patches)
     established = read_lanes_json(feature_dir)
     baseline_topology = {lane.lane_id: sorted(lane.wp_ids) for lane in established.lanes}
-    assert len(baseline_topology) == 2, (
-        f"sanity: two disjoint WPs must materialize two lanes; got {baseline_topology}"
+    assert sorted(baseline_topology.values()) == [["WP01"], ["WP02"]], (
+        "sanity: two disjoint WPs must materialize two independent single-WP "
+        f"lanes; got {baseline_topology}"
     )
 
     # Stand in a recorded planning provenance SHA (finalize cannot capture one in a

--- a/tests/regression/test_issue_3311_finalize_rewrites_active_lanes.py
+++ b/tests/regression/test_issue_3311_finalize_rewrites_active_lanes.py
@@ -1,0 +1,124 @@
+"""Red-first reproduction of #3311 — rerunning ``finalize-tasks`` after
+implementation has begun rewrites the established lane topology and clears
+planning provenance in response to an ownership-only WP amendment.
+
+Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3311
+
+Root cause (verified against current source): the finalize path
+(``_compute_and_write_lanes`` in
+``src/specify_cli/cli/commands/agent/mission_finalize.py``) NEVER reads the
+existing ``lanes.json`` — it calls ``compute_lanes`` (a pure recompute-from-scratch
+whose Rule-1 union-find merges any WPs with overlapping ``owned_files``) and
+overwrites ``lanes.json`` + ``planning_commit_sha`` unconditionally on every
+non-``--validate-only`` run. So adding one path to a single WP's ``owned_files``
+recomputes and renumbers the whole topology, collapses established lanes, and
+clears ``planning_commit_sha``.
+
+This drives the REAL ``finalize_tasks`` entry point twice: once to materialize the
+established lanes, then again after an ownership-only ``owned_files`` amendment.
+
+Desired post-fix outcome (either resolution turns this green): for a mission whose
+lanes are already materialized, finalization preserves the established lane
+identities and planning provenance (updating only the amended WP's write scope),
+or refuses before writing any bytes — it must NOT regenerate executed topology or
+clear ``planning_commit_sha`` as a side effect of an ownership-only amendment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from specify_cli.lanes.persistence import read_lanes_json, write_lanes_json
+
+from tests.specify_cli.cli.commands.agent.test_feature_finalize_bootstrap import (
+    MODULE,
+    _common_patches,
+    _make_bootstrap_result,
+    _setup_lane_based_feature,
+)
+
+pytestmark = pytest.mark.regression
+
+_SEEDED_PLANNING_SHA = "deadbeef000deadbeef000deadbeef000deadbeef"
+
+
+def _run_finalize(mission_slug: str, patches: dict[str, object]) -> None:
+    from specify_cli.cli.commands.agent.mission import finalize_tasks
+
+    ctx_patches = {k: patch(k, v) for k, v in patches.items()}
+    for p in ctx_patches.values():
+        p.start()
+    try:
+        finalize_tasks(feature=mission_slug, json_output=True, validate_only=False)
+    except (typer.Exit, SystemExit):
+        pass  # finalize-tasks may exit; the file writes are what we assert on
+    finally:
+        for p in ctx_patches.values():
+            p.stop()
+
+
+def test_ownership_only_amendment_preserves_established_lanes_and_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Keep finalize-tasks on the offline path: tests/conftest.py enables SaaS sync
+    # globally, which can let a machine-local daemon-owner record short-circuit
+    # finalize before these assertions run (mirrors the source module's autouse
+    # guard, which does not apply to this importing module).
+    monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+
+    mission_slug = "061-lane-feature"
+    feature_dir = _setup_lane_based_feature(tmp_path, mission_slug)
+
+    patches = _common_patches(tmp_path, mission_slug)
+    patches[f"{MODULE}._find_feature_directory"] = MagicMock(return_value=feature_dir)
+    patches[f"{MODULE}.bootstrap_canonical_state"] = MagicMock(
+        return_value=_make_bootstrap_result()
+    )
+
+    # Run 1: materialize the established topology (WP01 and WP02 own disjoint
+    # files → two independent lanes).
+    _run_finalize(mission_slug, patches)
+    established = read_lanes_json(feature_dir)
+    baseline_topology = {lane.lane_id: sorted(lane.wp_ids) for lane in established.lanes}
+    assert len(baseline_topology) == 2, (
+        f"sanity: two disjoint WPs must materialize two lanes; got {baseline_topology}"
+    )
+
+    # Stand in a recorded planning provenance SHA (finalize cannot capture one in a
+    # non-git tmp workspace), representing an established mission's committed plan.
+    established.planning_commit_sha = _SEEDED_PLANNING_SHA
+    write_lanes_json(feature_dir, established)
+
+    # Ownership-only amendment: add a path WP02 already owns to WP01's owned_files.
+    # Nothing about dependencies, requirements, or lifecycle changes.
+    wp01 = feature_dir / "tasks" / "WP01-test.md"
+    wp01.write_text(
+        wp01.read_text(encoding="utf-8").replace(
+            "owned_files:\n  - src/alpha.py\n",
+            "owned_files:\n  - src/alpha.py\n  - src/beta.py\n",
+        ),
+        encoding="utf-8",
+    )
+
+    # Run 2: the ownership-only amendment.
+    _run_finalize(mission_slug, patches)
+    after = read_lanes_json(feature_dir)
+
+    # Sanity: the established lanes.json is what got rewritten (same mission).
+    assert after.mission_slug == established.mission_slug
+
+    # RED today: finalization unconditionally recomputes lanes.json and overwrites
+    # planning_commit_sha on every re-run — an ownership-only amendment destroys the
+    # established planning provenance instead of preserving it (here the recompute
+    # cannot re-derive a SHA, so the recorded value is clobbered to None; in a real
+    # repo it would be overwritten with the current branch tip, equally destroying
+    # the recorded plan provenance).
+    assert after.planning_commit_sha == _SEEDED_PLANNING_SHA, (
+        "an ownership-only amendment must not clear/overwrite established planning "
+        f"provenance; planning_commit_sha went {_SEEDED_PLANNING_SHA!r} -> "
+        f"{after.planning_commit_sha!r}"
+    )

--- a/tests/regression/test_issue_3320_retrospect_update_reports_stale_findings.py
+++ b/tests/regression/test_issue_3320_retrospect_update_reports_stale_findings.py
@@ -1,0 +1,126 @@
+"""Red-first reproduction of #3320 — ``retrospect create --update`` reports a
+result and appends an event that contradict the record it actually persisted.
+
+Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3320
+
+Root cause (verified against current source): in
+``src/specify_cli/cli/commands/retrospect.py`` the ``create`` command builds its
+JSON result (and the ``RetrospectiveCaptured`` event) from the PRE-MERGE
+``record`` (the freshly generated ``ran_no_findings`` record), while
+``write_gen_record(mode="update")`` (``src/specify_cli/retrospective/writer.py``)
+MERGES that with the existing on-disk record and recomputes ``findings_status``
+from the union — preserving the existing gap, so the persisted record stays
+``has_findings``. The CLI never reads back the merged record, so ``--update``
+reports ``ran_no_findings`` / zero gaps while the file on disk still says
+``has_findings`` with its gap intact.
+
+This drives the REAL ``retrospect create --update`` command through the REAL
+merging writer (``write_gen_record`` is NOT mocked); only the mission-resolution
+and generation collaborators are stubbed, and the generator is stubbed to a real
+``ran_no_findings`` record exactly as the empty-mission generator would produce.
+
+Desired post-fix outcome: ``--update`` reports from the merged record (or migrates
+and rewrites so result/event agree with the record), or fails before mutating
+anything — the reported ``findings_status`` / gap count must match what is
+actually persisted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.retrospect import app as retrospect_app
+from specify_cli.retrospective.schema import GenFinding, GenRetrospectiveRecord
+from specify_cli.retrospective.writer import write_gen_record
+
+from tests.cli.commands.test_retrospect import (
+    MISSION_ID_COMPLETED,
+    MISSION_SLUG_COMPLETED,
+    _build_resolved_mission,
+    _make_minimal_gen_record,
+    _setup_project,
+    _write_kitty_meta,
+    _write_status_events_all_done,
+)
+
+pytestmark = pytest.mark.regression
+
+RUNNER = CliRunner()
+
+_RETRO_MODULE = "specify_cli.cli.commands.retrospect"
+
+
+def _legacy_record_with_gap() -> GenRetrospectiveRecord:
+    """A completed mission's existing record: has_findings with one real gap."""
+    base = _make_minimal_gen_record(findings_status="has_findings")
+    base.gaps = [
+        GenFinding(
+            id="g-001",
+            category="process",
+            summary="lane bounced before approval",
+        )
+    ]
+    return base
+
+
+def test_update_result_and_event_agree_with_persisted_record(tmp_path: Path) -> None:
+    repo_root, _missions_dir, kitty_specs_dir = _setup_project(tmp_path)
+    feature_dir = kitty_specs_dir / MISSION_SLUG_COMPLETED
+    _write_kitty_meta(feature_dir, MISSION_ID_COMPLETED, MISSION_SLUG_COMPLETED)
+    _write_status_events_all_done(feature_dir, MISSION_SLUG_COMPLETED)
+
+    # Seed the existing on-disk record (has_findings + one gap) via the real writer.
+    record_path = write_gen_record(
+        _legacy_record_with_gap(), mode="overwrite", repo_root=repo_root
+    )
+    assert record_path.exists(), "sanity: existing record seeded on disk"
+
+    # The generator, on this artifact-poor mission, yields ran_no_findings — the
+    # exact input that the CLI then reports from instead of the merged result.
+    generated = _make_minimal_gen_record(findings_status="ran_no_findings")
+    resolved = _build_resolved_mission(
+        MISSION_ID_COMPLETED, MISSION_SLUG_COMPLETED, feature_dir
+    )
+
+    with (
+        patch(f"{_RETRO_MODULE}.locate_project_root", return_value=repo_root),
+        patch(f"{_RETRO_MODULE}._resolve_handle", return_value=resolved),
+        patch(f"{_RETRO_MODULE}._check_mission_completed", return_value=[]),
+        patch(f"{_RETRO_MODULE}.resolve_policy", return_value=(MagicMock(), {})),
+        patch(f"{_RETRO_MODULE}.generate_retrospective", return_value=generated),
+        patch(f"{_RETRO_MODULE}.emit_captured", return_value=None),
+        patch(f"{_RETRO_MODULE}._maybe_auto_commit"),
+    ):
+        # NOTE: write_gen_record is intentionally NOT mocked — the real merge runs.
+        result = RUNNER.invoke(
+            retrospect_app,
+            ["create", "--mission", MISSION_SLUG_COMPLETED, "--update", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    reported = json.loads(result.output)
+
+    persisted = yaml.safe_load(record_path.read_text(encoding="utf-8"))
+    on_disk_status = persisted["findings_status"]
+    on_disk_gap_count = len(persisted.get("gaps", []))
+
+    # Sanity: the merge preserved the existing gap on disk.
+    assert on_disk_status == "has_findings"
+    assert on_disk_gap_count == 1
+
+    # RED today: the reported result contradicts the persisted record — the CLI
+    # reports the pre-merge ran_no_findings/zero-gaps while disk is has_findings.
+    assert reported["findings_status"] == on_disk_status, (
+        "reported findings_status must match the persisted record; "
+        f"reported={reported['findings_status']!r} on_disk={on_disk_status!r}"
+    )
+    assert reported.get("counts", {}).get("gaps") == on_disk_gap_count, (
+        "reported gap count must match the persisted record; "
+        f"reported={reported.get('counts', {}).get('gaps')} on_disk={on_disk_gap_count}"
+    )

--- a/tests/regression/test_issue_3334_failed_upgrade_wedges_repair.py
+++ b/tests/regression/test_issue_3334_failed_upgrade_wedges_repair.py
@@ -1,0 +1,100 @@
+"""Red-first reproduction of #3334 — a failed upgrade strips ``schema_version``
+from ``.kittify/metadata.yaml``, and the compatibility classifier then treats the
+project as pre-3.x ``legacy`` and blocks every non-exempt command, so the tool
+cannot recover a project its own failure broke.
+
+Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3334
+
+Root cause (verified against current source): ``_scan_project``
+(``src/specify_cli/compat/planner.py``) maps a *missing* ``schema_version``
+UNCONDITIONALLY to ``ProjectState.LEGACY`` and never consults
+``migrations.applied``. ``decide`` then answers ``BLOCK_PROJECT_MIGRATION``
+(exit 4) for ``LEGACY`` + ``UNSAFE``. The failed-upgrade path removes the
+``schema_version`` key without advancing ``version`` or restoring it, so a
+project whose ``migrations.applied`` log clearly shows 3.x history is
+classified identically to a genuinely pre-3.x project — the repair path is
+gated behind exactly the state the failure destroyed.
+
+This drives the REAL production entry point ``plan()`` with a non-exempt
+(``UNSAFE``) command against a post-failed-upgrade metadata fixture (version
+stamped behind, ``schema_version`` absent, ``migrations.applied`` carrying 3.x
+records).
+
+Desired post-fix outcome: a project missing ``schema_version`` but whose
+``migrations.applied`` log shows 3.x history is distinguishable from a genuinely
+pre-3.x project and is NOT classified ``LEGACY``-blocked — ``plan()`` must not
+return ``BLOCK_PROJECT_MIGRATION`` / exit 4, so the project remains recoverable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.compat.planner import Decision, Invocation, plan
+from specify_cli.compat.provider import FakeLatestVersionProvider
+
+from tests.specify_cli.compat.test_planner import (
+    _INSTALLED,
+    _NOW,
+    _make_nag_cache_tmp,
+    _make_project_root_resolver,
+)
+
+pytestmark = pytest.mark.regression
+
+# Post-failed-upgrade metadata: version stamped several releases behind,
+# `schema_version` ABSENT (stripped by the failure), but `migrations.applied`
+# shows real 3.x history — i.e. this is NOT a genuinely pre-3.x legacy project.
+_WEDGED_METADATA = """\
+spec_kitty:
+  version: "3.0.0"
+  initialized_at: "2025-01-01T00:00:00+00:00"
+  last_upgraded_at: "2025-06-01T00:00:00+00:00"
+migrations:
+  applied:
+    - id: m_3_0_0_canonical_context
+      applied_at: "2025-06-01T00:00:00+00:00"
+      result: success
+      notes: null
+    - id: m_3_2_4_derived_views_gitignore_backfill
+      applied_at: "2025-06-01T00:00:00+00:00"
+      result: success
+      notes: null
+"""
+
+
+def test_missing_schema_version_with_3x_history_is_not_legacy_blocked(
+    tmp_path: Path,
+) -> None:
+    resolver = _make_project_root_resolver(tmp_path, metadata_content=_WEDGED_METADATA)
+    # A non-exempt (UNSAFE) command — the wedge fires for any command that is not
+    # `upgrade`/`init`; an unregistered command fails closed to UNSAFE.
+    inv = Invocation(
+        command_path=("spec-kitty-test-unknown-cmd",),
+        raw_args=(),
+        is_help=False,
+        is_version=False,
+        flag_no_nag=False,
+        env_ci=False,
+        stdout_is_tty=True,
+    )
+
+    result = plan(
+        inv,
+        latest_version_provider=FakeLatestVersionProvider(version=_INSTALLED),
+        nag_cache=_make_nag_cache_tmp(tmp_path),
+        now=_NOW,
+        project_root_resolver=resolver,
+    )
+
+    # RED today: missing schema_version -> classified LEGACY -> LEGACY + UNSAFE ->
+    # BLOCK_PROJECT_MIGRATION (exit 4), even though migrations.applied shows 3.x
+    # history. The project its own failed upgrade broke cannot be recovered.
+    assert result.decision != Decision.BLOCK_PROJECT_MIGRATION, (
+        "a project missing schema_version but carrying 3.x migrations.applied "
+        "history must not be classified as pre-3.x legacy and blocked; got "
+        f"decision={result.decision}"
+    )
+    assert result.exit_code != 4, f"expected recoverable (exit != 4), got {result.exit_code}"


### PR DESCRIPTION
## ⚠️ These tests are INTENTIONALLY RED

Five issue-pinned, **red-first P0 reproductions** under `tests/regression/`, each `@pytest.mark.regression` and driven through the **real production entry point**. They are **expected to red the blocking `regression tests` CI job** — that red is the honest signal of the open P0s, per [ADR 2026-07-17-1](docs/adr/3.x/2026-07-17-1-red-main-is-honest-ci-is-release-authority.md) and [`tests/regression/README.md`](tests/regression/README.md). **Do not weaken/skip/xfail them to go green** — the product fix is separate work; once it lands, the test turns green on its own and then leaves this suite (README exit rule).

Marker-isolated: verified locally they are **deselected under `-m "not regression"`**, so no other CI job (`fast-*`, `integration-*`, unit/contract) is reddened — only the dedicated blocking `regression` job runs them.

No closing keywords: the issues stay **open** until the product defect is fixed; these PRs add the reproduction, not the fix.

## The five reproductions

| Issue | Entry point exercised | RED assertion (documented reason) |
|---|---|---|
| [#3231](https://github.com/Priivacy-ai/spec-kitty/issues/3231) | `reconcile_acceptance_matrix_documents` (real 3-way merge) | a leftover finalize-tasks scaffold placeholder row makes the merged `overall_verdict` `pending` and blocks acceptance though every real criterion is `pass` |
| [#3307](https://github.com/Priivacy-ai/spec-kitty/issues/3307) | `build_transition_plan` → shared `spec_kitty_events.validate_transition` | the CLI emits `force=False` for all four review-rejection backward edges; the `spec-kitty-events==6.1.0` contract rejects them (`requires force=True` / `requires review_ref`) |
| [#3311](https://github.com/Priivacy-ai/spec-kitty/issues/3311) | `finalize_tasks` (real, run twice) | an ownership-only `owned_files` amendment makes the re-run overwrite `lanes.json` and clear the established `planning_commit_sha` (no read of existing `lanes.json`) |
| [#3320](https://github.com/Priivacy-ai/spec-kitty/issues/3320) | `retrospect create --update` (real merging writer, unmocked) | reports `ran_no_findings` / zero gaps from the pre-merge record while the persisted record stays `has_findings` with its gap |
| [#3334](https://github.com/Priivacy-ai/spec-kitty/issues/3334) | `compat.planner.plan` (non-exempt command) | a project missing `schema_version` but with 3.x `migrations.applied` history is classified pre-3.x `LEGACY` → `BLOCK_PROJECT_MIGRATION` (exit 4), unrecoverable |

Each test's module docstring pins the issue, the verified root-cause file:lines, and the desired post-fix outcome (including where the fix direction is a maintainer/product decision, for #3231 and #3307 — either resolution turns the test green).

## Validation

- `pytest -m regression tests/regression/` → all reproductions RED for the documented reason through real entry points (8 cases — #3307 parametrizes into 4 backward edges), no fixture/setup errors.
- `pytest -m "not regression" tests/regression/` → all deselected.
- `ruff check tests/regression/` → clean.

## Landing note

Rebased onto current `upstream/main`. One maintainer fold rode the landing:
- **`test(landing): convert golden-count sanity assert in #3311 repro`** — the `#3311` setup used `assert len(baseline_topology) == 2`, a convert-classified golden-count site, which reddened the `arch-adversarial` golden-count-ban gate (`tests/regression` baseline ceiling is 0). Converted it to the stronger contents-equality the gate asks for — `sorted(baseline_topology.values()) == [["WP01"], ["WP02"]]` — asserting the exact two-singleton-lane partition. The repro still red-firsts at its real assertion (planning-provenance clobber); only the setup precondition changed. Gate green, no baseline re-freeze.

The two remaining CI reds — **`regression tests (blocking)`** and its **`quality-gate`** aggregate — are the *intended* honest red-first signal (ADR 2026-07-17-1), left red by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa
