### PR TITLE
fix(doctrine): finish researcher-robbie rename in prose fields

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -88,6 +88,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **The `researcher-robbie` agent profile no longer introduces itself under the
+  wrong name (`#3377`).** Before, the profile's `purpose` and
+  initialization-declaration prose still read "Researcher Rosa" — a leftover the
+  profile rename missed — so any agent that loaded `researcher-robbie` and
+  followed its initialization declaration announced itself as "Researcher Rosa",
+  even though the profile's own `name` field, its docs page, and every sibling
+  profile said "Researcher Robbie". Now the prose matches the profile's own
+  `name`, and a parametrized test asserts every shipped profile's self-identity
+  prose equals its `name` field, so this class of identity drift cannot silently
+  recur.
+
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission
   `worktree-owned-root-3328-01KZRG01`; `#3346`, closes `#3328`).** Before,

--- a/packs/built-in/agent_profiles/researcher-robbie.agent.yaml
+++ b/packs/built-in/agent_profiles/researcher-robbie.agent.yaml
@@ -28,7 +28,7 @@ context-sources:
 purpose: >
   Investigate unknowns, synthesize domain knowledge, evaluate technology options, and
   produce structured research findings that inform architectural and product decisions.
-  Researcher Rosa reduces uncertainty before costly implementation begins. Does NOT
+  Researcher Robbie reduces uncertainty before costly implementation begins. Does NOT
   implement production code, make final decisions, or own delivery timelines.
 
 specialization:
@@ -77,7 +77,7 @@ mode-defaults:
     use-case: Checking compatibility claims, validating benchmarks, verifying documentation accuracy
 
 initialization-declaration: >
-  I am Researcher Rosa. I investigate unknowns, evaluate technologies, and synthesize
+  I am Researcher Robbie. I investigate unknowns, evaluate technologies, and synthesize
   domain knowledge into structured, actionable findings. I reduce uncertainty before
   expensive decisions are made. I collaborate with architects to understand what they
   need to know, and with curators to ensure findings are preserved in the knowledge

