### PR TITLE
docs: remove dead release skill reference

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -411,7 +411,7 @@ When working on spec-kitty:
 
 Spec Kitty follows a structured release process using GitHub Actions for automated PyPI publishing.
 
-> **For AI agents**: Use the `/release` skill (`.claude/skills/release/SKILL.md`) for a step-by-step guide.
+> **For AI agents**: Follow the Quick Release or Full Release steps below for a step-by-step release guide.
 
 ### Branch Strategy
 


### PR DESCRIPTION
## Summary

- Removed a reference to the nonexistent `.claude/skills/release/SKILL.md` file.
- Updated the contributor guide to point AI agents to the existing Quick Release and Full Release instructions.

## Why Now

- Refs #3363\n\nSuperseded by #3631; do not merge this duplicate., which identified a broken reference in the contributor documentation.
- The referenced release skill does not exist, while the release procedures are already documented in the contributor guide.

## What This PR Does

- Replaces the dead `/release` skill reference in `docs/development/contributing.md`.
- No other documentation or source files are changed.

## Effect on Existing Projects

- Runtime / compatibility: No impact; documentation-only change.
- Upgrade / migration: None.
- Operator / reviewer impact: Prevents contributors and AI agents from being directed to a nonexistent release skill.

## Validation

- [x] Reviewed the resulting Git diff; only the intended documentation line was changed.
- [x] Backward compatibility impact considered; no runtime behavior is affected.
- [x] No follow-up work is required for this documentation fix.

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| #3363 | Fixes the broken release skill reference |

## Mission Artifacts

- Spec: N/A
- Plan: N/A
- Research: N/A
- Review: N/A
- PR summary: N/A

## Follow-ups

- None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789195177&installation_model_id=427282&pr_number=3374&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3374&signature=bb1bc8826555c6e5c80c08af5d027a119b3ff0aa8197860bb9be13c47aed630d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->