### PR TITLE
fix(auth): login resolves server via config, not env-only (#3406 FR-005)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -345,6 +345,15 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   drain on recovery (consistent with the offline queue's transient-retry
   handling), and — for the decommissioned case — naming the URL and the exact
   recovery (`spec-kitty sync server <url>` then `auth login --force`).
+- **`auth login` now resolves the server the same way `sync` does — env over
+  `[sync].server_url` over the documented default — instead of the env-only
+  accessor that errored when only `spec-kitty sync server` had been set
+  (`#3406`, FR-005).** Before, a user who set their server via `sync server`
+  still hit "SPEC_KITTY_SAAS_URL environment variable is not set" on login, so a
+  token could only be minted against one server while sync targeted another. It
+  still refuses (with a remedy naming both `SPEC_KITTY_SAAS_URL` and
+  `sync server`) when neither is set, rather than silently defaulting to the dev
+  URL. One of the ten-gate first-sync gauntlet fixes.
 
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission

--- a/src/specify_cli/cli/commands/_auth_login.py
+++ b/src/specify_cli/cli/commands/_auth_login.py
@@ -9,9 +9,15 @@ The ``--headless`` branch lazy-imports a future ``auth.flows.device_code``
 module that WP05 will supply. Until WP05 lands, attempting to use
 ``--headless`` surfaces a clear "not yet implemented" error.
 
