### PR TITLE
Upgrade/migration atomicity & recoverability (epic #3347): recovery, atomicity, honest reporting

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -146,6 +146,31 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   `planning_commit_sha`; it now preserves provenance once any work package has left
   `planned` (`#3311`).
 
+- **Six upgrade-wedge failures, where a stuck migration left no self-service way
+  out, are fixed (`#3383`; `#3335`, `#3336`, `#3337`, `#3338`, `#3339`,
+  `#3372`).** Concretely: a failed `runtime_state_backfill` aborted mid-walk with
+  no record of what it had already written, leaving the operator unable to tell
+  how far the migration got; it now enumerates every mission and file already
+  persisted before it stopped (`#3335`). `spec-kitty upgrade --dry-run` (and
+  `--json`) could report nothing pending while the real run went on to apply many
+  migrations, because the preview computed pending work through a different path
+  than the real run; the preview now drives off the same migration selector, so it
+  reports the true pending set (`#3336`). `agent mission create --json` returned a
+  bare `CHARTER_PACK_CONFIG_INVALID` error code with no fix steps, discarding the
+  human-readable remediation text a plain-text run would have shown; the `--json`
+  envelope now carries the remediation body alongside the code (`#3337`). The
+  `migrate backfill-runtime-state ... --dry-run` diagnostic a failed migration
+  told operators to run was itself blocked behind that same failed migration — a
+  catch-22 with no way out; the `--dry-run` form is now ungated (the mutating form
+  stays blocked) (`#3338`). A failed `mission create` left the operator's checkout
+  switched onto the coordination branch it had just minted, and left that orphan
+  branch behind; it now restores the original checkout and deletes the branch it
+  created (`#3339`). The review cycle could append a duplicate `review_feedback`
+  frontmatter key, producing invalid YAML that later wedged upgrades trying to
+  parse it; the writer that appended on a miss is retired (it now fails closed),
+  duplicate-key artifacts are detected and can be repaired non-destructively, and
+  the frontmatter reader names every offending key (`#3372`).
+
 ## [3.2.6rc1] - 2026-08-12
 
 > [!WARNING]

--- a/src/specify_cli/cli/commands/_mission_state_doctor.py
+++ b/src/specify_cli/cli/commands/_mission_state_doctor.py
@@ -210,6 +210,45 @@ def _emit_mission_state(report: object, *, json_output: bool, pretty_renderer: C
         pretty_renderer(report)
 
 
+def _heal_duplicate_key_artifacts(
+    repo_root: Path,
+    fixture_dir: Path | None,
+    allow_dirty: bool,
+    json_output: bool,
+) -> None:
+    """Opt-in FR-008 heal: repair legacy dual-key ``review_feedback`` artifacts.
+
+    Runs as part of ``--fix`` (``doctor`` itself is unconditionally SAFE), before
+    the mission-state canonicalization, so a project is healed *before* an
+    upgrade trips over the invalid YAML. Batch-atomic + non-destructive; an
+    un-repairable artifact aborts with a non-zero exit and leaves the corpus
+    untouched.
+    """
+    from specify_cli.migration.mission_state import (
+        MissionStateRepairError,
+        repair_duplicate_key_artifacts,
+    )
+    from specify_cli.status.dup_key_repair import DuplicateKeyRepairError
+
+    try:
+        report = repair_duplicate_key_artifacts(
+            repo_root, scan_root=fixture_dir, allow_dirty=allow_dirty
+        )
+    except (DuplicateKeyRepairError, MissionStateRepairError) as exc:
+        if json_output:
+            _emit_json_error("DUPLICATE_KEY_REPAIR_FAILED", message=str(exc))
+        else:
+            typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    healed = sum(len(result.file_changes) for result in report.missions)
+    if healed and not json_output:
+        console.print(
+            f"[green]Healed {healed} duplicate-key artifact(s)[/green] "
+            f"(keep-last-non-empty). Manifest: {report.manifest_path}"
+        )
+
+
 def _run_mission_repair(
     repo_root: Path,
     fixture_dir: Path | None,
@@ -220,6 +259,9 @@ def _run_mission_repair(
 ) -> None:
     """Execute the --fix dispatch arm: repair repo and emit the manifest."""
     from specify_cli.migration.mission_state import MissionStateRepairError, repair_repo
+
+    # FR-008: heal legacy dual-key artifacts before mission-state canonicalization.
+    _heal_duplicate_key_artifacts(repo_root, fixture_dir, allow_dirty, json_output)
 
     try:
         report = repair_repo(

--- a/src/specify_cli/cli/commands/_mission_state_doctor.py
+++ b/src/specify_cli/cli/commands/_mission_state_doctor.py
@@ -228,7 +228,7 @@ def _heal_duplicate_key_artifacts(
         MissionStateRepairError,
         repair_duplicate_key_artifacts,
     )
-    from specify_cli.status.dup_key_repair import DuplicateKeyRepairError
+    from specify_cli.status import DuplicateKeyRepairError
 
     try:
         report = repair_duplicate_key_artifacts(

--- a/src/specify_cli/cli/commands/agent/mission_create.py
+++ b/src/specify_cli/cli/commands/agent/mission_create.py
@@ -268,6 +268,7 @@ def _run_create_core_phase(
     a ``MissionCreationError`` (with worktree navigation hint), or any other
     unexpected exception.
     """
+    from charter.pack_context import CharterPackConfigError
     from specify_cli.core.mission_creation import (
         MissionCreationError,
         create_mission_core,
@@ -320,6 +321,24 @@ def _run_create_core_phase(
         else:
             console.print(f"[bold red]Error:[/bold red] {error_msg}")
             _print_worktree_navigation_hint(mission_slug, error_msg)
+        raise typer.Exit(1) from exc
+    except CharterPackConfigError as exc:
+        # FR-010 (#3337): the fail-closed charter-pack gate raises a
+        # ``KittyInternalConsistencyError`` whose ``str(exc)`` is only the
+        # stable ``.code`` — the actionable remediation lives on ``.body``. The
+        # generic handler below would emit ``{"error": "<CODE>"}`` and drop the
+        # remediation entirely, so carry both the code and the body into the
+        # --json envelope for scripted callers.
+        if json_output:
+            _emit_json(
+                {
+                    "error_code": exc.code,
+                    "error": exc.body,
+                    "remediation": exc.body,
+                }
+            )
+        else:
+            console.print(f"[bold red]Error:[/bold red] {exc.body}")
         raise typer.Exit(1) from exc
     except Exception as e:
         if json_output:

--- a/src/specify_cli/cli/commands/upgrade.py
+++ b/src/specify_cli/cli/commands/upgrade.py
@@ -492,6 +492,55 @@ def _provision_missing_mission_type_activations(
     return []
 
 
+def _mission_type_activation_provisioning_pending(project_path: Path) -> bool:
+    """Return True when a real upgrade would seed ``mission_type_activations``.
+
+    Mirrors :func:`provision_default_mission_type_activations`'s additive
+    no-op rule (FR-009 preview parity): the seed writes only when the key is
+    *entirely absent*. An authored list — including an authored empty
+    ``mission_type_activations: []`` — is a deliberate state the real run leaves
+    untouched, so it is never reported as pending. A ``--dry-run`` skips the
+    real seed, so this predicate is how the preview stays honest about it.
+
+    Args:
+        project_path: Root of the project directory (``.kittify``'s parent).
+
+    Returns:
+        True if the seed would create the key on a real run, else False.
+    """
+    config_file = project_path / ".kittify" / "config.yaml"
+    if not config_file.exists():
+        return True
+    try:
+        from ruamel.yaml import YAML
+
+        with config_file.open("r", encoding="utf-8") as fh:
+            data = YAML(typ="safe").load(fh)
+    except Exception:  # noqa: BLE001 — unreadable config: do not claim a pending seed
+        return False
+    if not isinstance(data, dict):
+        return True
+    return "mission_type_activations" not in data
+
+
+def _print_dry_run_provisioning_notice(
+    project_path: Path, *, dry_run: bool, json_output: bool
+) -> None:
+    """Print a human-readable preview line for the provisioning seed.
+
+    FR-009: a ``--dry-run`` skips the real ``mission_type_activations`` seed, so
+    the human preview must still say it would happen. No-ops outside dry-run and
+    for the ``--json`` surface (which reports ``pending_provisioning`` instead).
+    """
+    if not dry_run or json_output:
+        return
+    if _mission_type_activation_provisioning_pending(project_path):
+        console.print(
+            "[dim]Would provision missing mission_type_activations "
+            "(seeded on a real upgrade).[/dim]"
+        )
+
+
 def _check_project_not_too_new(
     project_path: Path,
     *,
@@ -686,10 +735,20 @@ def upgrade(  # noqa: C901
     # old project-upgrade JSON.  For --project mode, the planner is always
     # consulted; for default mode, the planner runs only when --json is used.
     if json_output and (project or dry_run):
-        # Emit compat-planner contract
+        # Emit compat-planner contract. FR-009: the pending set is computed
+        # against the same target the real run would use (explicit --target, or
+        # the installed CLI version) so the preview matches the applied set.
+        if target is None:
+            from specify_cli import __version__ as _installed_version
+
+            planner_target = _installed_version
+        else:
+            planner_target = target
         _run_planner_json(
             dry_run=dry_run,
             no_nag=no_nag,
+            project_path=project_path,
+            target_version=planner_target,
         )
         return  # _run_planner_json always raises typer.Exit
 
@@ -820,6 +879,9 @@ def upgrade(  # noqa: C901
         mission_type_activation_errors = _provision_missing_mission_type_activations(
             project_path, dry_run=dry_run
         )
+        _print_dry_run_provisioning_notice(
+            project_path, dry_run=dry_run, json_output=json_output
+        )
         upgrade_failed = surface_drift_failed or bool(mission_type_activation_errors)
 
         if json_output:
@@ -878,6 +940,10 @@ def upgrade(  # noqa: C901
 
         console.print(table)
         console.print()
+
+        _print_dry_run_provisioning_notice(
+            project_path, dry_run=dry_run, json_output=json_output
+        )
 
         if verbose:
             # Show detection results
@@ -1115,10 +1181,53 @@ def _display_upgrade_results(
 # ---------------------------------------------------------------------------
 
 
+def _real_pending_migrations_contract(
+    project_path: Path, target_version: str
+) -> list[dict[str, object]]:
+    """Return the contract-shaped pending-migration list the real run applies.
+
+    Drives the preview through :meth:`VersionDetector.applicable_migrations`
+    (→ :meth:`MigrationRegistry.get_applicable`) — the *same* selector the real
+    ``upgrade`` run uses — so the reported pending set can never under-report
+    the applied set (FR-009 / SC-004). The dict shape matches
+    ``compat.messages.render_json``'s ``pending_migrations`` entries.
+
+    Args:
+        project_path: Root of the project directory.
+        target_version: Version the real run would target.
+
+    Returns:
+        A list of ``{migration_id, target_schema_version, description,
+        files_modified}`` dicts, in application order.
+    """
+    from specify_cli.compat.planner import _migration_step_from
+    from specify_cli.upgrade.detector import VersionDetector
+
+    steps = [
+        _migration_step_from(m)
+        for m in VersionDetector(project_path).applicable_migrations(target_version)
+    ]
+    return [
+        {
+            "migration_id": step.migration_id,
+            "target_schema_version": int(step.target_schema_version),
+            "description": step.description,
+            "files_modified": (
+                [str(f) for f in step.files_modified]
+                if step.files_modified is not None
+                else None
+            ),
+        }
+        for step in steps
+    ]
+
+
 def _run_planner_json(
     *,
     dry_run: bool,
     no_nag: bool,
+    project_path: Path,
+    target_version: str,
     latest_version_provider: object = None,
 ) -> None:
     """Emit the compat-planner JSON contract to stdout and raise typer.Exit.
@@ -1126,9 +1235,24 @@ def _run_planner_json(
     Suppresses all human output.  Exit code follows R-08 unless ``dry_run``
     is True, in which case exit code is always 0.
 
+    FR-009: the compat planner gates its own ``pending_migrations`` on a block
+    decision, so a schema-compatible-but-stale project would preview ``[]``.
+    Here we overwrite that field with the *real* applied set (the same
+    ``MigrationRegistry.get_applicable`` selection the real run uses) so the
+    preview never under-reports the migrations a real run would apply.
+
+    The ``mission_type_activations`` provisioning seed (the second FR-009
+    divergence) is surfaced on the human ``--dry-run`` preview
+    (:func:`_print_dry_run_provisioning_notice`) rather than here: the
+    ``compat-planner.json`` contract is externally frozen
+    (``additionalProperties: false``) and owns no provisioning field, so the
+    machine surface stays contract-clean.
+
     Args:
         dry_run: When True, always exit 0.
         no_nag: Suppress nag flag passed to the Invocation.
+        project_path: Root of the project being previewed.
+        target_version: Resolved target version for the pending-set computation.
         latest_version_provider: Optional override for tests.
     """
     from specify_cli.compat.planner import Invocation, is_ci_env, plan
@@ -1158,8 +1282,13 @@ def _run_planner_json(
 
     result = plan(invocation, **kwargs)  # type: ignore[arg-type]
 
+    payload = dict(result.rendered_json)
+    payload["pending_migrations"] = _real_pending_migrations_contract(
+        project_path, target_version
+    )
+
     exit_code = 0 if dry_run else result.exit_code
-    print(json.dumps(result.rendered_json, indent=2))
+    print(json.dumps(payload, indent=2))
     raise typer.Exit(exit_code)
 
 

--- a/src/specify_cli/compat/planner.py
+++ b/src/specify_cli/compat/planner.py
@@ -631,58 +631,79 @@ def _scan_project(
     )
 
 
-def _pending_migrations_for(project: ProjectStatus) -> tuple[MigrationStep, ...]:
-    """Return pending migration steps for a STALE/LEGACY project.
+def _migration_step_from(migration: Any) -> MigrationStep:
+    """Convert a registry ``BaseMigration`` into a contract ``MigrationStep``.
 
-    Returns an empty tuple if the registry does not expose the needed data
-    (WP07 may not have landed yet).
+    ``target_schema_version`` is read from the migration when present and
+    otherwise inferred best-effort from the target version's major component so
+    the JSON contract always carries an integer.
+
+    Args:
+        migration: A registry migration instance.
+
+    Returns:
+        The corresponding :class:`MigrationStep`.
+    """
+    schema_int: int | None = getattr(migration, "target_schema_version", None)
+    if schema_int is None:
+        try:
+            from packaging.version import Version
+
+            schema_int = int(Version(migration.target_version).major)
+        except Exception:  # noqa: BLE001
+            schema_int = 0
+
+    files_raw = getattr(migration, "files_modified", None)
+    files: tuple[Path, ...] | None = None
+    if files_raw is not None:
+        try:
+            files = tuple(Path(f) for f in files_raw)
+        except Exception:  # noqa: BLE001
+            files = None
+
+    return MigrationStep(
+        migration_id=str(migration.migration_id),
+        target_schema_version=int(schema_int),
+        description=str(getattr(migration, "description", "")),
+        files_modified=files,
+    )
+
+
+def _pending_migrations_for(
+    project: ProjectStatus, target_version: str | None = None
+) -> tuple[MigrationStep, ...]:
+    """Return the pending migration steps a real upgrade run would apply.
+
+    Drives the preview through the *same* selector the real run uses
+    (:meth:`VersionDetector.applicable_migrations` →
+    :meth:`MigrationRegistry.get_applicable`) so the compat preview can never
+    diverge from the applied set (FR-009). When ``target_version`` is omitted it
+    defaults to the installed CLI version, matching the real run's default
+    target.
+
+    Returns an empty tuple when the project root is unknown or the registry is
+    unavailable (fail-open: an empty preview beats a crash).
 
     Args:
         project: Project status snapshot.
+        target_version: Version the real run would target; defaults to the
+            installed CLI version.
 
     Returns:
-        Tuple of :class:`MigrationStep` instances.
+        Tuple of :class:`MigrationStep` instances, in application order.
     """
     _ensure_registry_loaded()
+    if project.project_root is None:
+        return ()
+    if target_version is None:
+        from specify_cli import __version__
+
+        target_version = __version__
     try:
-        from specify_cli.upgrade.registry import MigrationRegistry
+        from specify_cli.upgrade.detector import VersionDetector
 
-        migrations = MigrationRegistry.get_all()
-        steps: list[MigrationStep] = []
-        for m in migrations:
-            try:
-                from packaging.version import Version
-
-                target_v = Version(m.target_version)
-                # Only include schema-changing migrations targeting > current schema
-                current = project.schema_version or 0
-                # Convert packaging version to schema int best-effort
-                # (use major.minor.micro → schema int mapping via description)
-                schema_int: int | None = getattr(m, "target_schema_version", None)
-                if schema_int is None:
-                    # Attempt to infer: if target version > REQUIRED_SCHEMA_VERSION
-                    schema_int = int(target_v.major) if target_v else 0
-
-                if isinstance(schema_int, int) and schema_int > current:
-                    files_raw = getattr(m, "files_modified", None)
-                    files: tuple[Path, ...] | None = None
-                    if files_raw is not None:
-                        try:
-                            files = tuple(Path(f) for f in files_raw)
-                        except Exception:  # noqa: BLE001
-                            files = None
-
-                    steps.append(
-                        MigrationStep(
-                            migration_id=str(m.migration_id),
-                            target_schema_version=schema_int,
-                            description=str(getattr(m, "description", "")),
-                            files_modified=files,
-                        )
-                    )
-            except Exception:  # noqa: BLE001, S112
-                continue
-        return tuple(steps)
+        migrations = VersionDetector(project.project_root).applicable_migrations(target_version)
+        return tuple(_migration_step_from(m) for m in migrations)
     except Exception:  # noqa: BLE001
         return ()
 
@@ -1024,7 +1045,11 @@ def _plan_impl(
         fr023_case = Fr023Case.INSTALL_METHOD_UNKNOWN
 
     # --- Step 9: Pending migrations ---
-    pending_migrations = _pending_migrations_for(project_status) if decision == Decision.BLOCK_PROJECT_MIGRATION else ()  # noqa: SIM108
+    # Computed via the real detector (FR-009) but still gated on the block
+    # decision here to keep the general per-command compat check off the
+    # migration-discovery hot path. The `upgrade` preview overrides this with
+    # the unconditional real set (see cli/commands/upgrade.py).
+    pending_migrations = _pending_migrations_for(project_status, cli_status.installed_version) if decision == Decision.BLOCK_PROJECT_MIGRATION else ()  # noqa: SIM108
 
     # --- Step 10: Exit code ---
     exit_code = _EXIT_CODE_MAP.get(decision, 0)

--- a/src/specify_cli/compat/safety.py
+++ b/src/specify_cli/compat/safety.py
@@ -70,6 +70,28 @@ _Invocation = _InvocationProtocol
 SafetyPredicate = Callable[[_InvocationProtocol], Safety]
 
 # ---------------------------------------------------------------------------
+# Predicate: the recommended runtime-state diagnostic (FR-003 / #3338)
+# ---------------------------------------------------------------------------
+# The failed ``backfill-runtime-state`` migration aborts recommending
+# ``spec-kitty migrate backfill-runtime-state --mission <slug> --dry-run`` to
+# inspect the cause (upgrade/migrations/m_zz_runtime_state_backfill.py).  That
+# read-only ``--dry-run`` diagnostic must stay reachable on a wedged/LEGACY
+# project, while the mutating form (no ``--dry-run``) stays UNSAFE under schema
+# mismatch.  ``classify()`` already treats any predicate exception as UNSAFE, so
+# this predicate is fail-closed by construction.
+_DRY_RUN_FLAG = "--dry-run"
+
+
+def _dry_run_is_safe(invocation: _InvocationProtocol) -> Safety:
+    """SAFE iff ``--dry-run`` is present in ``raw_args``; UNSAFE otherwise.
+
+    Any failure to read ``raw_args`` propagates as an exception, which
+    ``classify()`` converts to UNSAFE — so the mutating migration path is never
+    opened under a malformed or unexpected invocation (fail-closed).
+    """
+    return Safety.SAFE if _DRY_RUN_FLAG in invocation.raw_args else Safety.UNSAFE
+
+# ---------------------------------------------------------------------------
 # Central registry
 # ---------------------------------------------------------------------------
 # Keys   — command_path tuple matching Invocation.command_path
@@ -84,6 +106,10 @@ SAFETY_REGISTRY: dict[tuple[str, ...], SafetyPredicate | None] = {
     # Remediation path — must always be reachable
     ("upgrade",): None,
     ("migrate",): None,
+    # The recommended runtime-state diagnostic must be reachable on a wedged
+    # project (FR-003 / #3338): SAFE only in its read-only ``--dry-run`` form;
+    # the mutating form stays UNSAFE via the fail-closed predicate below.
+    ("migrate", "backfill-runtime-state"): _dry_run_is_safe,
     # Creates project, no existing metadata to mismatch against
     ("init",): None,
     # Read-only introspection commands

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 import re
 import shutil
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -50,6 +51,12 @@ logger = logging.getLogger(__name__)
 # reads) hoisted to named constants rather than restated as literals.
 _META_KEY_MISSION_TYPE = "mission_type"
 _META_KEY_CREATED_AT = "created_at"
+
+# WP12 (FR-011 / #3339): coordination branches are the only branch refs a
+# mission-create mints, and their names are all ``kitty/mission-<slug>-<mid8>``.
+# The glob lets the failure-atomic rollback diff pre- vs post-create refs so it
+# deletes exactly the orphan branch an aborted create left behind.
+_COORDINATION_BRANCH_GLOB = "kitty/mission-*"
 
 
 class MissionCreationError(RuntimeError):
@@ -223,6 +230,80 @@ def _commit_feature_file(
 
 
 # ---------------------------------------------------------------------------
+# Failure-atomic git rollback (WP12 / FR-011 / #3339)
+# ---------------------------------------------------------------------------
+
+
+def _list_coordination_branches(repo_root: Path) -> frozenset[str]:
+    """Return the local ``kitty/mission-*`` branch names in ``repo_root``.
+
+    Used to diff the coordination branches present before vs after a
+    mission-create so the rollback deletes exactly the ref an aborted create
+    minted, never a pre-existing one. A non-git or failing ``git`` invocation
+    yields an empty set (nothing to roll back).
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "branch",
+            "--list",
+            _COORDINATION_BRANCH_GLOB,
+            "--format=%(refname:short)",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return frozenset()
+    return frozenset(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _restore_git_state_after_failed_create(
+    repo_root: Path,
+    *,
+    original_branch: str | None,
+    pre_existing_coordination_branches: frozenset[str],
+) -> None:
+    """Best-effort rollback of a failed mission-create's git side-effects.
+
+    Restores the operator's original checkout and deletes any coordination
+    branch this create-run minted (FR-011, #3339), so a failed create leaves
+    the operator on their original branch with no orphan branch.
+
+    Rollback is best-effort and never raises — it must not mask the original
+    creation failure. The checkout is restored *before* any branch delete
+    because git refuses to delete a branch that is currently checked out.
+
+    Single-writer assumption: mission-create is an operator action, so the
+    coordination-branch diff (present now minus present before) identifies
+    exactly the ref this call minted.
+    """
+    # 1. Restore the operator's checkout first (a checked-out branch cannot be
+    #    deleted).
+    if original_branch is not None:
+        current = get_current_branch(repo_root)
+        if current is not None and current != original_branch:
+            subprocess.run(
+                ["git", "-C", str(repo_root), "checkout", original_branch],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+    # 2. Delete only the coordination branches that appeared during this create.
+    orphaned = _list_coordination_branches(repo_root) - pre_existing_coordination_branches
+    for branch in sorted(orphaned):
+        subprocess.run(
+            ["git", "-C", str(repo_root), "branch", "-D", branch],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -240,6 +321,59 @@ def create_mission_core(
     force_recreate_coordination_branch: bool = False,
     allow_worktree_context: bool = False,
     owned_checkout: Path | None = None,
+) -> MissionCreationResult:
+    """Create a new mission, restoring git state if creation fails (FR-011).
+
+    Failure-atomic wrapper around :func:`_create_mission_core_impl`. It captures
+    the operator's branch/checkout and the pre-existing coordination branches
+    *before* any git mutation, and on ANY failure restores the original checkout
+    and deletes the orphan coordination branch the aborted run minted (#3339).
+    See :func:`_create_mission_core_impl` for the full parameter contract.
+    """
+    rollback_root = repo_root if repo_root is not None else locate_project_root()
+    original_branch: str | None = None
+    pre_existing_coordination_branches: frozenset[str] = frozenset()
+    if rollback_root is not None and is_git_repo(rollback_root):
+        original_branch = get_current_branch(rollback_root)
+        pre_existing_coordination_branches = _list_coordination_branches(rollback_root)
+
+    try:
+        return _create_mission_core_impl(
+            repo_root,
+            mission_slug,
+            mission=mission,
+            target_branch=target_branch,
+            friendly_name=friendly_name,
+            purpose_tldr=purpose_tldr,
+            purpose_context=purpose_context,
+            topology=topology,
+            force_recreate_coordination_branch=force_recreate_coordination_branch,
+            allow_worktree_context=allow_worktree_context,
+        )
+    except BaseException:
+        # Re-raised below; the rollback is pure cleanup and must not swallow or
+        # replace the original failure (that is why we re-raise unconditionally).
+        if rollback_root is not None:
+            _restore_git_state_after_failed_create(
+                rollback_root,
+                original_branch=original_branch,
+                pre_existing_coordination_branches=pre_existing_coordination_branches,
+            )
+        raise
+
+
+def _create_mission_core_impl(
+    repo_root: Path | None,
+    mission_slug: str,
+    *,
+    mission: str | None = None,
+    target_branch: str | None = None,
+    friendly_name: str | None = None,
+    purpose_tldr: str | None = None,
+    purpose_context: str | None = None,
+    topology: MissionTopology = MissionTopology.COORD,
+    force_recreate_coordination_branch: bool = False,
+    allow_worktree_context: bool = False,
 ) -> MissionCreationResult:
     """Create a new feature with all scaffolding.
 

--- a/src/specify_cli/core/mission_creation.py
+++ b/src/specify_cli/core/mission_creation.py
@@ -349,6 +349,7 @@ def create_mission_core(
             topology=topology,
             force_recreate_coordination_branch=force_recreate_coordination_branch,
             allow_worktree_context=allow_worktree_context,
+            owned_checkout=owned_checkout,
         )
     except BaseException:
         # Re-raised below; the rollback is pure cleanup and must not swallow or
@@ -374,6 +375,7 @@ def _create_mission_core_impl(
     topology: MissionTopology = MissionTopology.COORD,
     force_recreate_coordination_branch: bool = False,
     allow_worktree_context: bool = False,
+    owned_checkout: Path | None = None,
 ) -> MissionCreationResult:
     """Create a new feature with all scaffolding.
 

--- a/src/specify_cli/frontmatter.py
+++ b/src/specify_cli/frontmatter.py
@@ -170,8 +170,11 @@ class FrontmatterManager:
         scanner does not enumerate (e.g. a *nested* duplicate key), so the key
         stays named in every case.
         """
-        # Deferred import (cycle break): see docstring.
-        from specify_cli.status.dup_key_repair import find_duplicate_keys_in_text
+        # Deferred import (cycle break): see docstring. Routed through the
+        # ``status`` facade (SR-2 module-boundary rule) — safe here because this
+        # is a function-scoped import, so the facade is fully initialized by the
+        # time this read path runs.
+        from specify_cli.status import find_duplicate_keys_in_text
 
         duplicates = find_duplicate_keys_in_text(content)
         if duplicates:

--- a/src/specify_cli/frontmatter.py
+++ b/src/specify_cli/frontmatter.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
+from ruamel.yaml.constructor import DuplicateKeyError
 
 # The additive PID-reuse identity baseline (C-007), historically co-written
 # alongside ``shell_pid`` at claim-write time (D3b); WP05
@@ -85,6 +86,13 @@ class FrontmatterManager:
         self.yaml.preserve_quotes = False  # Don't preserve quotes - let YAML decide
         self.yaml.width = 4096  # Prevent line wrapping
         self.yaml.indent(mapping=2, sequence=2, offset=0)
+        # Fail closed on duplicate frontmatter keys (WP09, FR-007/C-002). The
+        # round-trip loader already defaults to this, but pinning it explicitly
+        # makes the guard a hard invariant of this canonical boundary: a future
+        # ``typ``/config change cannot silently reintroduce YAML last-wins
+        # semantics. Duplicates raise ``DuplicateKeyError``, translated into a
+        # legible ``FrontmatterError`` (see ``read`` / ``_format_duplicate_key_error``).
+        self.yaml.allow_duplicate_keys = False
 
     def read(self, file_path: Path) -> tuple[dict[str, Any], str]:
         """Read frontmatter and body from a markdown file.
@@ -123,6 +131,11 @@ class FrontmatterManager:
             frontmatter = self.yaml.load(frontmatter_text)
             if frontmatter is None:
                 frontmatter = {}
+        except DuplicateKeyError as e:
+            # Fail closed *legibly* (WP09, FR-007): a single ruamel raise names
+            # only the FIRST duplicate. Enumerate every duplicated key via WP03's
+            # raw-text detector so the operator sees each offending key and line.
+            raise FrontmatterError(self._format_duplicate_key_error(file_path, content, e)) from e
         except Exception as e:
             raise FrontmatterError(f"Invalid YAML in {file_path}: {e}") from e
 
@@ -141,6 +154,33 @@ class FrontmatterManager:
         body = "\n".join(lines[closing_idx + 1 :])
 
         return frontmatter, body
+
+    @staticmethod
+    def _format_duplicate_key_error(file_path: Path, content: str, error: DuplicateKeyError) -> str:
+        """Build a legible duplicate-key message naming every offending key.
+
+        Consumes WP03's raw-text detector
+        (:func:`specify_cli.status.dup_key_repair.find_duplicate_keys_in_text`)
+        to enumerate ALL duplicated top-level keys with their 1-based line
+        numbers -- ruamel's own raise names only the first. The import is
+        deferred to break the ``frontmatter`` <-> ``status`` package cycle
+        (``status`` sits above this foundational boundary and imports it back).
+
+        Falls back to ruamel's own message for a duplicate the top-level
+        scanner does not enumerate (e.g. a *nested* duplicate key), so the key
+        stays named in every case.
+        """
+        # Deferred import (cycle break): see docstring.
+        from specify_cli.status.dup_key_repair import find_duplicate_keys_in_text
+
+        duplicates = find_duplicate_keys_in_text(content)
+        if duplicates:
+            detail = "; ".join(
+                f"'{key}' (lines {', '.join(str(occ.line_index + 1) for occ in occurrences)})"
+                for key, occurrences in duplicates.items()
+            )
+            return f"Duplicate frontmatter key(s) in {file_path}: {detail}"
+        return f"Duplicate frontmatter key in {file_path}: {error}"
 
     def write(self, file_path: Path, frontmatter: dict[str, Any], body: str) -> None:
         """Write frontmatter and body to a markdown file.

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -19,8 +19,11 @@ from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from specify_cli.status.dup_key_repair import ArtifactRepairPlan, DuplicateKeyFinding
 
 from packaging.version import Version
 from pydantic import BaseModel, ConfigDict
@@ -587,6 +590,173 @@ def repair_repo(
             policy=_build_policy(),
         )
         atomic_write(manifest_abs, report.to_json(), mkdir=True)
+        return report
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-key artifact repair (FR-008, #3372)
+#
+# Legacy dual-key ``review_feedback`` artifacts (an empty ``''`` write followed
+# by a real ``review-cycle://`` pointer) are invalid YAML that fails closed at
+# the frontmatter boundary and trips an upgrade. This heals them BEFORE upgrade,
+# reusing this module's ADR 2026-05-10-1 repair framework (git-safety preflight,
+# run lock, ``atomic_write``, ``FileChange`` / ``RepairReport`` evidence). The
+# detector is the raw-text scanner in ``specify_cli.status.dup_key_repair`` (the
+# boundary cannot parse a dup-key file to detect it).
+# ---------------------------------------------------------------------------
+
+_DUP_KEY_MANIFEST_PREFIX = "dup-key-"
+_DUP_KEY_POLICY_TRACKED: tuple[str, ...] = ("kitty-specs/**/*.md",)
+
+
+def _build_dup_key_policy() -> dict[str, list[str]]:
+    """Return the dup-key repair manifest ``policy`` block (deterministic)."""
+    return {
+        "tracked": sorted(_DUP_KEY_POLICY_TRACKED),
+        "optional": [],
+        "ignored": sorted(_POLICY_IGNORED),
+    }
+
+
+def _dup_key_scan_dir(resolved_repo_root: Path, scan_root: Path | None) -> Path:
+    """Resolve the directory tree scanned for dual-key artifacts."""
+    return (scan_root or resolved_repo_root / "kitty-specs").resolve()
+
+
+def _plan_duplicate_key_batch(
+    findings: Sequence[DuplicateKeyFinding],
+) -> list[ArtifactRepairPlan]:
+    """Plan + validate EVERY affected artifact before any write (NFR-004).
+
+    One un-repairable artifact raises ``DuplicateKeyRepairError`` here, before
+    the caller has mutated a single file — the batch-atomic abort.
+    """
+    from specify_cli.status.dup_key_repair import plan_artifact_repair
+
+    plans: list[ArtifactRepairPlan] = []
+    seen: set[Path] = set()
+    for finding in findings:
+        if finding.path in seen:
+            continue
+        seen.add(finding.path)
+        plan = plan_artifact_repair(finding.path, finding.path.read_text(encoding="utf-8"))
+        if plan is not None:
+            plans.append(plan)
+    return plans
+
+
+def _dup_key_mission_slug(scan_dir: Path, path: Path) -> str:
+    """Best-effort mission slug for report grouping (first path segment)."""
+    try:
+        rel = path.resolve().relative_to(scan_dir)
+    except ValueError:
+        return path.parent.name
+    return rel.parts[0] if len(rel.parts) > 1 else path.name
+
+
+def _compute_dup_key_run_id(repo_root: Path, plans: Sequence[ArtifactRepairPlan]) -> str:
+    """Deterministic run id derived from the repaired-content set."""
+    payload = "spec-kitty:dup-key-repair:v1\n"
+    for plan in sorted(plans, key=lambda item: str(item.path)):
+        payload += _repo_relpath(repo_root, plan.path) + "\0" + plan.repaired_text + "\0"
+    return _sha256_text(payload)[:16]
+
+
+def _write_duplicate_key_plans(
+    repo_root: Path, plans: Sequence[ArtifactRepairPlan]
+) -> list[FileChange]:
+    """Write every validated plan atomically, returning digest evidence."""
+    changes: list[FileChange] = []
+    for plan in plans:
+        before = _file_fingerprint(plan.path)
+        atomic_write(plan.path, plan.repaired_text)
+        after = _file_fingerprint(plan.path)
+        if before != after:
+            changes.append(_file_change(repo_root, plan.path, before, after))
+    return changes
+
+
+def _safe_argv() -> list[str]:
+    try:
+        return list(sys.argv[1:])
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _build_dup_key_report(
+    repo_root: Path,
+    scan_dir: Path,
+    run_id: str,
+    plans: Sequence[ArtifactRepairPlan],
+    file_changes: Sequence[FileChange],
+    manifest_abs: Path,
+) -> RepairReport:
+    """Assemble the shared :class:`RepairReport` grouped by mission slug."""
+    changes_by_path = {change.path: change for change in file_changes}
+    grouped: dict[str, MissionRepairResult] = {}
+    for plan in plans:
+        slug = _dup_key_mission_slug(scan_dir, plan.path)
+        result = grouped.setdefault(
+            slug,
+            MissionRepairResult(mission_slug=slug, mission_id=None, status="unchanged"),
+        )
+        change = changes_by_path.get(_repo_relpath(repo_root, plan.path))
+        if change is not None:
+            result.file_changes.append(change)
+            result.status = "updated"
+    return RepairReport(
+        run_id=run_id,
+        repo_head=_git_head(repo_root),
+        target_missions=sorted(grouped),
+        manifest_path=_repo_relpath(repo_root, manifest_abs),
+        missions=[grouped[slug] for slug in sorted(grouped)],
+        cli_version=_resolve_cli_version(),
+        command_args=_scrub_secret_args(_safe_argv()),
+        generated_ids=[run_id],
+        policy=_build_dup_key_policy(),
+    )
+
+
+def repair_duplicate_key_artifacts(
+    repo_root: Path,
+    *,
+    scan_root: Path | None = None,
+    manifest_path: Path | None = None,
+    allow_dirty: bool = False,
+) -> RepairReport:
+    """Heal legacy dual-key ``review_feedback`` artifacts (FR-008, #3372).
+
+    BATCH-ATOMIC (NFR-004): every artifact's repair is planned and validated
+    before ANY file is written; a single un-repairable artifact raises
+    ``DuplicateKeyRepairError`` and the corpus is left untouched. NON-DESTRUCTIVE
+    (NFR-002): the keep-last-non-empty policy preserves the recorded pointer.
+    Opt-in — reached only from ``doctor mission-state --fix`` (``doctor`` itself
+    is unconditionally SAFE).
+    """
+    from specify_cli.status.dup_key_repair import detect_duplicate_key_artifacts
+
+    resolved_repo_root = _anchor_repair_root(repo_root, scan_root=scan_root)
+    scan_dir = _dup_key_scan_dir(resolved_repo_root, scan_root)
+
+    # Detect + plan + validate the entire batch BEFORE taking the lock or
+    # writing anything (NFR-004 batch-atomicity). Any un-repairable artifact
+    # raises out of the planner here, so nothing on disk is touched.
+    plans = _plan_duplicate_key_batch(detect_duplicate_key_artifacts(scan_dir))
+    run_id = _compute_dup_key_run_id(resolved_repo_root, plans)
+    manifest_rel = manifest_path or MANIFEST_ROOT / f"{_DUP_KEY_MANIFEST_PREFIX}{run_id}.json"
+    manifest_abs = _resolve_repo_relative(resolved_repo_root, manifest_rel)
+
+    rel_paths = [_repo_relpath(resolved_repo_root, plan.path) for plan in plans]
+    _assert_git_safe(
+        resolved_repo_root, [*rel_paths, str(MANIFEST_ROOT)], allow_dirty=allow_dirty
+    )
+    with _git_lock(resolved_repo_root):
+        file_changes = _write_duplicate_key_plans(resolved_repo_root, plans)
+        report = _build_dup_key_report(
+            resolved_repo_root, scan_dir, run_id, plans, file_changes, manifest_abs
+        )
+        if file_changes:
+            atomic_write(manifest_abs, report.to_json(), mkdir=True)
         return report
 
 
@@ -2122,6 +2292,7 @@ __all__ = [
     "MissionStateRepairError",
     "TeamspaceDryRunReport",
     "rebuild_mission_event_log",
+    "repair_duplicate_key_artifacts",
     "repair_repo",
     "teamspace_dry_run",
 ]

--- a/src/specify_cli/migration/mission_state.py
+++ b/src/specify_cli/migration/mission_state.py
@@ -631,7 +631,7 @@ def _plan_duplicate_key_batch(
     One un-repairable artifact raises ``DuplicateKeyRepairError`` here, before
     the caller has mutated a single file — the batch-atomic abort.
     """
-    from specify_cli.status.dup_key_repair import plan_artifact_repair
+    from specify_cli.status import plan_artifact_repair
 
     plans: list[ArtifactRepairPlan] = []
     seen: set[Path] = set()
@@ -733,7 +733,7 @@ def repair_duplicate_key_artifacts(
     Opt-in — reached only from ``doctor mission-state --fix`` (``doctor`` itself
     is unconditionally SAFE).
     """
-    from specify_cli.status.dup_key_repair import detect_duplicate_key_artifacts
+    from specify_cli.status import detect_duplicate_key_artifacts
 
     resolved_repo_root = _anchor_repair_root(repo_root, scan_root=scan_root)
     scan_dir = _dup_key_scan_dir(resolved_repo_root, scan_root)

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -273,6 +273,12 @@ from .doctor_husks import (
     registered_worktree_paths,
     scan_workspace_husks,
 )
+from .dup_key_repair import (
+    DuplicateKeyRepairError,
+    detect_duplicate_key_artifacts,
+    find_duplicate_keys_in_text,
+    plan_artifact_repair,
+)
 # WP03/WP04 (runtime-state-birth-cutover-all-paths-01KYH654): the cut-over
 # predicate reaches its src/ consumer (``cli.commands.cutover_guard``) through
 # this package surface, not by importing the submodule directly -- the status
@@ -391,6 +397,10 @@ __all__ = [
     "materialize_snapshot",
     "repo_root_for_lifecycle_log",
     "run_doctor",
+    "DuplicateKeyRepairError",
+    "detect_duplicate_key_artifacts",
+    "find_duplicate_keys_in_text",
+    "plan_artifact_repair",
     "start_implementation_status",
     "start_review_status",
     "CanonicalStatusNotFoundError",

--- a/src/specify_cli/status/doctor.py
+++ b/src/specify_cli/status/doctor.py
@@ -37,6 +37,7 @@ class Category(StrEnum):
     ISSUE_MATRIX = "issue_matrix"
     SPARSE_CHECKOUT = "sparse_checkout"
     UNINITIALIZED_STATUS = "uninitialized_status"
+    DUPLICATE_FRONTMATTER_KEY = "duplicate_frontmatter_key"
 
 
 @dataclass
@@ -440,6 +441,40 @@ def check_issue_matrix(
     return findings
 
 
+def check_duplicate_frontmatter_keys(scan_dir: Path) -> list[Finding]:
+    """Flag legacy dual-key artifacts (FR-008, #3372) — diagnostic only.
+
+    Thin delegation to the raw-text detector in
+    :mod:`specify_cli.status.dup_key_repair`. Detection CANNOT use the canonical
+    frontmatter boundary: it fails closed on duplicate keys (ruamel
+    ``DuplicateKeyError``), so loading a dual-key artifact raises rather than
+    reporting it. This check NEVER mutates; repair is opt-in via
+    ``spec-kitty doctor mission-state --fix`` (keep-last-non-empty, batch-atomic).
+    """
+    from specify_cli.status.dup_key_repair import detect_duplicate_key_artifacts
+
+    findings: list[Finding] = []
+    for finding in detect_duplicate_key_artifacts(scan_dir):
+        line_list = ", ".join(str(number) for number in finding.line_numbers)
+        findings.append(
+            Finding(
+                severity=Severity.WARNING,
+                category=Category.DUPLICATE_FRONTMATTER_KEY,
+                wp_id=None,
+                message=(
+                    f"{finding.path.name} has a duplicate frontmatter key "
+                    f"'{finding.key}' (lines {line_list}) — invalid YAML that "
+                    f"fails closed at the frontmatter boundary and will trip an upgrade."
+                ),
+                recommended_action=(
+                    "Run 'spec-kitty doctor mission-state --fix' to repair "
+                    "duplicate-key artifacts (keep-last-non-empty, batch-atomic)."
+                ),
+            )
+        )
+    return findings
+
+
 def check_sparse_checkout(repo_root: Path) -> list[Finding]:
     """Repo-level check: legacy sparse-checkout state lingering from pre-3.x.
 
@@ -588,5 +623,9 @@ def run_doctor(
     # findings keep their position — scripts scraping doctor output rely on
     # the order of prior findings; new ones are safe to add at the tail.
     result.findings.extend(check_sparse_checkout(repo_root))
+
+    # Legacy dual-key artifact finding (FR-008, #3372). Scoped to this mission's
+    # own artifact tree; appended at the tail for the same order-stability reason.
+    result.findings.extend(check_duplicate_frontmatter_keys(feature_dir))
 
     return result

--- a/src/specify_cli/status/dup_key_repair.py
+++ b/src/specify_cli/status/dup_key_repair.py
@@ -1,0 +1,261 @@
+"""Raw-text duplicate-key detector + repair planner for mission artifacts.
+
+The canonical frontmatter boundary (:mod:`specify_cli.frontmatter`) fails
+**closed** on duplicate keys — ruamel raises ``DuplicateKeyError`` before a
+caller ever sees the mapping (``frontmatter.py:83,122-127``). That is correct
+for the read path but means the boundary CANNOT be used to *detect* the legacy
+dual-key ``review_feedback`` artifacts (#3372): loading them raises. This module
+is the net-new RAW-TEXT scanner FR-008 needs — it inspects the frontmatter block
+as lines, never parsing it through the failing boundary, so a malformed dual-key
+artifact is discoverable.
+
+Repair policy is **keep-last-non-empty**: the legacy shape is
+``review_feedback: ''`` followed by a real path, so the last non-empty value is
+the recorded state and the empty duplicate is the noise. Repair is
+NON-DESTRUCTIVE (the recorded value is preserved — NFR-002) and the planner
+REFUSES (raising :class:`DuplicateKeyRepairError`) any shape it cannot heal to
+valid YAML, so the batch-atomic caller aborts the whole run rather than writing
+a half-repaired corpus (NFR-004).
+
+This module is diagnostic + planning only: it never writes to disk. The mutating
+half reuses the ADR 2026-05-10-1 repair framework in
+:mod:`specify_cli.migration.mission_state`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+# Opening/closing frontmatter fence. Mirrors the ``content.startswith("---")``
+# opening probe and the ``line.strip() == "---"`` closing probe used by the
+# canonical boundary (``frontmatter.py``) so this scanner and the read path
+# agree on where the frontmatter block begins and ends.
+_FRONTMATTER_FENCE = "---"
+
+# A top-level (column-0) ``key:`` line. Leading-whitespace keys are nested and
+# are deliberately NOT scanned: removing a nested duplicate would require
+# block-aware surgery this keep-last-non-empty planner does not attempt.
+_TOP_LEVEL_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):(.*)$")
+
+# Scalar values treated as "empty" for the keep-last-non-empty policy.
+_EMPTY_SCALARS = frozenset({"", "''", '""'})
+
+
+class DuplicateKeyRepairError(Exception):
+    """Raised when a duplicate-key artifact cannot be safely repaired.
+
+    Propagated by the batch caller so an un-repairable artifact aborts the
+    entire repair run (NFR-004) instead of leaving a half-repaired corpus.
+    """
+
+
+@dataclass(frozen=True)
+class KeyOccurrence:
+    """One column-0 occurrence of a frontmatter key."""
+
+    line_index: int  # 0-based index into the file's ``split("\n")`` lines
+    value: str  # stripped inline scalar value ("" when the value is off-line)
+    is_empty: bool
+
+
+@dataclass(frozen=True)
+class DuplicateKeyFinding:
+    """A single artifact carrying one duplicated top-level frontmatter key."""
+
+    path: Path
+    key: str
+    line_numbers: tuple[int, ...]  # 1-based line numbers of every occurrence
+
+
+@dataclass(frozen=True)
+class ArtifactRepairPlan:
+    """A validated, non-destructive repair for one artifact (batch-atomic input)."""
+
+    path: Path
+    original_text: str
+    repaired_text: str
+    removed_line_numbers: tuple[int, ...]  # 1-based
+    keys: tuple[str, ...]
+
+
+def _frontmatter_closing_index(lines: list[str]) -> int | None:
+    """Return the index of the closing fence, or ``None`` when absent.
+
+    Matches the canonical boundary: the document must *open* with ``---`` and
+    the closing fence is the first subsequent line that is exactly ``---``.
+    """
+    if not lines or not lines[0].startswith(_FRONTMATTER_FENCE):
+        return None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == _FRONTMATTER_FENCE:
+            return idx
+    return None
+
+
+def _scan_occurrences(lines: list[str], closing_idx: int) -> dict[str, list[KeyOccurrence]]:
+    """Collect every column-0 ``key:`` occurrence inside the frontmatter block."""
+    seen: dict[str, list[KeyOccurrence]] = {}
+    for idx in range(1, closing_idx):
+        match = _TOP_LEVEL_KEY_RE.match(lines[idx])
+        if match is None:
+            continue
+        key = match.group(1)
+        value = match.group(2).strip()
+        seen.setdefault(key, []).append(
+            KeyOccurrence(line_index=idx, value=value, is_empty=value in _EMPTY_SCALARS)
+        )
+    return seen
+
+
+def _duplicates(seen: dict[str, list[KeyOccurrence]]) -> dict[str, list[KeyOccurrence]]:
+    """Filter to keys that occur more than once (dict insertion order preserved)."""
+    return {key: occurrences for key, occurrences in seen.items() if len(occurrences) > 1}
+
+
+def find_duplicate_keys_in_text(text: str) -> dict[str, list[KeyOccurrence]]:
+    """Return duplicated top-level frontmatter keys for one artifact's *text*.
+
+    Empty mapping when the file has no frontmatter or no duplicate keys.
+    """
+    lines = text.split("\n")
+    closing_idx = _frontmatter_closing_index(lines)
+    if closing_idx is None:
+        return {}
+    return _duplicates(_scan_occurrences(lines, closing_idx))
+
+
+def scan_artifact(path: Path) -> list[DuplicateKeyFinding]:
+    """Return one :class:`DuplicateKeyFinding` per duplicated key in *path*."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    duplicates = find_duplicate_keys_in_text(text)
+    return [
+        DuplicateKeyFinding(
+            path=path,
+            key=key,
+            line_numbers=tuple(occurrence.line_index + 1 for occurrence in occurrences),
+        )
+        for key, occurrences in sorted(duplicates.items())
+    ]
+
+
+def detect_duplicate_key_artifacts(scan_dir: Path) -> list[DuplicateKeyFinding]:
+    """Scan ``scan_dir/**/*.md`` and return every dual-key artifact finding.
+
+    Deterministic: findings are ordered by path then key.
+    """
+    if not scan_dir.exists():
+        return []
+    findings: list[DuplicateKeyFinding] = []
+    for path in sorted(scan_dir.glob("**/*.md")):
+        if not path.is_file():
+            continue
+        findings.extend(scan_artifact(path))
+    return findings
+
+
+def _choose_survivor(occurrences: list[KeyOccurrence]) -> KeyOccurrence:
+    """Keep-last-non-empty: the last non-empty occurrence, else the last one."""
+    non_empty = [occurrence for occurrence in occurrences if not occurrence.is_empty]
+    return non_empty[-1] if non_empty else occurrences[-1]
+
+
+def _removal_is_safe(lines: list[str], idx: int, closing_idx: int) -> bool:
+    """True when the key line at *idx* can be dropped without orphaning content.
+
+    A line with an inline scalar value is self-contained and always safe. A key
+    with an *empty* inline value may open a nested block (its value hangs on the
+    following indented / list lines); dropping such a line would orphan that
+    block, so it is safe to remove only when the next frontmatter line is itself
+    a top-level key (nothing hangs beneath it) or the block has ended.
+    """
+    match = _TOP_LEVEL_KEY_RE.match(lines[idx])
+    if match is None:
+        return False
+    if match.group(2).strip():
+        return True
+    next_idx = idx + 1
+    if next_idx >= closing_idx:
+        return True
+    return _TOP_LEVEL_KEY_RE.match(lines[next_idx]) is not None
+
+
+def _assert_repaired_frontmatter_valid(
+    path: Path, repaired_lines: list[str], original_closing_idx: int, removed: set[int]
+) -> None:
+    """Re-parse the repaired frontmatter with duplicate keys forbidden.
+
+    Guarantees the planned output is valid YAML *and* free of residual duplicate
+    keys before the batch caller writes anything. Raises
+    :class:`DuplicateKeyRepairError` otherwise (aborting the whole batch).
+    """
+    new_closing_idx = original_closing_idx - len(removed)
+    body = "\n".join(repaired_lines[1:new_closing_idx])
+    yaml = YAML()
+    yaml.allow_duplicate_keys = False
+    try:
+        yaml.load(body)
+    except Exception as exc:  # ruamel raises subclasses of YAMLError / DuplicateKeyError
+        raise DuplicateKeyRepairError(
+            f"{path}: repaired frontmatter is still invalid YAML: {exc}"
+        ) from exc
+
+
+def plan_artifact_repair(path: Path, text: str) -> ArtifactRepairPlan | None:
+    """Plan a non-destructive, validated repair for one artifact.
+
+    Returns ``None`` when the artifact has no frontmatter or no duplicate keys.
+    Raises :class:`DuplicateKeyRepairError` when the artifact cannot be safely
+    healed (a non-scalar duplicate occurrence, or a repaired body that still
+    fails to parse) — the signal the batch caller uses to abort all-or-nothing.
+    """
+    lines = text.split("\n")
+    closing_idx = _frontmatter_closing_index(lines)
+    if closing_idx is None:
+        return None
+    duplicates = _duplicates(_scan_occurrences(lines, closing_idx))
+    if not duplicates:
+        return None
+
+    remove: set[int] = set()
+    for key, occurrences in duplicates.items():
+        survivor = _choose_survivor(occurrences)
+        for occurrence in occurrences:
+            if occurrence.line_index == survivor.line_index:
+                continue
+            if not _removal_is_safe(lines, occurrence.line_index, closing_idx):
+                raise DuplicateKeyRepairError(
+                    f"{path}: cannot safely repair duplicate key {key!r} at line "
+                    f"{occurrence.line_index + 1} (non-scalar occurrence)."
+                )
+            remove.add(occurrence.line_index)
+
+    repaired_lines = [line for index, line in enumerate(lines) if index not in remove]
+    _assert_repaired_frontmatter_valid(path, repaired_lines, closing_idx, remove)
+    return ArtifactRepairPlan(
+        path=path,
+        original_text=text,
+        repaired_text="\n".join(repaired_lines),
+        removed_line_numbers=tuple(sorted(index + 1 for index in remove)),
+        keys=tuple(sorted(duplicates)),
+    )
+
+
+# ``__all__`` lists only the cross-module surface (imported by
+# ``migration.mission_state`` + ``status.doctor`` + the ``_mission_state_doctor``
+# CLI). ``find_duplicate_keys_in_text`` / ``scan_artifact`` / ``KeyOccurrence``
+# are module-internal helpers (and test seams); leaving them out of ``__all__``
+# keeps the symbol-level dead-code gate green while they remain importable.
+__all__ = [
+    "ArtifactRepairPlan",
+    "DuplicateKeyFinding",
+    "DuplicateKeyRepairError",
+    "detect_duplicate_key_artifacts",
+    "plan_artifact_repair",
+]

--- a/src/specify_cli/task_utils/support.py
+++ b/src/specify_cli/task_utils/support.py
@@ -184,24 +184,34 @@ def delete_scalar(frontmatter: str, key: str) -> str:
 
 
 def set_scalar(frontmatter: str, key: str, value: str) -> str:
-    """Replace or insert a scalar value while preserving trailing comments."""
+    """Replace an EXISTING scalar value while preserving trailing comments.
+
+    FR-006 (mission upgrade-atomicity-recovery, WP08): the append-on-miss
+    branch is RETIRED. This writer once appended ``key: value`` inline when the
+    key was absent -- the latent mechanism behind the #3372 duplicate
+    ``review_feedback`` key (invalid-YAML dual-write). The symbol is retained
+    because ``task_utils/__init__.py`` and ``cli/commands/agent/workflow.py``
+    re-export it, but it now FAILS CLOSED on a miss: an absent key raises
+    :class:`TaskCliError` rather than materialising a new inline key, so no path
+    can re-introduce the dual-key. The canonical review path stores a
+    ``review-cycle://`` pointer on the event log, never an inline frontmatter
+    key.
+
+    Raises:
+        TaskCliError: When *key* is not already present in *frontmatter*
+            (the retired append-on-miss path).
+    """
     match = match_frontmatter_line(frontmatter, key)
-    replacement_line = f'{key}: "{value}"'
-    if match:
-        prefix = match.group(1)
-        comment = match.group(3)
-        comment_suffix = f"{comment}" if comment else ""
-        return frontmatter[: match.start()] + f'{prefix}"{value}"{comment_suffix}' + frontmatter[match.end() :]
-
-    insertion = f"{replacement_line}\n"
-    history_match = re.search(r"^\s*history:\s*$", frontmatter, flags=re.MULTILINE)
-    if history_match:
-        idx = history_match.start()
-        return frontmatter[:idx] + insertion + frontmatter[idx:]
-
-    if frontmatter and not frontmatter.endswith("\n"):
-        frontmatter += "\n"
-    return frontmatter + insertion
+    if match is None:
+        raise TaskCliError(
+            f"set_scalar refuses to append a new inline '{key}' frontmatter key "
+            f"(FR-006: the append-on-miss writer is retired to prevent the #3372 "
+            f"duplicate-key regression). It may only update an existing key."
+        )
+    prefix = match.group(1)
+    comment = match.group(3)
+    comment_suffix = f"{comment}" if comment else ""
+    return frontmatter[: match.start()] + f'{prefix}"{value}"{comment_suffix}' + frontmatter[match.end() :]
 
 
 def split_frontmatter(text: str) -> tuple[str, str, str]:

--- a/src/specify_cli/upgrade/detector.py
+++ b/src/specify_cli/upgrade/detector.py
@@ -9,10 +9,14 @@ been removed — the schema version integer is the sole source of truth.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from specify_cli.migration.schema_version import get_project_schema_version
 
 from .metadata import ProjectMetadata
+
+if TYPE_CHECKING:
+    from .migrations.base import BaseMigration
 
 
 class VersionDetector:
@@ -57,6 +61,35 @@ class VersionDetector:
             return 0
         return schema_version
 
+    def applicable_migrations(self, target_version: str) -> list[BaseMigration]:
+        """Return the migrations a real upgrade run would apply.
+
+        This is the single source of truth for "what is pending": it mirrors the
+        real run's selection in ``upgrade`` exactly — the same
+        ``"unknown" -> "0.0.0"`` normalization, the same
+        :meth:`MigrationRegistry.get_applicable` call, and the same
+        ``project_path`` so current-version ``detect()`` migrations are included.
+        The compat-planner preview and the ``--dry-run`` preview both consult
+        this method so the reported pending set can never diverge from the
+        applied set (FR-009 / SC-004).
+
+        Args:
+            target_version: Version string to upgrade to (e.g. ``"2.1.3"``).
+
+        Returns:
+            Applicable migration instances, in application order.
+        """
+        from .migrations import auto_discover_migrations
+        from .registry import MigrationRegistry
+
+        auto_discover_migrations()
+        current = self.detect_version()
+        from_version = "0.0.0" if current == "unknown" else current
+        applicable: list[BaseMigration] = MigrationRegistry.get_applicable(
+            from_version, target_version, project_path=self.project_path
+        )
+        return applicable
+
     def get_needed_migrations(self, target_version: str) -> list[str]:
         """Get list of migration IDs needed to reach *target_version*.
 
@@ -66,9 +99,4 @@ class VersionDetector:
         Returns:
             List of migration IDs in application order.
         """
-        from .registry import MigrationRegistry
-
-        current = self.detect_version()
-        from_version = "0.0.0" if current == "unknown" else current
-        migrations = MigrationRegistry.get_applicable(from_version, target_version)
-        return [m.migration_id for m in migrations]
+        return [m.migration_id for m in self.applicable_migrations(target_version)]

--- a/src/specify_cli/upgrade/migrations/__init__.py
+++ b/src/specify_cli/upgrade/migrations/__init__.py
@@ -48,6 +48,19 @@ def auto_discover_migrations() -> None:
 
                 # Check if module was already imported
                 if module_full_name in sys.modules:
+                    # base.py holds the shared migration base classes
+                    # (BaseMigration, MigrationResult, PartialWrite) that both
+                    # the migration modules and external callers hold live
+                    # references to. It registers no migration, so it would
+                    # ALWAYS fall through the "not registered -> reload" branch
+                    # below -- and reloading it mints fresh class objects,
+                    # silently breaking isinstance()/identity across the process
+                    # (e.g. a reloaded m_zz constructs the new base.PartialWrite
+                    # while a caller still holds the original). base only ever
+                    # needs its one-time fresh import, never a reload.
+                    if module_name == "base":
+                        continue
+
                     # Only reload if the migration isn't already registered
                     # This handles test scenarios where MigrationRegistry.clear()
                     # was called but modules are still in sys.modules

--- a/src/specify_cli/upgrade/migrations/base.py
+++ b/src/specify_cli/upgrade/migrations/base.py
@@ -7,6 +7,23 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+@dataclass(frozen=True)
+class PartialWrite:
+    """A single file a migration persisted before a non-atomic abort (FR-005).
+
+    A migration that walks a corpus mission-by-mission (e.g. the runtime-state
+    backfill) is intentionally *not* transactional across missions — there is no
+    cross-mission rollback primitive — so an abort mid-walk leaves the missions
+    already processed on disk. This record is the machine-readable account of
+    one such write: the mission it belongs to and the absolute path written, so
+    an operator (or a caller) can enumerate the on-disk residue instead of
+    guessing at it. See :attr:`MigrationResult.partial_writes`.
+    """
+
+    mission: str
+    path: str
+
+
 @dataclass
 class MigrationResult:
     """Result of a migration operation."""
@@ -17,6 +34,10 @@ class MigrationResult:
     warnings: list[str] = field(default_factory=list)
     manual_review_required: bool = False
     preserved_paths: list[str] = field(default_factory=list)
+    #: Files already persisted when a non-atomic migration aborted mid-walk
+    #: (FR-005). Empty on a clean run; populated on abort so the partial write is
+    #: never silent. Each entry names one mission and one absolute file path.
+    partial_writes: list[PartialWrite] = field(default_factory=list)
 
 
 class BaseMigration(ABC):

--- a/src/specify_cli/upgrade/migrations/m_zz_runtime_state_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_zz_runtime_state_backfill.py
@@ -97,11 +97,18 @@ from specify_cli.migration.runtime_state_cutover import (
 )
 
 from ..registry import MigrationRegistry
-from .base import BaseMigration, MigrationResult
+from .base import BaseMigration, MigrationResult, PartialWrite
 
 #: Corpus root, relative to the project root -- the canonical enumeration
 #: mirrors ``backfill_runtime_state_repo``/``cutover_repo``: no divergent glob.
 _KITTY_SPECS_DIRNAME = "kitty-specs"
+
+#: The two per-mission files :func:`cutover_mission` can persist: the seed
+#: event log (written by the backfill/seed phase) and ``meta.json`` (written by
+#: the ``status_phase`` flip). Named constants so the report-on-abort derivation
+#: (:func:`_partial_writes`) and any reader agree on the exact basenames (S1192).
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+_META_FILENAME = "meta.json"
 
 #: ``meta.json`` key read by the cheap ``detect()`` skip-hint. Kept as a
 #: constant (not re-imported from the reused helper's private module symbol)
@@ -227,6 +234,40 @@ def _cutover_corpus(
     return results, None
 
 
+def _partial_writes(results: list[CutoverResult], project_path: Path) -> list[PartialWrite]:
+    """Enumerate every file the aborted walk already persisted (FR-005, US2-AC1).
+
+    report-on-abort — NOT a corpus rollback (the "already-flipped missions stay
+    flipped" per-mission design is intentional, research D-03). ``_cutover_corpus``
+    stops right after appending the failing mission's result, so *results* holds
+    exactly the missions visited up to and including the failure; anything sorted
+    after it was never touched and correctly never appears here.
+
+    The two per-mission paths are DERIVED from the mission slug and *project_path*
+    (``<project>/kitty-specs/<slug>/<file>``) rather than re-read off
+    :class:`CutoverResult` (which carries no path) — matching how the corpus walk
+    enumerates missions in the first place (:func:`_iter_mission_dirs`). A mission
+    is recorded per file it actually wrote THIS run: the event log iff it seeded
+    (``seeded_count > 0``) and ``meta.json`` iff it flipped (``flipped``). A
+    mission that failed verify before writing either (the common live-run abort
+    case: the divergent rows pre-existed, so the idempotent re-seed adds nothing
+    and the flip is unreachable) contributes no phantom path.
+    """
+    kitty_specs = project_path / _KITTY_SPECS_DIRNAME
+    writes: list[PartialWrite] = []
+    for result in results:
+        mission_dir = kitty_specs / result.slug
+        if result.seeded_count > 0:
+            writes.append(
+                PartialWrite(mission=result.slug, path=str(mission_dir / _STATUS_EVENTS_FILENAME))
+            )
+        if result.flipped:
+            writes.append(
+                PartialWrite(mission=result.slug, path=str(mission_dir / _META_FILENAME))
+            )
+    return writes
+
+
 def _summarize_changes(results: list[CutoverResult], *, dry_run: bool) -> list[str]:
     """Build the ``changes_made`` summary. Empty means a clean no-op (INV-4).
 
@@ -283,7 +324,11 @@ class RuntimeStateBackfillMigration(BaseMigration):
 
         results, abort_message = _cutover_corpus(missions, dry_run=dry_run)
         if abort_message is not None:
-            return MigrationResult(success=False, errors=[abort_message])
+            return MigrationResult(
+                success=False,
+                errors=[abort_message],
+                partial_writes=_partial_writes(results, project_path),
+            )
 
         return MigrationResult(
             success=True, changes_made=_summarize_changes(results, dry_run=dry_run)

--- a/src/specify_cli/upgrade/runner.py
+++ b/src/specify_cli/upgrade/runner.py
@@ -15,7 +15,10 @@ from packaging.version import InvalidVersion, Version
 from rich.console import Console
 
 from specify_cli.core.constants import KITTIFY_DIR, WORKTREES_DIR
-from specify_cli.migration.schema_version import REQUIRED_SCHEMA_VERSION
+from specify_cli.migration.schema_version import (
+    REQUIRED_SCHEMA_VERSION,
+    get_project_schema_version,
+)
 
 from . import autocommit
 from .detector import VersionDetector
@@ -154,6 +157,17 @@ class MigrationRunner:
             norm_changes = metadata.normalize_and_save_legacy_ids(self.kittify_dir)
             result.warnings.extend(norm_changes)
 
+        # FR-002 (#3334): capture the on-disk schema_version BEFORE the loop.
+        # A failed migration's _record_migration_result -> save() rewrites
+        # metadata.yaml from a fixed dict and, on the mid-loop break, the
+        # success-guarded stamp below never runs -- so without this capture the
+        # value is lost and a re-run re-detects the project as legacy and
+        # re-hits the same failing migration. We restore this CAPTURED value on
+        # failure, never REQUIRED_SCHEMA_VERSION: re-stamping the target onto a
+        # half-migrated project would open the gate on a corpus the migration
+        # never finished (the exact dishonest-state bug this mission closes).
+        pre_run_schema_version = get_project_schema_version(self.project_path)
+
         # Apply each migration to main project
         for migration in migrations:
             migration_result, status = self._apply_migration(migration, metadata, dry_run)
@@ -178,16 +192,10 @@ class MigrationRunner:
                 break
 
         # Update and save metadata for main project
-        if not dry_run and result.success:
-            metadata.version = target_version
-            metadata.last_upgraded_at = now_utc()
-            metadata.save(self.kittify_dir)
-            # Why: MUST run after metadata.save(). ProjectMetadata.save() reconstructs
-            # the YAML from a fixed three-key dict and does not preserve unknown keys,
-            # so stamping schema_version before save() would silently clobber it.
-            # See FR-002 / #705.
-            if REQUIRED_SCHEMA_VERSION is not None:
-                self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
+        if not dry_run:
+            self._finalize_main_metadata(
+                metadata, target_version, result, pre_run_schema_version
+            )
 
         # Handle worktrees
         if include_worktrees:
@@ -488,6 +496,35 @@ class MigrationRunner:
         if recorded:
             metadata.save(metadata_dir)
         return recorded
+
+    def _finalize_main_metadata(
+        self,
+        metadata: ProjectMetadata,
+        target_version: str,
+        result: UpgradeResult,
+        pre_run_schema_version: int | None,
+    ) -> None:
+        """Persist metadata and settle ``schema_version`` after the loop.
+
+        On **success**: bump ``version`` + stamp ``REQUIRED_SCHEMA_VERSION`` (the
+        target). The stamp MUST run after ``metadata.save()`` because
+        ``ProjectMetadata.save()`` reconstructs the YAML from a fixed dict, so a
+        stamp written first would be clobbered (FR-002 / #705).
+
+        On **failure** (FR-002 / #3334): restore the captured pre-run
+        ``schema_version`` so a failed migration NEVER advances -- or erases --
+        the schema the project actually satisfies. A legacy project (captured
+        value ``None``) is intentionally left unstamped so it is never advanced
+        to the target.
+        """
+        if result.success:
+            metadata.version = target_version
+            metadata.last_upgraded_at = now_utc()
+            metadata.save(self.kittify_dir)
+            if REQUIRED_SCHEMA_VERSION is not None:
+                self._stamp_schema_version(self.kittify_dir, REQUIRED_SCHEMA_VERSION)
+        elif pre_run_schema_version is not None:
+            self._stamp_schema_version(self.kittify_dir, pre_run_schema_version)
 
     @staticmethod
     def _stamp_schema_version(kittify_dir: Path, schema_version: int) -> None:

--- a/tests/architectural/test_safety_registry_completeness.py
+++ b/tests/architectural/test_safety_registry_completeness.py
@@ -111,17 +111,23 @@ class TestSafetyRegistryCompleteness:
     """Walk the live typer app and assert the fail-closed policy holds."""
 
     def test_registered_commands_in_registry_are_safe(self, all_command_paths: list[tuple[str, ...]]) -> None:
-        """Commands present in SAFETY_REGISTRY must classify as SAFE.
+        """Commands seeded with ``None`` must classify as unconditionally SAFE.
 
-        If a command is seeded with ``None`` it should be SAFE.  If it has a
-        predicate and the predicate returns UNSAFE, this test will also catch
-        that (but no seeded predicates are UNSAFE in the initial registry).
+        Entries registered with a ``None`` value are unconditionally SAFE and
+        this invariant checks them.  Entries registered with a *predicate* are
+        argument-dependent by design — e.g. ``("migrate", "backfill-runtime-state")``
+        is SAFE only in its read-only ``--dry-run`` form and UNSAFE (fail-closed)
+        otherwise (FR-003 / #3338).  ``_inv`` supplies empty ``raw_args``, so a
+        predicate entry legitimately classifies UNSAFE here; asserting
+        unconditional SAFE for those would contradict the fail-closed guard.
+        Predicate behaviour is pinned by the predicate's own unit tests
+        (``tests/compat/test_diagnostic_safe_predicate.py``).
         """
         for path in all_command_paths:
-            if path in SAFETY_REGISTRY:
+            if path in SAFETY_REGISTRY and SAFETY_REGISTRY[path] is None:
                 result = classify(_inv(path))
                 assert result == Safety.SAFE, (
-                    f"Registered path {path!r} classified as UNSAFE. If you added a predicate, ensure it returns SAFE for normal invocations."
+                    f"Registered path {path!r} (seeded None → unconditionally SAFE) classified as UNSAFE."
                 )
 
     def test_unregistered_commands_are_unsafe(self, all_command_paths: list[tuple[str, ...]]) -> None:

--- a/tests/architectural/test_single_mission_surface_resolver.py
+++ b/tests/architectural/test_single_mission_surface_resolver.py
@@ -323,7 +323,7 @@ _RAW_JOIN_SITES: tuple[ContentDescriptor, ...] = (
     # name — not a raw slug bypass.
     ContentDescriptor(
         rel_path="specify_cli/core/mission_creation.py",
-        qualname="create_mission_core",
+        qualname="_create_mission_core_impl",
         token_substring="feature_dir = effective_root / KITTY_SPECS_DIR / mission_slug_formatted",
         occurrence=None,
         rationale=(
@@ -332,7 +332,9 @@ _RAW_JOIN_SITES: tuple[ContentDescriptor, ...] = (
             "input); seam is defined in lanes/branch_naming.py (FR-032/FR-044). "
             "Create-time-canonical: the mission dir is being created here "
             "(feature_dir.mkdir follows immediately), so there is no prior surface "
-            "to resolve through."
+            "to resolve through. Re-pinned 2026-08-13 (#3339/WP12): create_mission_core "
+            "is now a thin failure-atomic wrapper delegating to _create_mission_core_impl, "
+            "which owns this join line."
         ),
     ),
     # ----- DRAINED by mission retrospective-durable-home-01KVYM1W (#2136/#2164):

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compat-surface tests (dry-run parity, FR-009)."""

--- a/tests/compat/test_diagnostic_safe_predicate.py
+++ b/tests/compat/test_diagnostic_safe_predicate.py
@@ -1,0 +1,125 @@
+"""FR-003 (#3338) — the recommended diagnostic must be reachable on a wedged project.
+
+The failed ``backfill-runtime-state`` migration aborts with a message telling the
+operator to run ``spec-kitty migrate backfill-runtime-state --mission <slug> --dry-run``
+to inspect the cause.  Before this work package only the bare ``("migrate",)`` path
+was registered SAFE, and ``classify()`` fails closed on the missing subcommand path
+(``("migrate", "backfill-runtime-state")``) -> UNSAFE -> BLOCK_PROJECT_MIGRATION.  The
+recommended diagnostic was therefore gated behind the very failure it diagnoses.
+
+This module pins the fail-closed ``--dry-run`` predicate that ungates the diagnostic:
+
+* ``--dry-run`` present in ``raw_args``            -> SAFE (diagnostic reachable)
+* ``--dry-run`` absent (the mutating form)         -> UNSAFE (stays blocked)
+* the predicate raising for any reason             -> UNSAFE (fail closed)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from specify_cli.compat.safety import (
+    SAFETY_REGISTRY,
+    Safety,
+    classify,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+#: The command path the failed migration recommends the operator runs.
+_DIAGNOSTIC_PATH: tuple[str, ...] = ("migrate", "backfill-runtime-state")
+
+
+def _inv(
+    command_path: tuple[str, ...],
+    raw_args: tuple[str, ...] = (),
+) -> SimpleNamespace:
+    """Build a minimal Invocation-like object for classify()."""
+    return SimpleNamespace(command_path=command_path, raw_args=raw_args)
+
+
+# ---------------------------------------------------------------------------
+# Registration: the diagnostic path carries a predicate (not unconditional SAFE)
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_path_is_registered_with_a_predicate() -> None:
+    """The subcommand path is registered, and with a callable predicate.
+
+    A bare ``None`` registration would make the *mutating* form SAFE too, which
+    would defeat the fail-closed guard — so the value must be callable.
+    """
+    assert _DIAGNOSTIC_PATH in SAFETY_REGISTRY, (
+        f"{_DIAGNOSTIC_PATH!r} must be registered so classify() does not fail "
+        "closed on the recommended diagnostic."
+    )
+    predicate = SAFETY_REGISTRY[_DIAGNOSTIC_PATH]
+    assert callable(predicate), (
+        "The diagnostic must be gated by a --dry-run predicate, not registered "
+        "as unconditionally SAFE (that would open the mutating migration path)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# SAFE iff --dry-run present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_args",
+    [
+        ("--dry-run",),
+        ("--mission", "some-slug", "--dry-run"),
+        ("--dry-run", "--mission", "some-slug"),
+    ],
+)
+def test_dry_run_form_is_safe(raw_args: tuple[str, ...]) -> None:
+    """With ``--dry-run`` present the diagnostic classifies SAFE (reachable)."""
+    result = classify(_inv(_DIAGNOSTIC_PATH, raw_args))
+    assert result == Safety.SAFE, (
+        f"Expected SAFE for raw_args={raw_args!r} (diagnostic must be reachable "
+        "on a blocked project), got {result!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# UNSAFE when --dry-run absent (the mutating form stays blocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_args",
+    [
+        (),
+        ("--mission", "some-slug"),
+        ("--force",),
+    ],
+)
+def test_mutating_form_is_unsafe(raw_args: tuple[str, ...]) -> None:
+    """Without ``--dry-run`` the mutating migration form remains UNSAFE."""
+    result = classify(_inv(_DIAGNOSTIC_PATH, raw_args))
+    assert result == Safety.UNSAFE, (
+        f"Expected UNSAFE for raw_args={raw_args!r} (mutating form must stay "
+        "blocked under schema mismatch), got {result!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail closed: any predicate exception -> UNSAFE
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_failure_is_unsafe() -> None:
+    """A malformed invocation (raw_args missing) must classify UNSAFE, not crash.
+
+    ``classify()`` swallows predicate exceptions and returns UNSAFE; the predicate
+    inspecting a missing ``raw_args`` attribute is the realistic fail-closed path.
+    """
+    broken = SimpleNamespace(command_path=_DIAGNOSTIC_PATH)  # no raw_args attribute
+    result = classify(broken)  # type: ignore[arg-type]
+    assert result == Safety.UNSAFE, (
+        "A predicate that raises while inspecting the invocation must fall back "
+        "to UNSAFE (fail closed)."
+    )

--- a/tests/compat/test_dry_run_parity.py
+++ b/tests/compat/test_dry_run_parity.py
@@ -1,0 +1,214 @@
+"""FR-009 (#3336, WP10): the ``upgrade --dry-run`` preview must be honest.
+
+``spec-kitty upgrade --dry-run`` (and ``--dry-run --json``) has to report the
+*same* pending work a real run would apply. Two historical divergences made the
+preview under-report:
+
+1. **Pending migrations.** The ``--json`` preview routed through the
+   compat-planner's ``_pending_migrations_for`` (gated on
+   ``BLOCK_PROJECT_MIGRATION`` — ``()`` for any project that is
+   schema-compatible but version-stale), while the real run selects via
+   ``MigrationRegistry.get_applicable``. A stale-but-schema-OK project could
+   therefore preview ``[]`` while the real run applied migrations.
+
+2. **Provisioning.** ``_provision_missing_mission_type_activations`` never runs
+   under ``--dry-run`` (it returns early), so the preview never signalled the
+   pending ``mission_type_activations`` seed the real run performs.
+
+These tests pin parity for both divergences: the ``--json`` preview's
+``pending_migrations`` is driven through the exact selector the real run uses
+(``MigrationRegistry.get_applicable``), and the provisioning seed is surfaced on
+the human ``--dry-run`` preview (the frozen ``compat-planner.json`` machine
+contract, ``additionalProperties: false``, owns no provisioning field).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from specify_cli import __version__
+from specify_cli.cli.commands.upgrade import upgrade
+from specify_cli.migration.schema_version import MAX_SUPPORTED_SCHEMA
+from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.registry import MigrationRegistry
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+# A version far enough behind the CLI that ``get_applicable`` selects a
+# non-empty window of real migrations, yet with a *current* schema_version so
+# the planner's block decision stays ALLOW (schema-compatible) — the exact
+# shape that exposed divergence #1.
+_STALE_VERSION = "0.0.1"
+
+_test_app = typer.Typer(add_completion=False)
+_test_app.command()(upgrade)
+_runner = CliRunner()
+
+
+def _write_project(
+    project: Path,
+    *,
+    version: str,
+    config_body: str,
+    schema_version: int = MAX_SUPPORTED_SCHEMA,
+) -> None:
+    """Materialize a minimal Spec Kitty project on disk.
+
+    Writes ``.kittify/metadata.yaml`` (version + schema_version) and
+    ``.kittify/config.yaml`` (``config_body``). No git required: the
+    ``--dry-run``/``--json`` preview short-circuits before any commit path.
+    """
+    kittify = project / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "metadata.yaml").write_text(
+        "spec_kitty:\n"
+        f'  version: "{version}"\n'
+        f"  schema_version: {schema_version}\n"
+        "  initialized_at: '2026-01-01T00:00:00+00:00'\n",
+        encoding="utf-8",
+    )
+    (kittify / "config.yaml").write_text(config_body, encoding="utf-8")
+
+
+def _invoke_upgrade(project: Path, args: list[str], monkeypatch: pytest.MonkeyPatch) -> object:
+    """Invoke ``upgrade`` with *args* inside *project* (CI=1 → no network)."""
+    monkeypatch.setenv("CI", "1")
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(project)
+        return _runner.invoke(_test_app, args, catch_exceptions=False)
+    finally:
+        os.chdir(old_cwd)
+
+
+def _run_dry_run_json(project: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Invoke ``upgrade --dry-run --json --no-nag`` in *project* and parse JSON."""
+    result = _invoke_upgrade(project, ["--dry-run", "--json", "--no-nag"], monkeypatch)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def _run_dry_run_human(project: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Invoke the human ``upgrade --dry-run --no-nag`` preview; return its output.
+
+    The provisioning divergence is surfaced on the human preview (the frozen
+    ``compat-planner.json`` machine contract owns no provisioning field). The
+    generated-surface repair is stubbed out so the assertion stays scoped to
+    the provisioning notice.
+    """
+    monkeypatch.setattr(
+        "specify_cli.cli.commands.upgrade._run_upgrade_surface_repair",
+        lambda *a, **k: None,
+    )
+    result = _invoke_upgrade(project, ["--dry-run", "--no-nag", "--no-worktrees"], monkeypatch)
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def _real_applied_ids(project: Path, target_version: str, from_version: str) -> list[str]:
+    """The migration ids a real ``upgrade`` run would apply (upgrade.py:751)."""
+    auto_discover_migrations()
+    version_for_migration = "0.0.0" if from_version == "unknown" else from_version
+    applicable = MigrationRegistry.get_applicable(
+        version_for_migration, target_version, project_path=project
+    )
+    return sorted(m.migration_id for m in applicable)
+
+
+# ---------------------------------------------------------------------------
+# Divergence #1 — pending-migration parity
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_json_pending_set_equals_real_applied_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Preview ``pending_migrations`` == the real run's ``get_applicable`` set.
+
+    The project is schema-compatible (block decision ALLOW) but version-stale,
+    so the pre-fix planner path reported ``[]`` while a real run applied the
+    windowed migrations. This is the FR-009 SC-004 parity guarantee.
+    """
+    project = tmp_path / "stale"
+    _write_project(
+        project,
+        version=_STALE_VERSION,
+        config_body="vcs:\n  type: git\nmission_type_activations:\n  - software-development\n",
+    )
+
+    real_ids = _real_applied_ids(project, __version__, _STALE_VERSION)
+    # Sanity: the scenario must actually have pending work, else the parity
+    # assertion below would pass vacuously.
+    assert real_ids, "fixture must have >=1 pending migration for a meaningful parity check"
+
+    payload = _run_dry_run_json(project, monkeypatch)
+    preview_ids = sorted(step["migration_id"] for step in payload["pending_migrations"])
+
+    assert preview_ids == real_ids
+
+
+# ---------------------------------------------------------------------------
+# Divergence #2 — provisioning parity
+# ---------------------------------------------------------------------------
+
+
+_PROVISION_NOTICE = "Would provision missing mission_type_activations"
+
+
+def test_dry_run_reflects_pending_provisioning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A project missing ``mission_type_activations`` previews the pending seed.
+
+    The real run seeds the key (``_provision_missing_mission_type_activations``);
+    the pre-fix dry-run skipped it silently. The preview must surface it so the
+    reported pending work matches what a real run performs.
+    """
+    project = tmp_path / "unprovisioned"
+    _write_project(
+        project,
+        version=__version__,  # current version → isolate provisioning from migrations
+        config_body="vcs:\n  type: git\n",  # no mission_type_activations key
+    )
+
+    output = _run_dry_run_human(project, monkeypatch)
+
+    assert _PROVISION_NOTICE in output
+
+
+def test_dry_run_no_provisioning_when_key_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An already-provisioned project previews no pending provisioning."""
+    project = tmp_path / "provisioned"
+    _write_project(
+        project,
+        version=__version__,
+        config_body="vcs:\n  type: git\nmission_type_activations:\n  - software-development\n",
+    )
+
+    output = _run_dry_run_human(project, monkeypatch)
+
+    assert _PROVISION_NOTICE not in output
+
+
+def test_dry_run_no_provisioning_for_authored_empty_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An authored empty list is a deliberate state — never a pending seed."""
+    project = tmp_path / "empty-authored"
+    _write_project(
+        project,
+        version=__version__,
+        config_body="vcs:\n  type: git\nmission_type_activations: []\n",
+    )
+
+    output = _run_dry_run_human(project, monkeypatch)
+
+    assert _PROVISION_NOTICE not in output

--- a/tests/core/test_mission_create_checkout_restore.py
+++ b/tests/core/test_mission_create_checkout_restore.py
@@ -1,0 +1,164 @@
+"""FR-011 (#3339): a failed mission-create must be atomic for git side-effects.
+
+WP12 — mission-create checkout restore. A ``create_mission_core`` that fails
+*after* minting the coordination branch must:
+
+  (a) leave the operator on their ORIGINAL branch/checkout, and
+  (b) delete the orphan coordination branch it minted.
+
+These tests drive a real git repository (``git init`` + subprocess), so they
+carry the ``git_repo`` marker.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.core.git_ops import get_current_branch
+from specify_cli.core.mission_creation import (
+    _restore_git_state_after_failed_create,
+    create_mission_core,
+)
+
+from tests._factories import provision_test_charter
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+_ORIGINAL_BRANCH = "operator-work"
+_COORDINATION_GLOB = "kitty/mission-*"
+
+
+def _init_git_repo(repo: Path) -> None:
+    (repo / ".kittify").mkdir(exist_ok=True)
+    # WP04 fail-closed: create_mission_core requires a provisioned charter.
+    provision_test_charter(repo)
+    (repo / "kitty-specs").mkdir(exist_ok=True)
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=repo, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=repo, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init", "--allow-empty"], cwd=repo, capture_output=True, check=True
+    )
+    # Deterministic, operator-named branch so the assertion is decoupled from
+    # the ambient git ``init.defaultBranch`` (master vs main).
+    subprocess.run(
+        ["git", "branch", "-M", _ORIGINAL_BRANCH], cwd=repo, capture_output=True, check=True
+    )
+
+
+def _mission_summary(slug: str) -> dict[str, str]:
+    title = slug.replace("-", " ").strip() or "test mission"
+    return {
+        "friendly_name": title.title(),
+        "purpose_tldr": f"Deliver {title} cleanly for the team.",
+        "purpose_context": (
+            f"This mission delivers {title} so product and engineering can move "
+            "forward with a clear outcome and shared understanding."
+        ),
+    }
+
+
+def _coordination_branches(repo: Path) -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "branch",
+            "--list",
+            _COORDINATION_GLOB,
+            "--format=%(refname:short)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def test_failed_create_restores_branch_and_leaves_no_orphan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC2 / FR-011: a create that fails AFTER the coordination branch is minted
+    restores the operator's original branch and leaves no orphan branch."""
+    _init_git_repo(tmp_path)
+    assert get_current_branch(tmp_path) == _ORIGINAL_BRANCH
+    assert _coordination_branches(tmp_path) == []
+
+    # Inject a failure that fires AFTER the coordination branch is minted:
+    # ``write_meta`` runs immediately after the mint + topology corroboration.
+    boom = RuntimeError("injected failure after branch mint")
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        raise boom
+
+    monkeypatch.setattr("specify_cli.mission_metadata.write_meta", _explode)
+
+    with pytest.raises(RuntimeError, match="injected failure after branch mint"):
+        create_mission_core(
+            tmp_path,
+            "atomicity-check",
+            allow_worktree_context=True,
+            **_mission_summary("atomicity-check"),
+        )
+
+    # (a) operator is back on their original branch.
+    assert get_current_branch(tmp_path) == _ORIGINAL_BRANCH
+    # (b) no orphan coordination branch remains.
+    assert _coordination_branches(tmp_path) == []
+
+
+def test_restore_helper_switches_back_and_deletes_new_branches(tmp_path: Path) -> None:
+    """Focused coverage: the rollback helper restores the checkout and deletes
+    the coordination branch that appeared during the aborted create."""
+    _init_git_repo(tmp_path)
+    pre = frozenset(_coordination_branches(tmp_path))  # empty
+    orphan = "kitty/mission-simulated-abcd1234"
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "branch", orphan], capture_output=True, text=True, check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "checkout", orphan], capture_output=True, text=True, check=True
+    )
+    assert get_current_branch(tmp_path) == orphan
+
+    _restore_git_state_after_failed_create(
+        tmp_path,
+        original_branch=_ORIGINAL_BRANCH,
+        pre_existing_coordination_branches=pre,
+    )
+
+    assert get_current_branch(tmp_path) == _ORIGINAL_BRANCH
+    assert _coordination_branches(tmp_path) == []
+
+
+def test_restore_helper_preserves_pre_existing_coordination_branches(tmp_path: Path) -> None:
+    """The rollback deletes only NEW coordination branches, never one that was
+    already present before the aborted create (no collateral deletion)."""
+    _init_git_repo(tmp_path)
+    keep = "kitty/mission-keep-me-00000000"
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "branch", keep], capture_output=True, text=True, check=True
+    )
+    pre = frozenset(_coordination_branches(tmp_path))  # {keep}
+    new = "kitty/mission-new-11111111"
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "branch", new], capture_output=True, text=True, check=True
+    )
+
+    _restore_git_state_after_failed_create(
+        tmp_path,
+        original_branch=_ORIGINAL_BRANCH,  # already on it
+        pre_existing_coordination_branches=pre,
+    )
+
+    remaining = _coordination_branches(tmp_path)
+    assert keep in remaining
+    assert new not in remaining

--- a/tests/specify_cli/cli/commands/agent/test_mission_create_json_remediation.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create_json_remediation.py
@@ -60,6 +60,7 @@ def _run_core_phase_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dic
             purpose_tldr=None,
             purpose_context=None,
             force_recreate_coordination_branch=False,
+            owned_checkout=None,
             json_output=True,
         )
     assert exc_info.value.exit_code == 1

--- a/tests/specify_cli/cli/commands/agent/test_mission_create_json_remediation.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create_json_remediation.py
@@ -1,0 +1,96 @@
+"""FR-010: the CHARTER_PACK_CONFIG_INVALID remediation body survives ``--json``.
+
+Mission ``upgrade-atomicity-recovery-01KZWSHC`` / WP11 / #3337.
+
+``CharterPackConfigError`` (``kernel.errors.KittyInternalConsistencyError``
+subclass) carries a JSON-stable ``.code`` (``"CHARTER_PACK_CONFIG_INVALID"``)
+and a human-readable ``.body`` with the remediation steps. ``str(exc)`` returns
+only the ``code`` — so the generic ``except Exception -> _emit_json({"error":
+str(e)})`` funnel in ``_run_create_core_phase`` DROPS the remediation body,
+leaving scripted ``--json`` callers with an opaque code and no fix instructions.
+
+These tests pin the dedicated ``except CharterPackConfigError`` branch: the
+``--json`` failure envelope must carry the remediation ``.body`` (not just the
+code). The body text is supplied by the raising test double so the assertion is
+decoupled from the WP12-owned prose at ``core/mission_creation.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from specify_cli.cli.commands.agent import mission_create as seam
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+_REMEDIATION_BODY = (
+    "This project has no activated mission types, so a mission cannot be "
+    "created. Provision the project's charter: run `spec-kitty init` "
+    "(new project) or `spec-kitty upgrade` (existing project)."
+)
+
+
+def _raise_charter_config_error(**_kwargs: object) -> None:
+    """Stand-in for ``create_mission_core`` that fails the charter-pack gate."""
+    from charter.pack_context import CharterPackConfigError
+
+    raise CharterPackConfigError(_REMEDIATION_BODY)
+
+
+def _run_core_phase_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, object]:
+    """Drive ``_run_create_core_phase`` in ``--json`` mode, capturing the payload."""
+    import specify_cli.core.mission_creation as core
+
+    monkeypatch.setattr(core, "create_mission_core", _raise_charter_config_error)
+
+    emitted: dict[str, object] = {}
+    monkeypatch.setattr(seam, "_emit_json", lambda payload: emitted.update(payload))
+
+    with pytest.raises(typer.Exit) as exc_info:
+        seam._run_create_core_phase(
+            repo_root=tmp_path,
+            mission_slug="001-demo",
+            resolved_mission_type="software-dev",
+            target_branch="main",
+            friendly_name=None,
+            purpose_tldr=None,
+            purpose_context=None,
+            force_recreate_coordination_branch=False,
+            json_output=True,
+        )
+    assert exc_info.value.exit_code == 1
+    return emitted
+
+
+def test_json_envelope_carries_remediation_body(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # FR-010 / US5 AC1: the remediation prose must reach the --json envelope.
+    envelope = _run_core_phase_json(monkeypatch, tmp_path)
+    serialized = repr(envelope)
+    assert _REMEDIATION_BODY in serialized, (
+        "remediation body dropped from --json envelope; "
+        f"got only: {serialized}"
+    )
+
+
+def test_json_envelope_exposes_stable_error_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The stable machine code accompanies the body so scripted callers can
+    # branch on it (NFR-007-style stable error_code contract).
+    envelope = _run_core_phase_json(monkeypatch, tmp_path)
+    assert envelope.get("error_code") == "CHARTER_PACK_CONFIG_INVALID"
+
+
+def test_json_envelope_error_is_not_bare_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # Regression guard: the pre-fix generic funnel emitted {"error":
+    # "CHARTER_PACK_CONFIG_INVALID"} (str(exc) == code), dropping the body.
+    envelope = _run_core_phase_json(monkeypatch, tmp_path)
+    assert envelope.get("error") != "CHARTER_PACK_CONFIG_INVALID"

--- a/tests/status/test_dup_key_repair.py
+++ b/tests/status/test_dup_key_repair.py
@@ -1,0 +1,333 @@
+"""WP03 / FR-008 (#3372): raw-text duplicate-key detect + batch-atomic repair.
+
+The legacy write-path once emitted ``review_feedback`` twice in a WP artifact's
+frontmatter (an empty ``''`` then a real ``review-cycle://`` pointer), producing
+a duplicate-key, invalid-YAML file that the canonical frontmatter boundary fails
+CLOSED on (ruamel ``DuplicateKeyError``). These tests pin:
+
+* a RAW-TEXT detector that can find such artifacts (the boundary cannot);
+* an opt-in repair that is NON-DESTRUCTIVE (NFR-002: the recorded pointer is
+  preserved) and BATCH-ATOMIC (NFR-004: one un-repairable artifact aborts the
+  whole run, leaving the corpus untouched);
+* the ``doctor`` diagnostic surface and the ``--fix`` CLI wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager
+from specify_cli.migration.mission_state import repair_duplicate_key_artifacts
+from specify_cli.status.dup_key_repair import (
+    DuplicateKeyRepairError,
+    detect_duplicate_key_artifacts,
+    find_duplicate_keys_in_text,
+    plan_artifact_repair,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (raw artifact text)
+# ---------------------------------------------------------------------------
+
+_DUAL_KEY_EMPTY_FIRST = (
+    "---\n"
+    "work_package_id: WP01\n"
+    "title: Something\n"
+    "review_feedback: ''\n"
+    "subtasks:\n"
+    "- T001\n"
+    "review_feedback: review-cycle-1.md\n"
+    "---\n"
+    "Body content.\n"
+)
+
+_DUAL_KEY_EMPTY_LAST = (
+    "---\n"
+    "work_package_id: WP02\n"
+    "review_feedback: docs/review-cycle-2.md\n"
+    "title: Other\n"
+    "review_feedback: ''\n"
+    "---\n"
+    "Body.\n"
+)
+
+_CLEAN_ARTIFACT = (
+    "---\n"
+    "work_package_id: WP09\n"
+    "title: Clean\n"
+    "review_feedback: review-cycle-9.md\n"
+    "---\n"
+    "Body.\n"
+)
+
+# After dropping the empty duplicate line the body STILL fails to parse (an
+# unclosed flow sequence), so the planner must refuse this artifact.
+_UNREPAIRABLE_STILL_INVALID = (
+    "---\n"
+    "work_package_id: WP03\n"
+    "review_feedback: ''\n"
+    "review_feedback: review-cycle-3.md\n"
+    "broken: [unclosed\n"
+    "---\n"
+    "Body.\n"
+)
+
+# The duplicate whose losing occurrence opens a nested block cannot be removed
+# line-wise without orphaning the block, so the planner refuses it.
+_UNREPAIRABLE_BLOCK_OCCURRENCE = (
+    "---\n"
+    "work_package_id: WP04\n"
+    "review_feedback:\n"
+    "  nested: value\n"
+    "review_feedback: review-cycle-4.md\n"
+    "---\n"
+    "Body.\n"
+)
+
+
+def _write_artifact(root: Path, slug: str, text: str) -> Path:
+    path = root / slug / "tasks" / "WP.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _parse_frontmatter_strict(path: Path) -> dict[str, object]:
+    """Parse a repaired file's frontmatter with duplicate keys forbidden."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+    closing = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+    yaml = YAML()
+    yaml.allow_duplicate_keys = False
+    loaded = yaml.load("\n".join(lines[1:closing]))
+    return dict(loaded)
+
+
+# ---------------------------------------------------------------------------
+# Detector
+# ---------------------------------------------------------------------------
+
+
+def test_raw_text_detector_finds_dual_key() -> None:
+    duplicates = find_duplicate_keys_in_text(_DUAL_KEY_EMPTY_FIRST)
+    assert "review_feedback" in duplicates
+    assert [occ.line_index + 1 for occ in duplicates["review_feedback"]] == [4, 7]
+
+
+def test_detector_ignores_clean_artifact() -> None:
+    assert find_duplicate_keys_in_text(_CLEAN_ARTIFACT) == {}
+
+
+def test_detector_ignores_file_without_frontmatter() -> None:
+    assert find_duplicate_keys_in_text("no frontmatter here\nreview_feedback: a\n") == {}
+
+
+def test_detect_walks_directory(tmp_path: Path) -> None:
+    _write_artifact(tmp_path, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+    _write_artifact(tmp_path, "mission-b", _CLEAN_ARTIFACT)
+    findings = detect_duplicate_key_artifacts(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].key == "review_feedback"
+    assert findings[0].path.parent.parent.name == "mission-a"
+
+
+def test_canonical_boundary_fails_closed_on_dual_key(tmp_path: Path) -> None:
+    """Documents WHY a raw-text scanner is required: the boundary raises."""
+    path = _write_artifact(tmp_path, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+    with pytest.raises(FrontmatterError):
+        FrontmatterManager().read(path)
+
+
+# ---------------------------------------------------------------------------
+# Repair planner (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_keep_last_non_empty_when_empty_first(tmp_path: Path) -> None:
+    path = _write_artifact(tmp_path, "m", _DUAL_KEY_EMPTY_FIRST)
+    plan = plan_artifact_repair(path, _DUAL_KEY_EMPTY_FIRST)
+    assert plan is not None
+    assert plan.repaired_text.count("review_feedback:") == 1
+    assert "review-cycle-1.md" in plan.repaired_text
+    assert plan.removed_line_numbers == (4,)
+
+
+def test_plan_keeps_recorded_value_when_empty_last(tmp_path: Path) -> None:
+    path = _write_artifact(tmp_path, "m", _DUAL_KEY_EMPTY_LAST)
+    plan = plan_artifact_repair(path, _DUAL_KEY_EMPTY_LAST)
+    assert plan is not None
+    assert plan.repaired_text.count("review_feedback:") == 1
+    assert "docs/review-cycle-2.md" in plan.repaired_text
+
+
+def test_plan_returns_none_for_clean_and_bodyless(tmp_path: Path) -> None:
+    path = _write_artifact(tmp_path, "m", _CLEAN_ARTIFACT)
+    assert plan_artifact_repair(path, _CLEAN_ARTIFACT) is None
+    assert plan_artifact_repair(path, "plain text, no frontmatter\n") is None
+
+
+def test_plan_refuses_still_invalid_after_dedup(tmp_path: Path) -> None:
+    path = _write_artifact(tmp_path, "m", _UNREPAIRABLE_STILL_INVALID)
+    with pytest.raises(DuplicateKeyRepairError):
+        plan_artifact_repair(path, _UNREPAIRABLE_STILL_INVALID)
+
+
+def test_plan_refuses_block_occurrence(tmp_path: Path) -> None:
+    path = _write_artifact(tmp_path, "m", _UNREPAIRABLE_BLOCK_OCCURRENCE)
+    with pytest.raises(DuplicateKeyRepairError):
+        plan_artifact_repair(path, _UNREPAIRABLE_BLOCK_OCCURRENCE)
+
+
+# ---------------------------------------------------------------------------
+# Repair function — non-destructive + batch-atomic (the load-bearing invariants)
+# ---------------------------------------------------------------------------
+
+
+def test_repair_is_non_destructive_and_yields_valid_yaml(tmp_path: Path) -> None:
+    scan_dir = tmp_path / "kitty-specs"
+    path = _write_artifact(scan_dir, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+
+    report = repair_duplicate_key_artifacts(tmp_path, scan_root=scan_dir, allow_dirty=True)
+
+    # Recorded state preserved: the real pointer survives, the empty noise is gone.
+    frontmatter = _parse_frontmatter_strict(path)
+    assert frontmatter["review_feedback"] == "review-cycle-1.md"
+    assert frontmatter["work_package_id"] == "WP01"
+    assert frontmatter["subtasks"] == ["T001"]
+    assert path.read_text(encoding="utf-8").endswith("Body content.\n")
+    # Report evidence records the change.
+    assert sum(len(m.file_changes) for m in report.missions) == 1
+
+
+def test_repair_is_idempotent(tmp_path: Path) -> None:
+    scan_dir = tmp_path / "kitty-specs"
+    path = _write_artifact(scan_dir, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+    repair_duplicate_key_artifacts(tmp_path, scan_root=scan_dir, allow_dirty=True)
+    healed = path.read_text(encoding="utf-8")
+
+    report = repair_duplicate_key_artifacts(tmp_path, scan_root=scan_dir, allow_dirty=True)
+    assert path.read_text(encoding="utf-8") == healed
+    assert sum(len(m.file_changes) for m in report.missions) == 0
+
+
+def test_repair_is_batch_atomic_on_partial_failure(tmp_path: Path) -> None:
+    """One un-repairable artifact aborts the run; the repairable one is untouched."""
+    scan_dir = tmp_path / "kitty-specs"
+    good = _write_artifact(scan_dir, "mission-good", _DUAL_KEY_EMPTY_FIRST)
+    bad = _write_artifact(scan_dir, "mission-bad", _UNREPAIRABLE_STILL_INVALID)
+    good_before = good.read_text(encoding="utf-8")
+    bad_before = bad.read_text(encoding="utf-8")
+
+    with pytest.raises(DuplicateKeyRepairError):
+        repair_duplicate_key_artifacts(tmp_path, scan_root=scan_dir, allow_dirty=True)
+
+    # Nothing was partially repaired — both files are byte-identical to before.
+    assert good.read_text(encoding="utf-8") == good_before
+    assert bad.read_text(encoding="utf-8") == bad_before
+
+
+def test_repair_no_findings_returns_empty_report(tmp_path: Path) -> None:
+    scan_dir = tmp_path / "kitty-specs"
+    _write_artifact(scan_dir, "mission-a", _CLEAN_ARTIFACT)
+    report = repair_duplicate_key_artifacts(tmp_path, scan_root=scan_dir, allow_dirty=True)
+    assert report.missions == []
+
+
+# ---------------------------------------------------------------------------
+# Doctor diagnostic surface (read-only)
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_check_surfaces_finding(tmp_path: Path) -> None:
+    from specify_cli.status.doctor import Category, check_duplicate_frontmatter_keys
+
+    _write_artifact(tmp_path, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+    findings = check_duplicate_frontmatter_keys(tmp_path)
+    assert len(findings) == 1
+    assert findings[0].category == Category.DUPLICATE_FRONTMATTER_KEY
+    assert "review_feedback" in findings[0].message
+
+
+def test_doctor_check_clean_repo_no_findings(tmp_path: Path) -> None:
+    from specify_cli.status.doctor import check_duplicate_frontmatter_keys
+
+    _write_artifact(tmp_path, "mission-a", _CLEAN_ARTIFACT)
+    assert check_duplicate_frontmatter_keys(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI --fix wiring (opt-in; doctor itself is unconditionally SAFE)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_fix_heals_duplicate_key_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import specify_cli.migration.mission_state as mission_state
+    from specify_cli.cli.commands import _mission_state_doctor as cmd
+
+    scan_dir = tmp_path / "kitty-specs"
+    path = _write_artifact(scan_dir, "mission-a", _DUAL_KEY_EMPTY_FIRST)
+
+    # Isolate the dup-key wiring from the mission-state canonicalization pass.
+    def _fake_repair_repo(*_args: object, **_kwargs: object) -> object:
+        from specify_cli.migration.mission_state import RepairReport
+
+        return RepairReport(
+            run_id="x", repo_head=None, target_missions=[], manifest_path="m", missions=[]
+        )
+
+    monkeypatch.setattr(mission_state, "repair_repo", _fake_repair_repo)
+
+    cmd.run_mission_state(
+        audit=False,
+        fix=True,
+        teamspace_dry_run=False,
+        json_output=False,
+        mission=None,
+        fail_on=None,
+        fixture_dir=scan_dir,
+        include_fixtures=False,
+        manifest_path=None,
+        allow_dirty=True,
+        repo_root=tmp_path,
+    )
+
+    frontmatter = _parse_frontmatter_strict(path)
+    assert frontmatter["review_feedback"] == "review-cycle-1.md"
+
+
+def test_cli_fix_aborts_on_unrepairable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import typer
+
+    import specify_cli.migration.mission_state as mission_state
+    from specify_cli.cli.commands import _mission_state_doctor as cmd
+
+    scan_dir = tmp_path / "kitty-specs"
+    good = _write_artifact(scan_dir, "mission-good", _DUAL_KEY_EMPTY_FIRST)
+    _write_artifact(scan_dir, "mission-bad", _UNREPAIRABLE_STILL_INVALID)
+    good_before = good.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(mission_state, "repair_repo", lambda *a, **k: None)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        cmd.run_mission_state(
+            audit=False,
+            fix=True,
+            teamspace_dry_run=False,
+            json_output=False,
+            mission=None,
+            fail_on=None,
+            fixture_dir=scan_dir,
+            include_fixtures=False,
+            manifest_path=None,
+            allow_dirty=True,
+            repo_root=tmp_path,
+        )
+    assert excinfo.value.exit_code == 1
+    # Batch-atomic through the CLI too: the repairable artifact is untouched.
+    assert good.read_text(encoding="utf-8") == good_before

--- a/tests/status/test_reducer_recovery_integrity.py
+++ b/tests/status/test_reducer_recovery_integrity.py
@@ -1,0 +1,264 @@
+"""NFR-005 verification: recovery never breaks reducer determinism or append-only integrity.
+
+Maps **NFR-005** / **US2-AC3** (spec.md) and the binding plan revision item 8
+(``§Post-Plan Adversarial Revisions``): after a *half-applied* corpus backfill —
+some missions cut over, then an abort on the first mission whose fail-closed
+verify fails (WP05's report-on-abort path) — the recovered ``status.events.jsonl``
+must satisfy two invariants:
+
+1. **Reducer determinism (no divergence).** ``reduce()`` over the recovered log
+   yields the *same* snapshot as ``reduce()`` over (pre-abort log ∪ committed
+   cutover events), regardless of the order those two sets are presented in. The
+   reducer sorts by ``(at, event_id)`` and de-dups on ``event_id`` (WP03
+   :func:`~specify_cli.status.reducer.reduce`), so recovery ordering cannot move
+   the snapshot — and a *duplicated* committed batch (what a crash-then-retry
+   could leave) folds to the identical snapshot.
+2. **Idempotent re-run appends no duplicate transitions.** After the partial
+   backfill, ``detect()``/``_mission_needs_cutover`` skips the already-cut-over
+   mission (it is at snapshot authority), and even the always-executed
+   ``cutover_mission`` seed step is byte-idempotent — so a second migration run
+   appends **zero** new rows to the recovered mission's log (the #3334
+   regression assertion).
+
+This suite composes shipped behaviour (WP01 schema-preserve + WP05
+report-on-abort + WP03 reducer de-dup); it must PASS once both dependencies are
+present. A failure here is a real event-log integrity gap, not a red-first stub.
+
+Every test drives the REAL library backfill/cutover over a REAL fixture event
+log with genuine fault injection (a divergent same-slot annotation) — no
+``cutover_mission``/``verify_backfill`` is mocked to force an outcome, matching
+WP05's non-vacuous discipline
+(``tests/upgrade/test_backfill_report_on_abort.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from specify_cli.migration.backfill_runtime_state import backfill_runtime_state
+from specify_cli.status.reducer import reduce
+from specify_cli.status.store import (
+    EventStream,
+    read_event_stream,
+    read_event_stream_from_text,
+    read_events_raw,
+)
+from specify_cli.upgrade.migrations.m_zz_runtime_state_backfill import (
+    RuntimeStateBackfillMigration,
+    _mission_needs_cutover,
+)
+from tests.unit.migration._backfill_fixture import build_mission, corrupt_seed_value
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+_META_FILENAME = "meta.json"
+
+
+def _inject_conflicting_seed(feature_dir: Path) -> None:
+    """Corrupt the canonical assignee seed payload so *feature_dir*'s verify is red.
+
+    A REAL divergent same-slot annotation (fault injection, not a mock), mirroring
+    ``tests/upgrade/test_backfill_report_on_abort.py``: the live fail-closed verify
+    genuinely reports a mismatch, which drives the whole-step abort.
+    """
+    corrupt_seed_value(
+        feature_dir,
+        field_name="assignee",
+        slot_name="assignee",
+        value="EVIL-DIVERGENT",
+    )
+
+
+def _has_status_phase(feature_dir: Path) -> bool:
+    return "status_phase" in json.loads((feature_dir / _META_FILENAME).read_text())
+
+
+def _snapshot_dict(stream: EventStream) -> dict[str, object]:
+    """Reduce a stream to its deterministic snapshot dict (transitions + annotations)."""
+    snapshot_dict: dict[str, object] = reduce(stream.transitions, stream.annotations).to_dict()
+    return snapshot_dict
+
+
+@dataclass(frozen=True)
+class _HalfApplied:
+    """The recovered state of a corpus backfill that aborted mid-walk.
+
+    ``alpha`` was fully cut over (seeded + flipped) BEFORE the abort; ``beta``
+    (sorted next) failed the fail-closed verify and aborted the whole step;
+    ``gamma`` (sorted after) was never visited. ``alpha_pre_abort_text`` is
+    alpha's on-disk event log captured BEFORE the migration ran — the "pre-abort
+    log" half of the NFR-005 union.
+    """
+
+    alpha: Path
+    beta: Path
+    gamma: Path
+    alpha_pre_abort_text: str
+
+
+def _seed_half_applied_backfill(tmp_path: Path) -> _HalfApplied:
+    """Build a half-applied backfill and return the recovered corpus handles.
+
+    Reuses WP05's report-on-abort path: ``alpha`` cuts over, then ``beta``'s
+    fault-injected divergent seed trips the fail-closed verify and aborts the
+    walk, leaving the corpus half-applied (``gamma`` untouched).
+    """
+    alpha = build_mission(tmp_path, slug="alpha")
+    beta = build_mission(tmp_path, slug="beta")
+    gamma = build_mission(tmp_path, slug="gamma")
+
+    # Capture alpha's pre-abort event log BEFORE any cutover writes to it.
+    alpha_pre_abort_text = (alpha / _STATUS_EVENTS_FILENAME).read_text(encoding="utf-8")
+
+    # Fault-inject beta with a REAL divergent same-slot annotation so its live
+    # verify is genuinely red (drives the abort) — not a mocked outcome.
+    backfill_runtime_state(beta)
+    _inject_conflicting_seed(beta)
+
+    result = RuntimeStateBackfillMigration().apply(tmp_path)
+
+    # Sanity: the walk really was half-applied (WP05 contract).
+    assert result.success is False, "fixture must abort mid-walk (beta verify red)"
+    assert not _has_status_phase(gamma), "gamma sorts after beta -> never visited"
+    assert _has_status_phase(alpha), "alpha sorts before beta -> cut over pre-abort"
+
+    return _HalfApplied(
+        alpha=alpha,
+        beta=beta,
+        gamma=gamma,
+        alpha_pre_abort_text=alpha_pre_abort_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFR-005 / US2-AC3 -- INVARIANT 1: reducer determinism after recovery
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_over_recovered_log_equals_pre_abort_union_committed(tmp_path: Path) -> None:
+    """AC1: ``reduce(recovered) == reduce(pre-abort ∪ committed)`` — no divergence.
+
+    The recovered log is (by append-only construction) exactly
+    ``pre-abort ∪ committed cutover events``. This test reconstructs that union
+    INDEPENDENTLY (pre-abort captured before the run; committed = recovered minus
+    pre-abort by ``event_id``) and reduces it in the OPPOSITE on-disk order
+    (committed first, then pre-abort). Order-invariance of the snapshot is the
+    proof that recovery ordering never moves the reduced state.
+    """
+    fixture = _seed_half_applied_backfill(tmp_path)
+
+    # Append-only integrity: the cutover NEVER rewrote alpha's prior lines — the
+    # recovered log begins with the byte-identical pre-abort prefix.
+    recovered_text = (fixture.alpha / _STATUS_EVENTS_FILENAME).read_text(encoding="utf-8")
+    assert recovered_text.startswith(fixture.alpha_pre_abort_text), (
+        "recovery mutated pre-abort rows -> append-only integrity broken"
+    )
+
+    recovered = read_event_stream(fixture.alpha)
+    recovered_snapshot = _snapshot_dict(recovered)
+
+    # Independently split the union into its two halves.
+    pre_abort = read_event_stream_from_text(fixture.alpha, fixture.alpha_pre_abort_text)
+    pre_ids = {e.event_id for e in pre_abort.transitions} | {
+        a.event_id for a in pre_abort.annotations
+    }
+    committed_transitions = [e for e in recovered.transitions if e.event_id not in pre_ids]
+    committed_annotations = [a for a in recovered.annotations if a.event_id not in pre_ids]
+
+    # Non-vacuous: the cutover genuinely committed events for alpha this run.
+    assert committed_transitions or committed_annotations, (
+        "fixture committed nothing for alpha -> the union invariant would be trivial"
+    )
+
+    # reduce(pre-abort ∪ committed), presented committed-first (the OPPOSITE of the
+    # on-disk order) -> must match reduce(recovered).
+    reordered_union = EventStream(
+        transitions=committed_transitions + pre_abort.transitions,
+        annotations=committed_annotations + pre_abort.annotations,
+    )
+    assert _snapshot_dict(reordered_union) == recovered_snapshot, (
+        "reducer diverged when the recovered log was presented in a different order"
+    )
+
+
+def test_duplicated_committed_batch_folds_to_the_same_snapshot(tmp_path: Path) -> None:
+    """AC1 (de-dup mechanism): a duplicated committed batch reduces identically.
+
+    ``reduce()`` de-dups on ``event_id`` (WP03), so even if recovery re-appended
+    the committed cutover events a second time (a crash-then-retry residue), the
+    snapshot is unchanged — the exact append-only-integrity guarantee NFR-005
+    names. This exercises the reducer's de-dup leg directly, complementing the
+    detect()-gating leg proven below.
+    """
+    fixture = _seed_half_applied_backfill(tmp_path)
+
+    recovered = read_event_stream(fixture.alpha)
+    recovered_snapshot = _snapshot_dict(recovered)
+
+    pre_abort = read_event_stream_from_text(fixture.alpha, fixture.alpha_pre_abort_text)
+    pre_ids = {e.event_id for e in pre_abort.transitions} | {
+        a.event_id for a in pre_abort.annotations
+    }
+    committed_transitions = [e for e in recovered.transitions if e.event_id not in pre_ids]
+    committed_annotations = [a for a in recovered.annotations if a.event_id not in pre_ids]
+    assert committed_transitions or committed_annotations
+
+    duplicated = EventStream(
+        transitions=recovered.transitions + committed_transitions,
+        annotations=recovered.annotations + committed_annotations,
+    )
+    assert _snapshot_dict(duplicated) == recovered_snapshot, (
+        "reducer failed to de-dup a duplicated committed batch on event_id"
+    )
+
+
+# ---------------------------------------------------------------------------
+# NFR-005 / #3334 -- INVARIANT 2: idempotent re-run appends no duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_after_partial_backfill_appends_no_duplicate_transitions(tmp_path: Path) -> None:
+    """AC2: a second migration run appends NO new rows to the cut-over mission's log.
+
+    Two cooperating mechanisms guarantee this: ``_mission_needs_cutover`` reports
+    alpha as no-longer-needing cutover (it is at snapshot authority), and the
+    always-executed ``cutover_mission`` seed step is byte-idempotent (deterministic
+    seed ids already on disk). Together they mean the recovered mission's event log
+    is byte-identical across the re-run — no duplicate transitions, ever.
+    """
+    fixture = _seed_half_applied_backfill(tmp_path)
+    recovered_text = (fixture.alpha / _STATUS_EVENTS_FILENAME).read_text(encoding="utf-8")
+
+    # detect()-gating: the cut-over mission is skipped; the still-corrupt one is not.
+    assert _mission_needs_cutover(fixture.alpha) is False, (
+        "already-cut-over mission must be skipped by the idempotency gate"
+    )
+    assert _mission_needs_cutover(fixture.beta) is True, (
+        "the aborted (never-flipped) mission still needs cutover"
+    )
+
+    before_snapshot = _snapshot_dict(read_event_stream(fixture.alpha))
+
+    # Re-run the whole migration. It walks alpha (a no-op cutover) then aborts on
+    # beta again (still corrupt) -- deterministic.
+    second_result = RuntimeStateBackfillMigration().apply(tmp_path)
+    assert second_result.success is False, "beta is still corrupt -> the re-run still aborts"
+
+    # No new rows appended for alpha: the on-disk log is byte-identical.
+    assert (fixture.alpha / _STATUS_EVENTS_FILENAME).read_text(encoding="utf-8") == recovered_text, (
+        "re-run appended rows to the already-cut-over mission's log"
+    )
+
+    # No event_id occurs twice in the recovered log (append-only, de-dup-safe).
+    ids = [row["event_id"] for row in read_events_raw(fixture.alpha) if "event_id" in row]
+    assert len(ids) == len(set(ids)), "re-run introduced duplicate event ids"
+
+    # Reducer determinism across the re-run: the snapshot is unchanged.
+    assert _snapshot_dict(read_event_stream(fixture.alpha)) == before_snapshot, (
+        "the reduced snapshot changed across an idempotent re-run"
+    )

--- a/tests/task_utils/test_set_scalar_retired.py
+++ b/tests/task_utils/test_set_scalar_retired.py
@@ -1,0 +1,145 @@
+"""FR-006 (WP08, mission upgrade-atomicity-recovery): retire the append-on-miss
+frontmatter writer that once caused the #3372 dual-``review_feedback`` key.
+
+Three guards land here:
+
+1. ``set_scalar`` STILL updates an existing scalar key (the symbol is retained
+   because ``task_utils/__init__.py`` and ``cli/commands/agent/workflow.py``
+   re-export it — deleting it would break those unowned imports).
+2. ``set_scalar`` FAILS CLOSED on the append-on-miss path: when the key is
+   absent it raises instead of appending ``key: value`` inline, so no path can
+   re-introduce the inline ``review_feedback`` key #3372 was born from.
+3. SC-003 clause 1: two consecutive review cycles on one WP go through the real
+   ``create_rejected_review_cycle`` path, which stores a ``review-cycle://``
+   pointer — never an inline ``review_feedback`` frontmatter key. The WP file
+   therefore never gains an inline ``review_feedback`` key (0, never 2).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from specify_cli.task_utils.support import TaskCliError, extract_scalar, set_scalar, split_frontmatter
+
+pytestmark = [pytest.mark.git_repo]
+
+
+# ---------------------------------------------------------------------------
+# FR-006 guard 1: update-existing behavior is PRESERVED
+# ---------------------------------------------------------------------------
+
+
+def test_set_scalar_updates_existing_key() -> None:
+    frontmatter = 'work_package_id: "WP01"\nlane: "planned"\n'
+    updated = set_scalar(frontmatter, "lane", "in_progress")
+    assert extract_scalar(updated, "lane") == "in_progress"
+    # No duplicate key is introduced by the update.
+    assert updated.count("lane:") == 1
+
+
+def test_set_scalar_update_preserves_trailing_comment() -> None:
+    frontmatter = 'work_package_id: "WP01"\nlane: "planned"  # keep me\n'
+    updated = set_scalar(frontmatter, "lane", "in_progress")
+    assert extract_scalar(updated, "lane") == "in_progress"
+    assert "# keep me" in updated
+
+
+# ---------------------------------------------------------------------------
+# FR-006 guard 2: append-on-miss is FAIL-CLOSED (never appends an inline key)
+# ---------------------------------------------------------------------------
+
+
+def test_set_scalar_refuses_append_on_miss() -> None:
+    frontmatter = 'work_package_id: "WP01"\n'
+    with pytest.raises(TaskCliError):
+        set_scalar(frontmatter, "lane", "planned")
+
+
+def test_set_scalar_never_appends_inline_review_feedback_key() -> None:
+    """The exact #3372 shape: an absent ``review_feedback`` key must NOT be
+    appended inline. Fail closed instead."""
+    frontmatter = 'work_package_id: "WP01"\ntitle: "Test"\n'
+    with pytest.raises(TaskCliError):
+        set_scalar(frontmatter, "review_feedback", "review-cycle://x/y/review-cycle-1.md")
+
+
+def test_set_scalar_refuses_append_even_with_history_anchor() -> None:
+    """The retired branch had a ``history:`` insertion anchor — it must be
+    fully neutralized, not merely the tail-append leg."""
+    frontmatter = 'work_package_id: "WP01"\nhistory:\n  - action: created\n'
+    with pytest.raises(TaskCliError):
+        set_scalar(frontmatter, "review_feedback", "value")
+    # And nothing was written before the raise.
+    assert "review_feedback" not in frontmatter
+
+
+# ---------------------------------------------------------------------------
+# SC-003 clause 1: two review cycles never produce an inline review_feedback key
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@e.com"], cwd=repo, check=True, capture_output=True)
+    (repo / ".kittify").mkdir()
+    return repo
+
+
+def test_two_review_cycles_never_write_inline_review_feedback_key(tmp_path: Path) -> None:
+    from specify_cli.review.cycle import create_rejected_review_cycle
+
+    repo = _init_repo(tmp_path)
+    mission_slug = "001-test-mission"
+    wp_id = "WP01"
+    wp_slug = "WP01-test-task"
+
+    tasks_dir = repo / "kitty-specs" / mission_slug / "tasks"
+    tasks_dir.mkdir(parents=True)
+    wp_path = tasks_dir / f"{wp_slug}.md"
+    wp_path.write_text(
+        '---\nwork_package_id: "WP01"\ntitle: "Test Task"\n---\n\n# WP01 Prompt\n',
+        encoding="utf-8",
+    )
+
+    feedback_one = tmp_path / "feedback-1.md"
+    feedback_one.write_text("**Issue**: first cycle problem\n", encoding="utf-8")
+    cycle_one = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        wp_slug=wp_slug,
+        feedback_source=feedback_one,
+        reviewer_agent="reviewer",
+    )
+
+    feedback_two = tmp_path / "feedback-2.md"
+    feedback_two.write_text("**Issue**: second cycle problem\n", encoding="utf-8")
+    cycle_two = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=mission_slug,
+        wp_id=wp_id,
+        wp_slug=wp_slug,
+        feedback_source=feedback_two,
+        reviewer_agent="reviewer",
+    )
+
+    # The canonical writer stores review-cycle:// pointers, never inline keys.
+    assert cycle_one.pointer.startswith("review-cycle://")
+    assert cycle_two.pointer.startswith("review-cycle://")
+    assert cycle_one.pointer != cycle_two.pointer
+
+    # Two distinct cycles actually ran.
+    artifacts = sorted(cycle_one.artifact_path.parent.glob("review-cycle-*.md"))
+    assert [p.name for p in artifacts] == ["review-cycle-1.md", "review-cycle-2.md"]
+
+    # The WP frontmatter never gains an inline review_feedback key (the #3372
+    # dual-key can never form: not two, not even one).
+    frontmatter, _body, _padding = split_frontmatter(wp_path.read_text(encoding="utf-8"))
+    assert extract_scalar(frontmatter, "review_feedback") is None
+    assert wp_path.read_text(encoding="utf-8").count("review_feedback:") == 0

--- a/tests/task_utils/test_set_scalar_retired.py
+++ b/tests/task_utils/test_set_scalar_retired.py
@@ -24,7 +24,14 @@ import pytest
 
 from specify_cli.task_utils.support import TaskCliError, extract_scalar, set_scalar, split_frontmatter
 
-pytestmark = [pytest.mark.fast, pytest.mark.unit, pytest.mark.git_repo]
+# [fast, unit] (not git_repo): the one review-cycle case does a light, isolated
+# `git init` in tmp_path (<1s, parallel-safe), so these belong in the fast lane.
+# tests/task_utils/ is a new top-level dir that only the fast-tests-core-misc
+# catch-all covers; a git_repo marker would pull it into the legacy integration
+# core-misc selector that the live integration lane does not scope for this dir
+# (dropping it from the #3284 replacement-union guard), so git_repo is the wrong
+# route here.
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/task_utils/test_set_scalar_retired.py
+++ b/tests/task_utils/test_set_scalar_retired.py
@@ -24,7 +24,7 @@ import pytest
 
 from specify_cli.task_utils.support import TaskCliError, extract_scalar, set_scalar, split_frontmatter
 
-pytestmark = [pytest.mark.git_repo]
+pytestmark = [pytest.mark.fast, pytest.mark.unit, pytest.mark.git_repo]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_frontmatter_dup_key.py
+++ b/tests/test_frontmatter_dup_key.py
@@ -1,0 +1,119 @@
+"""WP09 (FR-007, C-002): the canonical frontmatter boundary raises a *legible*
+duplicate-key error that names every duplicated key, and pins
+``allow_duplicate_keys=False`` so a future ``typ``/config change cannot silently
+reintroduce YAML last-wins semantics.
+
+The read boundary already fails closed (ruamel raises ``DuplicateKeyError``), but
+the generic ``except Exception`` wrap at ``frontmatter.py`` erased the key name
+behind a bare "Invalid YAML". These tests assert the key(s) survive into the
+raised :class:`FrontmatterError` message, and that every duplicate is enumerated
+(a single ruamel raise names only the first) via WP03's raw-text detector.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager, read_frontmatter
+
+pytestmark = pytest.mark.unit
+
+
+def _write(tmp_path: Path, content: str, name: str = "WP01.md") -> Path:
+    file_path = tmp_path / name
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+def test_single_duplicate_key_names_the_key(tmp_path: Path) -> None:
+    """A dual-key artifact raises a FrontmatterError that NAMES the duplicate key."""
+    path = _write(
+        tmp_path,
+        "---\ntitle: First\ntitle: Second\n---\nbody\n",
+    )
+
+    with pytest.raises(FrontmatterError) as exc_info:
+        read_frontmatter(path)
+
+    message = str(exc_info.value)
+    assert "title" in message, message
+    # The legible branch must not fall through to the opaque generic wrap.
+    assert "Invalid YAML" not in message, message
+
+
+def test_all_duplicate_keys_are_enumerated(tmp_path: Path) -> None:
+    """Every duplicated key is named, not only the first ruamel would raise on."""
+    path = _write(
+        tmp_path,
+        "---\n"
+        "review_feedback: ''\n"
+        "review_feedback: path/to/review.md\n"
+        "status: draft\n"
+        "status: final\n"
+        "---\nbody\n",
+    )
+
+    with pytest.raises(FrontmatterError) as exc_info:
+        read_frontmatter(path)
+
+    message = str(exc_info.value)
+    assert "review_feedback" in message, message
+    assert "status" in message, message
+
+
+def test_duplicate_key_message_includes_file_path(tmp_path: Path) -> None:
+    """The legible error still points the reader at the offending file."""
+    path = _write(
+        tmp_path,
+        "---\ntitle: a\ntitle: b\n---\nbody\n",
+    )
+
+    with pytest.raises(FrontmatterError) as exc_info:
+        read_frontmatter(path)
+
+    assert str(path) in str(exc_info.value)
+
+
+def test_nested_duplicate_key_falls_back_to_named_error(tmp_path: Path) -> None:
+    """A *nested* duplicate (not scanned by the top-level detector) still names the key.
+
+    The raw-text detector only enumerates column-0 keys; a nested duplicate makes
+    ruamel raise while the detector finds nothing, so the guard falls back to
+    ruamel's own (key-naming) message rather than the opaque generic wrap.
+    """
+    path = _write(
+        tmp_path,
+        "---\nparent:\n  child: 1\n  child: 2\n---\nbody\n",
+    )
+
+    with pytest.raises(FrontmatterError) as exc_info:
+        read_frontmatter(path)
+
+    message = str(exc_info.value)
+    assert "Duplicate frontmatter key" in message, message
+    assert "child" in message, message
+    assert "Invalid YAML" not in message, message
+
+
+def test_allow_duplicate_keys_is_pinned_false() -> None:
+    """Regression: the YAML() instance pins allow_duplicate_keys=False explicitly.
+
+    A future ``typ``/config change (e.g. switching away from round-trip mode,
+    whose default happens to forbid duplicates) must not silently reintroduce
+    last-wins duplicate-key semantics at this canonical read boundary.
+    """
+    manager = FrontmatterManager()
+    assert manager.yaml.allow_duplicate_keys is False
+
+
+def test_non_duplicate_frontmatter_still_reads(tmp_path: Path) -> None:
+    """The guard is inert on well-formed frontmatter — no false positives."""
+    path = _write(
+        tmp_path,
+        "---\ntitle: Only once\nwork_package_id: WP01\n---\nbody\n",
+    )
+
+    frontmatter, body = read_frontmatter(path)
+
+    assert frontmatter["title"] == "Only once"
+    assert body.strip() == "body"

--- a/tests/upgrade/test_auto_discovery.py
+++ b/tests/upgrade/test_auto_discovery.py
@@ -164,6 +164,39 @@ class TestAutoDiscovery:
 
         assert len(MigrationRegistry.get_all()) == 0
 
+    def test_auto_discover_does_not_reload_base_module(self):
+        """clear() + auto-discover must NOT reload ``base`` (class identity).
+
+        ``base`` holds the shared migration base classes (``BaseMigration``,
+        ``MigrationResult``, ``PartialWrite``) that both the migration modules
+        and external callers hold live references to, and it registers no
+        migration. Before the fix, auto-discover always fell through the
+        "not registered -> reload" branch for ``base`` and ``importlib.reload``
+        minted fresh class objects — silently breaking ``isinstance`` across the
+        process (a reloaded ``m_zz`` constructed the new ``base.PartialWrite``
+        while a caller still held the original, so ``isinstance(write, PartialWrite)``
+        went False). This is the cross-file pollution that flaked
+        ``tests/upgrade/test_backfill_report_on_abort.py`` under ``--dist loadfile``.
+        """
+        import specify_cli.upgrade.migrations.base as base_module
+        from specify_cli.upgrade.migrations.base import PartialWrite
+
+        original_base = base_module
+        original_partial_write = PartialWrite
+
+        # The exact test scenario that used to trigger the base reload.
+        MigrationRegistry.clear()
+        auto_discover_migrations()
+
+        import specify_cli.upgrade.migrations.base as base_after
+
+        assert base_after is original_base, "auto-discover reloaded the base module"
+        assert base_after.PartialWrite is original_partial_write, (
+            "base.PartialWrite identity changed — a base reload broke isinstance()"
+        )
+        # A freshly-constructed record is an instance of the caller's imported class.
+        assert isinstance(base_after.PartialWrite(mission="m", path="/p"), PartialWrite)
+
     def test_all_migration_files_have_registration_decorator(self):
         """All m_*.py files use @MigrationRegistry.register decorator."""
         for migration_file in MIGRATIONS_DIR.glob("m_*.py"):

--- a/tests/upgrade/test_backfill_report_on_abort.py
+++ b/tests/upgrade/test_backfill_report_on_abort.py
@@ -1,0 +1,157 @@
+"""ATDD tests for report-on-abort of the corpus backfill migration (WP05).
+
+Maps FR-005 / NFR-003 / US2-AC1 (spec.md). The corpus cutover
+(:class:`RuntimeStateBackfillMigration`) aborts the whole step on the first
+mission whose fail-closed verify fails. Before WP05 that abort discarded the
+per-mission results it had already accumulated (m_zz ``apply()`` at :284-286),
+so the operator-facing :class:`MigrationResult` was SILENT about the missions
+and files the non-atomic walk had already written to disk.
+
+report-on-abort (research US2, the PRIMARY path — NOT a corpus rollback: the
+per-mission "already-flipped missions stay flipped" design is intentional,
+D-03) instead ENUMERATES every mission/file already persisted before the abort,
+machine-readably, via the new ``MigrationResult.partial_writes`` channel.
+
+Every test drives the REAL library verify over a REAL fixture event log — the
+same non-vacuous fault-injection discipline as WP02's sibling suite
+(``tests/specify_cli/upgrade/test_runtime_state_backfill_migration.py``); no
+``cutover_mission``/``verify_backfill`` is mocked to force an outcome.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from specify_cli.migration.backfill_runtime_state import backfill_runtime_state
+from specify_cli.upgrade.migrations.base import PartialWrite
+from specify_cli.upgrade.migrations.m_zz_runtime_state_backfill import (
+    RuntimeStateBackfillMigration,
+)
+from tests.unit.migration._backfill_fixture import build_mission, corrupt_seed_value
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_STATUS_EVENTS_FILENAME = "status.events.jsonl"
+_META_FILENAME = "meta.json"
+
+
+def _inject_conflicting_seed(feature_dir: Path) -> None:
+    """Corrupt the canonical assignee seed payload under its deterministic ID."""
+    corrupt_seed_value(
+        feature_dir,
+        field_name="assignee",
+        slot_name="assignee",
+        value="EVIL-DIVERGENT",
+    )
+
+
+def _has_status_phase(feature_dir: Path) -> bool:
+    return "status_phase" in json.loads((feature_dir / _META_FILENAME).read_text())
+
+
+def _missions_in(writes: list[PartialWrite]) -> set[str]:
+    return {w.mission for w in writes}
+
+
+def _paths_for(writes: list[PartialWrite], mission: str) -> set[str]:
+    return {w.path for w in writes if w.mission == mission}
+
+
+# ---------------------------------------------------------------------------
+# FR-005 / US2-AC1 -- a non-atomic abort enumerates every mission/file written
+# ---------------------------------------------------------------------------
+
+
+def test_abort_enumerates_every_mission_file_already_written(tmp_path: Path) -> None:
+    """The abort result lists the files persisted for missions BEFORE the failure.
+
+    ``alpha`` sorts first: apply() seeds it and flips it (both
+    ``status.events.jsonl`` and ``meta.json`` written this run). ``beta`` (sorted
+    next) fails the fail-closed verify and triggers the whole-step abort. Before
+    WP05 the accumulated result was discarded — the operator had no
+    machine-readable account of alpha's on-disk residue. It must now be
+    enumerated.
+    """
+    alpha = build_mission(tmp_path, slug="alpha")
+    beta = build_mission(tmp_path, slug="beta")
+    gamma = build_mission(tmp_path, slug="gamma")
+
+    # Corrupt beta with a REAL divergent same-slot annotation (fault injection,
+    # not a mock) so its verify is genuinely red on a live run.
+    backfill_runtime_state(beta)
+    _inject_conflicting_seed(beta)
+
+    migration = RuntimeStateBackfillMigration()
+    result = migration.apply(tmp_path)
+
+    # The step aborted (unchanged WP02 contract).
+    assert result.success is False
+    assert len(result.errors) == 1
+    assert "beta" in result.errors[0]
+
+    # FR-005: the abort is no longer silent about the partial write.
+    assert result.partial_writes, "abort discarded the partial-write account (the bug)"
+
+    # alpha was fully written (seeded + flipped) BEFORE the abort -> both files.
+    assert "alpha" in _missions_in(result.partial_writes)
+    assert _paths_for(result.partial_writes, "alpha") == {
+        str(alpha / _STATUS_EVENTS_FILENAME),
+        str(alpha / _META_FILENAME),
+    }
+
+    # gamma sorts AFTER beta -- the abort means it was never visited, so nothing
+    # was written for it and it must not appear in the account.
+    assert "gamma" not in _missions_in(result.partial_writes)
+    assert not _has_status_phase(gamma)
+
+    # The account is machine-readable: every entry names a mission and a real,
+    # on-disk path (not a prose blob).
+    for write in result.partial_writes:
+        assert isinstance(write, PartialWrite)
+        assert write.mission
+        assert Path(write.path).exists()
+
+
+def test_abort_account_paths_are_derived_from_slug_and_project_path(tmp_path: Path) -> None:
+    """Each enumerated path is ``<project>/kitty-specs/<slug>/<file>`` (FR-005).
+
+    Pins the derivation contract: the migration reconstructs the two per-mission
+    file paths from the mission slug and the project root, so the account stays
+    truthful even though ``cutover_mission`` canonicalizes the write target
+    internally.
+    """
+    alpha = build_mission(tmp_path, slug="alpha")
+    beta = build_mission(tmp_path, slug="beta")
+    backfill_runtime_state(beta)
+    _inject_conflicting_seed(beta)
+
+    result = migration_apply(tmp_path)
+
+    kitty_specs = tmp_path / "kitty-specs"
+    for write in result.partial_writes:
+        assert Path(write.path).parent == kitty_specs / write.mission
+    # alpha's event log path resolves exactly under its own mission directory.
+    assert str(alpha / _STATUS_EVENTS_FILENAME) in _paths_for(result.partial_writes, "alpha")
+
+
+def test_clean_run_reports_empty_partial_write_account(tmp_path: Path) -> None:
+    """AC2: a successful (non-abort) run carries no partial-write account.
+
+    The channel is abort-only bookkeeping — a clean corpus cutover reports its
+    outcome through ``changes_made`` (truthful count), not ``partial_writes``.
+    """
+    build_mission(tmp_path, slug="alpha")
+    build_mission(tmp_path, slug="beta")
+
+    result = migration_apply(tmp_path)
+
+    assert result.success is True
+    assert result.partial_writes == []
+    assert result.changes_made  # something was migrated (truthful count)
+
+
+def migration_apply(project_path: Path):  # small helper to keep the tests terse
+    return RuntimeStateBackfillMigration().apply(project_path)

--- a/tests/upgrade/test_recovery_composition.py
+++ b/tests/upgrade/test_recovery_composition.py
@@ -46,10 +46,13 @@ from specify_cli.migration.schema_version import (
 from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
 from specify_cli.upgrade.runner import MigrationRunner
 
-# End-to-end reproduction of the wedged -> recovered sequence (#3334 + #3372).
-# ``regression`` routes it into the always-on blocking regression CI job; the
-# git-backed SC-001 case additionally carries ``git_repo`` (real ``git init``).
-pytestmark = pytest.mark.regression
+# Green end-to-end acceptance of the wedged -> recovered sequence (#3334 +
+# #3372). No ``@pytest.mark.regression``: this is a green composition proof, not
+# a red-first open-P0 reproduction, so it stays in its path suite rather than the
+# ADR 2026-07-17-1 red-first home (``tests/regression/``). The SC-001 case carries
+# ``git_repo`` (real ``git init``) -> integration-tests-upgrade; the no-VCS case
+# carries ``fast`` -> fast-tests-upgrade.
+pytestmark = pytest.mark.unit
 
 _GET_APPLICABLE = "specify_cli.upgrade.runner.MigrationRegistry.get_applicable"
 
@@ -263,6 +266,7 @@ def test_sc001_wedged_project_recovers_with_zero_manual_git_steps(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.fast
 def test_no_vcs_wedged_project_recovers_on_disk(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/upgrade/test_recovery_composition.py
+++ b/tests/upgrade/test_recovery_composition.py
@@ -1,0 +1,299 @@
+"""WP04 / FR-001: recovery COMPOSES — ``doctor --fix`` -> re-run upgrade (SC-001).
+
+This is a **verification** WP: it owns no product module. It proves that three
+already-shipped behaviours compose into self-recovery for a wedged project, with
+**zero manual git steps** (SC-001) and without requiring version control at all:
+
+* **FR-002 / WP01** (``runner.py`` + ``metadata.py``): a failed migration
+  PRESERVES ``schema_version`` instead of erasing it. Before WP01 a mid-migration
+  abort dropped ``schema_version``, so a re-run re-detected the project as legacy
+  and re-hit the same failing migration on the still-invalid corpus — permanently
+  wedged (#3334, P0).
+* **FR-008 / WP03** (``status/dup_key_repair.py`` + ``doctor mission-state
+  --fix``): heals a legacy dual-key ``review_feedback`` artifact (invalid YAML the
+  frontmatter boundary fails CLOSED on, #3372) — the thing an upgrade migration
+  trips over.
+* **FR-012 / WP01**: a re-run after the corpus is healed applies the migration
+  cleanly and stamps the target schema (resumable, no-op on already-done work).
+
+The composition is a **SEQUENCE**, not a new orchestrator (paula-patterns
+post-tasks finding: no recovery surface exists and none is needed). The honest
+hinge proven here is that the SAME upgrade migration FAILS while the artifact
+carries the duplicate key and SUCCEEDS once ``--fix`` has healed it — so the heal
+is genuinely what unblocks the upgrade, not incidental.
+
+Scope discipline: ``doctor --fix`` also runs an unrelated mission-state
+canonicalization pass (``repair_repo``) that is a *separate* FR path needing full
+mission scaffolding (``meta.json`` / status logs). It is isolated here (WP03
+CLI-test precedent) so this proof stays pinned to the FR-002 + FR-008 + FR-012
+composition and cannot flake on mission-state-repair concerns it does not own.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from kernel.clock import now_utc
+
+from specify_cli.frontmatter import FrontmatterError, FrontmatterManager
+from specify_cli.migration.schema_version import (
+    REQUIRED_SCHEMA_VERSION,
+    get_project_schema_version,
+)
+from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
+from specify_cli.upgrade.runner import MigrationRunner
+
+# End-to-end reproduction of the wedged -> recovered sequence (#3334 + #3372).
+# ``regression`` routes it into the always-on blocking regression CI job; the
+# git-backed SC-001 case additionally carries ``git_repo`` (real ``git init``).
+pytestmark = pytest.mark.regression
+
+_GET_APPLICABLE = "specify_cli.upgrade.runner.MigrationRegistry.get_applicable"
+
+# Legacy dual-key ``review_feedback`` artifact: an empty ``''`` write followed by
+# the real recorded pointer. This is invalid YAML that the canonical frontmatter
+# boundary fails CLOSED on (ruamel ``DuplicateKeyError``), so an upgrade migration
+# reading it dies — the exact wedge WP03's keep-last-non-empty heal repairs.
+_WEDGED_ARTIFACT = (
+    "---\n"
+    "work_package_id: WP01\n"
+    "title: Wedged mission artifact\n"
+    "review_feedback: ''\n"
+    "subtasks:\n"
+    "- T001\n"
+    "review_feedback: review-cycle-1.md\n"
+    "---\n"
+    "Body content.\n"
+)
+_RECORDED_POINTER = "review-cycle-1.md"
+
+
+class _ArtifactBoundaryMigration(BaseMigration):
+    """A migration that reads a mission artifact via the fail-closed boundary.
+
+    Reproduces a real upgrade tripping over invalid YAML: it FAILS while the
+    artifact carries the duplicate ``review_feedback`` key and SUCCEEDS once the
+    ``--fix`` heal has removed the empty duplicate. Trigger is the artifact's
+    validity, so the heal is the load-bearing precondition for success.
+    """
+
+    migration_id = "99.0.0_artifact_boundary"
+    description = "Reads a mission artifact through the fail-closed frontmatter boundary"
+    target_version = "99.0.0"
+
+    def __init__(self, artifact_path: Path) -> None:
+        self._artifact_path = artifact_path
+
+    def detect(self, project_path: Path) -> bool:  # noqa: ARG002
+        return True
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:  # noqa: ARG002
+        try:
+            FrontmatterManager().read(self._artifact_path)
+        except FrontmatterError as exc:
+            return MigrationResult(
+                success=False,
+                errors=[f"upgrade tripped on invalid artifact YAML: {exc}"],
+            )
+        return MigrationResult(success=True, changes_made=["migrated mission artifact"])
+
+
+def _write_metadata(kittify_dir: Path, version: str, schema_version: int) -> None:
+    """Write ``metadata.yaml`` directly (not via the code under test)."""
+    kittify_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "spec_kitty": {
+            "version": version,
+            "initialized_at": now_utc().isoformat(),
+            "schema_version": schema_version,
+        },
+        "environment": {},
+        "migrations": {"applied": []},
+    }
+    (kittify_dir / "metadata.yaml").write_text(
+        yaml.safe_dump(data, sort_keys=False), encoding="utf-8"
+    )
+
+
+def _write_wedged_artifact(project_path: Path) -> Path:
+    """Materialize the invalid dual-key artifact under ``kitty-specs/``."""
+    path = project_path / "kitty-specs" / "mission-wedged" / "tasks" / "WP01.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_WEDGED_ARTIFACT, encoding="utf-8")
+    return path
+
+
+def _build_wedged_project(project_path: Path, schema_version: int) -> Path:
+    """Create a project with a below-target schema and the invalid artifact."""
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=schema_version)
+    return _write_wedged_artifact(project_path)
+
+
+def _run_upgrade(
+    monkeypatch: pytest.MonkeyPatch, project_path: Path, migration: BaseMigration
+) -> object:
+    runner = MigrationRunner(project_path)
+    monkeypatch.setattr(
+        _GET_APPLICABLE,
+        lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+    )
+    return runner.upgrade("99.0.0", include_worktrees=False)
+
+
+def _doctor_fix(
+    project_path: Path, monkeypatch: pytest.MonkeyPatch, *, allow_dirty: bool
+) -> None:
+    """Drive the real ``doctor mission-state --fix`` CLI dispatch.
+
+    The FR-008 dup-key heal runs for real; the unrelated mission-state
+    canonicalization arm (``repair_repo``) is stubbed to a no-op report so this
+    proof stays scoped to the recovery composition (WP03 CLI-test precedent).
+    """
+    import specify_cli.migration.mission_state as mission_state
+    from specify_cli.cli.commands import _mission_state_doctor as cmd
+    from specify_cli.migration.mission_state import RepairReport
+
+    monkeypatch.setattr(
+        mission_state,
+        "repair_repo",
+        lambda *_a, **_k: RepairReport(
+            run_id="noop-composition",
+            repo_head=None,
+            target_missions=[],
+            manifest_path="noop",
+            missions=[],
+        ),
+    )
+    cmd.run_mission_state(
+        audit=False,
+        fix=True,
+        teamspace_dry_run=False,
+        json_output=False,
+        mission=None,
+        fail_on=None,
+        fixture_dir=None,
+        include_fixtures=False,
+        manifest_path=None,
+        allow_dirty=allow_dirty,
+        repo_root=project_path,
+    )
+
+
+def _artifact_is_invalid(path: Path) -> bool:
+    """True when the artifact still trips the fail-closed frontmatter boundary."""
+    try:
+        FrontmatterManager().read(path)
+    except FrontmatterError:
+        return True
+    return False
+
+
+def _git(project_path: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(project_path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# T013 — SC-001: a wedged git-backed project recovers with ZERO manual git steps.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.git_repo
+def test_sc001_wedged_project_recovers_with_zero_manual_git_steps(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """doctor --fix -> re-run upgrade heals a wedged project without any git step.
+
+    The wedge (invalid artifact + below-target schema) is COMMITTED, mirroring a
+    real repo. Recovery then runs with ``allow_dirty=False`` — the operator does
+    not pass ``--allow-dirty`` or stash/commit/reset anything. The concrete
+    zero-git-steps proof: ``HEAD`` is byte-identical before and after recovery
+    (the sequence creates NO commits) yet the project ends consistent.
+    """
+    assert REQUIRED_SCHEMA_VERSION is not None
+    below_required = REQUIRED_SCHEMA_VERSION - 1
+
+    project_path = tmp_path / "repo"
+    project_path.mkdir()
+    artifact = _build_wedged_project(project_path, schema_version=below_required)
+
+    # Commit the wedged state so the working tree is clean before recovery.
+    _git(project_path, "init")
+    _git(project_path, "config", "user.email", "test@example.com")
+    _git(project_path, "config", "user.name", "Test")
+    _git(project_path, "add", "-A")
+    _git(project_path, "commit", "-m", "wedged state")
+    setup_head = _git(project_path, "rev-parse", "HEAD")
+
+    # 1. A first upgrade trips over the invalid artifact and FAILS.
+    first = _run_upgrade(monkeypatch, project_path, _ArtifactBoundaryMigration(artifact))
+    assert first.success is False
+    # WP01: the failure PRESERVES schema_version (recoverable, not erased/advanced).
+    assert get_project_schema_version(project_path) == below_required
+    # Still wedged: the artifact remains invalid until healed.
+    assert _artifact_is_invalid(artifact) is True
+
+    # 2. Recovery step one: doctor --fix heals the artifact (no --allow-dirty).
+    _doctor_fix(project_path, monkeypatch, allow_dirty=False)
+    fm, _body = FrontmatterManager().read(artifact)
+    assert fm["review_feedback"] == _RECORDED_POINTER  # NFR-002: recorded value kept
+    assert fm["work_package_id"] == "WP01"
+
+    # 3. Recovery step two: re-run upgrade now SUCCEEDS and stamps the target.
+    second = _run_upgrade(monkeypatch, project_path, _ArtifactBoundaryMigration(artifact))
+    assert second.success is True
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION
+
+    # SC-001: recovery created ZERO commits — no manual git steps were required.
+    assert _git(project_path, "rev-parse", "HEAD") == setup_head
+
+
+# ---------------------------------------------------------------------------
+# T014 — no-VCS: a wedged project NOT under version control recovers on-disk.
+# ---------------------------------------------------------------------------
+
+
+def test_no_vcs_wedged_project_recovers_on_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Recovery needs no git checkpoint: a non-git project heals purely on disk.
+
+    ``doctor --fix``'s git-safety preflight is skipped when there is no repo, and
+    ``atomic_write`` mutates files directly — so the same doctor --fix -> re-run
+    upgrade sequence recovers a project that was never under version control.
+    """
+    assert REQUIRED_SCHEMA_VERSION is not None
+    below_required = REQUIRED_SCHEMA_VERSION - 1
+
+    project_path = tmp_path / "repo"
+    project_path.mkdir()
+    artifact = _build_wedged_project(project_path, schema_version=below_required)
+    # Precondition: genuinely no version control anywhere in the project.
+    assert not (project_path / ".git").exists()
+
+    first = _run_upgrade(monkeypatch, project_path, _ArtifactBoundaryMigration(artifact))
+    assert first.success is False
+    assert get_project_schema_version(project_path) == below_required
+    assert _artifact_is_invalid(artifact) is True
+
+    # doctor --fix with allow_dirty=False: git-safety is auto-skipped (no repo),
+    # proving no git checkpoint is required to recover.
+    _doctor_fix(project_path, monkeypatch, allow_dirty=False)
+    fm, _body = FrontmatterManager().read(artifact)
+    assert fm["review_feedback"] == _RECORDED_POINTER
+
+    second = _run_upgrade(monkeypatch, project_path, _ArtifactBoundaryMigration(artifact))
+    assert second.success is True
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION
+    # Recovery never introduced version control.
+    assert not (project_path / ".git").exists()

--- a/tests/upgrade/test_schema_version_recovery.py
+++ b/tests/upgrade/test_schema_version_recovery.py
@@ -1,0 +1,267 @@
+"""#3334 red-first: a failed migration must PRESERVE ``schema_version``.
+
+Scope: ``MigrationRunner.upgrade`` + ``ProjectMetadata.save`` schema-version
+handling on the abort path (FR-002 / FR-012, US1 acceptance scenarios 3, 4, 6).
+
+FR-002 is **preserve, not re-stamp-to-target**. ``_stamp_schema_version`` writes
+the *target* schema (``REQUIRED_SCHEMA_VERSION``); a naive ``try/finally`` that
+stamped it on the abort path would advance a FAILED/LEGACY project to the target
+and open the gate on a half-backfilled corpus. The correct behaviour: capture the
+pre-run on-disk ``schema_version`` before the migration loop and restore that
+captured value on abort (and stop ``save()`` erasing it); stamp the target only on
+success. Invariant proven here: **a failed migration NEVER advances
+``schema_version``.**
+
+The mid-loop abort is forced with a synthetic always-failing migration
+(trigger-agnostic — it touches no duplicate-key artifact), so the P0 proof
+isolates the save/stamp ordering defect and cannot be masked by FR-008 artifact
+healing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from kernel.clock import now_utc
+
+from specify_cli.migration.schema_version import (
+    REQUIRED_SCHEMA_VERSION,
+    get_project_schema_version,
+)
+from specify_cli.upgrade import metadata as metadata_module
+from specify_cli.upgrade.metadata import ProjectMetadata
+from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
+from specify_cli.upgrade.runner import MigrationRunner
+
+# Issue-pinned #3334 reproduction (NFR-001, ADR 2026-07-17-1). The ``fast``/
+# ``unit`` category markers keep the node collectible by the fast-tests-misc CI
+# job (path-gated on tests/upgrade/**); ``regression`` routes it into the
+# always-on blocking regression job.
+pytestmark = [pytest.mark.regression, pytest.mark.fast, pytest.mark.unit]
+
+_GET_APPLICABLE = "specify_cli.upgrade.runner.MigrationRegistry.get_applicable"
+
+
+class _AlwaysFailingMigration(BaseMigration):
+    """Synthetic, trigger-agnostic migration that always fails mid-loop."""
+
+    migration_id = "99.0.0_synthetic_always_fail"
+    description = "Synthetic always-failing migration for the #3334 red-first repro"
+    target_version = "99.0.0"
+
+    def detect(self, project_path: Path) -> bool:  # noqa: ARG002
+        return True
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:  # noqa: ARG002
+        return MigrationResult(
+            success=False,
+            errors=["synthetic mid-loop abort (#3334 repro)"],
+        )
+
+
+class _SuccessMigration(BaseMigration):
+    """Migration that applies cleanly once and is idempotent thereafter."""
+
+    migration_id = "99.0.0_synthetic_success"
+    description = "Synthetic succeeding migration for FR-012 resumable no-op"
+    target_version = "99.0.0"
+
+    def detect(self, project_path: Path) -> bool:  # noqa: ARG002
+        return True
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:  # noqa: ARG002
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:  # noqa: ARG002
+        return MigrationResult(success=True, changes_made=["cut over one mission"])
+
+
+def _write_metadata(kittify_dir: Path, version: str, schema_version: int | None) -> None:
+    """Write a ``metadata.yaml`` with an explicit (or absent) ``schema_version``.
+
+    Written directly (not via the code under test) so the fixture cannot mask a
+    save/stamp regression.
+    """
+    kittify_dir.mkdir(parents=True, exist_ok=True)
+    spec_kitty: dict[str, object] = {
+        "version": version,
+        "initialized_at": now_utc().isoformat(),
+    }
+    if schema_version is not None:
+        spec_kitty["schema_version"] = schema_version
+    data = {"spec_kitty": spec_kitty, "environment": {}, "migrations": {"applied": []}}
+    (kittify_dir / "metadata.yaml").write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _run_failing_upgrade(monkeypatch: pytest.MonkeyPatch, project_path: Path) -> object:
+    runner = MigrationRunner(project_path)
+    monkeypatch.setattr(
+        _GET_APPLICABLE,
+        lambda _from, _to, project_path=None: [_AlwaysFailingMigration()],  # noqa: ARG005
+    )
+    return runner.upgrade("99.0.0", include_worktrees=False)
+
+
+# ---------------------------------------------------------------------------
+# US1 acceptance scenario 3 (NFR-001) — #3334 red-first: preserve schema_version.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_migration_preserves_required_schema_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A mid-loop abort on a REQUIRED-schema project keeps schema_version intact.
+
+    Red on the pre-fix tree (the in-loop failed-migration ``save()`` rewrites
+    metadata.yaml without ``schema_version`` and the compensating stamp only
+    runs on success), green after the preserve/restore fix.
+    """
+    project_path = tmp_path / "repo"
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=REQUIRED_SCHEMA_VERSION)
+
+    result = _run_failing_upgrade(monkeypatch, project_path)
+
+    assert result.success is False
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# US1 acceptance scenario 4 — invariant: a failed migration NEVER advances.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_migration_does_not_advance_legacy_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A legacy project (no schema_version) is never advanced to the target."""
+    project_path = tmp_path / "repo"
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=None)
+
+    result = _run_failing_upgrade(monkeypatch, project_path)
+
+    assert result.success is False
+    # Invariant: still legacy (None) — NOT stamped up to REQUIRED_SCHEMA_VERSION.
+    assert get_project_schema_version(project_path) is None
+
+
+def test_failed_migration_does_not_advance_below_required_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``< REQUIRED`` project keeps its own schema; it is not advanced.
+
+    Also red on the pre-fix tree: the pre-run value 2 is erased to ``None``.
+    """
+    below_required = REQUIRED_SCHEMA_VERSION - 1  # type: ignore[operator]
+    project_path = tmp_path / "repo"
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=below_required)
+
+    result = _run_failing_upgrade(monkeypatch, project_path)
+
+    assert result.success is False
+    assert get_project_schema_version(project_path) == below_required
+    assert get_project_schema_version(project_path) != REQUIRED_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# T002 unit (isolation): the runner's post-loop restore holds even when a
+# save() caller erases schema_version — proving the guarantee is orchestration
+# level, not merely a side effect of save() preservation.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_restores_pre_run_schema_even_if_save_erases_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Runner restores the captured pre-run schema after an erasing save().
+
+    We force ``ProjectMetadata.save`` to drop ``schema_version`` (simulating a
+    lossy caller / the pre-fix save-rewrite) and assert the runner still lands
+    the pre-run value on the abort path.
+    """
+    project_path = tmp_path / "repo"
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=REQUIRED_SCHEMA_VERSION)
+
+    def _erasing_save(self: ProjectMetadata, kittify_dir: Path) -> bool:
+        data = {
+            "spec_kitty": {
+                "version": self.version,
+                "initialized_at": self.initialized_at.isoformat(),
+            },
+            "migrations": {
+                "applied": [
+                    {"id": m.id, "applied_at": m.applied_at.isoformat(), "result": m.result, "notes": m.notes}
+                    for m in self.applied_migrations
+                ]
+            },
+        }
+        (kittify_dir / "metadata.yaml").write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(metadata_module.ProjectMetadata, "save", _erasing_save)
+
+    result = _run_failing_upgrade(monkeypatch, project_path)
+
+    assert result.success is False
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Guard: a SUCCESSFUL upgrade still advances/stamps the target schema — the
+# preserve-on-failure path must not leak into the success path.
+# ---------------------------------------------------------------------------
+
+
+def test_successful_upgrade_stamps_target_schema(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project_path = tmp_path / "repo"
+    below_required = REQUIRED_SCHEMA_VERSION - 1  # type: ignore[operator]
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=below_required)
+
+    runner = MigrationRunner(project_path)
+    monkeypatch.setattr(
+        _GET_APPLICABLE,
+        lambda _from, _to, project_path=None: [_SuccessMigration()],  # noqa: ARG005
+    )
+    result = runner.upgrade("99.0.0", include_worktrees=False)
+
+    assert result.success is True
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# US1 acceptance scenario 6 (FR-012) — resumable no-op: a re-run after a
+# completed upgrade applies ZERO migrations.
+# ---------------------------------------------------------------------------
+
+
+def test_rerun_after_successful_upgrade_applies_zero_migrations(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    project_path = tmp_path / "repo"
+    _write_metadata(project_path / ".kittify", version="3.0.0", schema_version=REQUIRED_SCHEMA_VERSION)
+    migration = _SuccessMigration()
+
+    def _run() -> object:
+        runner = MigrationRunner(project_path)
+        monkeypatch.setattr(
+            _GET_APPLICABLE,
+            lambda _from, _to, project_path=None: [migration],  # noqa: ARG005
+        )
+        return runner.upgrade("99.0.0", include_worktrees=False)
+
+    first = _run()
+    assert first.success is True
+    assert first.migrations_applied == [migration.migration_id]
+
+    second = _run()
+    assert second.success is True
+    # FR-012: safe no-op/resume — the already-applied migration is not re-run.
+    assert second.migrations_applied == []
+    assert second.migrations_skipped == [migration.migration_id]
+    assert get_project_schema_version(project_path) == REQUIRED_SCHEMA_VERSION

--- a/tests/upgrade/test_schema_version_recovery.py
+++ b/tests/upgrade/test_schema_version_recovery.py
@@ -35,11 +35,13 @@ from specify_cli.upgrade.metadata import ProjectMetadata
 from specify_cli.upgrade.migrations.base import BaseMigration, MigrationResult
 from specify_cli.upgrade.runner import MigrationRunner
 
-# Issue-pinned #3334 reproduction (NFR-001, ADR 2026-07-17-1). The ``fast``/
-# ``unit`` category markers keep the node collectible by the fast-tests-misc CI
-# job (path-gated on tests/upgrade/**); ``regression`` routes it into the
-# always-on blocking regression job.
-pytestmark = [pytest.mark.regression, pytest.mark.fast, pytest.mark.unit]
+# Green regression-guard coverage for WP01's runner-surface abort-restore (the
+# #3334 *erasure* class is owned by main's ProjectMetadata round-trip fix +
+# tests). ``fast``/``unit`` route the nodes into fast-tests-upgrade
+# (``tests/upgrade/ -m fast``). No ``@pytest.mark.regression``: these are green
+# permanent tests, not a red-first open-P0 reproduction, so they do not belong
+# in the ADR 2026-07-17-1 red-first regression home (``tests/regression/``).
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
 
 _GET_APPLICABLE = "specify_cli.upgrade.runner.MigrationRegistry.get_applicable"
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -135,7 +135,6 @@ def write_wp(
     from specify_cli.task_utils.support import (
         append_activity_log,
         build_document,
-        set_scalar,
         split_frontmatter,
     )
 
@@ -170,12 +169,12 @@ def write_wp(
         body,
         f"- {timestamp} – {agent} – shell_pid={shell_pid} – {note}",
     )
-    updated_front = front
-    if legacy:
-        updated_front = set_scalar(updated_front, "lane", lane)
-    updated_front = set_scalar(set_scalar(updated_front, "agent", agent), "assignee", assignee)
-    updated_front = set_scalar(updated_front, "shell_pid", shell_pid)
-    path.write_text(build_document(updated_front, updated_body, padding), encoding="utf-8")
+    # FR-006 (WP08): ``set_scalar`` is retired for append-on-miss and only
+    # updates existing keys. ``lane``/``agent``/``assignee``/``shell_pid`` are
+    # already composed into ``frontmatter`` above at their final values, so the
+    # former ``set_scalar`` re-writes were byte-neutral no-ops; drop them and
+    # rely solely on ``build_document`` (a supported writer).
+    path.write_text(build_document(front, updated_body, padding), encoding="utf-8")
     if seed_canonical and not legacy:
         _seed_canonical_wp_state(
             repo_root,


### PR DESCRIPTION
## What this fixes (operator impact)

A failed `spec-kitty upgrade` used to strand your project with **no self-service way out** — a migration would fail partway, and the command that could have repaired it was itself blocked. This PR closes the six interlocking failures behind that wedge, so a stuck upgrade is now **atomic, self-recoverable, and honestly reported**.

| What you saw | What happens now | Issue |
|---|---|---|
| A backfill migration stopped partway and said **nothing** about what it had already written | The abort **enumerates every mission and file** already persisted, so you can see how far it got | `#3335` |
| `spec-kitty upgrade --dry-run` reported **nothing pending**, then the real run applied dozens of migrations | The preview drives off the **same selector** the real run uses and reports the true pending set | `#3336` |
| `agent mission create --json` returned a bare `CHARTER_PACK_CONFIG_INVALID` code with **no fix steps** | The `--json` error carries the full **remediation body** alongside the code | `#3337` |
| The diagnostic a failed migration told you to run was itself **blocked behind that migration** (catch‑22) | The `--dry-run` diagnostic is **ungated** (the mutating form stays blocked) | `#3338` |
| A failed `mission create` left an **orphan branch** behind and moved your checkout onto it | A failed create **restores your original checkout** and **deletes only the branch it minted** | `#3339` |
| The review cycle appended a **duplicate `review_feedback`** frontmatter key (invalid YAML) that later wedged upgrades | The append-on-miss writer is **retired** (fails closed); duplicate-key artifacts are **detected and repairable non-destructively**; the reader **names every offending key** | `#3372` |

## How

11 work packages, each landed **ATDD-first** (a failing test before the code) and passed independent adversarial review — one commit per WP. The recovery repair (US1) conforms to ADR `2026-05-10-1` (deterministic, non-destructive); the mission-create rollback (US3) reuses the existing `mission_state` repair machinery rather than reinventing it. Composition and event-log/reducer integrity after recovery are proven by dedicated verification WPs.

## Landing notes — rescope (WP01 / #3334)

This branch was **rebased onto current `upstream/main`** during landing. While it was in flight, main's "Mission A" (`16648229f7`) **independently fixed the original P0 #3334** — a failed upgrade erasing `schema_version` — via a cleaner canonical route: `ProjectMetadata` now round-trips `schema_version` through `save()`, with its own green tests. WP01 was therefore **rescoped** rather than landed as-authored:

- its **competing `metadata.py` change was dropped** — `metadata.py` is now byte-identical to main;
- its **duplicate `#3334` regression test was pruned** — main owns that coverage;
- the **still-additive part was kept**: a `runner.py` abort-restore that undoes a *partial* `schema_version` stamp-advance which main's `save()`-preserve alone does not recover. This was **red-first proven** during landing (revert `runner.py` → the isolation test fails `None == 3`; restore → passes).

**`#3334` is already closed by main and is not re-closed here.**

Landing folds (`git log --grep '(landing)'`), each single-purpose: the WP01 reshape reword; a CI test-suite routing fix so the new test files land in a job on push (and no `@pytest.mark.regression` lives outside `tests/regression/`); a seam-descriptor re-pin after WP12 split `create_mission_core` into a thin failure-atomic wrapper; the changelog entry; a **root-cause fix** for a pre-existing flake WP05 surfaced — `auto_discover_migrations()` was reloading the shared `base` module and breaking `isinstance()` (see below); routing WP03's `dup_key_repair` imports through the `status` facade (module-boundary gate); and a final marker correction so the new `tests/task_utils/` dir satisfies both the push-collection and the #3284 core-misc replacement-union guards.

**Notable pre-existing bug surfaced & fixed:** `auto_discover_migrations()` reloaded every already-imported migration module whose migration wasn't registered — including `base.py`, which holds the shared `BaseMigration`/`MigrationResult`/`PartialWrite` classes and registers nothing, so it was *always* reloaded. `importlib.reload(base)` minted fresh class objects, silently breaking `isinstance()` across the process. It was latent until WP05 added the shared `PartialWrite` class to `base` and an `isinstance` check that ran after a migration test's `clear()+rediscover`, flaking `fast-tests-upgrade` under `--dist loadfile`. Fixed by never reloading `base`.

## Compatibility note (`#3337`)

For scripted callers of `agent mission create --json`: on a `CHARTER_PACK_CONFIG_INVALID` error the `error` field used to be the bare stable code; it now carries the human-readable remediation body, with the code moved to a new `error_code` field (and the full remediation under `remediation`). **A caller that matched `error == "CHARTER_PACK_CONFIG_INVALID"` should switch to `error_code`.** Plain-text output is unchanged.

## Landing refresh — re-rebase onto current `main` (2026-08-14)

The branch had gone 11 commits behind and CONFLICTING since the first pass. Re-landed onto current `upstream/main` (now carrying `#3346` owned-checkout, `#3293` per-project sync consent, `#738`, and Mission A). All prior landing folds are preserved; two conflicts and one new defect were resolved:

- **`metadata.py` conflict → resolved to main.** The competing WP01 `save()` change was dropped so the file is byte-identical to main's canonical `schema_version` round-trip (Mission A) — exactly the WP01 rescope intent. The additive `runner.py` abort-restore (undo a *partial* stamp-advance that main's `save()`-preserve alone can't recover) is retained and **red-first re-proven on this base**: swap in main's `runner.py` and `test_runner_restores_pre_run_schema_even_if_save_erases_it` fails `None == 3`; restore and it passes.
- **Seam-descriptor pin conflict → hybrid resolve.** `test_single_mission_surface_resolver.py`'s `create_mission_core` descriptor was re-pinned to the WP12 split target `_create_mission_core_impl` (branch) **and** main's `#3346` body variable `effective_root` (not the branch's stale `resolved_root`) — because the live body is `feature_dir = effective_root / …`.
- **New fold — `fix(landing): re-thread owned_checkout after rebase onto #3346`.** WP12's `create_mission_core` split applied cleanly at the text level onto main's `#3346`, but silently dropped the parameter threading: the wrapper accepted `owned_checkout` yet neither passed it to `_create_mission_core_impl` nor did the impl declare it, while the impl body already used it — a runtime `NameError` (ruff F821 / mypy `name-defined`). Restored the threading and fed `owned_checkout=None` into the FR-010 `--json` remediation test, which drives the CLI seam directly and hadn't seen `#3346`'s now-required kw-only arg. `#3346`'s own coverage (seam + owned-root concurrency, 44 tests) stays green.

**Two red checks are the same honest red-`main` P0 (`#3307`), not this PR's:** `regression tests (blocking)` fails on the 4 `test_issue_3307_*` parametrizations, and `quality-gate` fails *because* that job does. The branch touches none of `build_transition_plan` (`tasks_transition_core.py`); the identical 4-failure set reproduces on `main` itself (run `31769443009`, commit `7923fda40`). `#3307` is OPEN/P0 carrying a `@pytest.mark.regression` red-first reproduction — left red per ADR `2026-07-17-1`.

## Tests & gates (on the rebased tip)

- **86 focused tests** across the changed surfaces pass; `ruff` clean on all changed source; `mypy` (advisory/non-blocking) has no branch-introduced errors — the residual `no-any-return` notes reproduce on `main` and are file-in-isolation artifacts.
- Completeness gates green: `test_ci_collection_completeness` (0 orphans), `test_marker_job_completeness`, `test_single_mission_surface_resolver`.
- `markdownlint` clean on the changelog; docs-freshness `errors=0`; terminology guard 10/10.

## Deferred (tracked, not dropped)

- **`#3376`** — the worktree upgrade path still stamps `schema_version` unconditionally after a failed migration (same FR-002 class; filed from WP01 review).
- **SIGKILL crash-atomicity** — the optional corpus staging-promote WP was deliberately descoped (it would rework the intentional per-mission design); durable cross-run accounting is parked on the migration-ledger issue **`#2933`**. Report-on-abort (`#3335`) covers graceful aborts.

Closes #3335
Closes #3336
Closes #3337
Closes #3338
Closes #3339
Closes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

