### PR TITLE
fix(mission): surface internal-error remediation body in create (#3406 FR-012)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -88,6 +88,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **`agent mission create` now surfaces the actionable remediation body of an
+  internal-consistency error instead of only the bare code (`#3406`, FR-012).**
+  A `KittyInternalConsistencyError` (e.g. `CHARTER_PACK_CONFIG_INVALID`, raised
+  when a project has no activated mission types) carries both a stable `code`
+  and a human `body`, but the command's broad handler emitted only `str(exc)` —
+  the code — so `mission create --json` returned an opaque error with no next
+  step and the console showed the same. It now emits the `body` as `detail` in
+  `--json` and prints it to the console, so the user is told to run
+  `spec-kitty charter activate mission-type <name>`. Second fix in the
+  first-sync gauntlet.
+
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission
   `worktree-owned-root-3328-01KZRG01`; `#3346`, closes `#3328`).** Before,

--- a/src/specify_cli/cli/commands/agent/mission_create.py
+++ b/src/specify_cli/cli/commands/agent/mission_create.py
@@ -268,6 +268,7 @@ def _run_create_core_phase(
     a ``MissionCreationError`` (with worktree navigation hint), or any other
     unexpected exception.
     """
+    from kernel.errors import KittyInternalConsistencyError
     from specify_cli.core.mission_creation import (
         MissionCreationError,
         create_mission_core,
@@ -320,6 +321,22 @@ def _run_create_core_phase(
         else:
             console.print(f"[bold red]Error:[/bold red] {error_msg}")
             _print_worktree_navigation_hint(mission_slug, error_msg)
+        raise typer.Exit(1) from exc
+    except KittyInternalConsistencyError as exc:
+        # Internal-consistency errors (e.g. CHARTER_PACK_CONFIG_INVALID) carry a
+        # stable `code` AND a human-actionable `body`. The broad handler below
+        # emits only `str(exc)`, which is the bare code — the #3406 FR-012
+        # opacity where `mission create --json` returned a code with no next
+        # step. Surface the remediation body in both JSON and console modes.
+        if json_output:
+            payload: dict[str, str] = {"error": exc.code}
+            if exc.body:
+                payload["detail"] = exc.body
+            _emit_json(payload)
+        else:
+            console.print(f"[bold red]Error:[/bold red] {exc.code}")
+            if exc.body:
+                console.print(exc.body)
         raise typer.Exit(1) from exc
     except Exception as e:
         if json_output:

--- a/tests/specify_cli/cli/commands/agent/test_mission_create.py
+++ b/tests/specify_cli/cli/commands/agent/test_mission_create.py
@@ -702,3 +702,56 @@ def test_start_branch_target_branch_mismatch_refuses_before_switch(tmp_path: Pat
     assert _git(tmp_path, "branch", "--show-current").stdout.strip() == "main"
     assert not _branch_exists(tmp_path, "feat/json-pr-bound-mismatch")
     assert list((tmp_path / "kitty-specs").iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# #3406 FR-012: internal-consistency errors surface their actionable body
+# ---------------------------------------------------------------------------
+
+
+def test_create_json_surfaces_internal_error_body(tmp_path: Path) -> None:
+    """A ``KittyInternalConsistencyError`` (e.g. CHARTER_PACK_CONFIG_INVALID) must
+    expose BOTH the stable ``code`` and its actionable ``body`` in ``--json``
+    output (#3406 FR-012). Before, the broad handler emitted only ``str(exc)`` —
+    the bare code — so `mission create --json` returned an opaque error with no
+    next step (this is what made the empty-mission-type gate unreadable)."""
+    _init_repo(tmp_path)
+    from charter.pack_context import CharterPackConfigError
+
+    body = (
+        "This project has no activated mission types. Run "
+        "`spec-kitty charter activate mission-type software-dev` to activate one."
+    )
+
+    runner = CliRunner()
+    with (
+        patch(f"{_CORE_MODULE}.locate_project_root", return_value=tmp_path),
+        patch(f"{_CORE_MODULE}.is_worktree_context", return_value=False),
+        patch(f"{_CORE_MODULE}.is_git_repo", return_value=True),
+        patch(f"{_CORE_MODULE}.get_current_branch", return_value="main"),
+        patch("specify_cli.cli.commands.agent.mission.locate_project_root", return_value=tmp_path),
+        patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main"),
+        patch(f"{_CORE_MODULE}.create_mission_core", side_effect=CharterPackConfigError(body)),
+    ):
+        result = runner.invoke(
+            mission_app,
+            [
+                "create",
+                "cli-err-test",
+                "--json",
+                "--target-branch",
+                "main",
+                "--friendly-name",
+                "CLI Err Test",
+                "--purpose-tldr",
+                "Validate the error body reaches JSON.",
+                "--purpose-context",
+                "Issue #3406 FR-012 — the remediation must not be swallowed.",
+            ],
+        )
+
+    assert result.exit_code != 0, result.output
+    payload = _json_payload_from_output(result.output)
+    assert payload["error"] == "CHARTER_PACK_CONFIG_INVALID"
+    assert "detail" in payload, f"remediation body dropped: {payload!r}"
+    assert "charter activate mission-type" in payload["detail"]


### PR DESCRIPTION
Second fix in the [#3406](https://github.com/Priivacy-ai/spec-kitty/issues/3406) first-sync gauntlet — and this one is gate **10**, the one that made *creating the mission to spec the fix* fail opaquely tonight.

## The bug

`agent mission create` funnels errors through a broad `except Exception: {"error": str(exc)}`. A `KittyInternalConsistencyError` (e.g. `CHARTER_PACK_CONFIG_INVALID`, raised when a project has no activated mission types) carries both a stable `.code` **and** a human-actionable `.body` — but its `__str__` returns only the code. So `mission create --json` returned:

```json
{"error": "CHARTER_PACK_CONFIG_INVALID"}
```

…with zero indication of what to do. The console path printed the same bare code.

## The fix

A typed `except KittyInternalConsistencyError` before the broad handler (the intended pattern per that base class's own docstring), emitting `.code` as `error` and `.body` as `detail` in JSON, and printing both to the console. The user now sees the remedy — "run `spec-kitty charter activate mission-type <name>`" — instead of an opaque code.

Net diff: one typed handler + its import, one test, one changelog line.

## Scope note

This surfaces the *existing* message; it does **not** change the fail-closed behaviour or auto-activate a default mission-type set. Whether a fresh repo should self-heal an empty activation set (vs. fail-closed with guidance) is the other half of FR-012 — left for a follow-up so this stays a small, safe diff. Your call, @stijn-dejongh, on whether you want the self-heal too.

## Verification

- `test_create_json_surfaces_internal_error_body` — a raised `CharterPackConfigError` now yields `error=code` + `detail=body` in `--json`, with the activation remedy present.
- `ruff` + `mypy` clean; the create JSON tests pass (5).

Refs #3406 (FR-012).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789277583&installation_model_id=427282&pr_number=3409&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3409&signature=6a90b118c1618d5e64a9029307b9865cf1f9c3b55046b45f8affe602a0ba3576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->