### PR TITLE
docs(architecture): declarative transition gates + nested mission subtree — design ADRs + diagrams

### DIFF
--- a/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
+++ b/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
@@ -1,0 +1,162 @@
+---
+title: 'ADR: The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface'
+description: 'Rejects flattening packs/built-in/missions/ into top-level dirs; fixes the nested per-type bundle as canonical and retires built_in_step_contracts (MissionStepContract) in favour of the unified MissionStep model.'
+status: Accepted
+date: '2026-08-13'
+related:
+- docs/architecture/mission-type-resolution.md
+- docs/architecture/doctrine-kinds.md
+- docs/adr/3.x/2026-08-05-1-mission-type-availability-before-kind-promotion.md
+- docs/adr/3.x/2026-07-26-2-doctrine-artefact-pack-layout-convention.md
+---
+# The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface
+
+**Filename:** `2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md`
+
+**Status:** Accepted
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** Discharges the nested-vs-flat mission-type layout decision that
+[ADR 2026-08-05-1](2026-08-05-1-mission-type-availability-before-kind-promotion.md) (§"a
+short decision record of its own") explicitly reserved. Completes the FR-011 unified-step
+migration begun in mission `charter-doctrine-mission-type-configuration-01KSWJVX`.
+
+---
+
+## Context and Problem Statement
+
+`packs/built-in/missions/` is a **nested subtree**, unlike the flat `<plural>/` content
+dirs the other doctrine kinds use. It holds, per grounding research
+(`work/doctrine-pack-restructure-research/01-current-structure-and-loaders.md`):
+
+- `mission_types/*.yaml` — the mission-type **identity registry** (`id` + `display_name`).
+- `mission-steps/<type>/<step>/{step.yaml,prompt.md,guidelines.md}` — the **unified
+  `MissionStep`** model (FR-011), the canonical per-step authority.
+- `built_in_step_contracts/*.step-contract.yaml` — the **legacy `MissionStepContract`**
+  shape, explicitly "retained as a compatibility surface … until later WPs migrate those
+  callers to the unified model" (`src/doctrine/missions/step_contracts.py:1-17`).
+- Per-type **self-contained bundles** `<type>/` — `mission.yaml` (state machine),
+  `actions/<action>/index.yaml` (delegation map), `templates/`, `mission-runtime.yaml`,
+  `expected-artifacts.yaml`, `governance-profile.yaml`.
+
+A restructure was proposed to **flatten** the subtree into two top-level dirs
+(`packs/built-in/mission-types/` + `packs/built-in/step-contracts/`, deprecating
+`missions/`) so built-in would look like a "normal" pack. Grounding showed this flatten
+is expensive and fights existing invariants: it does not account for the unified
+`mission-steps/` surface or the per-type runtime bundles (the two-dir target names neither);
+it would red the Accepted layout gate in
+[ADR 2026-07-26-2](2026-07-26-2-doctrine-artefact-pack-layout-convention.md) that pins step-contracts
+at `missions/built_in_step_contracts/`; it collides with kernel-floor path constants; and it
+pulls built-in toward a DRG layout that still conflicts with the org-pack `drg/fragment.yaml`
+convention (so "one canonical structure" would not actually be achieved). Meanwhile the
+nested per-type organisation is already clean: each mission type is a self-contained
+directory that offers its own identity, steps, state machine, actions, templates, and
+governance.
+
+Two things are therefore in tension and need a recorded decision: **(1)** whether to flatten,
+and **(2)** what to do about the two coexisting step surfaces (`built_in_step_contracts/`
+legacy vs `mission-steps/` unified), which are a live drift hazard.
+
+## Decision Drivers
+
+* **Single canonical authority** — two step surfaces (`MissionStepContract` vs `MissionStep`)
+  for "a mission's steps" violate it and must collapse to one.
+* **Self-containment / legibility** — a per-mission-type directory that carries everything
+  that type needs is easier to reason about, override, and extend than a flat collapse.
+* **Do not break Accepted ADRs or kernel-floor invariants without cause.**
+* **Avoid speculative convergence** — matching the org-pack shape is only worthwhile if it is
+  actually reached; a half-flatten that still differs from org packs buys nothing.
+
+## Considered Options
+
+* **Option A — Flatten** to top-level `mission-types/` + `step-contracts/`, deprecate
+  `missions/`.
+* **Option B — Keep the nested subtree canonical; retire the legacy step-contract surface**
+  so the remaining structure is unambiguous.
+* **Option C — Keep everything as-is**, including both step surfaces (status quo).
+
+## Decision Outcome
+
+**Chosen option: "Option B".** The nested `packs/built-in/missions/` subtree is the canonical
+built-in mission layout. It is **not** flattened. The legacy step-contract surface is
+**retired in its entirety**.
+
+### Canonical structure (fixed by this ADR)
+
+```
+packs/built-in/missions/
+├── mission_types/<type>.yaml                     # identity registry (id + display_name)
+├── mission-steps/<type>/<step>/                  # UNIFIED MissionStep (sole step authority)
+│   ├── step.yaml
+│   ├── prompt.md
+│   └── guidelines.md
+└── <type>/                                        # self-contained per-type bundle
+    ├── mission.yaml                               # state machine
+    ├── mission-runtime.yaml                       # runtime DAG
+    ├── expected-artifacts.yaml                    # dossier manifest
+    ├── governance-profile.yaml                    # type-grain governance
+    ├── actions/<action>/index.yaml                # action-grain delegation map
+    └── templates/                                 # content scaffolds
+```
+
+Each mission type is a **self-contained directory**; two flat registries (`mission_types/`,
+`mission-steps/`) index identity and steps across types. This is the intended shape and
+should not be flattened toward the org-pack `<plural>/` + `drg/fragment.yaml` convention.
+Built-in remaining structurally distinct from org packs is **accepted and intentional** — it
+is the positionally-anchored base layer, not a registered path-resolved pack.
+
+### The legacy step-contract surface is removed
+
+`built_in_step_contracts/` (the on-disk `*.step-contract.yaml` files, 17 today), the
+`MissionStepContract` / `MissionStepContractStep` models and repository/loader
+(`src/doctrine/missions/step_contracts.py`), the `src/specify_cli/mission_step_contracts/`
+package, the `mission_step_contract` `ArtifactKind` and its DRG fragment
+(`packs/built-in/mission_step_contract.graph.yaml`, 34 nodes), and every remaining caller of
+that surface are migrated onto the unified `MissionStep` model and then deleted. This
+completes FR-011.
+
+### Consequences
+
+#### Positive
+
+* One step model (`MissionStep`), one step surface (`mission-steps/`) — the drift hazard is
+  gone.
+* The per-type bundle stays legible and self-contained; overrides and new mission types have
+  an obvious home.
+* No churn against the kernel-floor `missions` leaf, the missions-root authority, or the
+  ~23 `default_missions_root()` consumers (nothing moves).
+
+#### Negative
+
+* Removing the legacy surface is a **large, cross-cutting migration** (~45 src files + ~40
+  test files reference it; the runtime contract registry, contract synthesis, and review
+  gate bindings must move to `MissionStep` first). It is breaking and must land behind the
+  unified model being feature-complete for gates.
+* Deleting the `mission_step_contract` DRG fragment changes the built-in graph identity
+  (node/edge cardinality drops by 34 nodes); the parity fixture/golden must be re-baselined
+  in the same change, not silently.
+
+#### Neutral
+
+* Built-in stays asymmetric to org packs by design; the separate pack-meta / README /
+  built-in-validator work (see the pack-restructure research) is orthogonal and unaffected.
+
+### Confirmation
+
+Enforced, not aspirational: after migration, no `src/` symbol imports
+`MissionStepContract*` and no `*.step-contract.yaml` remains under `packs/built-in/`
+(architectural guard); the unified `MissionStep` resolver carries the gate semantics the
+contracts previously held (behavioural test); the built-in DRG parity fixture is
+re-baselined to the post-removal cardinality; `spec-kitty doctor doctrine --json` reports
+healthy.
+
+## More Information
+
+* Grounding research: `work/doctrine-pack-restructure-research/` (`01`–`05`, `99-SYNTHESIS.md`).
+* Supersedes point 5 of [ADR 2026-07-26-2](2026-07-26-2-doctrine-artefact-pack-layout-convention.md)
+  (which pins step-contracts at `missions/built_in_step_contracts/`) — that path is removed.
+* Does not contradict [ADR 2026-05-16-1](2026-05-16-1-doctrine-layer-merge-semantics.md)
+  (merge semantics) or the shared-package-boundary ADR (packaging).

--- a/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
+++ b/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
@@ -62,21 +62,21 @@ legacy vs `mission-steps/` unified), which are a live drift hazard.
 
 ## Decision Drivers
 
-* **Single canonical authority** — two step surfaces (`MissionStepContract` vs `MissionStep`)
+- **Single canonical authority** — two step surfaces (`MissionStepContract` vs `MissionStep`)
   for "a mission's steps" violate it and must collapse to one.
-* **Self-containment / legibility** — a per-mission-type directory that carries everything
+- **Self-containment / legibility** — a per-mission-type directory that carries everything
   that type needs is easier to reason about, override, and extend than a flat collapse.
-* **Do not break Accepted ADRs or kernel-floor invariants without cause.**
-* **Avoid speculative convergence** — matching the org-pack shape is only worthwhile if it is
+- **Do not break Accepted ADRs or kernel-floor invariants without cause.**
+- **Avoid speculative convergence** — matching the org-pack shape is only worthwhile if it is
   actually reached; a half-flatten that still differs from org packs buys nothing.
 
 ## Considered Options
 
-* **Option A — Flatten** to top-level `mission-types/` + `step-contracts/`, deprecate
+- **Option A — Flatten** to top-level `mission-types/` + `step-contracts/`, deprecate
   `missions/`.
-* **Option B — Keep the nested subtree canonical; retire the legacy step-contract surface**
+- **Option B — Keep the nested subtree canonical; retire the legacy step-contract surface**
   so the remaining structure is unambiguous.
-* **Option C — Keep everything as-is**, including both step surfaces (status quo).
+- **Option C — Keep everything as-is**, including both step surfaces (status quo).
 
 ## Decision Outcome
 
@@ -122,26 +122,26 @@ completes FR-011.
 
 #### Positive
 
-* One step model (`MissionStep`), one step surface (`mission-steps/`) — the drift hazard is
+- One step model (`MissionStep`), one step surface (`mission-steps/`) — the drift hazard is
   gone.
-* The per-type bundle stays legible and self-contained; overrides and new mission types have
+- The per-type bundle stays legible and self-contained; overrides and new mission types have
   an obvious home.
-* No churn against the kernel-floor `missions` leaf, the missions-root authority, or the
+- No churn against the kernel-floor `missions` leaf, the missions-root authority, or the
   ~23 `default_missions_root()` consumers (nothing moves).
 
 #### Negative
 