-Per constraint C-012 and decision D-5, this module never hardcodes a SaaS
-URL — it always reads from :func:`specify_cli.auth.config.get_saas_base_url`
-so operators must set ``SPEC_KITTY_SAAS_URL`` in the environment.
+This module never hardcodes a SaaS URL. It resolves the login target through the
+canonical resolver :func:`specify_cli.sync.target_authority.resolve_sync_target`,
+which folds ``SPEC_KITTY_SAAS_URL`` (env) over ``[sync].server_url`` in
+``config.toml`` over the documented default — the *same* precedence ``sync`` uses.
+This is deliberate (#3406, FR-005): login previously read the env-only accessor
+``get_saas_base_url`` and errored when the env var was unset, even when the user
+had already set a server via ``spec-kitty sync server``. That inconsistency meant
+a token could be obtained one way while sync targeted another; resolving both the
+same way removes it.
 """
 
 from __future__ import annotations
@@ -27,10 +33,9 @@ from specify_cli.auth import (
     BrowserLaunchError,
     CallbackTimeoutError,
     CallbackValidationError,
-    ConfigurationError,
     get_token_manager,
 )
-from specify_cli.auth.config import get_saas_base_url
+from specify_cli.sync.target_authority import resolve_sync_target
 
 if TYPE_CHECKING:
     from specify_cli.auth.session import StorageBackend, StoredSession
@@ -55,11 +60,22 @@ async def login_impl(*, headless: bool, force: bool) -> None:
         ``enforce_teamspace_mission_state_ready`` themselves — those are
         the commands that actually depend on TeamSpace state.
     """
-    try:
-        saas_url = get_saas_base_url()
-    except ConfigurationError as exc:
-        console.print(f"[red]X {exc}[/red]")
-        raise typer.Exit(1) from exc
+    # Resolve the login target the same way sync does — env over config.toml
+    # over the documented default (#3406, FR-005). Login previously read the
+    # env-only accessor and errored when only `sync server` had been set, so a
+    # token could be minted against one server while sync targeted another.
+    # We still refuse when NEITHER an env override nor an explicit config
+    # server_url is set, rather than silently defaulting to the descriptive dev
+    # URL — preserving the "choose your server" intent while honouring config.
+    target = resolve_sync_target()
+    if target.env_server_url is None and target.configured_server_url is None:
+        console.print(
+            "[red]X No sync server is configured. Set SPEC_KITTY_SAAS_URL, or run "
+            "`spec-kitty sync server <url>` (e.g. https://app.spec-kitty.ai), then "
+            "try again.[/red]"
+        )
+        raise typer.Exit(1)
+    saas_url = target.resolved_server_url
 
     tm = get_token_manager()
 

--- a/tests/cli/commands/test_auth_login.py
+++ b/tests/cli/commands/test_auth_login.py
@@ -185,13 +185,43 @@ class TestAuthLoginDispatch:
 
 class TestAuthLoginConfigErrors:
 
-    def test_missing_saas_url_exits_nonzero(self, monkeypatch):
+    def test_missing_env_and_config_exits_nonzero(self, monkeypatch):
+        # #3406 FR-005: with NEITHER SPEC_KITTY_SAAS_URL nor a configured
+        # `[sync].server_url`, login refuses rather than silently targeting the
+        # descriptive dev default. The remedy names both ways to set a server.
         monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
         result = runner.invoke(app, ["login"])
 
         assert result.exit_code != 0
+        assert "No sync server is configured" in result.stdout
         assert "SPEC_KITTY_SAAS_URL" in result.stdout
-        assert "https://app.spec-kitty.ai) and try again." in result.stdout
+        assert "spec-kitty sync server" in result.stdout
+
+    def test_missing_env_uses_configured_sync_server_url(self, monkeypatch):
+        # #3406 FR-005: the actual bug. When the env var is unset but the user
+        # already set a server via `spec-kitty sync server`, login must use that
+        # configured server_url (the same target sync uses) instead of erroring.
+        from specify_cli.sync.config import SyncConfig
+
+        monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+        SyncConfig().set_server_url("https://configured.example")
+
+        async def _noop(*_args, **_kwargs):
+            return None
+
+        with patch(
+            "specify_cli.cli.commands._auth_login.get_token_manager"
+        ) as mock_factory, patch(
+            "specify_cli.cli.commands._auth_login._run_browser_flow",
+            new=AsyncMock(side_effect=_noop),
+        ) as mock_browser:
+            mock_factory.return_value.is_authenticated = False
+            result = runner.invoke(app, ["login"])
+
+        assert result.exit_code == 0, result.stdout
+        assert mock_browser.called
+        # Login resolved the configured server_url and handed it to the flow.
+        assert mock_browser.call_args.args[1] == "https://configured.example"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Impact

If you picked your server with `spec-kitty sync server <url>` but never set the `SPEC_KITTY_SAAS_URL` env var, `spec-kitty auth login` used to dead-end with *"SPEC_KITTY_SAAS_URL environment variable is not set"* — even though `sync` was already targeting the server you configured. You did everything right and still couldn't log in, and a token could end up minted against one server while sync pointed at another. This fixes that: **login now honours your configured server the same way `sync` does.**

## The bug (gate 3 of the #3406 first-sync gauntlet)

`auth login` resolved its server through the env-only accessor `get_saas_base_url()`, which raises whenever `SPEC_KITTY_SAAS_URL` is unset. `sync`, meanwhile, resolves through `resolve_sync_target` (env → `[sync].server_url` → documented default). The two disagreed, so a config set via `sync server` was invisible to login.

## The fix

Login now resolves through the same canonical `resolve_sync_target` that sync uses (one resolution site in `_auth_login.py`). It still **refuses when neither an env override nor an explicit `[sync].server_url` is set** — naming both remedies — rather than silently defaulting to the descriptive dev URL. So config is honoured without losing the "choose your server" intent.

This aligns login with the contract already documented on `main`: `get_saas_base_url`'s own docstring now says it is *"intentionally not the live-target surface — higher-level callers must read `ResolvedSyncTarget.resolved_server_url` rather than calling this directly."*

## D-5 resolution

This changes what the old env-only gate on `auth login` encoded. That requirement lived *only* on login, not on `sync` (which already defaults) — which is exactly why they diverged. **Operator decision (2026-08-16): LAND as-is** — resolve login the same way sync does; if an explicit opt-in gate is wanted later, it belongs at the resolver level for *both* auth and sync, not on login alone. (`readiness.py`'s `MISSING_HOST_CONFIG` check still uses the env-only accessor — a separate later gate in the same #3406 gauntlet, tracked there.)

## Tests

- `test_missing_env_uses_configured_sync_server_url` — the fix: env unset + `sync server` set → login uses the configured URL and hands it to the flow.
- `test_missing_env_and_config_exits_nonzero` — refuse (with remedy) when neither is set.
- `ruff` + `mypy` clean; `tests/cli/commands/test_auth_login.py` green (12 passed). Red-first verified: both new tests fail against the pre-fix `_auth_login.py`.

## Landing notes

- Rebased onto current `upstream/main` (was 152 commits behind); the one changelog conflict resolved in `docs/changelog/CHANGELOG.md`, keeping both entries.
- The only red check, `arch-adversarial (arch_shard_3)`, is **pre-existing on `main`** (reproduces on a clean checkout with none of this PR's changes): a stale re-baseline of the frozen `SPEC_KITTY_HOME` pin census, tracked debt under `#3121`. Not caused by, and out of scope for, this auth fix.

Refs #3406 (FR-005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
