### PR TITLE
fix(sync): fail-closed ingress scope — no drift to the credentials team (#738)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -71,7 +71,7 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   contract and skips queueing when the Private Teamspace can't be resolved, rather
   than attributing the event to the wrong scope. The credentials reader stays for
   the diagnostic call sites (e.g. `sync doctor`/preflight, which compare the two
-  scopes to *detect* exactly this drift).
+  scopes to _detect_ exactly this drift).
 
 - **Root README guide links point at the post-IA `tutorials/` and `how-to/`
   paths.** Fixes GitHub 404s from stale flat `docs/guides/*.md` hrefs after the

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -56,6 +56,23 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **Direct sync ingress no longer drifts to a shared/primary team when the
+  session read transiently returns None (`#738`/spec-kitty-saas `#911`).** The
+  fan-out handler resolved the producer scope as
+  `read_queue_scope_from_session() or read_queue_scope_from_credentials()`. The
+  session path is fail-closed to the user's Private Teamspace, but the credentials
+  fallback returns whatever `team_slug` the credentials TOML last stored (often a
+  shared/primary team, e.g. `stijn` rather than `stijn-private`). During a token
+  refresh or a rehydrate miss the session read returns None and ingress silently
+  rerouted to that team — forking the producer-scoped journal (`journal-<scope>.db`)
+  and materializing the project under the wrong team server-side, so the
+  private→shared share could never find it (the Kitty Prime "I can't see the
+  team's work" symptom). Ingress is now session-only: it honours the fail-closed
+  contract and skips queueing when the Private Teamspace can't be resolved, rather
+  than attributing the event to the wrong scope. The credentials reader stays for
+  the diagnostic call sites (e.g. `sync doctor`/preflight, which compare the two
+  scopes to *detect* exactly this drift).
+
 - **Root README guide links point at the post-IA `tutorials/` and `how-to/`
   paths.** Fixes GitHub 404s from stale flat `docs/guides/*.md` hrefs after the
   guides subdivision (e.g. Your First Mission).

--- a/src/specify_cli/sync/__init__.py
+++ b/src/specify_cli/sync/__init__.py
@@ -227,13 +227,24 @@ def _lifecycle_saas_fanout_handler(**kwargs):  # type: ignore[no-untyped-def]
     from specify_cli.sync.feature_flags import is_saas_sync_enabled
     from specify_cli.sync.queue import (
         OfflineQueue,
-        read_queue_scope_from_credentials,
         read_queue_scope_from_session,
     )
 
     if not is_saas_sync_enabled():
         return
-    scope = read_queue_scope_from_session() or read_queue_scope_from_credentials()
+    # Direct sync ingress is fail-closed to the Private Teamspace. Do NOT fall
+    # back to the credentials file's team_slug: it stores whatever team was last
+    # written (often a shared/primary team, e.g. `stijn`, not `stijn-private`),
+    # so when the session read transiently returns None (a token refresh in
+    # flight, a rehydrate miss) the old `session() or credentials()` silently
+    # rerouted ingress to that team. That forks the producer-scoped journal
+    # (`journal-<scope>.db`) and materializes the project under the wrong team on
+    # the server, so the private->shared share can never find it (#738/#911).
+    # `read_queue_scope_from_session` already fails closed (returns None rather
+    # than a shared team, per `require_private_team_id`); honour that here and
+    # skip queueing when the Private Teamspace can't be resolved, rather than
+    # attribute the event to the wrong scope.
+    scope = read_queue_scope_from_session()
     if not scope:
         return
 

--- a/tests/status/test_lifecycle_events.py
+++ b/tests/status/test_lifecycle_events.py
@@ -764,9 +764,11 @@ def test_lifecycle_saas_outbox_queues_when_scoped(
         "specify_cli.sync.feature_flags.is_saas_sync_enabled",
         lambda: True,
     )
-    monkeypatch.setattr("specify_cli.sync.queue.read_queue_scope_from_session", lambda: None)
+    # Ingress scope is session-only and fail-closed (#738/#3380): the outbox
+    # queues when the session resolves the Private Teamspace scope. The removed
+    # credentials fallback is no longer part of this path, so scope via session.
     monkeypatch.setattr(
-        "specify_cli.sync.queue.read_queue_scope_from_credentials",
+        "specify_cli.sync.queue.read_queue_scope_from_session",
         lambda: "https://example.test|user@example.test|team-a",
     )
     monkeypatch.setattr("specify_cli.sync.queue.OfflineQueue", _Queue)

--- a/tests/sync/test_lifecycle_fanout_mission_created.py
+++ b/tests/sync/test_lifecycle_fanout_mission_created.py
@@ -116,3 +116,29 @@ def test_non_mission_created_does_not_fire_daemon_or_dashboard(tmp_path: Path, e
 
     assert publish_spy.call_count == 0, f"daemon publish must not fire for {event_type}"
     assert dashboard_spy.call_count == 0, f"dashboard sync must not fire for {event_type}"
+
+
+def test_ingress_does_not_fall_back_to_credentials_scope(tmp_path: Path) -> None:
+    """Fail-closed ingress: no drift to the credentials file's team_slug (#738/#911).
+
+    When ``read_queue_scope_from_session`` cannot resolve the Private Teamspace it
+    returns None. The handler must then skip — never reroute to
+    ``read_queue_scope_from_credentials`` (which returns whatever team_slug the
+    credentials TOML last stored, often a shared/primary team). Reaching that
+    fallback is what forked the producer journal and materialized the project
+    under the wrong team on the server.
+    """
+    publish_spy = MagicMock(name="_publish_event_via_sync_daemon")
+    with (
+        patch("specify_cli.sync.feature_flags.is_saas_sync_enabled", return_value=True),
+        patch("specify_cli.sync.queue.read_queue_scope_from_session", return_value=None),
+        patch("specify_cli.sync.queue.read_queue_scope_from_credentials") as creds_fallback,
+        patch("specify_cli.sync.events._publish_event_via_sync_daemon", publish_spy),
+    ):
+        _lifecycle_saas_fanout_handler(
+            envelope=_envelope("MissionCreated"),
+            log_path=tmp_path / "status.events.jsonl",
+        )
+
+    creds_fallback.assert_not_called()  # the fail-open fallback is gone
+    publish_spy.assert_not_called()  # nothing published under a drifted scope


### PR DESCRIPTION
## For @stijn-dejongh — the CLI half of the Kitty Prime "can't see the team's work" drift

Handing this over rather than merging — it's your consent/scope surface, and there's a fail-closed tradeoff below that's your call. Paired with the SaaS-side guard fix (spec-kitty-saas #913) and the diagnosis in #738 / spec-kitty-saas #911.

## Root cause

`_lifecycle_saas_fanout_handler` (`sync/__init__.py`) resolved the producer scope as:

```python
scope = read_queue_scope_from_session() or read_queue_scope_from_credentials()
```

`read_queue_scope_from_session` is **fail-closed** to the user's Private Teamspace (`require_private_team_id` — "NEVER returns a shared team as a fallback"). But `read_queue_scope_from_credentials` returns `build_queue_scope(..., team_slug)` where `team_slug` is whatever the credentials TOML last stored — often the **shared/primary** team (`stijn`), not `stijn-private`.

So when the session read transiently returns None — a token refresh in flight, a rehydrate miss — ingress silently fell through to the credentials team_slug. That is the `stijn ↔ stijn-private` drift from your #738 field report: it forks the producer-scoped journal (`journal-<scope>.db`) and materializes the project under the wrong team server-side, so the private→shared share resolves against the Private Teamspace and 404s ("Unknown private source project"). Net user symptom: everyone sees their own local work but not the team's in Kitty Prime.

The `pick_default_team_id` docstring already says this fallback is invalid here: *"This is display-only — it is NOT valid as a fallback for direct sync ingress."* The code just wasn't honouring it at this site.

## The change

- Ingress scope is now **session-only**: `scope = read_queue_scope_from_session()`. When it can't resolve the Private Teamspace we skip queueing rather than attribute the event to the wrong scope.
- The credentials reader is untouched — it stays for the diagnostic sites that use it deliberately (`sync doctor`/preflight compare session-vs-credentials scope precisely to *detect* this drift). Only the fail-open ingress fallback is removed.
- Left `mission_setup_plan.py`'s `session() or credentials()` alone: that's an auth-*presence* gate ("is there any auth?"), not ingress scope, so the fallback is legitimate there.

## The tradeoff for you to weigh

Removing the fallback means that during a genuine session-None window (refresh race, or a user with no resolvable Private Teamspace) an event is **not queued** rather than queued under the wrong team. That's the fail-closed-correct behaviour for a consent boundary, but it trades a possible event-drop window for scope safety. If you'd rather not drop, the right direction is hardening `read_queue_scope_from_session` so it returns None less often (it already rehydrates) — not re-adding the shared-team fallback. Your call on whether this is enough or wants that follow-up.

## Tests

`tests/sync/test_lifecycle_fanout_mission_created.py::test_ingress_does_not_fall_back_to_credentials_scope` — session None ⇒ the credentials fallback is never called and nothing is published under a drifted scope. The existing MissionCreated fan-out tests still pass (they patch the session scope truthy, so they never depended on the fallback).

## Left for your release cadence

- CHANGELOG entry added under Unreleased/Fixed. **Version bump + `mypy`/typecheck sign-off left to you** — versioning is yours to own on the RC cycle, and I didn't want to collide with it.

Refs: #738, spec-kitty-saas #911, spec-kitty-saas #913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789219621&installation_model_id=427282&pr_number=3380&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3380&signature=9b5430e8a49b2ce264aa7b67ef742a4faf161c1739a2d422820dfc372a3bbb57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->