--- a/tests/architectural/test_home_pin_scan_limbs.py
+++ b/tests/architectural/test_home_pin_scan_limbs.py
@@ -947,10 +947,15 @@ def test_render_baseline_header_is_the_tombstone_lists_named_home(tmp_path: Path
 
 def test_both_generators_are_byte_identical_on_a_second_run(tmp_path: Path) -> None:
     members = _three_members(tmp_path)
-    assert scan.render_census(members, sha=FROZEN_SHA, owed_to="#3121") == scan.render_census(
-        members, sha=FROZEN_SHA, owed_to="#3121"
-    )
-    assert scan.render_baseline(members, exempt=()) == scan.render_baseline(members, exempt=())
+    # Two independent invocations, bound to distinct names, so the determinism
+    # check compares separate render results rather than a self-identical
+    # expression (SonarCloud python:S5863).
+    census_first = scan.render_census(members, sha=FROZEN_SHA, owed_to="#3121")
+    census_second = scan.render_census(members, sha=FROZEN_SHA, owed_to="#3121")
+    assert census_first == census_second
+    baseline_first = scan.render_baseline(members, exempt=())
+    baseline_second = scan.render_baseline(members, exempt=())
+    assert baseline_first == baseline_second
 
 
 def test_main_demonstrates_the_exempt_module_absent(tmp_path: Path) -> None:

--- a/tests/doctrine/test_shipped_profiles.py
+++ b/tests/doctrine/test_shipped_profiles.py
@@ -9,6 +9,7 @@ Verifies that all shipped reference profiles:
 - Have non-empty purpose and specialization.primary_focus
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -261,6 +262,32 @@ class TestShippedProfilesContent:
         profile = repo.get(profile_id)
         assert profile is not None
         assert profile.name.strip(), f"Profile '{profile_id}' has empty name"
+
+    @pytest.mark.parametrize("profile_id", sorted(EXPECTED_PROFILE_IDS))
+    def test_self_identity_prose_matches_name(self, repo: AgentProfileRepository, profile_id: str):
+        """Any "<role-word> <Token>"-shaped self-identity phrase in purpose/init prose
+        must equal the profile's own name.
+
+        DIRECTIVE_043 (Close Defect Classes by Construction): the profile's own
+        ``name:`` field is the single source of truth for identity. Prose that
+        restates identity (e.g. "Researcher Robbie reduces uncertainty...", "I am
+        Researcher Robbie...") is free to do so, but it must not drift from
+        ``name`` the way researcher-robbie's purpose/init once drifted to
+        "Researcher Rosa". This does not require every profile to declare an
+        identity at all -- several (generic-agent, human-in-charge,
+        retrospective-facilitator) phrase their prose differently and are left
+        untouched by this check.
+        """
+        profile = repo.get(profile_id)
+        assert profile is not None
+        role_word = profile.name.split()[0]
+        prose = f"{profile.purpose}\n{profile.initialization_declaration}"
+        pattern = re.compile(rf"\b{re.escape(role_word)}\s+[A-Z][A-Za-z'-]*\b")
+        for match in pattern.finditer(prose):
+            assert match.group(0) == profile.name, (
+                f"Profile '{profile_id}' prose declares identity '{match.group(0)}' "
+                f"which does not match its own name '{profile.name}'"
+            )
 
     @pytest.mark.parametrize(
         "profile_id,expected_priority",


### PR DESCRIPTION
## What changes for you

The **`researcher-robbie`** agent profile no longer introduces itself under the
wrong name. Before this fix, any agent that profile-loaded `researcher-robbie`
and followed its initialization declaration announced itself as **"Researcher
Rosa"** — even though the profile's own `name` field, its docs page, and every
sibling profile said **"Researcher Robbie"**. Operators saw an agent whose
self-introduction contradicted its own identity.

## The fix

The profile's `purpose` (line 31) and `initialization-declaration` (line 80)
prose still carried the pre-rename name "Researcher Rosa". Both now read
"Researcher Robbie", matching the profile's own `name:` field.

This finishes unfinished work from mission
`profile-roles-as-value-object-01KPRJRY`, which specified exactly this rename:
the `name:` field and the docs page were updated at the time, but the two YAML
prose fields were missed.

## Why it can't silently recur

Adds `TestShippedProfilesContent::test_self_identity_prose_matches_name`,
parametrized over **all** shipped profiles. It asserts that any
`"<role-word> <Token>"`-shaped self-identity phrase in a profile's
`purpose`/`initialization-declaration` prose equals that profile's own `name`
field — so identity drift between a profile's prose and its `name` is caught by
construction, not by review vigilance (DIRECTIVE_043). Profiles that phrase
their prose differently (e.g. `generic-agent`, `human-in-charge`,
`retrospective-facilitator`) are left untouched.

**Red-first proof** (run during landing): with the fix reverted, the new test
fails with `Profile 'researcher-robbie' prose declares identity 'Researcher
Rosa' which does not match its own name 'Researcher Robbie'`; with the fix
restored, all 25 cases pass.

## Tests

- `tests/doctrine/test_shipped_profiles.py` — new parametrized
  `test_self_identity_prose_matches_name` (existing file; already carries
  `pytestmark = [fast, doctrine, corpus]`).

## Landing notes

- Rebased onto current `upstream/main`; clean rebase, no conflicts.
- Both red checks (`regression tests (blocking)`, `quality-gate`) reproduce
  identically on the merge-base (`a369f781b`) — pre-existing honest red-main
  (the `tests/regression/` open-P0 suite, ADR 2026-07-17-1) and its downstream
  aggregation. **This PR introduces zero new reds.**
- Folds (2):
  - `docs(landing):` changelog entry under `[Unreleased] → 🐛 Fixed`.
  - `test(landing):` **boy-scout** — de-tautologizes two determinism
    assertions in `tests/architectural/test_home_pin_scan_limbs.py`
    (`assert f(x) == f(x)` → distinct-variable form). These were pre-existing
    **main** breakage from `#3121` (SonarCloud `python:S5863`) that had dropped
    new-code reliability to C and failed the main-only SonarCloud gate. Cleared
    here while the branch was open; determinism intent unchanged. (SonarCloud
    does not run on PRs, so this fold turns no PR check green — it keeps `main`
    green after merge.)
- `ruff` clean; terminology guard, docs-freshness (`errors=0`), and markdownlint
  on the changelog all pass. Both folded tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