-* Removing the legacy surface is a **large, cross-cutting migration** (~45 src files + ~40
+- Removing the legacy surface is a **large, cross-cutting migration** (~45 src files + ~40
   test files reference it; the runtime contract registry, contract synthesis, and review
   gate bindings must move to `MissionStep` first). It is breaking and must land behind the
   unified model being feature-complete for gates.
-* Deleting the `mission_step_contract` DRG fragment changes the built-in graph identity
+- Deleting the `mission_step_contract` DRG fragment changes the built-in graph identity
   (node/edge cardinality drops by 34 nodes); the parity fixture/golden must be re-baselined
   in the same change, not silently.
 
 #### Neutral
 
-* Built-in stays asymmetric to org packs by design; the separate pack-meta / README /
+- Built-in stays asymmetric to org packs by design; the separate pack-meta / README /
   built-in-validator work (see the pack-restructure research) is orthogonal and unaffected.
 
 ### Confirmation
@@ -155,8 +155,8 @@ healthy.
 
 ## More Information
 
-* Grounding research: `work/doctrine-pack-restructure-research/` (`01`–`05`, `99-SYNTHESIS.md`).
-* Supersedes point 5 of [ADR 2026-07-26-2](2026-07-26-2-doctrine-artefact-pack-layout-convention.md)
+- Grounding research: `work/doctrine-pack-restructure-research/` (`01`–`05`, `99-SYNTHESIS.md`).
+- Supersedes point 5 of [ADR 2026-07-26-2](2026-07-26-2-doctrine-artefact-pack-layout-convention.md)
   (which pins step-contracts at `missions/built_in_step_contracts/`) — that path is removed.
-* Does not contradict [ADR 2026-05-16-1](2026-05-16-1-doctrine-layer-merge-semantics.md)
+- Does not contradict [ADR 2026-05-16-1](2026-05-16-1-doctrine-layer-merge-semantics.md)
   (merge semantics) or the shared-package-boundary ADR (packaging).

--- a/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
+++ b/docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface'
-description: 'Rejects flattening packs/built-in/missions/ into top-level dirs; fixes the nested per-type bundle as canonical and retires built_in_step_contracts (MissionStepContract) in favour of the unified MissionStep model.'
+description: 'Keeps the nested per-type packs/built-in/missions/ bundle canonical (no flattening) and retires built_in_step_contracts in favour of the unified MissionStep model.'
 status: Accepted
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+++ b/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
@@ -24,6 +24,24 @@ Gate semantics must be re-homed onto the unified `MissionStep` model as part of 
 
 ---
 
+## Post-dialectics revision (2026-08-13)
+
+Hardened after the dialectics pass (`work/gate-design-dialectics/`, `99-COHERENCE.md`). Settled deltas:
+
+- **KEEP — gate is a first-class `ArtifactKind`** (operator decision, over the dialectic's
+  boilerplate objection). Accept the ~8 totality-map edits as the cost of a uniform kind model.
+- **CHANGE — no shell `entrypoint`.** Invocation is a **structured `interpreter` + `args` list**
+  with `{asset}` as one argv element, no shell string (removes injection + the
+  `sys.executable`-lacks-deps trap).
+- **CHANGE — outcome is a structured JSON verdict carrying a severity, not exit-code + a
+  fail-closed boolean.** Block-vs-proceed is decided by the operator's error-handling strategy
+  over the severity ladder — see [ADR 2026-08-13-6](2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md).
+  The "fail-closed by default" language below is **superseded** by that model.
+- **CLARIFY — `spec-kitty-pre-review` stays a grandfathered *code* gate** (its inputs are an
+  injected `ScopeSource` + baseline + changed-files SSOT, not cwd+exit-code). The dispatcher is
+  "one generic declarative dispatcher **plus a few code gates**," not a full collapse.
+- **ADD — determinism must be *enforced* by a sandbox** (network-denied, bounded), not asserted.
+
 ## Context and Problem Statement
 
 Today a transition gate is a **binding** in a step-contract YAML — `on_transition:

--- a/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+++ b/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
@@ -62,36 +62,36 @@ declared as data and shipped in the pack rather than compiled into the CLI.
 
 ## Decision Drivers
 
-* Gates should ship *with* the mission-type doctrine that needs them, per-type where relevant.
-* Single canonical authority — one step model (`MissionStep`), one gate mechanism.
-* Reuse the existing `asset` kind (the sanctioned way to ship executable logic downstream)
+- Gates should ship *with* the mission-type doctrine that needs them, per-type where relevant.
+- Single canonical authority — one step model (`MissionStep`), one gate mechanism.
+- Reuse the existing `asset` kind (the sanctioned way to ship executable logic downstream)
   rather than invent a second code-shipping mechanism.
-* Determinism must be preserved and enforced (gates are pure checks, never mutate state).
+- Determinism must be preserved and enforced (gates are pure checks, never mutate state).
 
 ## Considered Options
 
-* **A — Keep the Python handler registry**, add handlers as needed (status quo, code-deploy per gate).
-* **B — Declarative `gate` artefact kind**, check logic referenced from an `asset`, invoked via an entrypoint.
-* **C — Inline command strings** in the gate/step YAML (no asset), executed directly.
+- **A — Keep the Python handler registry**, add handlers as needed (status quo, code-deploy per gate).
+- **B — Declarative `gate` artefact kind**, check logic referenced from an `asset`, invoked via an entrypoint.
+- **C — Inline command strings** in the gate/step YAML (no asset), executed directly.
 
 ## Decision Outcome
 
 **Chosen option: "B".** A gate is a **first-class doctrine `ArtifactKind`** (`gate`), tiered
 and DRG-participating like every other kind, reusable by id.
 
-* **Code ships as an `asset`** (unchanged loose-contract inert blob, `mime` + `path`,
+- **Code ships as an `asset`** (unchanged loose-contract inert blob, `mime` + `path`,
   resolved to a path, never auto-executed). The gate *references* the asset by id.
-* **The gate declares how to run it** via an `entrypoint` (a Docker-style oneliner, e.g.
+- **The gate declares how to run it** via an `entrypoint` (a Docker-style oneliner, e.g.
   `python {asset} --strict`, where `{asset}` resolves to the asset path). Option C (inline
   command strings) is **rejected**: it creates an unsandboxed arbitrary-shell surface inside
   the pack for negligible convenience over an asset.
-* **Fail-closed by default** (`disposition: fail_closed`) — a flip from today's lone
+- **Fail-closed by default** (`disposition: fail_closed`) — a flip from today's lone
   fail-open gate. Exit `0` = pass; non-zero = fail; captured stderr becomes the
   `GateVerdict` reason.
-* **Binding lives on the `MissionStep`** (`gates: [{on_transition, gate: <id>, ...}]`) —
+- **Binding lives on the `MissionStep`** (`gates: [{on_transition, gate: <id>, ...}]`) —
   definition (what the check is) and binding (when it fires) are cleanly separated. This
   keeps the edge-scoped transition model and `TransitionGateContext`.
-* **`GATE_REGISTRY` collapses to one generic dispatcher** (`declarative-gate`) that reads the
+- **`GATE_REGISTRY` collapses to one generic dispatcher** (`declarative-gate`) that reads the
   gate, runs the entrypoint against the referenced asset, and returns a `GateVerdict`. Named
   per-gate Python handlers are retired; the existing `spec-kitty-pre-review` gate is
   re-expressed declaratively (or kept as a single grandfathered code gate — see open Q).
@@ -99,23 +99,27 @@ and DRG-participating like every other kind, reusable by id.
 ### Consequences
 
 #### Positive
-* Adding/changing a gate is a doctrine edit, shippable per mission-type in the pack.
-* One code-shipping mechanism (assets); the asset kind keeps its inert loose contract.
-* Determinism is enforceable (pure check, exit-code contract).
+
+- Adding/changing a gate is a doctrine edit, shippable per mission-type in the pack.
+- One code-shipping mechanism (assets); the asset kind keeps its inert loose contract.
+- Determinism is enforceable (pure check, exit-code contract).
 
 #### Negative
-* "Execute an asset" is **net-new machinery** — assets are resolved to a path today and
+
+- "Execute an asset" is **net-new machinery** — assets are resolved to a path today and
   never executed (see [ADR 2026-08-13-3](2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md)
   for *where* it runs and [ADR 2026-08-13-4](2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md)
   for *whether* it may run).
-* Fail-closed-by-default is a behaviour change; existing flows must be audited for gates that
+- Fail-closed-by-default is a behaviour change; existing flows must be audited for gates that
   were relying on fail-open.
 
 #### Neutral
-* A new `gate` `ArtifactKind` is added shortly after `mission_step_contract` is removed — net
+
+- A new `gate` `ArtifactKind` is added shortly after `mission_step_contract` is removed — net
   kind count roughly unchanged, but the new kind is declarative-data, not a code registry.
 
 ### Open questions (for the dialectics squad)
+
 1. Does `spec-kitty-pre-review` become a declarative gate, or stay a single grandfathered code gate?
 2. One asset per gate, or may a gate carry its own blob (collapsing asset+gate for non-reused checks)?
 3. Gate→asset DRG edge: reuse `requires`, or a dedicated relation?

--- a/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+++ b/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Transition gates are declarative, asset-backed, first-class doctrine artefacts'
-description: 'Replaces the named-Python-handler gate registry with a first-class declarative `gate` doctrine kind whose check logic ships as an asset invoked through an entrypoint, fail-closed by default, dispatched by one generic handler.'
+description: 'Replaces the named-Python-handler gate registry with a first-class declarative `gate` kind whose check ships as an asset invoked via an entrypoint, fail-closed by default.'
 status: Proposed
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+++ b/docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
@@ -1,0 +1,104 @@
+---
+title: 'ADR: Transition gates are declarative, asset-backed, first-class doctrine artefacts'
+description: 'Replaces the named-Python-handler gate registry with a first-class declarative `gate` doctrine kind whose check logic ships as an asset invoked through an entrypoint, fail-closed by default, dispatched by one generic handler.'
+status: Proposed
+date: '2026-08-13'
+related:
+- docs/architecture/mission-gates.md
+- docs/architecture/doctrine-kinds.md
+- docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
+---
+# Transition gates are declarative, asset-backed, first-class doctrine artefacts
+
+**Filename:** `2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md`
+
+**Status:** Proposed
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** Follows [ADR 2026-08-13-1](2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md),
+which retires the legacy `MissionStepContract` surface that currently carries gate bindings.
+Gate semantics must be re-homed onto the unified `MissionStep` model as part of that removal.
+
+---
+
+## Context and Problem Statement
+
+Today a transition gate is a **binding** in a step-contract YAML — `on_transition:
+"in_progress->for_review"`, `handler: "spec-kitty-pre-review"`, `fail_open: true` — where
+`handler` is a *name* into `GATE_REGISTRY` (`src/specify_cli/review/gate_registry.py`), a
+Python dict whose `run: Callable[[TransitionGateContext], GateVerdict]` is compiled code.
+The binding is data, but the **check logic is Python registered in-process**. There is
+exactly one handler, and it is **fail-open**.
+
+Two problems: (1) adding a gate requires a code deploy (a new registered handler), not a
+doctrine edit, so gates cannot ship as part of a mission-type's doctrine pack; (2) retiring
+`MissionStepContract` (ADR 2026-08-13-1) removes the surface the gate binding lives on, so
+gate semantics must move to the unified `MissionStep` model regardless.
+
+Gates are **deterministic** — a simple code check or a script (documentation linting,
+consistency checks, structural validation). That determinism is the lever: the check can be
+declared as data and shipped in the pack rather than compiled into the CLI.
+
+## Decision Drivers
+
+* Gates should ship *with* the mission-type doctrine that needs them, per-type where relevant.
+* Single canonical authority — one step model (`MissionStep`), one gate mechanism.
+* Reuse the existing `asset` kind (the sanctioned way to ship executable logic downstream)
+  rather than invent a second code-shipping mechanism.
+* Determinism must be preserved and enforced (gates are pure checks, never mutate state).
+
+## Considered Options
+
+* **A — Keep the Python handler registry**, add handlers as needed (status quo, code-deploy per gate).
+* **B — Declarative `gate` artefact kind**, check logic referenced from an `asset`, invoked via an entrypoint.
+* **C — Inline command strings** in the gate/step YAML (no asset), executed directly.
+
+## Decision Outcome
+
+**Chosen option: "B".** A gate is a **first-class doctrine `ArtifactKind`** (`gate`), tiered
+and DRG-participating like every other kind, reusable by id.
+
+* **Code ships as an `asset`** (unchanged loose-contract inert blob, `mime` + `path`,
+  resolved to a path, never auto-executed). The gate *references* the asset by id.
+* **The gate declares how to run it** via an `entrypoint` (a Docker-style oneliner, e.g.
+  `python {asset} --strict`, where `{asset}` resolves to the asset path). Option C (inline
+  command strings) is **rejected**: it creates an unsandboxed arbitrary-shell surface inside
+  the pack for negligible convenience over an asset.
+* **Fail-closed by default** (`disposition: fail_closed`) — a flip from today's lone
+  fail-open gate. Exit `0` = pass; non-zero = fail; captured stderr becomes the
+  `GateVerdict` reason.
+* **Binding lives on the `MissionStep`** (`gates: [{on_transition, gate: <id>, ...}]`) —
+  definition (what the check is) and binding (when it fires) are cleanly separated. This
+  keeps the edge-scoped transition model and `TransitionGateContext`.
+* **`GATE_REGISTRY` collapses to one generic dispatcher** (`declarative-gate`) that reads the
+  gate, runs the entrypoint against the referenced asset, and returns a `GateVerdict`. Named
+  per-gate Python handlers are retired; the existing `spec-kitty-pre-review` gate is
+  re-expressed declaratively (or kept as a single grandfathered code gate — see open Q).
+
+### Consequences
+
+#### Positive
+* Adding/changing a gate is a doctrine edit, shippable per mission-type in the pack.
+* One code-shipping mechanism (assets); the asset kind keeps its inert loose contract.
+* Determinism is enforceable (pure check, exit-code contract).
+
+#### Negative
+* "Execute an asset" is **net-new machinery** — assets are resolved to a path today and
+  never executed (see [ADR 2026-08-13-3](2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md)
+  for *where* it runs and [ADR 2026-08-13-4](2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md)
+  for *whether* it may run).
+* Fail-closed-by-default is a behaviour change; existing flows must be audited for gates that
+  were relying on fail-open.
+
+#### Neutral
+* A new `gate` `ArtifactKind` is added shortly after `mission_step_contract` is removed — net
+  kind count roughly unchanged, but the new kind is declarative-data, not a code registry.
+
+### Open questions (for the dialectics squad)
+1. Does `spec-kitty-pre-review` become a declarative gate, or stay a single grandfathered code gate?
+2. One asset per gate, or may a gate carry its own blob (collapsing asset+gate for non-reused checks)?
+3. Gate→asset DRG edge: reuse `requires`, or a dedicated relation?
+4. Where do gate *inputs* come from (env vars vs args vs cwd contents)? (Depth handled in ADR -3.)

--- a/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+++ b/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Gate execution targets a surface through a kernel selector and the topology placement seam'
-description: 'A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the topology-aware placement seam gains an execute verb that resolves it to a physical workdir, unifying where artifacts are read, written, and run.'
+description: 'A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the placement seam gains an execute verb that resolves it to a physical workdir.'
 status: Proposed
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+++ b/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
@@ -61,31 +61,31 @@ violation.
 
 ## Decision Drivers
 
-* One mechanism for "where to look / write / run" — do not fork a second workdir resolver.
-* Respect layer directionality (doctrine must not import upward into `mission_runtime`).
-* Keep the doctrine schema's dependency footprint minimal.
+- One mechanism for "where to look / write / run" — do not fork a second workdir resolver.
+- Respect layer directionality (doctrine must not import upward into `mission_runtime`).
+- Keep the doctrine schema's dependency footprint minimal.
 
 ## Considered Options
 
-* **A — Free-form workdir enum on the gate** (`repo_root` | `mission_dossier` | `wp_worktree`), resolved by a new gate-local helper.
-* **B — Surface selector routed through the placement seam.** The gate declares an
+- **A — Free-form workdir enum on the gate** (`repo_root` | `mission_dossier` | `wp_worktree`), resolved by a new gate-local helper.
+- **B — Surface selector routed through the placement seam.** The gate declares an
   `executionTarget` from a small **kernel-owned** surface-selector vocabulary; the
   topology-aware seam gains an `execute_dir` verb that resolves it.
-* **C — Ship the whole `MissionTopology` enum down into `doctrine`** so the gate schema types the field against it directly.
+- **C — Ship the whole `MissionTopology` enum down into `doctrine`** so the gate schema types the field against it directly.
 
 ## Decision Outcome
 
 **Chosen option: "B".**
 
-* A gate carries `executionTarget: <selector>` where the selector comes from a **small
+- A gate carries `executionTarget: <selector>` where the selector comes from a **small
   surface-selector vocabulary elevated into `kernel`** (e.g. `primary` | `coord` | `lane` |
   `repo_root`). Kernel is the root layer, so `doctrine` may import it without violating
   directionality. `src/kernel/` already hosts this class of shared primitive (`paths.py`,
   `clock.py`).
-* The placement seam gains a **third verb, `execute_dir`**, over the same
+- The placement seam gains a **third verb, `execute_dir`**, over the same
   `(surface, topology, materialization)` inputs it already uses for `read_dir`/`write_target`.
   The topology *math* stays in `mission_runtime`; doctrine only names a selector.
-* Option C is rejected — it drags a runtime-shaped enum into the doctrine layer. Option A is
+- Option C is rejected — it drags a runtime-shaped enum into the doctrine layer. Option A is
   rejected — it forks a second "where" resolver the placement seam already owns.
 
 This subsumes the gate's working-directory question into the one partition decision every
@@ -95,20 +95,24 @@ primary; in `LANES_WITH_COORD` `coord` and `lane` diverge, exactly as reads/writ
 ### Consequences
 
 #### Positive
-* Gate execution location is topology-correct for free, and consistent with read/write placement.
-* Elevating the selector strengthens the seam (the placement doc notes callers that still bypass it).
+
+- Gate execution location is topology-correct for free, and consistent with read/write placement.
+- Elevating the selector strengthens the seam (the placement doc notes callers that still bypass it).
 
 #### Negative
-* Elevating a vocabulary into `kernel` + adding a seam verb is cross-cutting (touches kernel,
+
+- Elevating a vocabulary into `kernel` + adding a seam verb is cross-cutting (touches kernel,
   the placement seam, and the gate schema) — larger than a gate-local field.
-* The selector vocabulary and `MissionTopology`/`TopologySurface` must be kept in sync; a
+- The selector vocabulary and `MissionTopology`/`TopologySurface` must be kept in sync; a
   contract test is required to prevent drift.
 
 #### Neutral
-* Whether the elevated vocabulary is a brand-new selector enum or a subset of the existing
+
+- Whether the elevated vocabulary is a brand-new selector enum or a subset of the existing
   `TopologySurface` is a design detail (open Q).
 
 ### Open questions (for the dialectics squad)
+
 1. New kernel selector enum, or elevate/reuse `TopologySurface` itself?
 2. Is `execute_dir` truly the same resolution as `read_dir`, or does execution need a distinct
    materialization rule (e.g. must the lane worktree already exist)?

--- a/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+++ b/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
@@ -24,6 +24,23 @@ context**. Rather than a free-form enum, this reuses the existing placement seam
 
 ---
 
+## Post-dialectics revision (2026-08-13)
+
+Hardened after the dialectics pass (`work/gate-design-dialectics/02-...`, `99-COHERENCE.md`). Settled deltas:
+
+- **CHANGE — no kernel elevation.** Doctrine only needs to validate a token **string**, so
+  **doctrine owns the surface-selector `frozenset[str]`** (it owns the gate schema anyway),
+  **specify_cli owns the resolver map**, and a **parity test** binds them. Layer directionality
+  is satisfied with **zero kernel change**. Option C below (ship `MissionTopology` into doctrine)
+  and the "elevate a vocabulary into kernel" framing are **superseded** by this.
+- **CHANGE — `execute_dir` ≠ `read_dir`.** It must **reuse the existing stamped
+  `GateExecutionContext`** (`build_gate_execution_context`, honouring `surface_cannot_hold`),
+  never return a bare `Path` — a bare workdir strips the surface stamp and reopens the
+  #2885/#1834 pass-by-default-against-empty-tree failure. `lane` additionally needs a `wp_id`
+  and the materialization-aware `resolve_workspace_for_wp` (a different resolver from reads).
+- **CLARIFY — `repo_root` is a loud, non-default escape hatch** ("judge the ambient checkout"),
+  never the default selector.
+
 ## Context and Problem Statement
 
 A gate that runs a check needs to know *where* it runs — the repo root, the mission's

--- a/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+++ b/docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
@@ -1,0 +1,99 @@
+---
+title: 'ADR: Gate execution targets a surface through a kernel selector and the topology placement seam'
+description: 'A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the topology-aware placement seam gains an execute verb that resolves it to a physical workdir, unifying where artifacts are read, written, and run.'
+status: Proposed
+date: '2026-08-13'
+related:
+- docs/architecture/mission-gates.md
+- docs/architecture/artifact-placement-seam.md
+- docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+---
+# Gate execution targets a surface through a kernel selector and the topology placement seam
+
+**Filename:** `2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md`
+
+**Status:** Proposed
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** Depends on [ADR 2026-08-13-2](2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md).
+A declarative gate that executes an asset needs a defined **working directory / execution
+context**. Rather than a free-form enum, this reuses the existing placement seam.
+
+---
+
+## Context and Problem Statement
+
+A gate that runs a check needs to know *where* it runs — the repo root, the mission's
+primary planning tree, the coord status tree, or a WP lane worktree. Which physical tree each
+of those is depends on the mission's **topology**.
+
+That mapping already exists. The **placement seam**
+(`docs/architecture/artifact-placement-seam.md`) resolves `(MissionArtifactKind,
+MissionTopology, materialization)` → a `TopologySurface` (`src/mission_runtime/artifacts.py:22`)
+→ a physical tree, via `PlacementSeam` (`src/mission_runtime/resolution.py:1373`). It answers
+**read_dir** and **write_target** today. It does **not** answer "execute in".
+
+`MissionTopology` (`src/mission_runtime/context.py:55`) is the 2×2 coord×lanes grid
+(`SINGLE_BRANCH` / `LANES` / `COORD` / `LANES_WITH_COORD`). It lives in `mission_runtime`,
+which is **above `doctrine`** in the layer graph (`kernel ← doctrine ← charter ← runtime`).
+A doctrine-layer gate schema that referenced it would be an **upward import** — a layering
+violation.
+
+## Decision Drivers
+
+* One mechanism for "where to look / write / run" — do not fork a second workdir resolver.
+* Respect layer directionality (doctrine must not import upward into `mission_runtime`).
+* Keep the doctrine schema's dependency footprint minimal.
+
+## Considered Options
+
+* **A — Free-form workdir enum on the gate** (`repo_root` | `mission_dossier` | `wp_worktree`), resolved by a new gate-local helper.
+* **B — Surface selector routed through the placement seam.** The gate declares an
+  `executionTarget` from a small **kernel-owned** surface-selector vocabulary; the
+  topology-aware seam gains an `execute_dir` verb that resolves it.
+* **C — Ship the whole `MissionTopology` enum down into `doctrine`** so the gate schema types the field against it directly.
+
+## Decision Outcome
+
+**Chosen option: "B".**
+
+* A gate carries `executionTarget: <selector>` where the selector comes from a **small
+  surface-selector vocabulary elevated into `kernel`** (e.g. `primary` | `coord` | `lane` |
+  `repo_root`). Kernel is the root layer, so `doctrine` may import it without violating
+  directionality. `src/kernel/` already hosts this class of shared primitive (`paths.py`,
+  `clock.py`).
+* The placement seam gains a **third verb, `execute_dir`**, over the same
+  `(surface, topology, materialization)` inputs it already uses for `read_dir`/`write_target`.
+  The topology *math* stays in `mission_runtime`; doctrine only names a selector.
+* Option C is rejected — it drags a runtime-shaped enum into the doctrine layer. Option A is
+  rejected — it forks a second "where" resolver the placement seam already owns.
+
+This subsumes the gate's working-directory question into the one partition decision every
+other mission artifact already routes through: in `SINGLE_BRANCH` all selectors collapse to
+primary; in `LANES_WITH_COORD` `coord` and `lane` diverge, exactly as reads/writes do.
+
+### Consequences
+
+#### Positive
+* Gate execution location is topology-correct for free, and consistent with read/write placement.
+* Elevating the selector strengthens the seam (the placement doc notes callers that still bypass it).
+
+#### Negative
+* Elevating a vocabulary into `kernel` + adding a seam verb is cross-cutting (touches kernel,
+  the placement seam, and the gate schema) — larger than a gate-local field.
+* The selector vocabulary and `MissionTopology`/`TopologySurface` must be kept in sync; a
+  contract test is required to prevent drift.
+
+#### Neutral
+* Whether the elevated vocabulary is a brand-new selector enum or a subset of the existing
+  `TopologySurface` is a design detail (open Q).
+
+### Open questions (for the dialectics squad)
+1. New kernel selector enum, or elevate/reuse `TopologySurface` itself?
+2. Is `execute_dir` truly the same resolution as `read_dir`, or does execution need a distinct
+   materialization rule (e.g. must the lane worktree already exist)?
+3. Do gates ever need to run *outside* any mission surface (e.g. repo-root global checks), and
+   is `repo_root` a first-class selector or an escape hatch?

--- a/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+++ b/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)'
-description: 'Shipped doctrine code (gate assets) executes only from trusted publishers: built-in is release-signed and trusted by default; org/project packs use trust-on-first-use keyed on pack-meta identity; untrusted gates are skipped with a warning and never block or prompt at run time.'
+description: 'Gate assets execute only from trusted publishers: built-in is release-signed and trusted; org/project packs use trust-on-first-use; untrusted gates are skipped with a warning.'
 status: Proposed
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+++ b/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
@@ -59,56 +59,60 @@ by construction.
 
 ## Decision Drivers
 
-* Never execute unreviewed third-party code silently.
-* Never hang or block a mission on a trust decision — gates fire in CI and (later) under a
+- Never execute unreviewed third-party code silently.
+- Never hang or block a mission on a trust decision — gates fire in CI and (later) under a
   daemon, where no operator is present to prompt.
-* Reuse the `pack-meta.yaml` identity/version/content-hash already proposed for the pack
+- Reuse the `pack-meta.yaml` identity/version/content-hash already proposed for the pack
   restructure rather than invent a parallel identity.
 
 ## Considered Options
 
-* **A — Trust everything** (execute any pack's gate). Rejected: supply-chain hole.
-* **B — Trust nothing but built-in** (never run org/project gates). Rejected: kills the ecosystem value.
-* **C — Trust-on-first-use (TOFU), SSH-`known_hosts` style**, keyed on publisher identity.
+- **A — Trust everything** (execute any pack's gate). Rejected: supply-chain hole.
+- **B — Trust nothing but built-in** (never run org/project gates). Rejected: kills the ecosystem value.
+- **C — Trust-on-first-use (TOFU), SSH-`known_hosts` style**, keyed on publisher identity.
 
 ## Decision Outcome
 
 **Chosen option: "C".**
 
-* **Built-in / spec-kitty-signed = trusted by default.** Built-in ships a signature over its
+- **Built-in / spec-kitty-signed = trusted by default.** Built-in ships a signature over its
   `pack-meta.yaml` **content-hash**, verifiable against a bundled public release key. This
   gives the content-hash a second job (it is signed) alongside its cache-invalidation role.
-* **Org/project packs = TOFU.** On first encounter of a pack that ships executable gates, the
+- **Org/project packs = TOFU.** On first encounter of a pack that ships executable gates, the
   operator is asked, once, whether they trust the publisher (identity from `pack-meta.yaml`).
   The decision persists in a `known_hosts`-equivalent trust store in the spec-kitty home,
   keyed on publisher identity + the signed/observed content-hash.
-* **The trust prompt happens at pack activation/install time, never mid-transition.** At run
+- **The trust prompt happens at pack activation/install time, never mid-transition.** At run
   time the decision is looked up non-interactively.
-* **Low-trust ⇒ skip + warn, transition proceeds.** An untrusted gate is **not run**; a loud
+- **Low-trust ⇒ skip + warn, transition proceeds.** An untrusted gate is **not run**; a loud
   warning records that a transition guard was skipped due to low trust, and the transition is
   **not blocked**. Consequence stated explicitly: a fail-closed gate from an *untrusted* pack
   provides **zero protection** — gate protection is only ever as strong as the trust decision.
-* **CI / non-interactive is the governing constraint.** Unknown publisher at run time defaults
+- **CI / non-interactive is the governing constraint.** Unknown publisher at run time defaults
   to skip+warn — never a prompt, never a hang. Trust must be **pre-seedable** (config/flag) so
   CI and the daemon can run trusted gates without interaction.
 
 ### Consequences
 
 #### Positive
-* Third-party code never runs unreviewed; the operator's trust decision is explicit and persisted.
-* CI and automation never block or hang on trust; the safe default is "don't run untrusted code".
+
+- Third-party code never runs unreviewed; the operator's trust decision is explicit and persisted.
+- CI and automation never block or hang on trust; the safe default is "don't run untrusted code".
 
 #### Negative
-* Signing infrastructure (release key, signature in `pack-meta.yaml`, verification path) is
+
+- Signing infrastructure (release key, signature in `pack-meta.yaml`, verification path) is
   net-new and must be got right (key rotation, offline verification).
-* "Skip + proceed" means an untrusted security gate silently protects nothing — this must be
+- "Skip + proceed" means an untrusted security gate silently protects nothing — this must be
   surfaced loudly, or an operator may believe a gate is guarding a transition that it is not.
 
 #### Neutral
-* Trust is orthogonal to gate correctness — a trusted gate can still be a bad check; a rejected
+
+- Trust is orthogonal to gate correctness — a trusted gate can still be a bad check; a rejected
   gate can still be a good one that simply won't run.
 
 ### Open questions (for the dialectics squad)
+
 1. Prompt at activation vs first-execution (TOFU-faithful but interrupts a transition)?
 2. Is "skip + proceed" the right low-trust default, or should certain gate classes be able to
    declare "block if I cannot run" (turning untrust into a hard stop)?

--- a/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+++ b/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
@@ -1,0 +1,95 @@
+---
+title: 'ADR: Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)'
+description: 'Shipped doctrine code (gate assets) executes only from trusted publishers: built-in is release-signed and trusted by default; org/project packs use trust-on-first-use keyed on pack-meta identity; untrusted gates are skipped with a warning and never block or prompt at run time.'
+status: Proposed
+date: '2026-08-13'
+related:
+- docs/architecture/mission-gates.md
+- docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+---
+# Executable doctrine runs only from trusted publishers
+
+**Filename:** `2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md`
+
+**Status:** Proposed
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** [ADR 2026-08-13-2](2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md)
+makes gates run shipped code. Org and project packs can ship gates too — arbitrary code
+executing on every mission transition. That is a supply-chain surface and needs a trust model.
+
+---
+
+## Context and Problem Statement
+
+Declarative gates execute code shipped inside a doctrine pack. Built-in gates are first-party.
+But the pack ecosystem (org packs, project packs) means a downstream pack could ship a gate
+whose asset runs on every transition — an unreviewed code-execution surface. There is **no
+trust, signing, or provenance-verification machinery today** (grep confirms: the nearest is
+`drg/override_policy.py`, which is merge policy, not trust).
+
+Inert doctrine (directives, tactics, styleguides) is text and is never executed — so a trust
+decision is only ever needed for **executing shipped code** (gate assets). The scope is narrow
+by construction.
+
+## Decision Drivers
+
+* Never execute unreviewed third-party code silently.
+* Never hang or block a mission on a trust decision — gates fire in CI and (later) under a
+  daemon, where no operator is present to prompt.
+* Reuse the `pack-meta.yaml` identity/version/content-hash already proposed for the pack
+  restructure rather than invent a parallel identity.
+
+## Considered Options
+
+* **A — Trust everything** (execute any pack's gate). Rejected: supply-chain hole.
+* **B — Trust nothing but built-in** (never run org/project gates). Rejected: kills the ecosystem value.
+* **C — Trust-on-first-use (TOFU), SSH-`known_hosts` style**, keyed on publisher identity.
+
+## Decision Outcome
+
+**Chosen option: "C".**
+
+* **Built-in / spec-kitty-signed = trusted by default.** Built-in ships a signature over its
+  `pack-meta.yaml` **content-hash**, verifiable against a bundled public release key. This
+  gives the content-hash a second job (it is signed) alongside its cache-invalidation role.
+* **Org/project packs = TOFU.** On first encounter of a pack that ships executable gates, the
+  operator is asked, once, whether they trust the publisher (identity from `pack-meta.yaml`).
+  The decision persists in a `known_hosts`-equivalent trust store in the spec-kitty home,
+  keyed on publisher identity + the signed/observed content-hash.
+* **The trust prompt happens at pack activation/install time, never mid-transition.** At run
+  time the decision is looked up non-interactively.
+* **Low-trust ⇒ skip + warn, transition proceeds.** An untrusted gate is **not run**; a loud
+  warning records that a transition guard was skipped due to low trust, and the transition is
+  **not blocked**. Consequence stated explicitly: a fail-closed gate from an *untrusted* pack
+  provides **zero protection** — gate protection is only ever as strong as the trust decision.
+* **CI / non-interactive is the governing constraint.** Unknown publisher at run time defaults
+  to skip+warn — never a prompt, never a hang. Trust must be **pre-seedable** (config/flag) so
+  CI and the daemon can run trusted gates without interaction.
+
+### Consequences
+
+#### Positive
+* Third-party code never runs unreviewed; the operator's trust decision is explicit and persisted.
+* CI and automation never block or hang on trust; the safe default is "don't run untrusted code".
+
+#### Negative
+* Signing infrastructure (release key, signature in `pack-meta.yaml`, verification path) is
+  net-new and must be got right (key rotation, offline verification).
+* "Skip + proceed" means an untrusted security gate silently protects nothing — this must be
+  surfaced loudly, or an operator may believe a gate is guarding a transition that it is not.
+
+#### Neutral
+* Trust is orthogonal to gate correctness — a trusted gate can still be a bad check; a rejected
+  gate can still be a good one that simply won't run.
+
+### Open questions (for the dialectics squad)
+1. Prompt at activation vs first-execution (TOFU-faithful but interrupts a transition)?
+2. Is "skip + proceed" the right low-trust default, or should certain gate classes be able to
+   declare "block if I cannot run" (turning untrust into a hard stop)?
+3. Publisher identity granularity — per pack, per publisher key, per source URL?
+4. Signing: detached signature over the content-hash vs a signed manifest; where the public
+   key ships and how it rotates.

--- a/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+++ b/docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
@@ -23,6 +23,28 @@ executing on every mission transition. That is a supply-chain surface and needs 
 
 ---
 
+## Post-dialectics revision (2026-08-13)
+
+Hardened after the dialectics pass (`work/gate-design-dialectics/03-...`, `99-COHERENCE.md`). Settled deltas:
+
+- **KEEP — built-in release signing as the architectural target** (operator decision). Note the
+  dialectic's caveat: built-in ships in the same wheel as its verifier + bundled key, so signing's
+  *near-term* threat value is low; its value is establishing the provenance chain for **fetched /
+  org** packs. Whether to *implement* signing now is a scoping decision, separate from keeping it
+  as the to-be design.
+- **CHANGE — untrusted is not a skip.** An untrusted publisher is one **severity-bearing
+  could-not-run outcome**; the operator's error-handling strategy decides the effect — see
+  [ADR 2026-08-13-6](2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md).
+  Security gates therefore **fail closed by default**. The "skip + warn, transition proceeds"
+  language below is **superseded** by that model.
+- **CHANGE — trust is keyed on the operator-config coordinate + observed content-hash**, not the
+  self-declared `pack-meta.yaml` identity (spoofable, and it fights the operator-authority
+  invariant where the loader overrides pack-side identity).
+- **KEEP — prompt at activation, never run time; CI blocks loudly on a missing trust seed** (never
+  a silent skip).
+- **STRIKE — the "one hash, three jobs" framing.** Signature + identity are sound; the cache-key
+  role is removed (deferred with the daemon — [ADR 2026-08-13-5](2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md)).
+
 ## Context and Problem Statement
 
 Declarative gates execute code shipped inside a doctrine pack. Built-in gates are first-party.

--- a/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+++ b/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
@@ -23,6 +23,23 @@ Captured now so the gate design is daemon-ready, but scoped as a follow-on.
 
 ---
 
+## Post-dialectics revision (2026-08-13) — DECISION HELD OPEN
+
+Per operator: **this decision is held open for further discussion**; the rest of the gate
+architecture proceeds without it. Recorded from the dialectics pass
+(`work/gate-design-dialectics/04-...`, `99-COHERENCE.md`), not yet settled:
+
+- **The verdict cache keyed on pack content-hash is contested as unsound.** The pack hash omits
+  the **working tree**, which is the dominant input of both the incumbent `spec-kitty-pre-review`
+  gate (scoped tests at head) and the `docs-structural-lint` example (lints the tree). Editing a
+  tracked file leaves the pack hash unchanged → a stale **PASS** could cross a blocking gate.
+  Capturing "everything a subprocess reads" is not feasible without tracing infra that dwarfs the
+  daemon.
+- **Parse-amortization is sound and daemon-independent** — the parse is a pure function of pack
+  bytes and can be a content-addressed on-disk cache with no daemon.
+- No decision is folded here yet. The daemon-as-warm-API and the verdict-cache question remain
+  **open** pending further discussion.
+
 ## Context and Problem Statement
 
 The CLI parses doctrine + DRG (and, with declarative gates, gate definitions) on **every

--- a/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+++ b/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
@@ -53,17 +53,17 @@ model for such a surface.
 
 ## Decision Drivers
 
-* Amortize doctrine/DRG/gate parse across invocations.
-* Exploit gate determinism: identical inputs ⇒ identical verdict ⇒ cache hit.
-* Do not couple the gate design to a daemon that does not exist yet.
+- Amortize doctrine/DRG/gate parse across invocations.
+- Exploit gate determinism: identical inputs ⇒ identical verdict ⇒ cache hit.
+- Do not couple the gate design to a daemon that does not exist yet.
 
 ## Decision Outcome
 
 **Direction (not yet a committed build):** a **local, loopback-only daemon** may host doctrine
 resolution and gate execution behind an API. It holds:
 
-* **Parsed doctrine / DRG**, loaded once and reused across calls.
-* **A deterministic gate-verdict cache**, keyed on `(gate id, gate/pack version, hash of the
+- **Parsed doctrine / DRG**, loaded once and reused across calls.
+- **A deterministic gate-verdict cache**, keyed on `(gate id, gate/pack version, hash of the
   inputs the gate reads)`. The **pack `pack-meta.yaml` content-hash** is the natural
   invalidation key — the same hash that is signed for trust (ADR 2026-08-13-4). Three
   concerns converge on one hash: **integrity (signature), identity (version), and cache-key**.
@@ -75,20 +75,24 @@ the daemon is an optimization, not a dependency.
 ### Consequences
 
 #### Positive
-* Repeated transitions collapse to cache hits; parse cost is paid once.
-* Reuses existing loopback-daemon precedent and security posture.
+
+- Repeated transitions collapse to cache hits; parse cost is paid once.
+- Reuses existing loopback-daemon precedent and security posture.
 
 #### Negative
-* A daemon that executes shipped code is a **persistent execution surface** with a real
+
+- A daemon that executes shipped code is a **persistent execution surface** with a real
   lifecycle (start/stop/staleness) and security story — deserves its own ADR + threat model
   before it is built.
-* Cache correctness depends entirely on the input-hash being complete; a gate that reads an
+- Cache correctness depends entirely on the input-hash being complete; a gate that reads an
   un-hashed input would return a stale verdict.
 
 #### Neutral
-* Whether this extends the existing dashboard daemon or is a new process is unresolved.
+
+- Whether this extends the existing dashboard daemon or is a new process is unresolved.
 
 ### Open questions (for the dialectics squad)
+
 1. Extend the dashboard daemon, or a separate gate/doctrine daemon?
 2. How is "the inputs the gate reads" captured completely enough to be a safe cache key?
 3. Is verdict caching even worth it before the daemon exists (cold CLI has no persistent cache)?

--- a/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+++ b/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
@@ -1,0 +1,77 @@
+---
+title: 'ADR: A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)'
+description: 'Direction-setting ADR: a local loopback-only daemon holds parsed doctrine and a deterministic gate-verdict cache keyed on pack content-hash, so gate execution becomes a warm API call instead of a cold CLI subprocess. Follow-on to the gate design, not a prerequisite.'
+status: Proposed
+date: '2026-08-13'
+related:
+- docs/architecture/mission-gates.md
+- docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+---
+# A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts
+
+**Filename:** `2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md`
+
+**Status:** Proposed (direction-setting; not a prerequisite for the gate work)
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** Records a direction surfaced while designing declarative gates
+([ADR 2026-08-13-2](2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md)).
+Captured now so the gate design is daemon-ready, but scoped as a follow-on.
+
+---
+
+## Context and Problem Statement
+
+The CLI parses doctrine + DRG (and, with declarative gates, gate definitions) on **every
+invocation**. Adding gate execution compounds that per-invocation cost. But gates are
+**deterministic and side-effect-free**, which makes their verdicts **cacheable**.
+
+There is precedent for a resident local process: the dashboard daemon
+(`.kittify/.dashboard`) and the `orchestrator-api` external surface already exist, and the
+project's loopback-only HTTP posture (127.0.0.1, no forced TLS) is the established security
+model for such a surface.
+
+## Decision Drivers
+
+* Amortize doctrine/DRG/gate parse across invocations.
+* Exploit gate determinism: identical inputs ⇒ identical verdict ⇒ cache hit.
+* Do not couple the gate design to a daemon that does not exist yet.
+
+## Decision Outcome
+
+**Direction (not yet a committed build):** a **local, loopback-only daemon** may host doctrine
+resolution and gate execution behind an API. It holds:
+
+* **Parsed doctrine / DRG**, loaded once and reused across calls.
+* **A deterministic gate-verdict cache**, keyed on `(gate id, gate/pack version, hash of the
+  inputs the gate reads)`. The **pack `pack-meta.yaml` content-hash** is the natural
+  invalidation key — the same hash that is signed for trust (ADR 2026-08-13-4). Three
+  concerns converge on one hash: **integrity (signature), identity (version), and cache-key**.
+
+Gate execution then becomes a warm API call; a cold CLI subprocess remains the fallback and
+the v1 path. **The gate design (ADRs -2/-3/-4) must stand on its own without the daemon** —
+the daemon is an optimization, not a dependency.
+
+### Consequences
+
+#### Positive
+* Repeated transitions collapse to cache hits; parse cost is paid once.
+* Reuses existing loopback-daemon precedent and security posture.
+
+#### Negative
+* A daemon that executes shipped code is a **persistent execution surface** with a real
+  lifecycle (start/stop/staleness) and security story — deserves its own ADR + threat model
+  before it is built.
+* Cache correctness depends entirely on the input-hash being complete; a gate that reads an
+  un-hashed input would return a stale verdict.
+
+#### Neutral
+* Whether this extends the existing dashboard daemon or is a new process is unresolved.
+
+### Open questions (for the dialectics squad)
+1. Extend the dashboard daemon, or a separate gate/doctrine daemon?
+2. How is "the inputs the gate reads" captured completely enough to be a safe cache key?
+3. Is verdict caching even worth it before the daemon exists (cold CLI has no persistent cache)?

--- a/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+++ b/docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)'
-description: 'Direction-setting ADR: a local loopback-only daemon holds parsed doctrine and a deterministic gate-verdict cache keyed on pack content-hash, so gate execution becomes a warm API call instead of a cold CLI subprocess. Follow-on to the gate design, not a prerequisite.'
+description: 'Direction-setting ADR: a local loopback daemon holds parsed doctrine and a content-hash-keyed verdict cache, making gate execution a warm API call rather than a cold subprocess.'
 status: Proposed
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
+++ b/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
@@ -76,12 +76,14 @@ effect.**
 ### Consequences
 
 #### Positive
+
 * One knob for strictness; the fail-closed/skip contradiction dissolves — the *operator's*
   threshold decides, uniformly, regardless of why a gate didn't pass.
 * Consolidates five drifting Severity definitions onto one ladder (a debt-reduction win).
 * `RECOVERABLE` expresses "proceed degraded," which no boolean could.
 
 #### Negative
+
 * Consolidating the existing Severity enums is a cross-cutting refactor with its own blast radius
   (audit, status/doctor, charter-lint, glossary) — must be sequenced carefully or scoped as a
   precursor.
@@ -89,10 +91,12 @@ effect.**
   the effective strategy should be surfaced (so "why did this pass?" is answerable).
 
 #### Neutral
+
 * The strategy grammar (`block_above(threshold)` vs a per-severity action map) is a config-schema
   detail (open Q).
 
 ### Open questions (for scoping / a later pass)
+
 1. Extend/rename `kernel.glossary_types.Severity`, or mint a new canonical `ERROR_SEVERITY` and
    migrate the others onto it?
 2. Strategy grammar: single `block_above(threshold)`, or a per-severity action map

--- a/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
+++ b/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect'
-description: 'Gate verdicts (and could-not-run conditions like untrusted/crash/timeout) emit a typed severity — BLOCKING / RECOVERABLE / WARN / INFO; the operator selects an error-handling strategy in .kittify (e.g. block_above(threshold)) that maps severities to CLI effect, reconciling the existing fragmented Severity enums onto one canonical ladder.'
+description: 'Gate outcomes emit a typed severity (BLOCKING / RECOVERABLE / WARN / INFO); an operator-configured error-handling strategy in .kittify maps severities to the CLI effect.'
 status: Proposed
 date: '2026-08-13'
 related:

--- a/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
+++ b/docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
@@ -1,0 +1,101 @@
+---
+title: 'ADR: Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect'
+description: 'Gate verdicts (and could-not-run conditions like untrusted/crash/timeout) emit a typed severity — BLOCKING / RECOVERABLE / WARN / INFO; the operator selects an error-handling strategy in .kittify (e.g. block_above(threshold)) that maps severities to CLI effect, reconciling the existing fragmented Severity enums onto one canonical ladder.'
+status: Proposed
+date: '2026-08-13'
+related:
+- docs/architecture/mission-gates.md
+- docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+- docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+---
+# Gate outcomes carry a typed severity; an operator-configured strategy decides the CLI effect
+
+**Filename:** `2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md`
+
+**Status:** Proposed
+
+**Date:** 2026-08-13
+
+**Deciders:** Operator (ATDD)
+
+**Technical Story:** Resolves the fail-closed ([ADR 2026-08-13-2](2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md))
+vs skip-and-proceed ([ADR 2026-08-13-4](2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md))
+contradiction the dialectics pass surfaced. Instead of a per-gate boolean disposition, gate
+outcomes are typed by severity and the CLI effect is an operator policy.
+
+---
+
+## Context and Problem Statement
+
+The gate design produced two conflicting per-gate booleans: gates flip **fail-closed** (block on
+failure), but untrusted packs were to be **skipped** (proceed). Same un-run gate, opposite
+outcomes, decided by *why* it didn't run — and the "skip" branch silently no-ops security gates
+in CI. A single boolean cannot express "proceed, but degraded, and record it," which is the real
+operator need for many checks (a docs lint failing should not necessarily block a transition; a
+missing security gate should).
+
+The codebase already has the ingredients, **fragmented across five sites**:
+`kernel.glossary_types.Severity` (`src/kernel/glossary_types.py:70`), `audit.models.Severity` +
+its threshold `fail_on: Severity | None` with `severity <= fail_on_threshold`
+(`src/specify_cli/audit/models.py:47,53,203`), `status.doctor.Severity`
+(`src/specify_cli/status/doctor.py:26`), the charter-lint `SEVERITY_ORDER` blocking ladder
+(`src/specify_cli/charter_runtime/lint/findings.py`, consumed by `analysis_report.py:338`), and
+the `strictness` literals (`kernel.glossary_types.Strictness`, `runtime … schema.py:465`). The
+`audit` module is already *exactly* the "block above a threshold" pattern requested.
+
+## Decision Drivers
+
+* One coherent model for "what happens when a check does not pass," across failed / degraded /
+  informational / could-not-run outcomes.
+* Operator owns strictness, not each gate author — mirrors linter/typechecker strictness config.
+* Do not add a **sixth** Severity enum; converge on one canonical ladder.
+
+## Decision Outcome
+
+**A gate produces a typed outcome; the operator's error-handling strategy maps it to a CLI
+effect.**
+
+* **Severity ladder** (`ERROR_SEVERITY`): `BLOCKING` > `RECOVERABLE` > `WARN` > `INFO`.
+  `RECOVERABLE` means "the system may proceed in a **degraded** fashion" (the outcome is
+  recorded/surfaced, the transition is not necessarily stopped).
+* **Every gate outcome carries a severity** — a check failure, and every *could-not-run*
+  condition (untrusted publisher, crash, timeout, missing interpreter), maps to a severity.
+  "Untrusted" is therefore not a special skip; it is one severity-bearing outcome among many.
+* **The operator selects an error-handling strategy** in `.kittify` config, e.g.
+  `block_above(RECOVERABLE)` — outcomes at or above the threshold block the transition; below it,
+  the CLI proceeds (degraded) and records the finding. This is the existing `audit` `fail_on`
+  threshold pattern, generalised.
+* **Canonical severity, not a new enum.** `ERROR_SEVERITY` is defined once (extend/rename the
+  kernel `Severity` — the layering-correct home, importable by doctrine) and the fragmented
+  per-module Severity enums are migrated onto it. A gate schema references the canonical ladder.
+* **A default strategy ships** (recommended `block_above(RECOVERABLE)` so `BLOCKING` and
+  `RECOVERABLE` stop a transition by default, `WARN`/`INFO` do not) — chosen so security gates
+  fail **closed** out of the box, and CI without operator config still blocks loudly rather than
+  silently no-ops.
+
+### Consequences
+
+#### Positive
+* One knob for strictness; the fail-closed/skip contradiction dissolves — the *operator's*
+  threshold decides, uniformly, regardless of why a gate didn't pass.
+* Consolidates five drifting Severity definitions onto one ladder (a debt-reduction win).
+* `RECOVERABLE` expresses "proceed degraded," which no boolean could.
+
+#### Negative
+* Consolidating the existing Severity enums is a cross-cutting refactor with its own blast radius
+  (audit, status/doctor, charter-lint, glossary) — must be sequenced carefully or scoped as a
+  precursor.
+* A permissive operator strategy can weaken security gates — the default must fail closed, and
+  the effective strategy should be surfaced (so "why did this pass?" is answerable).
+
+#### Neutral
+* The strategy grammar (`block_above(threshold)` vs a per-severity action map) is a config-schema
+  detail (open Q).
+
+### Open questions (for scoping / a later pass)
+1. Extend/rename `kernel.glossary_types.Severity`, or mint a new canonical `ERROR_SEVERITY` and
+   migrate the others onto it?
+2. Strategy grammar: single `block_above(threshold)`, or a per-severity action map
+   (`{BLOCKING: block, RECOVERABLE: block, WARN: warn, INFO: log}`)?
+3. Is severity gate-declared, outcome-declared (the check emits it), or both (gate caps it)?
+4. Does the Severity consolidation ship as a precursor mission, or inside the gate mission?

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -179,3 +179,4 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-13 | [Gate execution targets a surface through a kernel selector and the topology placement seam](2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md) |
 | 2026-08-13 | [Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)](2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md) |
 | 2026-08-13 | [A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)](2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
+| 2026-08-13 | [Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect](2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md) |

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -175,3 +175,7 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-12 | [Local, No-Egress PlantUML Rendering for Code-Grounded Doctrine Schema Diagrams](2026-08-12-1-plantuml-schema-diagram-rendering.md) |
 | 2026-08-12 | [Explicit Checkout Ownership for Mission Create and Next](2026-08-12-1-checkout-ownership-for-mission-create-and-next.md) |
 | 2026-08-13 | [The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface](2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md) |
+| 2026-08-13 | [Transition gates are declarative, asset-backed, first-class doctrine artefacts](2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md) |
+| 2026-08-13 | [Gate execution targets a surface through a kernel selector and the topology placement seam](2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md) |
+| 2026-08-13 | [Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)](2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md) |
+| 2026-08-13 | [A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)](2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -174,3 +174,4 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-07 | [A Mission-Halting Instrument Is Worth Its Cost — It Runs Before the Mission, and Its Verdict Is Acted On](2026-08-07-1-a-mission-halting-instrument-is-worth-its-cost.md) |
 | 2026-08-12 | [Local, No-Egress PlantUML Rendering for Code-Grounded Doctrine Schema Diagrams](2026-08-12-1-plantuml-schema-diagram-rendering.md) |
 | 2026-08-12 | [Explicit Checkout Ownership for Mission Create and Next](2026-08-12-1-checkout-ownership-for-mission-create-and-next.md) |
+| 2026-08-13 | [The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface](2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md) |

--- a/docs/architecture/doctrine-kinds.md
+++ b/docs/architecture/doctrine-kinds.md
@@ -317,11 +317,11 @@ evaluation, prompt binding, and delegation hooks. Mission step contracts are wha
 type's abstract action sequence (specify → plan → tasks → implement → review) into concrete,
 executable steps — each step can delegate to a directive, tactic, or procedure.
 
-**Location.** `src/doctrine/missions/built_in_step_contracts/*.step-contract.yaml`
+**Location.** `packs/built-in/missions/built_in_step_contracts/*.step-contract.yaml`
 (project overlay: `.kittify/doctrine/mission_step_contracts/`).
 
 **Example.** `specify` action, software-dev mission
-(`src/doctrine/missions/built_in_step_contracts/specify.step-contract.yaml`). Its `bootstrap`
+(`packs/built-in/missions/built_in_step_contracts/specify.step-contract.yaml`). Its `bootstrap`
 step loads charter context; `capture_intent` delegates to directives
 `010-specification-fidelity-requirement` and `037-living-documentation-sync`; `map_examples`
 delegates to the `example-mapping-workshop` procedure; `validate_requirements` delegates to the

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -59,6 +59,7 @@ boundary rule and layout).
 - [Git workflow: who does what](git-workflow.md) — infrastructure git vs content git.
 - [Multi-agent orchestration](multi-agent-orchestration.md) — coordinating work across agents.
 - [Kanban workflow](kanban-workflow.md) — the nine lanes and their transitions.
