### PR TITLE
feat(intake): optional v1 handoff packet overlay for structured briefs

### DIFF
--- a/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
+++ b/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
@@ -93,7 +93,7 @@ direction of travel — name the one meant.
   `docs/contracts/contract-registry.yaml` — that registry's `kind` vocabulary
   is currently `fallback_name` / `retired_literal` only, with no
   payload/intake-contract kind to register this record under. Adding that
-  `kind` and registering this contract is a follow-up (to be filed).
+  `kind` and registering this contract is a follow-up ([#3446](https://github.com/Priivacy-ai/spec-kitty/issues/3446)).
 
 ## Alternatives Considered
 

--- a/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
+++ b/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
@@ -1,0 +1,120 @@
+---
+title: 'ADR: Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract'
+description: 'Ratifies handoff-packet v1 — an additive, version-gated YAML-frontmatter overlay that lets upstream requirements tools seed spec-kitty intake with stable FR/AC ids, without Spec Kitty knowing any specific producer.'
+status: Accepted
+date: '2026-08-15'
+related:
+- docs/contracts/handoff-packet-v1.md
+---
+
+# Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract
+
+**Filename:** `2026-08-15-1-handoff-packet-intake-contract.md`
+
+**Status:** Accepted
+
+**Date:** 2026-08-15
+
+**Deciders:** Maintainer
+
+**Technical Story:** [PR #3379]
+
+---
+
+## Context and Problem Statement
+
+`spec-kitty intake` today only accepts unstructured Markdown. When a brief was
+authored (or exported) by an upstream requirements tool, `/spec-kitty.specify`
+re-mints FR and AC ids from prose and drops the producer's native identity —
+so a ticket, story, or use-case id that already existed upstream has no
+traceable link to the Spec Kitty artifact born from it. Upstream requirements
+tools generally do have stable ids worth preserving across that passage.
+
+Spec Kitty should be able to accept a structured seed from any such tool
+without knowing anything about that tool specifically — no ticket-key shape,
+no story-id convention, no producer-specific vocabulary baked into the
+schema. This ADR ratifies that PR #3379's answer to that problem is a
+contract Spec Kitty owns and commits to, not a one-off parsing convenience.
+
+## Decision Drivers
+
+* Preserve producer-native FR/AC identity across intake instead of re-minting it.
+* Never require a specific upstream tool, and never let any tool's vocabulary
+  leak into the schema.
+* Zero risk to the existing, already-working prose-intake path.
+* Producer-controlled strings are filesystem input from an untrusted source.
+
+## Decision
+
+Own a **tool-agnostic, optional, versioned** intake overlay — the handoff-packet
+contract at [`docs/contracts/handoff-packet-v1.md`] — bound by three invariants:
+
+1. **Additive; degrades to prose.** A packet-less or malformed brief behaves
+   exactly as today's intake. `spec-kitty intake` never fails because the
+   overlay is absent or invalid — a malformed packet still ingests the file
+   as a prose brief; only the structured overlay is dropped.
+2. **Version-gated.** The overlay activates only on `handoff_packet: 1`.
+   Unknown or future versions degrade to prose. A v2, if one is ever needed,
+   ships as a parallel, additive step alongside v1 rather than replacing it.
+3. **All producer strings are untrusted.** Provenance scalars are sanitised
+   (`escape_for_comment`, ASCII control-character stripping, a 256-byte clip)
+   before they land in `.kittify/brief-source.yaml` or any HTML/Markdown
+   comment. The brief's SHA-256 hash stays computed over the raw file, not
+   the parsed overlay.
+
+The existing discovery-gate confirmation at specify step 5 is preserved
+unchanged — the packet governs FR/AC id **numbering**, not whether the human
+confirms discovery. `source_tool` and `source_id` remain free-form strings;
+the schema encodes no producer-specific types (ticket keys, story ids, or
+similar).
+
+This intake-side **handoff packet** is a distinct artifact from the
+mission-side **handoff package** — the dossier/replay export produced by
+`src/specify_cli/dossier/` (mission 045,
+`kitty-specs/045-mission-handoff-package-version-matrix/`). The packet seeds a
+mission; the package is emitted after one. Same surface word, opposite
+direction of travel — name the one meant.
+
+## Consequences
+
+### Positive
+
+* Producers that emit v1 packets get stable, traceable FR/AC ids instead of
+  re-minted ones, and the producer-native id survives as a recorded trace.
+* Every other intake path is byte-for-byte unchanged; there is no migration
+  and no schema bump for projects that never emit a packet.
+
+### Negative and accepted trade-offs
+
+* Spec Kitty now commits to a producer-facing contract surface it must
+  version and eventually retire deliberately, rather than being free to
+  reshape intake parsing at will.
+* The contract is not yet registered in
+  `docs/contracts/contract-registry.yaml` — that registry's `kind` vocabulary
+  is currently `fallback_name` / `retired_literal` only, with no
+  payload/intake-contract kind to register this record under. Adding that
+  `kind` and registering this contract is a follow-up (to be filed).
+
+## Alternatives Considered
+
+### Require a mandatory structured format
+
+Rejected. Forcing every intake to be YAML-frontmatter-bearing would break the
+compatibility surface this contract exists to protect: "prose is always
+valid input" must remain true for every producer that never adopts the
+overlay.
+
+### Encode producer-specific vocabulary in the schema
+
+Rejected. Modeling ticket types, story shapes, or use-case ids directly in
+the frontmatter schema would couple Spec Kitty to a specific upstream tool's
+domain model. `source_tool` / `source_id` stay deliberately free-form so any
+producer can populate them without a schema change.
+
+## References
+
+* Contract: [`docs/contracts/handoff-packet-v1.md`]
+* [PR #3379]
+
+[`docs/contracts/handoff-packet-v1.md`]: ../../contracts/handoff-packet-v1.md
+[PR #3379]: https://github.com/Priivacy-ai/spec-kitty/pull/3379

--- a/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
+++ b/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract'
-description: 'Ratifies handoff-packet v1 — an additive, version-gated YAML-frontmatter overlay that lets upstream requirements tools seed spec-kitty intake with stable FR/AC ids, without Spec Kitty knowing any specific producer.'
+description: 'Ratifies handoff-packet v1: an additive, version-gated frontmatter overlay that seeds spec-kitty intake with stable FR/AC ids from upstream tools, degrading to prose when absent.'
 status: Accepted
 date: '2026-08-15'
 related:

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -181,3 +181,4 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-13 | [A local loopback daemon amortizes doctrine parse and caches deterministic gate verdicts (direction)](2026-08-13-5-local-daemon-amortizes-doctrine-parse-and-caches-gate-verdicts.md) |
 | 2026-08-13 | [Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect](2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md) |
 | 2026-08-13 | [Mission-Type Roster Layering Is the Availability Slice, Not the Kind-Promotion Slice](2026-08-13-1-mission-type-roster-layering-seam.md) |
+| 2026-08-15 | [Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract](2026-08-15-1-handoff-packet-intake-contract.md) |

--- a/docs/api/agent-plan-artifacts.md
+++ b/docs/api/agent-plan-artifacts.md
@@ -2,7 +2,7 @@
 title: Agent Plan Artifacts Reference
 description: Reference for agent plan artifacts generated during missions. Learn the role of spec.md, plan.md, tasks.md, and checklists/requirements.md.
 doc_status: active
-updated: '2026-06-15'
+updated: '2026-08-13'
 ---
 # Agent Plan Artifacts Reference
 
@@ -12,7 +12,7 @@ saves plan files to disk, and the confidence level of that information.
 Used by `spec-kitty intake --auto` via `src/specify_cli/intake_sources.py` to
 scan for pre-existing agent-generated plans that can serve as intake context.
 
-Last updated: 2026-04-20
+Last updated: 2026-08-13
 
 ---
 
@@ -311,6 +311,7 @@ configured harness key.
 | Amazon Q / Kiro | `q` / `kiro` | `amazon-q` |
 | Google Antigravity | `antigravity` | `antigravity` |
 | Mistral Vibe | `vibe` | `vibe` |
+| Generic handoff packet | `handoff` | omitted (`source_agent` taken from packet `source_tool` when present) |
 
 ---
 
@@ -335,6 +336,7 @@ project-level (or configurable) path are included as active tuples in `HARNESS_P
 | Kiro | Yes | `.kiro/specs/<slug>/requirements.md`, `design.md`, `tasks.md` are the verified spec artifacts. |
 | Antigravity | No | No confirmed project-level plan file path. |
 | Mistral Vibe | No | No confirmed plan file output on disk. |
+| Generic handoff packet | Yes | `.handoff/*.md` is the project-local drop directory for tool-agnostic handoff packets (`docs/contracts/handoff-packet-v1.md`). |
 
 ---
 

--- a/docs/api/slash-commands.md
+++ b/docs/api/slash-commands.md
@@ -2,7 +2,7 @@
 title: Spec Kitty slash commands reference — CLI quick reference
 description: Quick reference guide for Spec Kitty slash commands. Learn how to invoke specify, plan, tasks, implement, review, accept, and merge within AI coding agents.
 doc_status: active
-updated: '2026-06-09'
+updated: '2026-08-15'
 ---
 # Slash Command Reference
 
@@ -34,6 +34,14 @@ Syntax format in this reference:
 - `kitty-specs/<feature>/spec.md`
 - `kitty-specs/<feature>/meta.json`
 - `kitty-specs/<feature>/checklists/requirements.md`
+
+**Optional handoff-packet intake**: if `spec-kitty intake` staged a brief
+whose YAML frontmatter declares `handoff_packet: 1` (an upstream requirements
+tool's export), `/spec-kitty.specify` adopts that packet's FR/AC ids verbatim
+instead of re-minting them — the discovery interview above still runs. A
+packet-less brief, an unrecognised version, or malformed frontmatter all
+degrade to today's plain-prose intake; the command never fails because the
+overlay is absent or invalid. See [Handoff Packet v1](../contracts/handoff-packet-v1.md).
 
 **Related**: `/spec-kitty.plan`, `/spec-kitty.charter`
 

--- a/docs/architecture/spec-kitty-mission-workflow.md
+++ b/docs/architecture/spec-kitty-mission-workflow.md
@@ -2,7 +2,7 @@
 title: Spec Kitty Mission Workflow
 description: 'End-to-end authority for a local autonomous mission: the nine phases from specify through retrospective, and the focused-PR path when the target branch is not synchronized.'
 doc_status: active
-updated: '2026-08-10'
+updated: '2026-08-15'
 type: explanation
 audience: docs/context/audience/internal/lead-developer.md
 ---
@@ -21,6 +21,15 @@ Create the mission spec from the intake prompt:
 ```
 
 Confirm the mission slug, target branch, and requirement scope before planning.
+
+If the brief carries YAML frontmatter with `handoff_packet: 1` — emitted by an
+upstream requirements tool — `spec-kitty intake` picks it up automatically
+(`intake --auto` also scans `.handoff/*.md` at the project root) and
+`/spec-kitty.specify` adopts the packet's FR/AC ids verbatim instead of
+re-minting them; the discovery-gate confirmation above still runs. This
+overlay is optional and additive: a packet-less brief, an unrecognised
+version, or malformed frontmatter all behave exactly like plain prose intake.
+See [Handoff Packet v1](../contracts/handoff-packet-v1.md).
 
 ## Phase 2: Plan
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -82,6 +82,13 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   superseded working notes in place (content preserved, evidence-cited) and
   gathers the domain plans under `docs/plans/domains/`.
 
+- **`spec-kitty intake` now recognises an optional v1 handoff packet so upstream
+  requirements tools can seed a mission without the agent re-inventing FR/AC
+  ids.** A packet is ordinary Markdown; YAML frontmatter with `handoff_packet: 1`
+  is additive. Unknown versions and malformed YAML degrade to today's prose
+  intake. `intake --auto` also scans `.handoff/*.md`. Contract:
+  `docs/contracts/handoff-packet-v1.md`.
+
 - **The doctrine documentation site now shows rendered schema diagrams of the
   doctrine artefacts, drawn locally with no network egress (mission
   `doctrine-schema-diagrams-01KZTQTH`; `#3366`, `#3354`).** Before, the doctrine

--- a/docs/contracts/handoff-packet-v1.md
+++ b/docs/contracts/handoff-packet-v1.md
@@ -1,0 +1,162 @@
+---
+title: Handoff Packet v1
+description: Tool-agnostic optional YAML-frontmatter contract for seeding a Spec Kitty mission from an upstream requirements tool.
+doc_status: durable
+updated: '2026-08-13'
+related:
+- docs/api/agent-plan-artifacts.md
+- src/specify_cli/intake/packet.py
+---
+# Handoff Packet v1
+
+A **handoff packet** is a single Markdown file that any upstream requirements
+producer can emit so `spec-kitty intake` can seed `/spec-kitty.specify`
+without the agent re-inventing requirement identities.
+
+The prose body is the compatibility surface: today's unmodified
+`spec-kitty intake` already accepts any Markdown file. Optional YAML
+frontmatter is what preserves identity across the passage.
+
+## Design rules
+
+1. **Frontmatter is optional and additive.** A packet-less Markdown brief
+   behaves exactly as today's intake. Spec Kitty never requires this schema
+   to ingest a plan.
+2. **No producer vocabulary in the schema.** `source_tool` is a free-form
+   string. Do not encode producer-specific types (ticket keys, story ids,
+   use-case ids, or similar) into the field names.
+3. **Version-gated on `handoff_packet: 1`.** Unknown versions degrade to
+   prose intake rather than failing the command.
+4. **All strings are untrusted.** Producers and Spec Kitty must treat every
+   scalar as operator-controlled filesystem data. Spec Kitty sanitises
+   provenance fields with `escape_for_comment` before they land in
+   `.kittify/brief-source.yaml` or HTML comments.
+
+## Degradation rules
+
+| Input | Intake behaviour |
+|-------|------------------|
+| Markdown with no `---` frontmatter | Prose intake (today's path) |
+| Frontmatter present, no `handoff_packet` key | Prose intake |
+| `handoff_packet` present but not the integer `1` | Prose intake (unknown version) |
+| Frontmatter YAML that does not parse | Prose intake |
+| `handoff_packet: 1` with a non-list `requirements` | Prose intake |
+| `handoff_packet: 1` with a valid `requirements` list | Structured packet; FR/AC IDs adopted verbatim |
+
+Intake itself never exits non-zero because a packet is malformed. The file
+is still ingested as a brief; only the structured overlay is dropped.
+
+## Frontmatter schema (v1)
+
+    ---
+    handoff_packet: 1                  # required integer; only 1 is understood
+    source_tool: example-tool          # free-form producer name
+    source_tool_version: "1.0.0"       # optional
+    source_mission: widget-booking
+    source_ref: 0123456789abcdef0123456789abcdef01234567
+    source_url: https://example.invalid/items/widget-booking
+    generated_at: "2026-08-13T10:00:00Z"
+    requirements:
+      - id: FR-001                     # adopted verbatim into spec.md
+        statement: "Operator can book a widget against an open slot."
+        source_id: TKT-1042            # producer-native identity; recorded as a trace
+        acceptance_criteria:
+          - id: AC-001
+            statement: "An open slot accepts a widget booking."
+            source_id: AC-001
+    constraints:
+      - id: C-001
+        statement: "Must remain compatible with the existing booking API."
+        source_id: EXT-003
+    ---
+
+    # Human-readable rendering of the same content
+
+### Field notes
+
+| Field | Required when `handoff_packet: 1` | Notes |
+|-------|-----------------------------------|-------|
+| `handoff_packet` | yes | Integer `1` only |
+| `requirements` | yes | List, may be empty |
+| `requirements[].id` | yes | Spec Kitty FR id; do not renumber on ingest |
+| `requirements[].statement` | yes | One sentence; not Gherkin |
+| `requirements[].source_id` | no | Producer-native id (ticket, item, or similar) |
+| `requirements[].acceptance_criteria` | no | List |
+| `constraints` | no | List of `C-###` items |
+| `source_tool` / `source_mission` / `source_ref` | no | Copied into `brief-source.yaml` |
+
+Gherkin, sequencing, and Definition of Done belong in the **Markdown body**,
+not in `requirements[].statement`.
+
+## Security expectations
+
+- Strip ASCII control characters (except tab) from provenance scalars.
+- Neutralise `-->` and `*/` before embedding strings in HTML/Markdown comments.
+- Clip provenance scalars to 256 UTF-8 bytes.
+- YAML dump must quote strings so a statement cannot inject a second
+  document boundary or a crafted `handoff_packet` key.
+- Packet size is still bounded by `intake.max_brief_bytes` (default 5 MB).
+
+## Discovery
+
+`spec-kitty intake --auto` scans `.handoff/*.md` at the project root in
+addition to harness plan directories. Producers that cannot write that
+directory can pass an explicit path:
+
+    spec-kitty intake .handoff/widget-booking.md
+
+## Worked example
+
+One upstream item produces one packet. Each producer-native work item
+becomes one `FR-###`; each acceptance-criterion id is preserved; Gherkin
+scenarios render under **Definition of Done** in the body.
+
+    ---
+    handoff_packet: 1
+    source_tool: example-tool
+    source_tool_version: "1.0.0"
+    source_mission: widget-booking
+    source_ref: 0123456789abcdef0123456789abcdef01234567
+    generated_at: "2026-08-13T00:00:00.000Z"
+    requirements:
+      - id: FR-001
+        statement: "Book a widget against an open slot."
+        source_id: TKT-1042
+        acceptance_criteria:
+          - id: AC-001
+            statement: "An open slot accepts a widget booking."
+            source_id: AC-001
+    constraints:
+      - id: C-001
+        statement: "Bookings must not overlap an existing reservation."
+        source_id: EXT-003
+    ---
+
+    # widget-booking
+
+    ## Objective
+
+    Book widgets.
+
+    ## Requirements
+
+    ### FR-001 — Book a widget against an open slot.
+
+    - Source: `TKT-1042`
+    - `AC-001`: An open slot accepts a widget booking.
+
+    ## Constraints
+
+    - `C-001` (source `EXT-003`): Bookings must not overlap an existing reservation.
+
+    ## Sequencing
+
+    - `TKT-1042` has no blockers.
+
+    ## Definition of Done
+
+    ### TKT-1042 / TC-001
+
+        Given an open slot
+        When the operator books a widget
+        Then the slot is reserved

--- a/docs/contracts/handoff-packet-v1.md
+++ b/docs/contracts/handoff-packet-v1.md
@@ -17,6 +17,11 @@ The prose body is the compatibility surface: today's unmodified
 `spec-kitty intake` already accepts any Markdown file. Optional YAML
 frontmatter is what preserves identity across the passage.
 
+This intake-side **handoff packet** (input to `spec-kitty intake`, this
+contract) is a distinct artifact from the mission-side **handoff
+package** (the dossier/replay export produced from `src/specify_cli/dossier/`,
+mission 045) — the former seeds a mission, the latter is emitted after one.
+
 ## Design rules
 
 1. **Frontmatter is optional and additive.** A packet-less Markdown brief

--- a/docs/contracts/handoff-packet-v1.md
+++ b/docs/contracts/handoff-packet-v1.md
@@ -41,6 +41,8 @@ frontmatter is what preserves identity across the passage.
 | `handoff_packet` present but not the integer `1` | Prose intake (unknown version) |
 | Frontmatter YAML that does not parse | Prose intake |
 | `handoff_packet: 1` with a non-list `requirements` | Prose intake |
+| `handoff_packet: 1` with a malformed `acceptance_criteria` item (missing/empty `id` or `statement`) | Prose intake |
+| `handoff_packet: 1` with a malformed `constraints` item (missing/empty `id`) | Prose intake |
 | `handoff_packet: 1` with a valid `requirements` list | Structured packet; FR/AC IDs adopted verbatim |
 
 Intake itself never exits non-zero because a packet is malformed. The file
@@ -81,8 +83,8 @@ is still ingested as a brief; only the structured overlay is dropped.
 | `requirements[].id` | yes | Spec Kitty FR id; do not renumber on ingest |
 | `requirements[].statement` | yes | One sentence; not Gherkin |
 | `requirements[].source_id` | no | Producer-native id (ticket, item, or similar) |
-| `requirements[].acceptance_criteria` | no | List |
-| `constraints` | no | List of `C-###` items |
+| `requirements[].acceptance_criteria` | no | List; when present, every item's `id` and `statement` are validated (non-empty strings) — a malformed item degrades the whole packet to prose, it is not silently dropped or miscounted |
+| `constraints` | no | List of `C-###` items; every item's `id` is validated (non-empty string) — a malformed item degrades the whole packet to prose |
 | `source_tool` / `source_mission` / `source_ref` | no | Copied into `brief-source.yaml` |
 
 Gherkin, sequencing, and Definition of Done belong in the **Markdown body**,

--- a/docs/contracts/handoff-packet-v1.md
+++ b/docs/contracts/handoff-packet-v1.md
@@ -5,7 +5,7 @@ doc_status: durable
 updated: '2026-08-13'
 related:
 - docs/api/agent-plan-artifacts.md
-- src/specify_cli/intake/packet.py
+- docs/contracts/index.md
 ---
 # Handoff Packet v1
 

--- a/docs/contracts/index.md
+++ b/docs/contracts/index.md
@@ -2,10 +2,11 @@
 title: Contracts
 description: 'Contract-ownership boundary registry for Spec Kitty: the seeded contract manifest and its validation schema, checked by the doctor contracts gate.'
 doc_status: active
-updated: '2026-07-07'
+updated: '2026-08-14'
 related:
 - docs/api/cli-commands.md
 - docs/index.md
+- docs/contracts/handoff-packet-v1.md
 ---
 # Contracts
 

--- a/docs/contracts/index.md
+++ b/docs/contracts/index.md
@@ -13,6 +13,14 @@ This section holds the **Contract Registry** for the contract-ownership
 boundary (#2441): the single, canonical manifest of ownership contracts that
 Spec Kitty enforces, plus the schema that validates it.
 
+It also holds the **handoff packet** payload contract that external
+requirements tools use to seed `/spec-kitty.specify` without losing
+requirement identity:
+
+- `handoff-packet-v1.md` — optional YAML-frontmatter overlay on a Markdown
+  brief. Frontmatter is additive; unknown versions degrade to prose intake.
+  Parser: `src/specify_cli/intake/packet.py`.
+
 ## Files
 
 - `contract-registry.yaml` — the seeded contract manifest. Each record declares
@@ -23,6 +31,9 @@ Spec Kitty enforces, plus the schema that validates it.
   validated against: required fields, allowed `kind`/`status`/`enforcement`
   ranges, well-formed semver and tracker references, resolvable anchors, and the
   DIR-041 self-consistency rule that forbids positional `file:line` anchoring.
+- `handoff-packet-v1.md` — optional YAML-frontmatter overlay that lets an
+  upstream requirements tool seed `/spec-kitty.specify` without losing FR/AC
+  identity. Unknown versions degrade to prose intake.
 
 ## Validation
 

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2850,7 +2850,7 @@ pages:
   - path: "docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md"
     title: "ADR: Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract"
     divio_type: "none"
-    abstract: "Ratifies handoff-packet v1 — an additive, version-gated YAML-frontmatter overlay that lets upstream requirements tools seed spec-kitty intake with stable FR/AC ids, without Spec Kitty knowing any specific producer."
+    abstract: "Ratifies handoff-packet v1: an additive, version-gated frontmatter overlay that seeds spec-kitty intake with stable FR/AC ids from upstream tools, degrading to prose when absent."
     anchors:
     - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
     - {slug: "decision-drivers", text: "Decision Drivers", level: 2}

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2847,6 +2847,21 @@ pages:
     - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
     - {slug: "consequences", text: "Consequences", level: 3}
     - {slug: "open-questions-for-scoping-a-later-pass", text: "Open questions (for scoping / a later pass)", level: 3}
+  - path: "docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md"
+    title: "ADR: Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract"
+    divio_type: "none"
+    abstract: "Ratifies handoff-packet v1 — an additive, version-gated YAML-frontmatter overlay that lets upstream requirements tools seed spec-kitty intake with stable FR/AC ids, without Spec Kitty knowing any specific producer."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "decision", text: "Decision", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 2}
+    - {slug: "positive", text: "Positive", level: 3}
+    - {slug: "negative-and-accepted-trade-offs", text: "Negative and accepted trade-offs", level: 3}
+    - {slug: "alternatives-considered", text: "Alternatives Considered", level: 2}
+    - {slug: "require-a-mandatory-structured-format", text: "Require a mandatory structured format", level: 3}
+    - {slug: "encode-producer-specific-vocabulary-in-the-schema", text: "Encode producer-specific vocabulary in the schema", level: 3}
+    - {slug: "references", text: "References", level: 2}
   - path: "docs/adr/3.x/README.md"
     title: "3.x ADRs"
     divio_type: "none"
@@ -6453,6 +6468,18 @@ pages:
     - {slug: "orchestrator-smoke-availability-fixtures-happy-path-review-cycles-parallel", text: "Orchestrator Smoke / Availability / Fixtures / Happy Path / Review Cycles / Parallel", level: 3}
     - {slug: "core-agent-extended-agent", text: "Core Agent / Extended Agent", level: 3}
     - {slug: "exploratory", text: "Exploratory", level: 3}
+  - path: "docs/contracts/handoff-packet-v1.md"
+    title: "Handoff Packet v1"
+    divio_type: "none"
+    abstract: "Tool-agnostic optional YAML-frontmatter contract for seeding a Spec Kitty mission from an upstream requirements tool."
+    anchors:
+    - {slug: "design-rules", text: "Design rules", level: 2}
+    - {slug: "degradation-rules", text: "Degradation rules", level: 2}
+    - {slug: "frontmatter-schema-v1", text: "Frontmatter schema (v1)", level: 2}
+    - {slug: "field-notes", text: "Field notes", level: 3}
+    - {slug: "security-expectations", text: "Security expectations", level: 2}
+    - {slug: "discovery", text: "Discovery", level: 2}
+    - {slug: "worked-example", text: "Worked example", level: 2}
   - path: "docs/contracts/index.md"
     title: "Contracts"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -980,6 +980,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none
@@ -2019,6 +2025,12 @@
   current_target: true
   notes: null
 - path: docs/context/testing-taxonomy.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/contracts/handoff-packet-v1.md
   tag: current
   divio_type: none
   owning_workstream: none

--- a/docs/guides/tutorials/your-first-mission.md
+++ b/docs/guides/tutorials/your-first-mission.md
@@ -2,7 +2,7 @@
 title: 'Your First Mission: Complete Workflow'
 description: Walk through a complete Spec Kitty 3.2 mission from specification through plan, tasks, implementation, review, and merge.
 doc_status: active
-updated: '2026-08-09'
+updated: '2026-08-15'
 audience: docs/context/audience/external/project-owner.md
 type: tutorial
 related:
@@ -51,6 +51,15 @@ Expected results:
 
 - `kitty-specs/###-task-list/spec.md`
 - A new mission directory created under `kitty-specs/`
+
+**Starting from an upstream brief instead?** If your brief was exported by
+another requirements tool and carries YAML frontmatter with
+`handoff_packet: 1`, `spec-kitty intake --auto` (which also scans
+`.handoff/*.md` at the project root) picks it up automatically, and
+`/spec-kitty.specify` adopts its FR/AC ids instead of re-inventing them. This
+is optional and safe — a brief without that frontmatter behaves exactly like
+the plain-prose flow above, and the discovery interview still runs. See
+[Handoff Packet v1](../../contracts/handoff-packet-v1.md).
 
 ## Step 2: Create the Technical Plan
 

--- a/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
@@ -202,7 +202,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -236,6 +260,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/src/specify_cli/cli/commands/intake.py
+++ b/src/specify_cli/cli/commands/intake.py
@@ -15,6 +15,7 @@ from specify_cli.intake.errors import (
     IntakeFileUnreadableError,
     IntakeTooLargeError,
 )
+from specify_cli.intake.packet import parse_handoff_packet
 from specify_cli.intake.scanner import (
     load_max_brief_bytes,
     read_brief,
@@ -61,6 +62,26 @@ def _resolve_repo_root() -> Path:
         return Path.cwd().resolve()
 
 
+def _commit_brief(
+    repo_root: Path,
+    content: str,
+    source_file: str,
+    source_agent: str | None = None,
+) -> None:
+    """Write the brief pair, overlaying handoff-packet provenance when present."""
+    packet = parse_handoff_packet(content)
+    agent = source_agent
+    if agent is None and packet is not None and packet.source_tool:
+        agent = packet.source_tool
+    write_mission_brief(
+        repo_root,
+        content,
+        source_file,
+        source_agent=agent,
+        packet_meta=packet.sidecar_fields() if packet is not None else None,
+    )
+
+
 def _write_brief_from_candidate(
     repo_root: Path,
     found_path: Path,
@@ -93,7 +114,9 @@ def _write_brief_from_candidate(
     except IntakeFileUnreadableError as exc:
         err_console.print(f"[red]Could not read file: {exc.__cause__}[/red]")
         raise typer.Exit(1) from None
-    write_mission_brief(repo_root, content, str(found_path), source_agent=source_agent_value)
+    _commit_brief(
+        repo_root, content, str(found_path), source_agent=source_agent_value
+    )
     console.print("[green]\u2713[/green] Brief written to .kittify/mission-brief.md")
     console.print("[green]\u2713[/green] Provenance written to .kittify/brief-source.yaml")
 
@@ -249,6 +272,6 @@ def intake(
             raise typer.Exit(1) from None
         source_file = path
 
-    write_mission_brief(repo_root, content, source_file)
+    _commit_brief(repo_root, content, source_file)
     console.print("[green]\u2713[/green] Brief written to .kittify/mission-brief.md")
     console.print("[green]\u2713[/green] Provenance written to .kittify/brief-source.yaml")

--- a/src/specify_cli/intake/__init__.py
+++ b/src/specify_cli/intake/__init__.py
@@ -2,6 +2,8 @@
 
 This package centralises the boundary helpers used by ``spec-kitty intake``:
 
+* :mod:`packet` — optional handoff-packet frontmatter parser (v1); malformed
+  or unknown versions degrade to prose intake.
 * :mod:`provenance` — escape strings before writing them into provenance
   comments / YAML so untrusted source paths cannot break out of the
   comment context or smuggle markdown into the brief.
@@ -31,6 +33,7 @@ from .errors import (
     IntakeRootInconsistentError,
     IntakeTooLargeError,
 )
+from .packet import parse_handoff_packet
 from .provenance import escape_for_comment
 from .scanner import (
     DEFAULT_MAX_BRIEF_BYTES,
@@ -56,6 +59,7 @@ __all__ = [
     "assert_under_root",
     "escape_for_comment",
     "load_max_brief_bytes",
+    "parse_handoff_packet",
     "read_brief",
     "read_stdin_capped",
 ]

--- a/src/specify_cli/intake/packet.py
+++ b/src/specify_cli/intake/packet.py
@@ -73,7 +73,13 @@ def parse_handoff_packet(content: str) -> HandoffPacket | None:
     """
     if not content:
         return None
-    match = _FRONTMATTER_RE.match(content)
+    # A leading UTF-8 BOM defeats the ``\A---`` anchor below and would
+    # silently degrade a real packet to prose. Strip a single leading BOM
+    # from the parse view only; ``content`` itself (and thus the raw
+    # SHA-256 brief hash computed by callers over the untouched string) is
+    # never mutated.
+    view = content.removeprefix("\ufeff")
+    match = _FRONTMATTER_RE.match(view)
     if match is None:
         return None
     try:
@@ -83,7 +89,14 @@ def parse_handoff_packet(content: str) -> HandoffPacket | None:
     if not isinstance(loaded, dict):
         return None
     version = loaded.get("handoff_packet")
-    if version != HANDOFF_PACKET_VERSION:
+    # ``True == 1`` and ``1.0 == 1`` in Python, so a bare ``!=`` check would
+    # accept ``handoff_packet: true`` or ``handoff_packet: 1.0``. Only the
+    # literal int ``1`` is a valid v1 packet.
+    if (
+        not isinstance(version, int)
+        or isinstance(version, bool)
+        or version != HANDOFF_PACKET_VERSION
+    ):
         return None
     requirements = loaded.get("requirements")
     if not isinstance(requirements, list):

--- a/src/specify_cli/intake/packet.py
+++ b/src/specify_cli/intake/packet.py
@@ -1,0 +1,124 @@
+"""Parse optional handoff-packet frontmatter from an intake brief.
+
+A handoff packet is Markdown whose YAML frontmatter may declare
+``handoff_packet: 1``. The prose body is always valid intake; structured
+frontmatter is additive. Unknown or malformed packets degrade to prose
+(return ``None``) instead of failing the command.
+
+Contract: ``docs/contracts/handoff-packet-v1.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+from specify_cli.intake.provenance import escape_for_comment
+
+HANDOFF_PACKET_VERSION = 1
+
+_FRONTMATTER_RE = re.compile(
+    r"\A---\r?\n(?P<yaml>.*?)\r?\n---(?:\r?\n(?P<body>.*))?\Z",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HandoffPacket:
+    """Validated v1 packet overlay. Body is the original Markdown including frontmatter."""
+
+    source_tool: str | None
+    source_mission: str | None
+    source_ref: str | None
+    requirement_count: int
+    constraint_count: int
+    requirement_ids: tuple[str, ...]
+    body: str
+
+    def sidecar_fields(self) -> dict[str, Any]:
+        """Provenance fields for ``brief-source.yaml`` (already comment-escaped)."""
+        fields: dict[str, Any] = {
+            "packet_version": HANDOFF_PACKET_VERSION,
+            "requirement_count": self.requirement_count,
+            "constraint_count": self.constraint_count,
+        }
+        if self.source_tool:
+            fields["source_tool"] = escape_for_comment(self.source_tool)
+        if self.source_mission:
+            fields["source_mission"] = escape_for_comment(self.source_mission)
+        if self.source_ref:
+            fields["source_ref"] = escape_for_comment(self.source_ref)
+        if self.requirement_ids:
+            fields["requirement_ids"] = [
+                escape_for_comment(rid) for rid in self.requirement_ids
+            ]
+        return fields
+
+
+def _optional_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def parse_handoff_packet(content: str) -> HandoffPacket | None:
+    """Return a v1 packet when frontmatter is valid; otherwise ``None`` (prose).
+
+    Never raises for malformed YAML, unknown versions, or missing fields —
+    those degrade to prose intake.
+    """
+    if not content:
+        return None
+    match = _FRONTMATTER_RE.match(content)
+    if match is None:
+        return None
+    try:
+        loaded = yaml.safe_load(match.group("yaml"))
+    except yaml.YAMLError:
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    version = loaded.get("handoff_packet")
+    if version != HANDOFF_PACKET_VERSION:
+        return None
+    requirements = loaded.get("requirements")
+    if not isinstance(requirements, list):
+        return None
+    ids: list[str] = []
+    for item in requirements:
+        if not isinstance(item, dict):
+            return None
+        req_id = item.get("id")
+        statement = item.get("statement")
+        if not isinstance(req_id, str) or not req_id.strip():
+            return None
+        if not isinstance(statement, str) or not statement.strip():
+            return None
+        ids.append(req_id.strip())
+    constraints = loaded.get("constraints")
+    if constraints is None:
+        constraint_count = 0
+    elif isinstance(constraints, list):
+        constraint_count = len(constraints)
+    else:
+        return None
+    return HandoffPacket(
+        source_tool=_optional_str(loaded.get("source_tool")),
+        source_mission=_optional_str(loaded.get("source_mission")),
+        source_ref=_optional_str(loaded.get("source_ref")),
+        requirement_count=len(ids),
+        constraint_count=constraint_count,
+        requirement_ids=tuple(ids),
+        body=content,
+    )
+
+
+__all__ = [
+    "HANDOFF_PACKET_VERSION",
+    "HandoffPacket",
+    "parse_handoff_packet",
+]

--- a/src/specify_cli/intake/packet.py
+++ b/src/specify_cli/intake/packet.py
@@ -65,6 +65,52 @@ def _optional_str(value: object) -> str | None:
     return stripped or None
 
 
+def _acceptance_criteria_valid(value: object) -> bool:
+    """Return ``True`` when ``value`` is absent or a well-formed AC list.
+
+    Absent ``acceptance_criteria`` is fine (it's optional). When present,
+    each item must be a dict with a non-empty string ``id`` and a
+    non-empty string ``statement`` — the contract's "adopted verbatim"
+    promise (handoff-packet-v1.md degradation table, malformed-AC row)
+    only holds if the ids are actually validated, not just counted.
+    """
+    if value is None:
+        return True
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if not isinstance(item, dict):
+            return False
+        ac_id = item.get("id")
+        ac_statement = item.get("statement")
+        if not isinstance(ac_id, str) or not ac_id.strip():
+            return False
+        if not isinstance(ac_statement, str) or not ac_statement.strip():
+            return False
+    return True
+
+
+def _valid_constraint_count(value: object) -> int | None:
+    """Return the count of well-formed constraints, or ``None`` if malformed.
+
+    Absent ``constraints`` is fine (count 0). When present, every item
+    must be a dict with a non-empty string ``id``; a malformed item
+    degrades the whole packet to prose rather than silently inflating
+    ``constraint_count`` via a bare ``len()``.
+    """
+    if value is None:
+        return 0
+    if not isinstance(value, list):
+        return None
+    for item in value:
+        if not isinstance(item, dict):
+            return None
+        constraint_id = item.get("id")
+        if not isinstance(constraint_id, str) or not constraint_id.strip():
+            return None
+    return len(value)
+
+
 def parse_handoff_packet(content: str) -> HandoffPacket | None:
     """Return a v1 packet when frontmatter is valid; otherwise ``None`` (prose).
 
@@ -111,13 +157,11 @@ def parse_handoff_packet(content: str) -> HandoffPacket | None:
             return None
         if not isinstance(statement, str) or not statement.strip():
             return None
+        if not _acceptance_criteria_valid(item.get("acceptance_criteria")):
+            return None
         ids.append(req_id.strip())
-    constraints = loaded.get("constraints")
-    if constraints is None:
-        constraint_count = 0
-    elif isinstance(constraints, list):
-        constraint_count = len(constraints)
-    else:
+    constraint_count = _valid_constraint_count(loaded.get("constraints"))
+    if constraint_count is None:
         return None
     return HandoffPacket(
         source_tool=_optional_str(loaded.get("source_tool")),

--- a/src/specify_cli/intake/packet.py
+++ b/src/specify_cli/intake/packet.py
@@ -20,6 +20,16 @@ from specify_cli.intake.provenance import escape_for_comment
 
 HANDOFF_PACKET_VERSION = 1
 
+# This regex — not ``specify_cli.frontmatter.FrontmatterManager`` — does the
+# frontmatter split here deliberately. ``FrontmatterManager`` operates on a
+# file path and raises ``FrontmatterError`` on malformed input; this module
+# operates on an in-memory string handed to us by the caller and must NEVER
+# raise — every malformed shape degrades to prose (``return None``), per the
+# module docstring. Consequently we also do not share ``FrontmatterManager``'s
+# ``allow_duplicate_keys=False`` posture: a duplicate-key packet here simply
+# fails ``yaml.safe_load``'s last-key-wins parse or trips a downstream
+# validation check and degrades to prose, which is an acceptable outcome for
+# an optional, best-effort overlay.
 _FRONTMATTER_RE = re.compile(
     r"\A---\r?\n(?P<yaml>.*?)\r?\n---(?:\r?\n(?P<body>.*))?\Z",
     re.DOTALL,

--- a/src/specify_cli/intake/packet.py
+++ b/src/specify_cli/intake/packet.py
@@ -184,8 +184,11 @@ def parse_handoff_packet(content: str) -> HandoffPacket | None:
     )
 
 
+# Only ``parse_handoff_packet`` is consumed across module boundaries (by
+# ``cli/commands/intake.py``). ``HANDOFF_PACKET_VERSION`` and ``HandoffPacket``
+# remain importable module symbols (tests reference them directly) but are not
+# part of the exported surface — keeping them in ``__all__`` tripped the
+# dead-public-symbol gate, since no other ``src/`` file imports them.
 __all__ = [
-    "HANDOFF_PACKET_VERSION",
-    "HandoffPacket",
     "parse_handoff_packet",
 ]

--- a/src/specify_cli/intake_sources.py
+++ b/src/specify_cli/intake_sources.py
@@ -62,6 +62,16 @@ HARNESS_PLAN_SOURCES: list[tuple[str, str | None, list[str]]] = [
         "gemini",
         [".gemini/plans"],
     ),
+    # Generic handoff packet — Verified-docs (this repository).
+    # Tool-agnostic Markdown packets (optional YAML frontmatter `handoff_packet: 1`)
+    # dropped at the project root by any upstream requirements producer.
+    # Listed after harness-specific hidden dirs (ordering rule: generic last).
+    # Source: docs/contracts/handoff-packet-v1.md
+    (
+        "handoff",
+        None,
+        [".handoff"],
+    ),
 ]
 
 

--- a/src/specify_cli/mission_brief.py
+++ b/src/specify_cli/mission_brief.py
@@ -45,6 +45,7 @@ def write_mission_brief(
     source_file: str,
     *,
     source_agent: str | None = None,
+    packet_meta: dict[str, Any] | None = None,
 ) -> tuple[Path, Path]:
     """Write ``.kittify/mission-brief.md`` and ``.kittify/brief-source.yaml``.
 
@@ -90,7 +91,7 @@ def write_mission_brief(
     )
     brief_text = header + "\n\n" + content
 
-    source_data: dict[str, str] = {
+    source_data: dict[str, Any] = {
         # The cleaned form is what the YAML sidecar records.  Storing the
         # cleaned value (rather than the raw input) keeps the SHA-256 hash
         # the source of truth for the *content* and the YAML the source of
@@ -101,6 +102,8 @@ def write_mission_brief(
     }
     if safe_source_agent is not None:
         source_data["source_agent"] = safe_source_agent
+    if packet_meta:
+        source_data.update(packet_meta)
 
     # WP02 T010: atomic write via open + fsync + replace.  Cross-fs
     # writes are rejected unless explicitly allowed in config.yaml.

--- a/tests/cli/test_mission_brief.py
+++ b/tests/cli/test_mission_brief.py
@@ -176,3 +176,26 @@ def test_write_twice_overwrites(tmp_path: Path) -> None:
     assert brief_text is not None
     assert new_content in brief_text
     assert RAW_CONTENT not in brief_text
+
+
+def test_write_packet_meta_lands_in_sidecar_without_changing_content_hash(
+    tmp_path: Path,
+) -> None:
+    """Packet overlay fields are sidecar-only; brief_hash stays SHA-256 of raw content."""
+    packet_meta = {
+        "packet_version": 1,
+        "source_tool": "example-tool",
+        "source_mission": "widget-booking",
+        "requirement_count": 2,
+    }
+    write_mission_brief(
+        tmp_path, RAW_CONTENT, "packet.md", packet_meta=packet_meta
+    )
+    expected_hash = hashlib.sha256(RAW_CONTENT.encode()).hexdigest()  # noqa: TID251 — mission-brief content fingerprint, not charter freshness hashing
+    source = read_brief_source(tmp_path)
+    assert source is not None
+    assert source["brief_hash"] == expected_hash
+    assert source["source_tool"] == "example-tool"
+    assert source["source_mission"] == "widget-booking"
+    assert source["requirement_count"] == 2
+    assert source["packet_version"] == 1

--- a/tests/specify_cli/cli/commands/test_intake.py
+++ b/tests/specify_cli/cli/commands/test_intake.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import hashlib
 
 import pytest
 import typer
@@ -305,3 +306,37 @@ def test_auto_tty_zero_input_exits_1(
 
     assert result.exit_code == 1
     assert not (tmp_path / ".kittify" / MISSION_BRIEF_FILENAME).exists()
+
+
+def test_manual_intake_of_packet_writes_sidecar_overlay(
+    intake_app: typer.Typer, tmp_path: Path
+) -> None:
+    """A v1 packet overlays provenance fields; hash remains SHA-256 of raw content."""
+    packet = (
+        "---\n"
+        "handoff_packet: 1\n"
+        "source_tool: example-tool\n"
+        "source_mission: widget-booking\n"
+        "source_ref: abc123\n"
+        "requirements:\n"
+        "  - id: FR-001\n"
+        "    statement: Book a widget.\n"
+        "---\n\n"
+        "# widget-booking\n"
+    )
+    plan = _make_plan_file(tmp_path, "packet.md", content=packet)
+
+    with patched_intake_command_environment(tmp_path, patch_cwd=False):
+        result = runner.invoke(intake_app, [str(plan)], catch_exceptions=False)
+
+    assert result.exit_code == 0, f"output: {result.output}"
+    source_path = tmp_path / ".kittify" / BRIEF_SOURCE_FILENAME
+    source_data = yaml.safe_load(source_path.read_text(encoding="utf-8"))
+    assert source_data["source_tool"] == "example-tool"
+    assert source_data["source_mission"] == "widget-booking"
+    assert source_data["source_ref"] == "abc123"
+    assert source_data["packet_version"] == 1
+    assert source_data["requirement_count"] == 1
+    assert source_data["source_agent"] == "example-tool"
+    expected_hash = hashlib.sha256(packet.encode()).hexdigest()  # noqa: TID251 — mission-brief content fingerprint
+    assert source_data["brief_hash"] == expected_hash

--- a/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/antigravity/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/auggie/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/copilot/specify.prompt.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/cursor/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -220,7 +220,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -254,6 +278,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kilocode/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/kiro/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/opencode/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/q/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/qwen/specify.toml
@@ -220,7 +220,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -254,6 +278,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/windsurf/specify.md
@@ -221,7 +221,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -255,6 +279,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -219,7 +219,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -253,6 +277,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/vibe/specify.SKILL.md
@@ -219,7 +219,31 @@ Check in priority order:
 
 1. **Read the full brief.** Do not skim.
 
-2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview."
+1b. **If the brief is a structured handoff packet, adopt its IDs verbatim.**
+    A structured packet is a Markdown file whose YAML frontmatter declares
+    `handoff_packet: 1` (contract: `docs/contracts/handoff-packet-v1.md`).
+    Also inspect `.kittify/brief-source.yaml` for `packet_version` /
+    `requirement_ids` written by `spec-kitty intake`.
+
+    When a v1 packet is present:
+    - Use each `requirements[].id` as the `FR-###` id. Do **not** renumber.
+    - Copy `requirements[].statement` as the FR statement.
+    - Preserve `requirements[].source_id` as a trace on that FR (e.g.
+      `Source: TKT-1042` or an equivalent spec.md trace field).
+    - Adopt nested `acceptance_criteria[].id` verbatim; do not mint new AC ids
+      for criteria the packet already numbered.
+    - Adopt `constraints[].id` as `C-###` (and `NFR-###` only when the
+      constraint is genuinely non-functional and unnumbered).
+    - Treat packet quality as **Comprehensive** (0–1 gap-filling questions)
+      when `requirements` is non-empty.
+    - Unknown `handoff_packet` versions, malformed YAML, or a missing
+      `requirements` list are **not** packets — fall through to prose
+      extraction below. Do not fail specify because the overlay is absent.
+
+    Still run the one-round user confirmation in step 5. Packet intake does
+    not skip the discovery gate.
+
+2. **Summarise for the user.** Present a single paragraph: what the brief says the goal is, who it is for, and what the key constraints are. Example: "I found a plan document from Claude Code plan mode. Here's what I understand the goal to be: [summary]. I'll extract the spec from this brief rather than running a full discovery interview." For a structured packet, name the `source_tool` and how many FR ids you adopted.
 
 3. **Extract requirements directly.** Map the brief's content to `FR-###`, `NFR-###`, and `C-###` IDs. Do not ask questions the brief already answers. Specifically extract:
    - Objective → Functional Requirements
@@ -253,6 +277,7 @@ Check in priority order:
 - Does not skip the quality checklist
 - Does not skip the readiness gate
 - Does not require the brief to be in any particular format — Markdown prose is fine
+- Does not renumber `FR-###` / `AC-###` ids when a v1 handoff packet supplied them
 
 ### If no brief file is found → Proceed with normal Discovery Gate
 

--- a/tests/specify_cli/test_intake_sources.py
+++ b/tests/specify_cli/test_intake_sources.py
@@ -141,6 +141,6 @@ class TestScanForPlans:
         packet.write_text("# Packet\n", encoding="utf-8")
         results = scan_for_plans(tmp_path)
         found = [r for r in results if r[1] == "handoff"]
-        assert len(found) == 1
+        assert len(found) == 1  # golden-count: cardinality-is-contract
         assert found[0][0] == packet
         assert found[0][2] is None

--- a/tests/specify_cli/test_intake_sources.py
+++ b/tests/specify_cli/test_intake_sources.py
@@ -125,3 +125,22 @@ class TestScanForPlans:
         ):
             results = scan_for_plans(tmp_path)
         assert results == []
+
+
+    def test_handoff_dir_is_an_active_scan_entry(self):
+        keys = [entry[0] for entry in HARNESS_PLAN_SOURCES]
+        assert "handoff" in keys
+        handoff = next(e for e in HARNESS_PLAN_SOURCES if e[0] == "handoff")
+        assert handoff[1] is None
+        assert handoff[2] == [".handoff"]
+
+
+    def test_scans_handoff_markdown_files(self, tmp_path: Path):
+        packet = tmp_path / ".handoff" / "widget-booking.md"
+        packet.parent.mkdir()
+        packet.write_text("# Packet\n", encoding="utf-8")
+        results = scan_for_plans(tmp_path)
+        found = [r for r in results if r[1] == "handoff"]
+        assert len(found) == 1
+        assert found[0][0] == packet
+        assert found[0][2] is None

--- a/tests/unit/intake/test_packet.py
+++ b/tests/unit/intake/test_packet.py
@@ -93,6 +93,28 @@ def test_empty_requirements_list_is_valid_packet():
     assert packet.requirement_ids == ()
 
 
+def test_boolean_true_version_degrades_to_prose():
+    raw = "---\nhandoff_packet: true\nrequirements: []\n---\n\n# Bad\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_float_version_degrades_to_prose():
+    raw = "---\nhandoff_packet: 1.0\nrequirements: []\n---\n\n# Bad\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_string_version_degrades_to_prose():
+    raw = '---\nhandoff_packet: "1"\nrequirements: []\n---\n\n# Bad\n'
+    assert parse_handoff_packet(raw) is None
+
+
+def test_bom_prefixed_packet_still_parses():
+    raw = "\ufeff---\nhandoff_packet: 1\nrequirements: []\n---\n\n# BOM\n"
+    packet = parse_handoff_packet(raw)
+    assert packet is not None
+    assert packet.requirement_count == 0
+
+
 def test_comment_terminator_in_source_tool_is_escaped_in_sidecar():
     raw = (
         "---\nhandoff_packet: 1\nsource_tool: \"evil --> visible\"\n"

--- a/tests/unit/intake/test_packet.py
+++ b/tests/unit/intake/test_packet.py
@@ -1,0 +1,103 @@
+"""Unit tests for ``specify_cli.intake.packet.parse_handoff_packet``."""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.intake.packet import HANDOFF_PACKET_VERSION, parse_handoff_packet
+
+pytestmark = [pytest.mark.fast]
+
+
+VALID_PACKET = """\
+---
+handoff_packet: 1
+source_tool: example-tool
+source_tool_version: "1.0.0"
+source_mission: widget-booking
+source_ref: abc123
+generated_at: "2026-08-13T00:00:00.000Z"
+requirements:
+  - id: FR-001
+    statement: "Book a widget against an open slot."
+    source_id: TKT-1042
+    acceptance_criteria:
+      - id: AC-001
+        statement: "An open slot accepts a widget booking."
+        source_id: AC-001
+constraints:
+  - id: C-001
+    statement: "Bookings must not overlap."
+    source_id: EXT-003
+---
+
+# widget-booking
+
+## Objective
+
+Book widgets.
+"""
+
+
+def test_valid_v1_packet_is_parsed():
+    packet = parse_handoff_packet(VALID_PACKET)
+    assert packet is not None
+    assert packet.source_tool == "example-tool"
+    assert packet.source_mission == "widget-booking"
+    assert packet.source_ref == "abc123"
+    assert packet.requirement_count == 1
+    assert packet.constraint_count == 1
+    assert packet.requirement_ids == ("FR-001",)
+    sidecar = packet.sidecar_fields()
+    assert sidecar["packet_version"] == HANDOFF_PACKET_VERSION
+    assert sidecar["source_tool"] == "example-tool"
+    assert sidecar["requirement_count"] == 1
+
+
+def test_absent_frontmatter_is_prose():
+    assert parse_handoff_packet("# Just a plan\n\nDo the thing.\n") is None
+
+
+def test_frontmatter_without_handoff_packet_is_prose():
+    raw = "---\ntitle: Plan\n---\n\n# Plan\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_future_version_degrades_to_prose():
+    raw = "---\nhandoff_packet: 2\nrequirements: []\n---\n\n# Future\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_malformed_yaml_degrades_to_prose():
+    raw = "---\nhandoff_packet: [\n---\n\n# Broken\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_non_list_requirements_degrades_to_prose():
+    raw = "---\nhandoff_packet: 1\nrequirements: nope\n---\n\n# Bad\n"
+    assert parse_handoff_packet(raw) is None
+
+
+def test_requirement_missing_statement_degrades_to_prose():
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements:\n  - id: FR-001\n---\n\n# Bad\n"
+    )
+    assert parse_handoff_packet(raw) is None
+
+
+def test_empty_requirements_list_is_valid_packet():
+    raw = "---\nhandoff_packet: 1\nrequirements: []\n---\n\n# Empty\n"
+    packet = parse_handoff_packet(raw)
+    assert packet is not None
+    assert packet.requirement_count == 0
+    assert packet.requirement_ids == ()
+
+
+def test_comment_terminator_in_source_tool_is_escaped_in_sidecar():
+    raw = (
+        "---\nhandoff_packet: 1\nsource_tool: \"evil --> visible\"\n"
+        "requirements: []\n---\n\n# X\n"
+    )
+    packet = parse_handoff_packet(raw)
+    assert packet is not None
+    assert "-->" not in packet.sidecar_fields()["source_tool"]

--- a/tests/unit/intake/test_packet.py
+++ b/tests/unit/intake/test_packet.py
@@ -93,6 +93,62 @@ def test_empty_requirements_list_is_valid_packet():
     assert packet.requirement_ids == ()
 
 
+def test_acceptance_criterion_missing_id_degrades_to_prose():
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements:\n"
+        "  - id: FR-001\n    statement: \"Do the thing.\"\n"
+        "    acceptance_criteria:\n"
+        "      - statement: \"Missing id.\"\n"
+        "---\n\n# Bad\n"
+    )
+    assert parse_handoff_packet(raw) is None
+
+
+def test_acceptance_criterion_missing_statement_degrades_to_prose():
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements:\n"
+        "  - id: FR-001\n    statement: \"Do the thing.\"\n"
+        "    acceptance_criteria:\n"
+        "      - id: AC-001\n"
+        "---\n\n# Bad\n"
+    )
+    assert parse_handoff_packet(raw) is None
+
+
+def test_constraint_missing_id_degrades_to_prose():
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements: []\n"
+        "constraints:\n  - statement: \"No id here.\"\n"
+        "---\n\n# Bad\n"
+    )
+    assert parse_handoff_packet(raw) is None
+
+
+def test_valid_nested_acceptance_criteria_and_constraint_parses():
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements:\n"
+        "  - id: FR-001\n    statement: \"Do the thing.\"\n"
+        "    acceptance_criteria:\n"
+        "      - id: AC-001\n        statement: \"The thing is done.\"\n"
+        "constraints:\n  - id: C-001\n    statement: \"Must not overlap.\"\n"
+        "---\n\n# Good\n"
+    )
+    packet = parse_handoff_packet(raw)
+    assert packet is not None
+    assert packet.requirement_count == 1
+    assert packet.constraint_count == 1
+
+
+def test_malformed_constraint_does_not_inflate_constraint_count():
+    """A malformed constraint degrades the whole packet, it never inflates the count."""
+    raw = (
+        "---\nhandoff_packet: 1\nrequirements: []\n"
+        "constraints:\n  - id: C-001\n    statement: ok\n  - statement: \"no id\"\n"
+        "---\n\n# Bad\n"
+    )
+    assert parse_handoff_packet(raw) is None
+
+
 def test_boolean_true_version_degrades_to_prose():
     raw = "---\nhandoff_packet: true\nrequirements: []\n---\n\n# Bad\n"
     assert parse_handoff_packet(raw) is None


### PR DESCRIPTION
## Summary

Starting a mission from an upstream requirements brief (a ticket export, a
story bundle, anything a requirements tool can emit) used to force
`/spec-kitty.specify` to re-mint every FR and AC id from prose — the
producer's native identity (ticket key, story id) had no traceable link to
the Spec Kitty artifact born from it. `spec-kitty intake` now recognises an
optional **handoff packet v1** overlay: plain Markdown whose YAML frontmatter
declares `handoff_packet: 1`. When present, `/spec-kitty.specify` adopts the
packet's FR/AC ids verbatim instead of re-inventing them, and keeps the
producer's native id as a recorded trace.

## Why Now

Unstructured Markdown intake is (and remains) the only supported path today,
so any upstream tool integration was losing requirement identity on the way
in. This closes that gap without asking Spec Kitty to know anything about a
specific upstream producer.

## The Fix

- **Contract**: [`docs/contracts/handoff-packet-v1.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/contracts/handoff-packet-v1.md) —
  optional YAML frontmatter on an ordinary Markdown brief. `source_tool` is a
  free-form string; no producer-specific vocabulary (ticket types, story
  shapes, use-case ids) is baked into the schema.
- **Parser**: `src/specify_cli/intake/packet.py`.
- **Discovery**: `spec-kitty intake --auto` now also scans `.handoff/*.md` at
  the project root, in addition to the existing harness-plan-directory scan.
- **Specify prompt (step 1b)**: adopts `requirements[].id`,
  `acceptance_criteria[].id`, and `constraints[].id` verbatim when a valid
  packet is present, and records each item's `source_id` as a trace.

## Safety / Additive Guarantees

- **Additive, never load-bearing.** A packet-less brief, an unrecognised
  `handoff_packet` version, or malformed YAML all degrade to today's plain
  prose intake — `spec-kitty intake` never fails because the overlay is
  absent or invalid; the file is still ingested as a brief, only the
  structured overlay is dropped.
- **The discovery-gate confirmation is unchanged.** The packet governs FR/AC
  id **numbering**, not whether the human confirms discovery — specify still
  runs its one-round confirmation exactly as it does today.
- **Untrusted input.** Every packet scalar is treated as operator-controlled
  filesystem data: ASCII control characters are stripped, `-->`/`*/` are
  neutralised before landing in HTML/Markdown comments, provenance strings
  are clipped to 256 UTF-8 bytes, and the brief's SHA-256 hash is computed
  over the raw file, never the parsed overlay.

## Maintainer Landing Pass

This PR is a genuinely well-built external contribution — it reuses the
canonical seams (`write_mission_brief` extended additively, the existing
`escape_for_comment` provenance path, the single `HARNESS_PLAN_SOURCES` scan
registry) and already degraded to prose correctly on every malformed input.
The landing pass (folded onto the contributor's branch as separate commits,
AI-assisted with Claude Code per the trailers on each) closed four gaps found
by the maintainer's adversarial squad before merge:

1. **Parser degradation-fidelity.** `handoff_packet: true` and
   `handoff_packet: 1.0` both incorrectly passed the version gate (Python's
   `True == 1` and `1.0 == 1`), and a leading UTF-8 BOM defeated the
   frontmatter anchor and silently degraded real packets to prose. The gate
   is now restricted to the literal int `1`, and a single leading BOM is
   stripped from the parse view only — the raw content (and thus the brief's
   SHA-256 hash) is untouched.
2. **AC/constraint-id validation.** The specify prompt and the contract's
   degradation table both promised `acceptance_criteria[].id` and
   `constraints[].id` are "adopted verbatim," but the parser never validated
   either — a malformed nested item still parsed as a valid packet, and a
   malformed constraint inflated `constraint_count` via a bare `len()`
   instead of being rejected. Both are now validated the same way
   `requirements[].id` already was.
3. **Packet vs. package disambiguation.** The repo already has a
   mission-*output* "handoff **package**" (the mission-045 dossier/replay
   export from `src/specify_cli/dossier/`). This intake-*input* "handoff
   **packet**" is a distinct concept with no code-symbol collision, but one
   clarifying sentence was added to the contract so future readers don't
   conflate the two.
4. **Decision record.** [`docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md`](https://github.com/Priivacy-ai/spec-kitty/blob/main/docs/adr/3.x/2026-08-15-1-handoff-packet-intake-contract.md)
   ratifies the maintainer's ACCEPTED decision to own this as a durable,
   versioned producer-facing contract — not a one-off parsing convenience.

A separate documentation pass added a concise mention of the optional
overlay to the mission-start user docs (mission workflow, the
`/spec-kitty.specify` slash-command reference, and the first-mission
tutorial), each pointing back at the contract, so operators discover the
capability from the docs they already read when starting a mission.

## Not Superseded — Genuinely New Capability

This does not replace or duplicate any existing intake mechanism. Plain
Markdown intake is untouched and remains the default and only requirement
for every producer that doesn't emit a packet. The handoff-packet overlay is
a strictly additive extension point for upstream requirements tooling that
did not exist before this PR.

## Effect on Existing Projects

- **Runtime / compatibility**: additive. Packet-less briefs behave exactly
  as today, byte-for-byte.
- **Upgrade / migration**: none. No config or schema bump required.
- **Operator / reviewer impact**: producers that emit v1 packets get stable,
  traceable FR/AC ids; everyone else is unchanged.

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| `docs/contracts/handoff-packet-v1.md` | New payload contract |

## Validation

- [x] Relevant tests pass locally or in CI
- [x] Backward compatibility impact considered
- [x] Follow-up work called out if intentionally deferred (contract-registry
      `kind` vocabulary extension for this contract type is a follow-up, to
      be filed — see the ADR's accepted trade-offs)

## AI assistance disclosure (contributor)

This contribution was implemented with OpenAI Codex assistance. Ruslan (@Matang0) authorized the scope; Codex performed the repository analysis, RED/GREEN implementation, and local validation. The resulting commits and evidence were reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
