### PR TITLE
fix(sync): detect dead sync server endpoint and surface repoint remediation (#3406 FR-003)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -144,16 +144,18 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   while still validating known fields, so genuinely-malformed frontmatter is
   still skipped fail-loud. Authoring keeps the strict typo guard unchanged.
 
-- **`sync status` now names a dead sync server and how to repoint it, instead
-  of reporting a bare "Unexpected status" (mission
+- **`sync status` now flags an unreachable sync server and how to repoint it,
+  instead of reporting a bare "Unexpected status" (mission
   `first-sync-preflight-01KZZ9Q1` FR-003; `#3406`).** A configured server that
   answers with a gateway-class status (`502`/`503`/`504`) — the signature of a
   decommissioned platform env or a torn-down preview, which is exactly how a
   first sync against a stale `*.platformsh.site` URL stranded — was folded into
   the generic "Unexpected HTTP 502" branch, giving the operator no signal that
-  the URL itself was the fault. The health probe now reports these as
-  **Server endpoint down**, naming the dead URL and the exact recovery
-  (`spec-kitty sync server <url>` then `auth login --force`).
+  the URL itself might be the fault. The health probe now reports these as
+  **Server unavailable**, reassuring that queued events are retained and will
+  drain on recovery (consistent with the offline queue's transient-retry
+  handling), and — for the decommissioned case — naming the URL and the exact
+  recovery (`spec-kitty sync server <url>` then `auth login --force`).
 
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -144,6 +144,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   while still validating known fields, so genuinely-malformed frontmatter is
   still skipped fail-loud. Authoring keeps the strict typo guard unchanged.
 
+- **`sync status` now names a dead sync server and how to repoint it, instead
+  of reporting a bare "Unexpected status" (mission
+  `first-sync-preflight-01KZZ9Q1` FR-003; `#3406`).** A configured server that
+  answers with a gateway-class status (`502`/`503`/`504`) — the signature of a
+  decommissioned platform env or a torn-down preview, which is exactly how a
+  first sync against a stale `*.platformsh.site` URL stranded — was folded into
+  the generic "Unexpected HTTP 502" branch, giving the operator no signal that
+  the URL itself was the fault. The health probe now reports these as
+  **Server endpoint down**, naming the dead URL and the exact recovery
+  (`spec-kitty sync server <url>` then `auth login --force`).
+
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission
   `worktree-owned-root-3328-01KZRG01`; `#3346`, closes `#3328`).** Before,

--- a/src/specify_cli/auth/config.py
+++ b/src/specify_cli/auth/config.py
@@ -22,6 +22,14 @@ from .errors import ConfigurationError
 
 _ENV_VAR = "SPEC_KITTY_SAAS_URL"
 
+#: Illustrative hosted-SaaS URL, used only in operator-facing *examples* (error
+#: hints, remediation notes). This is NOT a functional default: per
+#: architectural decision D-5 (see module docstring) hosted activation has no
+#: hardcoded fallback — callers must set ``SPEC_KITTY_SAAS_URL``. It is shared so
+#: the example does not drift across the auth and sync surfaces that cite it
+#: (#3441). D-5 scopes the opt-in gate, not example literals like this one.
+EXAMPLE_HOSTED_SAAS_URL = "https://app.spec-kitty.ai"
+
 
 def get_saas_base_url() -> str:
     """Return the SaaS base URL from the ``SPEC_KITTY_SAAS_URL`` environment variable.
@@ -47,6 +55,6 @@ def get_saas_base_url() -> str:
         raise ConfigurationError(
             f"{_ENV_VAR} environment variable is not set. "
             f"Set it to your spec-kitty-saas instance URL (e.g. "
-            f"https://app.spec-kitty.ai) and try again."
+            f"{EXAMPLE_HOSTED_SAAS_URL}) and try again."
         )
     return url.rstrip("/")

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -3116,26 +3116,38 @@ def sync_workspace(  # noqa: C901
 
 
 #: Gateway-class HTTP statuses. A configured sync server that answers with one
-#: of these is almost always decommissioned or down at the edge (a dead
-#: platform env, a torn-down preview, DNS pointing at a retired load balancer) —
-#: not an application-level error. This is the exact shape that stranded a first
-#: sync against a stale ``*.platformsh.site`` URL: the probe saw HTTP 502 and
-#: reported a bare "Unexpected status", giving the operator no signal that the
-#: URL itself was the fault or how to repoint it. FR-003 of the first-sync
-#: preflight mission (#3406).
+#: of these is unavailable at the edge rather than returning an application-level
+#: error — either a transient outage (a rolling deploy or maintenance window) or
+#: a genuinely decommissioned endpoint (a dead platform env, a torn-down preview,
+#: DNS pointing at a retired load balancer). This is the exact shape that
+#: stranded a first sync against a stale ``*.platformsh.site`` URL: the probe saw
+#: HTTP 502 and reported a bare "Unexpected status", giving the operator no
+#: signal that the URL itself might be the fault or how to repoint it. FR-003 of
+#: the first-sync preflight mission (#3406).
+#:
+#: NB the delivery ledger / offline queue classifies these same statuses as
+#: *transient* (``failed_transient`` — the queue row is left untouched, never
+#: dead-lettered; see ``sync/batch.py`` and ``sync/queue.py``). The probe is a
+#: read-only health report and must stay consistent with that contract: it may
+#: surface repoint guidance for the decommissioned case, but must not imply
+#: queued events are lost.
 _GATEWAY_STATUS: frozenset[int] = frozenset({502, 503, 504})
 
 
-def _dead_endpoint_note(server_url: str, status_code: int) -> str:
+def _gateway_unavailable_note(server_url: str, status_code: int) -> str:
     """Remediation note for a sync server returning a gateway-class status.
 
-    Names the dead URL explicitly and gives the exact repoint command, since the
-    common cause is a configured server that no longer exists rather than a
-    transient outage.
+    Frames the transient case first (a gateway 5xx is most often a rolling
+    deploy or maintenance blip), reassures the operator their queued events are
+    retained and will drain on recovery — consistent with the offline queue's
+    ``failed_transient`` disposition — and only then offers the repoint recovery
+    for the case where the URL is genuinely decommissioned.
     """
     return (
-        f"HTTP {status_code} from {server_url} — the endpoint looks decommissioned "
-        "or down. If you switched environments, repoint with "
+        f"HTTP {status_code} from {server_url} — the sync endpoint is unavailable. "
+        "This is often a transient outage (for example a rolling deploy), so your "
+        "queued events are kept locally and will drain once it recovers. If instead "
+        "you have switched environments and this URL is decommissioned, repoint with "
         "`spec-kitty sync server <url>` (e.g. https://app.spec-kitty.ai), then "
         "`spec-kitty auth login --force`."
     )
@@ -3246,8 +3258,8 @@ def _check_server_connection(server_url: str) -> tuple[str, str]:
             )
         elif response.status_code in _GATEWAY_STATUS:
             return (
-                "[red]Server endpoint down[/red]",
-                _dead_endpoint_note(server_url, response.status_code),
+                "[red]Server unavailable[/red]",
+                _gateway_unavailable_note(server_url, response.status_code),
             )
         else:
             return (

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -3115,6 +3115,32 @@ def sync_workspace(  # noqa: C901
     console.print()
 
 
+#: Gateway-class HTTP statuses. A configured sync server that answers with one
+#: of these is almost always decommissioned or down at the edge (a dead
+#: platform env, a torn-down preview, DNS pointing at a retired load balancer) —
+#: not an application-level error. This is the exact shape that stranded a first
+#: sync against a stale ``*.platformsh.site`` URL: the probe saw HTTP 502 and
+#: reported a bare "Unexpected status", giving the operator no signal that the
+#: URL itself was the fault or how to repoint it. FR-003 of the first-sync
+#: preflight mission (#3406).
+_GATEWAY_STATUS: frozenset[int] = frozenset({502, 503, 504})
+
+
+def _dead_endpoint_note(server_url: str, status_code: int) -> str:
+    """Remediation note for a sync server returning a gateway-class status.
+
+    Names the dead URL explicitly and gives the exact repoint command, since the
+    common cause is a configured server that no longer exists rather than a
+    transient outage.
+    """
+    return (
+        f"HTTP {status_code} from {server_url} — the endpoint looks decommissioned "
+        "or down. If you switched environments, repoint with "
+        "`spec-kitty sync server <url>` (e.g. https://app.spec-kitty.ai), then "
+        "`spec-kitty auth login --force`."
+    )
+
+
 def _check_server_connection(server_url: str) -> tuple[str, str]:
     """Probe sync health using the user's real auth token.
 
@@ -3217,6 +3243,11 @@ def _check_server_connection(server_url: str) -> tuple[str, str]:
             return (
                 "[yellow]Permission denied[/yellow]",
                 "Check team membership for this project.",
+            )
+        elif response.status_code in _GATEWAY_STATUS:
+            return (
+                "[red]Server endpoint down[/red]",
+                _dead_endpoint_note(server_url, response.status_code),
             )
         else:
             return (

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -65,6 +65,7 @@ from specify_cli.core.vcs import (
 )
 
 from specify_cli.sync.queue import QueueStats
+from specify_cli.sync.http_status import GATEWAY_STATUSES
 from specify_cli.core.saas_sync_config import saas_sync_opt_in_recorded_message
 from kernel.clock import now_utc_iso
 from specify_cli.sync.feature_flags import (
@@ -3115,25 +3116,6 @@ def sync_workspace(  # noqa: C901
     console.print()
 
 
-#: Gateway-class HTTP statuses. A configured sync server that answers with one
-#: of these is unavailable at the edge rather than returning an application-level
-#: error — either a transient outage (a rolling deploy or maintenance window) or
-#: a genuinely decommissioned endpoint (a dead platform env, a torn-down preview,
-#: DNS pointing at a retired load balancer). This is the exact shape that
-#: stranded a first sync against a stale ``*.platformsh.site`` URL: the probe saw
-#: HTTP 502 and reported a bare "Unexpected status", giving the operator no
-#: signal that the URL itself might be the fault or how to repoint it. FR-003 of
-#: the first-sync preflight mission (#3406).
-#:
-#: NB the delivery ledger / offline queue classifies these same statuses as
-#: *transient* (``failed_transient`` — the queue row is left untouched, never
-#: dead-lettered; see ``sync/batch.py`` and ``sync/queue.py``). The probe is a
-#: read-only health report and must stay consistent with that contract: it may
-#: surface repoint guidance for the decommissioned case, but must not imply
-#: queued events are lost.
-_GATEWAY_STATUS: frozenset[int] = frozenset({502, 503, 504})
-
-
 def _gateway_unavailable_note(server_url: str, status_code: int) -> str:
     """Remediation note for a sync server returning a gateway-class status.
 
@@ -3256,7 +3238,12 @@ def _check_server_connection(server_url: str) -> tuple[str, str]:
                 "[yellow]Permission denied[/yellow]",
                 "Check team membership for this project.",
             )
-        elif response.status_code in _GATEWAY_STATUS:
+        elif response.status_code in GATEWAY_STATUSES:
+            # Gateway 5xx = the edge says the endpoint is unavailable (FR-003,
+            # #3406). Reclassify out of the generic "Unexpected" branch so a
+            # first sync against a stale/decommissioned URL gets an actionable
+            # signal, while staying consistent with the queue's transient
+            # (never-dead-lettered) disposition — see _gateway_unavailable_note.
             return (
                 "[red]Server unavailable[/red]",
                 _gateway_unavailable_note(server_url, response.status_code),

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -66,6 +66,7 @@ from specify_cli.core.vcs import (
 
 from specify_cli.sync.queue import QueueStats
 from specify_cli.sync.http_status import GATEWAY_STATUSES
+from specify_cli.auth.config import EXAMPLE_HOSTED_SAAS_URL
 from specify_cli.core.saas_sync_config import saas_sync_opt_in_recorded_message
 from kernel.clock import now_utc_iso
 from specify_cli.sync.feature_flags import (
@@ -3130,7 +3131,7 @@ def _gateway_unavailable_note(server_url: str, status_code: int) -> str:
         "This is often a transient outage (for example a rolling deploy), so your "
         "queued events are kept locally and will drain once it recovers. If instead "
         "you have switched environments and this URL is decommissioned, repoint with "
-        "`spec-kitty sync server <url>` (e.g. https://app.spec-kitty.ai), then "
+        f"`spec-kitty sync server <url>` (e.g. {EXAMPLE_HOSTED_SAAS_URL}), then "
         "`spec-kitty auth login --force`."
     )
 

--- a/src/specify_cli/sync/http_status.py
+++ b/src/specify_cli/sync/http_status.py
@@ -1,0 +1,25 @@
+"""Canonical HTTP status classes shared across the sync subsystem.
+
+Numeric status sets for *numeric* ``status_code in {...}`` checks. Kept here —
+not in :mod:`specify_cli.sync.batch` — because ``batch.py`` classifies failures
+by *string* keyword-matching over response text (its ``server_error`` bucket
+also matches ``"500"``, ``"internal"`` and ``"server error"``), a deliberately
+broader, differently-typed net than this numeric gateway class. The two are
+intentionally separate; see #3441.
+"""
+
+from __future__ import annotations
+
+#: Gateway-class HTTP statuses (502/503/504). A response carrying one of these
+#: came from the edge — a load balancer or reverse proxy — rather than the
+#: application, so it signals the endpoint is *unavailable* (a transient outage
+#: such as a rolling deploy or maintenance window, or a genuinely decommissioned
+#: host) rather than an application-level error. Note 500 is deliberately
+#: excluded: it is an application-level error, not an edge signal.
+#:
+#: The offline queue treats these as *transient* (``failed_transient`` — the
+#: queue row is left untouched, never dead-lettered; see
+#: :mod:`specify_cli.sync.queue` and :mod:`specify_cli.sync.batch`, issue #889),
+#: so any consumer that surfaces a gateway status to an operator must not imply
+#: that queued events are lost.
+GATEWAY_STATUSES: frozenset[int] = frozenset({502, 503, 504})

--- a/tests/sync/test_sync_status_check.py
+++ b/tests/sync/test_sync_status_check.py
@@ -197,6 +197,28 @@ class TestCheckServerConnectionValidToken:
         assert "Unexpected" in status
         assert "500" in note
 
+    @patch("specify_cli.auth.http.request_with_fallback_sync")
+    def test_gateway_status_reports_dead_endpoint_with_repoint(self, mock_request):
+        """A 502/503/504 is a dead endpoint, not a generic 'unexpected' status.
+
+        Regression for FR-003 (#3406): a configured server pointing at a
+        decommissioned host answered 502 and the probe reported a bare
+        "Unexpected status", giving no signal that the URL was the fault. The
+        note must name the dead URL and the repoint command.
+        """
+        for gateway_status in (502, 503, 504):
+            mock_request.side_effect = _mock_response_for_probe(get_status=gateway_status)
+            fake_tm = _fake_token_manager(access_token="valid-token")
+
+            with patch("specify_cli.auth.get_token_manager", return_value=fake_tm):
+                status, note = _check_server_connection(SERVER_URL)
+
+            assert "Unexpected" not in status
+            assert "down" in status.lower()
+            assert str(gateway_status) in note
+            assert SERVER_URL in note
+            assert "sync server" in note
+
 
 class TestCheckServerConnectionUnreachable:
     """Test behavior when server is unreachable."""

--- a/tests/sync/test_sync_status_check.py
+++ b/tests/sync/test_sync_status_check.py
@@ -197,8 +197,9 @@ class TestCheckServerConnectionValidToken:
         assert "Unexpected" in status
         assert "500" in note
 
+    @pytest.mark.parametrize("gateway_status", [502, 503, 504])
     @patch("specify_cli.auth.http.request_with_fallback_sync")
-    def test_gateway_status_reports_unavailable_with_repoint(self, mock_request):
+    def test_gateway_status_reports_unavailable_with_repoint(self, mock_request, gateway_status):
         """A 502/503/504 is a gateway-class outage, not a generic 'unexpected' status.
 
         Regression for FR-003 (#3406): a configured server pointing at a
@@ -211,20 +212,19 @@ class TestCheckServerConnectionValidToken:
         dead-lettered), so the note must also reassure that queued events are
         retained rather than implying data loss.
         """
-        for gateway_status in (502, 503, 504):
-            mock_request.side_effect = _mock_response_for_probe(get_status=gateway_status)
-            fake_tm = _fake_token_manager(access_token="valid-token")
+        mock_request.side_effect = _mock_response_for_probe(get_status=gateway_status)
+        fake_tm = _fake_token_manager(access_token="valid-token")
 
-            with patch("specify_cli.auth.get_token_manager", return_value=fake_tm):
-                status, note = _check_server_connection(SERVER_URL)
+        with patch("specify_cli.auth.get_token_manager", return_value=fake_tm):
+            status, note = _check_server_connection(SERVER_URL)
 
-            assert "Unexpected" not in status
-            assert "unavailable" in status.lower()
-            assert str(gateway_status) in note
-            assert SERVER_URL in note
-            assert "sync server" in note
-            # Consistent with the queue's transient-retry disposition.
-            assert "queued" in note.lower()
+        assert "Unexpected" not in status
+        assert "unavailable" in status.lower()
+        assert str(gateway_status) in note
+        assert SERVER_URL in note
+        assert "sync server" in note
+        # Consistent with the queue's transient-retry disposition.
+        assert "queued" in note.lower()
 
 
 class TestCheckServerConnectionUnreachable:

--- a/tests/sync/test_sync_status_check.py
+++ b/tests/sync/test_sync_status_check.py
@@ -198,13 +198,18 @@ class TestCheckServerConnectionValidToken:
         assert "500" in note
 
     @patch("specify_cli.auth.http.request_with_fallback_sync")
-    def test_gateway_status_reports_dead_endpoint_with_repoint(self, mock_request):
-        """A 502/503/504 is a dead endpoint, not a generic 'unexpected' status.
+    def test_gateway_status_reports_unavailable_with_repoint(self, mock_request):
+        """A 502/503/504 is a gateway-class outage, not a generic 'unexpected' status.
 
         Regression for FR-003 (#3406): a configured server pointing at a
         decommissioned host answered 502 and the probe reported a bare
         "Unexpected status", giving no signal that the URL was the fault. The
-        note must name the dead URL and the repoint command.
+        note must name the unreachable URL and offer the repoint command.
+
+        DLQ-contract consistency: a gateway 5xx is classified *transient* by the
+        offline queue (``failed_transient`` — events stay queued, never
+        dead-lettered), so the note must also reassure that queued events are
+        retained rather than implying data loss.
         """
         for gateway_status in (502, 503, 504):
             mock_request.side_effect = _mock_response_for_probe(get_status=gateway_status)
@@ -214,10 +219,12 @@ class TestCheckServerConnectionValidToken:
                 status, note = _check_server_connection(SERVER_URL)
 
             assert "Unexpected" not in status
-            assert "down" in status.lower()
+            assert "unavailable" in status.lower()
             assert str(gateway_status) in note
             assert SERVER_URL in note
             assert "sync server" in note
+            # Consistent with the queue's transient-retry disposition.
+            assert "queued" in note.lower()
 
 
 class TestCheckServerConnectionUnreachable:


### PR DESCRIPTION
## Impact

`sync status` now gives a clear, correct signal when the configured sync server is unreachable **at the edge** (a gateway-class `502`/`503`/`504`) instead of a bare **"Unexpected status"** — the exact failure that silently stranded a first sync against a stale `*.platformsh.site` URL during onboarding. The operator now sees **Server unavailable**, is reassured their queued events are safe and will drain on recovery, and — if the URL is genuinely decommissioned — gets the precise repoint recovery.

## Change

- `_check_server_connection` (the `sync status` health probe) reclassifies gateway-class HTTP (`502`/`503`/`504`) out of the generic "Unexpected" branch into **Server unavailable**, with a note (`_gateway_unavailable_note`) that:
  - frames the common **transient** case first (a rolling deploy / maintenance window);
  - reassures that **queued events are retained locally and drain on recovery** — consistent with the offline queue's transient (`failed_transient`, never dead-lettered) disposition;
  - offers the repoint recovery (`spec-kitty sync server <url>` then `spec-kitty auth login --force`) for the genuinely-decommissioned case.
- Application-level errors (e.g. `500`) still report the generic "Unexpected" — only the gateway class is reclassified.
- SSOT tidy-ups folded in the same pass: a canonical `GATEWAY_STATUSES` constant (`sync/http_status.py`) and a shared `EXAMPLE_HOSTED_SAAS_URL` example literal (`auth/config.py`), retiring two inline duplications (**Closes #3441**).

## DLQ ledger compatibility

The probe is a **read-only, display-only** health report — zero interaction with the delivery ledger (`SqliteDeliveryLedger`) or offline queue (`OfflineQueue`). The queue independently classifies gateway `5xx` as **transient** (queue row left untouched, never dead-lettered; #889). The messaging above is deliberately consistent with that contract: it never implies queued events are lost, and its "repoint" guidance is reserved for — and framed as — the decommissioned case.

## Test

`tests/sync/test_sync_status_check.py::TestCheckServerConnectionValidToken::test_gateway_status_reports_unavailable_with_repoint` — parametrized over `502`/`503`/`504`; asserts the status reads "unavailable" (not "Unexpected"), names the URL and status code, surfaces the `sync server` repoint, and **pins the "events stay queued" reassurance** so the DLQ-consistency guarantee is a tested contract. Full file green; `ruff` + `mypy` clean.

## Context

FR-003 of the first-sync preflight mission (`#3406`, spec `first-sync-preflight-01KZZ9Q1`) — detection + actionable guidance for a dead/unreachable server URL, one of the nine first-sync gates. Scoped small: **detection + guidance, not silent auto-repoint** (a self-hosted server's transient `502` must not trigger a config rewrite behind the operator's back; auto-heal belongs to the unified-preflight FR). Independent of the other #3406 PRs.

Closes #3441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