+- [Mission transition gates](mission-gates.md) — the declarative, asset-backed, trust-gated model for the checks that guard lane transitions.
 - [The runtime loop](runtime-loop.md) — how `spec-kitty next` inverts control.
 - [AI agent architecture](ai-agent-architecture.md) — how Spec Kitty stays agent-agnostic across agents.
 - [Why the Divio documentation system?](divio-documentation.md) — tutorials/how-to/reference/explanation mapping.

--- a/docs/architecture/mission-gates.md
+++ b/docs/architecture/mission-gates.md
@@ -1,6 +1,6 @@
 ---
 title: Mission transition gates — declarative, asset-backed, trust-gated
-description: How transition gates work under the declarative model — a first-class gate artefact kind whose check ships as an asset, is invoked via an entrypoint at a topology-resolved surface, runs only from trusted publishers, and is fail-closed by default.
+description: The declarative model for transition gates — a first-class gate artefact whose check ships as an asset, runs at a topology-resolved surface, fail-closed by default.
 doc_status: active
 updated: '2026-08-13'
 type: explanation

--- a/docs/architecture/mission-gates.md
+++ b/docs/architecture/mission-gates.md
@@ -1,0 +1,95 @@
+---
+title: Mission transition gates — declarative, asset-backed, trust-gated
+description: How transition gates work under the declarative model — a first-class gate artefact kind whose check ships as an asset, is invoked via an entrypoint at a topology-resolved surface, runs only from trusted publishers, and is fail-closed by default.
+doc_status: active
+updated: '2026-08-13'
+type: explanation
+related:
+- docs/architecture/mission-type-resolution.md
+- docs/architecture/artifact-placement-seam.md
+- docs/architecture/doctrine-kinds.md
+- docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+- docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+- docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+- docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+---
+# Mission transition gates — declarative, asset-backed, trust-gated
+
+> **Status: design (Proposed).** This page describes the intended model captured across
+> ADRs 2026-08-13-2 … -5. It is being hardened before implementation; treat it as the design
+> of record, not a description of shipped behaviour.
+
+A **transition gate** is a deterministic check that runs when a work package crosses a lane
+edge (e.g. `in_progress → for_review`) and returns a pass/fail verdict that can block the
+transition. This page explains the declarative model that replaces the legacy
+named-Python-handler registry.
+
+## The four moving parts
+
+| Concern | Answer | ADR |
+|---|---|---|
+| **What a gate is** | A first-class doctrine `gate` artefact kind (declarative YAML), reusable by id, tiered like every other kind. | [-2](../adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md) |
+| **What the check is** | Code shipped as an `asset` (inert blob, resolved by id), invoked by the gate's `entrypoint` oneliner. | [-2](../adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md) |
+| **Where it runs** | An `executionTarget` surface selector (kernel vocabulary) resolved by the topology-aware placement seam's new `execute_dir` verb. | [-3](../adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md) |
+| **Whether it may run** | Trust: built-in is release-signed and trusted; org/project packs are trust-on-first-use; untrusted ⇒ skip + warn. | [-4](../adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md) |
+| **How fast (later)** | An optional local daemon holds parsed doctrine + a deterministic verdict cache keyed on the pack content-hash. | [-5](../adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
+
+## Definition vs binding
+
+Two separated concerns:
+
+- **Definition** — the `gate` artefact says *what the check is*: which asset holds the code,
+  the `entrypoint`, the `executionTarget`, the timeout, and the fail disposition.
+- **Binding** — the `MissionStep` says *when it fires*: an `on_transition` edge plus the gate
+  id. Definition is reusable across steps and mission types; binding is per-step and ships in
+  the per-type mission bundle.
+
+```yaml
+# gate definition — packs/built-in/gates/docs-structural-lint.gate.yaml
+id: docs-structural-lint
+schema_version: "1.0"
+description: "DIRECTIVE_042 structural lint for documentation missions"
+asset: common-docs-structural-lint       # code blob (asset kind, inert, resolved by id)
+entrypoint: "python {asset} --strict"     # {asset} → resolved asset path
+executionTarget: primary                  # kernel surface selector → placement seam execute_dir
+timeout_seconds: 120
+disposition: fail_closed                   # exit 0 = pass; non-zero = fail (stderr → reason)
+```
+
+```yaml
+# binding — packs/built-in/missions/mission-steps/documentation/validate/step.yaml
+id: validate
+# … unified MissionStep fields …
+gates:
+  - on_transition: "in_progress->for_review"
+    gate: docs-structural-lint
+```
+
+## Execution model
+
+1. A lane transition fires; the single generic `declarative-gate` dispatcher (the shrunken
+   `GATE_REGISTRY`) is invoked with a `TransitionGateContext`.
+2. The dispatcher resolves the gate's `executionTarget` selector through the placement seam,
+   given the mission's `MissionTopology`, to a physical workdir (`execute_dir`).
+3. It checks the **trust** of the gate's owning pack. Untrusted ⇒ **skip + warn**, transition
+   proceeds unguarded. Trusted ⇒ continue.
+4. It resolves the referenced asset to a path, runs the `entrypoint` in the resolved workdir
+   under a bounded, network-denied context, and maps the exit code to a `GateVerdict`
+   (fail-closed by default).
+
+## Invariants
+
+- Gates are **deterministic and side-effect-free** — pure checks, never mutate mission state.
+  (Determinism is what makes verdict caching sound; see ADR -5.)
+- The `asset` kind stays inert — resolved to a path, never self-executing. The gate is the
+  only thing that turns a path into an invocation.
+- Trust is only ever consulted for **executing code**; inert doctrine needs no trust decision.
+- "Fail-closed" blocks only when the gate actually **runs**; an untrusted (skipped) gate
+  protects nothing — this is surfaced loudly, not silently.
+
+## Relationship to the mission subtree
+
+Gates that are mission-type dependent (documentation linting, per-type consistency checks)
+ship inside the per-type bundle under `packs/built-in/missions/<type>/`; shared gates live at
+the built-in tier and are referenced by id. This follows the nested, self-contained mission
+subtree fixed by [ADR 2026-08-13-1](../adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md).

--- a/docs/architecture/mission-gates.md
+++ b/docs/architecture/mission-gates.md
@@ -12,6 +12,7 @@ related:
 - docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
 - docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
 - docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+- docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
 ---
 # Mission transition gates — declarative, asset-backed, trust-gated
 
@@ -24,15 +25,16 @@ edge (e.g. `in_progress → for_review`) and returns a pass/fail verdict that ca
 transition. This page explains the declarative model that replaces the legacy
 named-Python-handler registry.
 
-## The four moving parts
+## The moving parts
 
 | Concern | Answer | ADR |
 |---|---|---|
 | **What a gate is** | A first-class doctrine `gate` artefact kind (declarative YAML), reusable by id, tiered like every other kind. | [-2](../adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md) |
 | **What the check is** | Code shipped as an `asset` (inert blob, resolved by id), invoked by the gate's `entrypoint` oneliner. | [-2](../adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md) |
-| **Where it runs** | An `executionTarget` surface selector (kernel vocabulary) resolved by the topology-aware placement seam's new `execute_dir` verb. | [-3](../adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md) |
-| **Whether it may run** | Trust: built-in is release-signed and trusted; org/project packs are trust-on-first-use; untrusted ⇒ skip + warn. | [-4](../adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md) |
-| **How fast (later)** | An optional local daemon holds parsed doctrine + a deterministic verdict cache keyed on the pack content-hash. | [-5](../adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
+| **Where it runs** | An `executionTarget` surface selector (doctrine-owned token set) resolved through the existing stamped `GateExecutionContext` via the topology placement seam's `execute_dir` verb. | [-3](../adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md) |
+| **Whether it may run** | Trust: built-in trusted (release-signed target); org/project packs are trust-on-first-use, keyed on operator coordinate + content-hash. | [-4](../adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md) |
+| **What its outcome does** | The outcome carries a typed severity (`BLOCKING`/`RECOVERABLE`/`WARN`/`INFO`); the operator's error-handling strategy (`block_above(threshold)` in `.kittify`) decides the CLI effect. | [-6](../adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md) |
+| **How fast (later)** | *Open.* Parse-amortization is sound (content-addressed parse cache, no daemon); a deterministic *verdict* cache is contested and held open. | [-5](../adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
 
 ## Definition vs binding
 
@@ -50,10 +52,11 @@ id: docs-structural-lint
 schema_version: "1.0"
 description: "DIRECTIVE_042 structural lint for documentation missions"
 asset: common-docs-structural-lint       # code blob (asset kind, inert, resolved by id)
-entrypoint: "python {asset} --strict"     # {asset} → resolved asset path
-executionTarget: primary                  # kernel surface selector → placement seam execute_dir
+interpreter: python                       # structured invocation — no shell string
+args: ["{asset}", "--strict"]            # {asset} → resolved asset path, as one argv element
+executionTarget: primary                  # doctrine-owned selector → placement seam execute_dir
 timeout_seconds: 120
-disposition: fail_closed                   # exit 0 = pass; non-zero = fail (stderr → reason)
+severity: RECOVERABLE                      # outcome severity; operator strategy decides the effect
 ```
 
 ```yaml
@@ -67,25 +70,30 @@ gates:
 
 ## Execution model
 
-1. A lane transition fires; the single generic `declarative-gate` dispatcher (the shrunken
-   `GATE_REGISTRY`) is invoked with a `TransitionGateContext`.
+1. A lane transition fires; the generic `declarative-gate` dispatcher (alongside a few
+   grandfathered code gates such as `spec-kitty-pre-review`) is invoked with a
+   `TransitionGateContext`.
 2. The dispatcher resolves the gate's `executionTarget` selector through the placement seam,
-   given the mission's `MissionTopology`, to a physical workdir (`execute_dir`).
-3. It checks the **trust** of the gate's owning pack. Untrusted ⇒ **skip + warn**, transition
-   proceeds unguarded. Trusted ⇒ continue.
-4. It resolves the referenced asset to a path, runs the `entrypoint` in the resolved workdir
-   under a bounded, network-denied context, and maps the exit code to a `GateVerdict`
-   (fail-closed by default).
+   given the mission's `MissionTopology`, to a **stamped `GateExecutionContext`** (not a bare
+   path — the stamp is what refuses a surface that cannot hold the artifact).
+3. It resolves the pack's **trust** (operator coordinate + content-hash). An untrusted pack is a
+   *could-not-run* outcome carrying a severity — it is **not** a silent skip.
+4. If trusted, it resolves the referenced asset to a path and runs `interpreter` + `args` in the
+   resolved context under a bounded, network-denied sandbox. The structured outcome (pass /
+   failed / could-not-run) carries a **severity**; the operator's error-handling strategy
+   (`block_above(threshold)`) maps that severity to the CLI effect (block vs proceed-degraded).
 
 ## Invariants
 
 - Gates are **deterministic and side-effect-free** — pure checks, never mutate mission state.
-  (Determinism is what makes verdict caching sound; see ADR -5.)
+  This must be **enforced by the sandbox** (network-denied, bounded), not merely asserted.
 - The `asset` kind stays inert — resolved to a path, never self-executing. The gate is the
   only thing that turns a path into an invocation.
 - Trust is only ever consulted for **executing code**; inert doctrine needs no trust decision.
-- "Fail-closed" blocks only when the gate actually **runs**; an untrusted (skipped) gate
-  protects nothing — this is surfaced loudly, not silently.
+- There is **one disposition model**: every outcome (pass / failed / could-not-run, the last
+  including *untrusted*) carries a severity, and the operator's error-handling strategy decides
+  the effect uniformly — so a security gate fails **closed by default** regardless of *why* it
+  did not pass, and a missing CI trust seed **blocks loudly** rather than silently no-ops.
 
 ## Relationship to the mission subtree
 

--- a/docs/architecture/mission-gates.md
+++ b/docs/architecture/mission-gates.md
@@ -36,6 +36,112 @@ named-Python-handler registry.
 | **What its outcome does** | The outcome carries a typed severity (`BLOCKING`/`RECOVERABLE`/`WARN`/`INFO`); the operator's error-handling strategy (`block_above(threshold)` in `.kittify`) decides the CLI effect. | [-6](../adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md) |
 | **How fast (later)** | *Open.* Parse-amortization is sound (content-addressed parse cache, no daemon); a deterministic *verdict* cache is contested and held open. | [-5](../adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
 
+## Diagrams
+
+> Rendered locally by the no-egress PlantUML pipeline (`scripts/docs/plantuml_render.py`,
+> `--network=none`, SANDBOX profile). The distribution view uses PlantUML's **native ArchiMate**
+> (bundled in the pinned jar — no `!include`, no egress).
+
+### Distribution & consumer value (ArchiMate)
+
+```plantuml
+@startuml
+title Gate distribution & consumer value (ArchiMate)
+archimate #Business "Operator" as op <<business-role>>
+archimate #Technology "built-in pack\n(signed - trusted)" as builtin <<technology-artifact>>
+archimate #Technology "org / project pack\n(TOFU)" as orgpack <<technology-artifact>>
+archimate #Technology "gate defs + assets" as gates <<technology-artifact>>
+archimate #Technology "Operator machine\n(CLI - optional daemon)" as machine <<node>>
+archimate #Application "Declarative gate engine" as engine <<application-component>>
+archimate #Business "Mission transition" as mission <<business-process>>
+archimate #Motivation "Deterministic governed checks" as value <<motivation-value>>
+builtin --> gates : ships
+orgpack --> gates : ships
+gates --> machine : resolved on
+machine *-- engine
+op --> machine : configures strategy (.kittify)
+engine --> mission : guards
+mission --> value : realizes
+@enduml
+```
+
+### Bounded contexts by layer (component)
+
+```plantuml
+@startuml
+title Gate subsystem - bounded contexts by layer
+skinparam componentStyle rectangle
+package "kernel" {
+  [ERROR_SEVERITY ladder] as sev
+}
+package "doctrine" {
+  [gate ArtifactKind - BC1] as gatekind
+  [MissionStep.gates - BC2] as binding
+  [executionTarget token set] as token
+  [asset - inert blob] as asset
+}
+package "charter" {
+  [activation and trust prompt] as charteract
+}
+package "mission_runtime" {
+  [placement seam + execute_dir - BC4] as seam
+}
+package "specify_cli" {
+  [declarative-gate dispatcher - BC3] as dispatch
+  [stamped GateExecutionContext] as stamp
+  [trust TOFU - BC5] as trust
+  [error-handling policy] as policy
+}
+gatekind --> asset : references
+binding --> gatekind : binds by id
+dispatch --> binding : reads
+dispatch --> stamp : runs in
+stamp --> seam : resolves via
+seam ..> token : parity ACL
+dispatch --> trust : checks
+dispatch --> policy : outcome to effect
+policy --> sev : uses
+trust ..> charteract : prompt at activation
+@enduml
+```
+
+### Runtime flow + internal resolution (sequence)
+
+```plantuml
+@startuml
+title Gate flows - runtime-charter-gate and internal resolution
+actor Runtime
+participant Charter
+participant "Dispatcher" as D
+participant "Doctrine" as Doc
+participant "Placement seam" as Seam
+participant "Trust" as Trust
+participant "Asset runner" as Run
+participant "Policy" as Pol
+== 1. Runtime calls gates through the charter ==
+Runtime -> Charter : transition WP on_transition
+Charter -> D : dispatch bound gates
+D -> Doc : gate id to definition and asset
+D -> Trust : trusted publisher?
+alt untrusted
+  Trust --> D : could-not-run severity
+else trusted
+  D -> Seam : executionTarget to execute_dir
+  Seam --> D : stamped GateExecutionContext
+  D -> Run : interpreter args, network=none
+  Run --> D : exit or JSON outcome
+end
+D -> Pol : outcome and severity
+Pol --> Charter : effect via block_above strategy
+Charter --> Runtime : allowed or blocked or degraded
+== 2. Internal resolution and files ==
+note over Doc: packs/built-in/gates/ID.gate.yaml then asset blob then executionTarget token
+note over Seam: token + MissionTopology then surface then workdir (stamped)
+note over Trust: .kittify trust store: operator coord + content-hash
+note over Pol: .kittify strategy then ERROR_SEVERITY ladder (kernel)
+@enduml
+```
+
 ## Definition vs binding
 
 Two separated concerns:

--- a/docs/architecture/mission-type-resolution.md
+++ b/docs/architecture/mission-type-resolution.md
@@ -29,8 +29,9 @@ doctrine (offers)  →  charter (activates & customises)  →  core FSM (consume
 ```
 
 - **Doctrine offers.** The canonical catalogue of mission types lives in
-  `src/doctrine/missions/<type>/`. It *offers* a mission type's governance,
-  action indices, step contracts, and templates.
+  `packs/built-in/missions/<type>/` (relocated from `src/doctrine/missions/<type>/`
+  by mission `doctrine-consumer-surface-missions-extraction`). It *offers* a
+  mission type's governance, action indices, step contracts, and templates.
 - **Charter activates and customises.** The charter layer selects a mission type
   and overlays project-specific customisation onto it, exactly as it overlays any
   other doctrine artifact (see [the per-type override](#the-charter-customise-layer)).
@@ -48,7 +49,8 @@ property of any one state (see [Governance is a sibling, not a property](#govern
 Before this decision, per-mission-type behaviour resolved through **two parallel
 mission trees and three competing governance surfaces**:
 
-- `src/doctrine/missions/<type>/` — the canonical catalogue (the source of truth).
+- `packs/built-in/missions/<type>/` — the canonical catalogue (the source of truth;
+  relocated from `src/doctrine/missions/<type>/`).
 - `src/specify_cli/missions/<type>/` — **derived copies** that several core
   readers still bind to directly. The two trees drifted with no parity guard.
 - Three governance surfaces per type: an inert-and-dangling `governance_refs`
@@ -120,8 +122,8 @@ Governance is authored at two grains, and the resolver unions and de-dupes them:
 
 | Grain | Canonical source | What it carries |
 |-------|------------------|-----------------|
-| **Action-grain** | `missions/<type>/actions/<action>/index.yaml` | Per-action `scope` edges (already live; generate DRG scope edges consumed by `charter context --action`) |
-| **Type-grain** | `missions/<type>/governance-profile.yaml` (`selected_*`) | The type-wide directive/tactic/styleguide/paradigm selections, and the project-override target |
+| **Action-grain** | `packs/built-in/missions/<type>/actions/<action>/index.yaml` | Per-action `scope` edges (already live; generate DRG scope edges consumed by `charter context --action`) |
+| **Type-grain** | `packs/built-in/missions/<type>/governance-profile.yaml` (`selected_*`) | The type-wide directive/tactic/styleguide/paradigm selections, and the project-override target |
 
 Neither grain is a generated rollup of the other — a rollup would incur a
 freshness gate and erase the grain distinction. An enforcement test forbids the

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -40,6 +40,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   refuses with guidance.
   See [Per-Project Sync Consent](../guides/project-sync-consent.md).
 
+- **The declarative transition-gate design is now documented as architecture,
+  and two mission-doctrine docs point at the right paths again (`#3378`).**
+  Before, the settled model for how transition gates work — the declarative
+  `gate` artefact kind, where a gate executes, the trusted-publisher rule, and
+  the typed-severity outcome — lived only in scattered discussion, and
+  `mission-type-resolution.md` / `doctrine-kinds.md` still named the
+  pre-relocation `src/doctrine/missions/` source of truth. Now six Proposed
+  ADRs plus a `mission-gates.md` explanation page (with three render-verified
+  diagrams) capture the design in one place, and those two docs are retargeted
+  to the live `packs/built-in/missions/` paths.
+
 - **Documentation can now be marked `durable` — a standing reference that is
   never flagged as stale draft (mission `docs-plans-closeout-01KZTK2J`;
   `#3368`).** Before, a long-lived throughline doc could only be `active`, so the

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -4678,6 +4678,10 @@ pages:
     abstract: "How transition gates work under the declarative model — a first-class gate artefact kind whose check ships as an asset, is invoked via an entrypoint at a topology-resolved surface, runs only from trusted publishers, and is fail-closed by default."
     anchors:
     - {slug: "the-moving-parts", text: "The moving parts", level: 2}
+    - {slug: "diagrams", text: "Diagrams", level: 2}
+    - {slug: "distribution-consumer-value-archimate", text: "Distribution & consumer value (ArchiMate)", level: 3}
+    - {slug: "bounded-contexts-by-layer-component", text: "Bounded contexts by layer (component)", level: 3}
+    - {slug: "runtime-flow-internal-resolution-sequence", text: "Runtime flow + internal resolution (sequence)", level: 3}
     - {slug: "definition-vs-binding", text: "Definition vs binding", level: 2}
     - {slug: "execution-model", text: "Execution model", level: 2}
     - {slug: "invariants", text: "Invariants", level: 2}

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2765,7 +2765,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md"
     title: "ADR: The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface"
     divio_type: "none"
-    abstract: "Rejects flattening packs/built-in/missions/ into top-level dirs; fixes the nested per-type bundle as canonical and retires built_in_step_contracts (MissionStepContract) in favour of the unified MissionStep model."
+    abstract: "Keeps the nested per-type packs/built-in/missions/ bundle canonical (no flattening) and retires built_in_step_contracts in favour of the unified MissionStep model."
     anchors:
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
     - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
@@ -2779,7 +2779,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md"
     title: "ADR: Transition gates are declarative, asset-backed, first-class doctrine artefacts"
     divio_type: "none"
-    abstract: "Replaces the named-Python-handler gate registry with a first-class declarative `gate` doctrine kind whose check logic ships as an asset invoked through an entrypoint, fail-closed by default, dispatched by one generic handler."
+    abstract: "Replaces the named-Python-handler gate registry with a first-class declarative `gate` kind whose check ships as an asset invoked via an entrypoint, fail-closed by default."
     anchors:
     - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
@@ -2791,7 +2791,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md"
     title: "ADR: Gate execution targets a surface through a kernel selector and the topology placement seam"
     divio_type: "none"
-    abstract: "A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the topology-aware placement seam gains an execute verb that resolves it to a physical workdir, unifying where artifacts are read, written, and run."
+    abstract: "A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the placement seam gains an execute verb that resolves it to a physical workdir."
     anchors:
     - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
@@ -2803,7 +2803,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md"
     title: "ADR: Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)"
     divio_type: "none"
-    abstract: "Shipped doctrine code (gate assets) executes only from trusted publishers: built-in is release-signed and trusted by default; org/project packs use trust-on-first-use keyed on pack-meta identity; untrusted gates are skipped with a warning and never block or prompt at run time."
+    abstract: "Gate assets execute only from trusted publishers: built-in is release-signed and trusted; org/project packs use trust-on-first-use; untrusted gates are skipped with a warning."
     anchors:
     - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
@@ -2815,7 +2815,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md"
     title: "ADR: A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)"
     divio_type: "none"
-    abstract: "Direction-setting ADR: a local loopback-only daemon holds parsed doctrine and a deterministic gate-verdict cache keyed on pack content-hash, so gate execution becomes a warm API call instead of a cold CLI subprocess. Follow-on to the gate design, not a prerequisite."
+    abstract: "Direction-setting ADR: a local loopback daemon holds parsed doctrine and a content-hash-keyed verdict cache, making gate execution a warm API call rather than a cold subprocess."
     anchors:
     - {slug: "post-dialectics-revision-2026-08-13-decision-held-open", text: "Post-dialectics revision (2026-08-13) — DECISION HELD OPEN", level: 2}
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
@@ -2826,7 +2826,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md"
     title: "ADR: Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect"
     divio_type: "none"
-    abstract: "Gate verdicts (and could-not-run conditions like untrusted/crash/timeout) emit a typed severity — BLOCKING / RECOVERABLE / WARN / INFO; the operator selects an error-handling strategy in .kittify (e.g. block_above(threshold)) that maps severities to CLI effect, reconciling the existing fragmented Severity enums onto one canonical ladder."
+    abstract: "Gate outcomes emit a typed severity (BLOCKING / RECOVERABLE / WARN / INFO); an operator-configured error-handling strategy in .kittify maps severities to the CLI effect."
     anchors:
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
     - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
@@ -4675,7 +4675,7 @@ pages:
   - path: "docs/architecture/mission-gates.md"
     title: "Mission transition gates — declarative, asset-backed, trust-gated"
     divio_type: "explanation"
-    abstract: "How transition gates work under the declarative model — a first-class gate artefact kind whose check ships as an asset, is invoked via an entrypoint at a topology-resolved surface, runs only from trusted publishers, and is fail-closed by default."
+    abstract: "The declarative model for transition gates — a first-class gate artefact whose check ships as an asset, runs at a topology-resolved surface, fail-closed by default."
     anchors:
     - {slug: "the-moving-parts", text: "The moving parts", level: 2}
     - {slug: "diagrams", text: "Diagrams", level: 2}

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2762,6 +2762,77 @@ pages:
     - {slug: "accessibility-carve-out-nfr-005", text: "Accessibility carve-out (NFR-005)", level: 3}
     - {slug: "consequences", text: "Consequences", level: 2}
     - {slug: "references", text: "References", level: 2}
+  - path: "docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md"
+    title: "ADR: The built-in mission subtree stays nested and self-contained; retire the legacy step-contract surface"
+    divio_type: "none"
+    abstract: "Rejects flattening packs/built-in/missions/ into top-level dirs; fixes the nested per-type bundle as canonical and retires built_in_step_contracts (MissionStepContract) in favour of the unified MissionStep model."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "canonical-structure-fixed-by-this-adr", text: "Canonical structure (fixed by this ADR)", level: 3}
+    - {slug: "the-legacy-step-contract-surface-is-removed", text: "The legacy step-contract surface is removed", level: 3}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "confirmation", text: "Confirmation", level: 3}
+    - {slug: "more-information", text: "More Information", level: 2}
+  - path: "docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md"
+    title: "ADR: Transition gates are declarative, asset-backed, first-class doctrine artefacts"
+    divio_type: "none"
+    abstract: "Replaces the named-Python-handler gate registry with a first-class declarative `gate` doctrine kind whose check logic ships as an asset invoked through an entrypoint, fail-closed by default, dispatched by one generic handler."
+    anchors:
+    - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "open-questions-for-the-dialectics-squad", text: "Open questions (for the dialectics squad)", level: 3}
+  - path: "docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md"
+    title: "ADR: Gate execution targets a surface through a kernel selector and the topology placement seam"
+    divio_type: "none"
+    abstract: "A gate declares an executionTarget from a kernel-owned surface-selector vocabulary; the topology-aware placement seam gains an execute verb that resolves it to a physical workdir, unifying where artifacts are read, written, and run."
+    anchors:
+    - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "open-questions-for-the-dialectics-squad", text: "Open questions (for the dialectics squad)", level: 3}
+  - path: "docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md"
+    title: "ADR: Executable doctrine runs only from trusted publishers (signed built-in; TOFU for the rest)"
+    divio_type: "none"
+    abstract: "Shipped doctrine code (gate assets) executes only from trusted publishers: built-in is release-signed and trusted by default; org/project packs use trust-on-first-use keyed on pack-meta identity; untrusted gates are skipped with a warning and never block or prompt at run time."
+    anchors:
+    - {slug: "post-dialectics-revision-2026-08-13", text: "Post-dialectics revision (2026-08-13)", level: 2}
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "open-questions-for-the-dialectics-squad", text: "Open questions (for the dialectics squad)", level: 3}
+  - path: "docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md"
+    title: "ADR: A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)"
+    divio_type: "none"
+    abstract: "Direction-setting ADR: a local loopback-only daemon holds parsed doctrine and a deterministic gate-verdict cache keyed on pack content-hash, so gate execution becomes a warm API call instead of a cold CLI subprocess. Follow-on to the gate design, not a prerequisite."
+    anchors:
+    - {slug: "post-dialectics-revision-2026-08-13-decision-held-open", text: "Post-dialectics revision (2026-08-13) — DECISION HELD OPEN", level: 2}
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "open-questions-for-the-dialectics-squad", text: "Open questions (for the dialectics squad)", level: 3}
+  - path: "docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md"
+    title: "ADR: Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect"
+    divio_type: "none"
+    abstract: "Gate verdicts (and could-not-run conditions like untrusted/crash/timeout) emit a typed severity — BLOCKING / RECOVERABLE / WARN / INFO; the operator selects an error-handling strategy in .kittify (e.g. block_above(threshold)) that maps severities to CLI effect, reconciling the existing fragmented Severity enums onto one canonical ladder."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "open-questions-for-scoping-a-later-pass", text: "Open questions (for scoping / a later pass)", level: 3}
   - path: "docs/adr/3.x/README.md"
     title: "3.x ADRs"
     divio_type: "none"
