### PR TITLE
docs: remove dead `/release` skill reference in contributing.md

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -411,8 +411,6 @@ When working on spec-kitty:
 
 Spec Kitty follows a structured release process using GitHub Actions for automated PyPI publishing.
 
-> **For AI agents**: Use the `/release` skill (`.claude/skills/release/SKILL.md`) for a step-by-step guide.
-
 ### Branch Strategy
 
 Spec Kitty maintains two long-lived branches:


### PR DESCRIPTION
Refs #3363\n\nSuperseded by #3631; do not merge this duplicate..

## Problem
The Release Process section of `docs/development/contributing.md` (line 414) told AI agents:

> **For AI agents**: Use the `/release` skill (`.claude/skills/release/SKILL.md`) for a step-by-step guide.

That path is a dead pointer: there is no `.claude/skills/` directory in the repo (nor a registered `/release` skill), so an agent following the release runbook hits a 404 and has to reconstruct the steps from the surrounding prose.

## Fix
Took option 1 from the issue: removed the dead reference. The inline runbook that immediately follows (Branch Strategy / Quick Release / Full Release) is already complete and self-contained, so it stands as the canonical release guide with no missing information.

## Verification
- `.claude/skills/release/SKILL.md` and the whole `.claude/skills/` tree return 404 on `main` — confirmed the pointer targets nothing.
- The removed line was the only reference to that skill path; the sections around it (release intro, Branch Strategy) still read coherently after removal.

Docs-only, no functional change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789264528&installation_model_id=427282&pr_number=3400&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3400&signature=068985d46ec3e85fd1e8d58c419c2690831dc3fcea302ded087656d31b5335cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->