@@ -4601,6 +4672,16 @@ pages:
     - {slug: "operator-playbook-for-the-launch-flip", text: "Operator playbook for the launch flip", level: 2}
     - {slug: "what-this-doc-deliberately-does-not-specify", text: "What this doc deliberately does not specify", level: 2}
     - {slug: "related", text: "Related", level: 2}
+  - path: "docs/architecture/mission-gates.md"
+    title: "Mission transition gates — declarative, asset-backed, trust-gated"
+    divio_type: "explanation"
+    abstract: "How transition gates work under the declarative model — a first-class gate artefact kind whose check ships as an asset, is invoked via an entrypoint at a topology-resolved surface, runs only from trusted publishers, and is fail-closed by default."
+    anchors:
+    - {slug: "the-moving-parts", text: "The moving parts", level: 2}
+    - {slug: "definition-vs-binding", text: "Definition vs binding", level: 2}
+    - {slug: "execution-model", text: "Execution model", level: 2}
+    - {slug: "invariants", text: "Invariants", level: 2}
+    - {slug: "relationship-to-the-mission-subtree", text: "Relationship to the mission subtree", level: 2}
   - path: "docs/architecture/mission-system.md"
     title: "The Mission System Explained"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -938,6 +938,30 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/adr/3.x/2026-08-13-3-gate-execution-targets-through-kernel-surface-selector.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/adr/3.x/2026-08-13-4-executable-doctrine-runs-only-from-trusted-publishers.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none
@@ -1509,6 +1533,12 @@
   current_target: true
   notes: null
 - path: docs/architecture/launch-readiness-future.md
+  tag: current
+  divio_type: explanation
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/architecture/mission-gates.md
   tag: current
   divio_type: explanation
   owning_workstream: none

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -938,6 +938,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md
   tag: current
   divio_type: none
@@ -957,6 +963,12 @@
   current_target: true
   notes: null
 - path: docs/adr/3.x/2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md
   tag: current
   divio_type: none
   owning_workstream: none


### PR DESCRIPTION
## What this is

A **design/architecture PR** (docs only, no code) capturing the settled design for **declarative transition gates** and the **nested built-in mission subtree**, hardened by an adversarial dialectics pass and a DDD bounded-domains review. All gate ADRs are **Proposed** — this is for design review, not implementation.

Continues **Epic #2535** (doctrine-controlled transition gates) and relates to #2599 (trust model), #2721 (step-model unification), #2661 (specify_cli/missions retirement), #2468 (promote mission-types/step-contracts to kinds).

## Contents

**ADRs (`docs/adr/3.x/`):**
- `2026-08-13-1` — the built-in **mission subtree stays nested & self-contained; retire the legacy `MissionStepContract` surface** (unified `MissionStep` is the sole step authority). Discharges the nested-vs-flat decision reserved by ADR `2026-08-05-1`; supersedes point 5 of `2026-07-26-2`.
- `2026-08-13-2` — gates are **declarative, asset-backed, first-class `gate` artefacts** (structured `interpreter`+`args`, one generic dispatcher + grandfathered code gates).
- `2026-08-13-3` — gate **`executionTarget`** via a doctrine-owned selector token set + a new `execute_dir` verb reusing the stamped `GateExecutionContext` (no kernel change).
- `2026-08-13-4` — **executable doctrine runs only from trusted publishers** (built-in signed target; org/project TOFU).
- `2026-08-13-6` — gate outcomes carry a typed **`ERROR_SEVERITY`**; an operator `.kittify` **error-handling strategy** (`block_above(threshold)`) decides the CLI effect; consolidates the fragmented Severity enums.
- `2026-08-13-5` — *(direction, decision HELD OPEN)* local daemon parse-amortization; verdict-cache contested.

**Architecture page:** `docs/architecture/mission-gates.md` ties the ADRs together with **three render-verified PlantUML diagrams** (native-ArchiMate distribution, bounded-context component, runtime+resolution sequence) — rendered offline under the SANDBOX profile.

**Doc-path fixes:** retarget `mission-type-resolution.md` / `doctrine-kinds.md` from `src/doctrine/missions/` to the relocated `packs/built-in/missions/`.

## Deferred by decision
- Daemon **verdict cache** (ADR-5) — held open (unsound for working-tree-reading gates).
- Built-in **signing implementation** — architecture kept, impl deprioritized.

## Provenance
Design hardened by an adversarial dialectics squad + a DDD bounded-domains squad; the full grounding + scoping (5-mission program, dependency-ordered, one atomic node) lives in a local `work/` research tree (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789211925&installation_model_id=427282&pr_number=3378&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3378&signature=d08d8903fd86c0ee39499a613be5da813210e740f83d043b557925568d049928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->