### PR TITLE
fix(sync): doctor never reports healthy while server probe is failing (#3406 FR-002)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -355,6 +355,16 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   `sync server`) when neither is set, rather than silently defaulting to the dev
   URL. One of the ten-gate first-sync gauntlet fixes.
 
+- **`sync doctor` no longer reports "Sync is healthy" while the server probe
+  says otherwise (mission `first-sync-preflight-01KZZ9Q1` FR-002; `#3406`).**
+  The health summary only escalated a server verdict of `Unreachable`/`Error`;
+  a `Permission denied` (403), gateway-down (5xx), or unexpected-status verdict
+  printed a coloured row in the table but never entered the issue list, so the
+  doctor still declared everything healthy while the live drain was blocked —
+  the false-green that hid a broken first sync. Every non-healthy server verdict
+  (anything but `Connected`/`Disabled`, excluding the auth states the
+  auth/session block already owns) now reaches the summary with the probe's own
+  remediation note.
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission
   `worktree-owned-root-3328-01KZRG01`; `#3346`, closes `#3328`).** Before,

--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -3134,6 +3134,17 @@ def _gateway_unavailable_note(server_url: str, status_code: int) -> str:
         f"`spec-kitty sync server <url>` (e.g. {EXAMPLE_HOSTED_SAAS_URL}), then "
         "`spec-kitty auth login --force`."
     )
+#: Server-connection verdicts (from :func:`_check_server_connection`) that are
+#: healthy or a deliberate non-problem state. "Connected" = the live probe
+#: succeeded; "Disabled" = hosted sync is off by design. Any verdict NOT matching
+#: one of these is a real fault the ``doctor`` summary must surface rather than
+#: swallow behind a green "healthy" (FR-002 of the first-sync preflight, #3406).
+_HEALTHY_CONNECTION_MARKERS: tuple[str, ...] = ("Connected", "Disabled")
+
+#: Verdicts the auth/session block of ``doctor`` already reports. The
+#: server-reachability block skips these so one authentication fault is not
+#: listed twice with two differently-worded remediations.
+_AUTH_OWNED_CONNECTION_MARKERS: tuple[str, ...] = ("Not authenticated", "Session expired")
 
 
 def _check_server_connection(server_url: str) -> tuple[str, str]:
@@ -6126,8 +6137,22 @@ def doctor() -> None:  # noqa: C901
     if connection_note:
         table.add_row("", f"[dim]{connection_note}[/dim]")
 
-    if "Unreachable" in connection_status or "Error" in connection_status:
-        issues.append(f"Cannot reach server at {server_url}. Events will continue to queue locally.")
+    # Every non-healthy server verdict must reach the summary, not just
+    # "Unreachable"/"Error". Before, a 401/403/unexpected-status verdict showed a
+    # coloured row in the table above but never entered `issues`, so the doctor
+    # still declared "Sync is healthy" while the live probe said otherwise -- the
+    # false-green that hid a broken drain during onboarding (FR-002, #3406). The
+    # healthy states are "Connected" (probe OK) and "Disabled" (sync off by
+    # design); "Not authenticated"/"Session expired" are already surfaced by the
+    # auth/session block above, so skip them here to avoid double-reporting one
+    # fault. Anything else is a real server-side problem the operator must see.
+    connection_is_healthy = any(marker in connection_status for marker in _HEALTHY_CONNECTION_MARKERS)
+    connection_is_auth_owned = any(marker in connection_status for marker in _AUTH_OWNED_CONNECTION_MARKERS)
+    if not connection_is_healthy and not connection_is_auth_owned:
+        issues.append(
+            connection_note
+            or f"Sync server at {server_url} is not reachable. Events will continue to queue locally."
+        )
 
     # --- 3b. Daemon singleton invariant (spec-kitty#1071) ---
     # Inspect for live `run_sync_daemon` processes that are not the registered

--- a/tests/sync/test_sync_doctor.py
+++ b/tests/sync/test_sync_doctor.py
@@ -209,6 +209,87 @@ class TestDoctorCommand:
     @patch("specify_cli.cli.commands.sync._check_server_connection")
     @patch("specify_cli.auth.get_token_manager")
     @patch("specify_cli.sync.config.SyncConfig")
+    def test_doctor_non_healthy_server_verdict_is_never_reported_healthy(
+        self,
+        mock_config_cls: MagicMock,
+        mock_get_tm: MagicMock,
+        mock_check: MagicMock,
+        mock_queue_cls: MagicMock,
+        mock_body_queue_cls: MagicMock,
+        mock_body_diag: MagicMock,
+        mock_scan_daemons: MagicMock,
+        _mock_orphan_records: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A server verdict that is neither Unreachable nor Error still counts.
+
+        Regression for FR-002 (#3406): everything else is healthy, but the live
+        server probe returns a non-"Connected" verdict (permission denied /
+        gateway-down / unexpected status). Before, only "Unreachable"/"Error"
+        strings fed the summary, so these verdicts printed a coloured row and the
+        doctor still declared "Sync is healthy" -- the false-green that hid a
+        broken drain. Each must now produce an "Issues found" summary carrying
+        the probe's own remediation note, never "No issues detected".
+        """
+        swallowed_verdicts = [
+            ("[yellow]Permission denied[/yellow]", "Check team membership for this project."),
+            ("[red]Server endpoint down[/red]", "HTTP 502 from https://test.example.com -- repoint with `spec-kitty sync server`."),
+            ("[yellow]Unexpected[/yellow]", "Server returned HTTP 418."),
+        ]
+        for verdict_status, verdict_note in swallowed_verdicts:
+            mock_scan_daemons.return_value = SimpleNamespace(orphan_count=0, orphan_processes=[])
+            mock_queue = MagicMock()
+            mock_queue.get_queue_stats.return_value = QueueStats(total_queued=0)
+            mock_queue.db_path = "/nonexistent/test.db"
+            mock_queue_cls.return_value = mock_queue
+            mock_body_queue_cls.return_value = MagicMock()
+            mock_body_diag.return_value = {
+                "body_queue": {
+                    "total_tasks": 0,
+                    "ready_to_send": 0,
+                    "in_backoff": 0,
+                    "max_retry_count": 0,
+                    "oldest_task_age_seconds": None,
+                    "retry_distribution": {},
+                    "recorded_failure_count": 0,
+                    "recent_failures": [],
+                }
+            }
+
+            mock_config = MagicMock()
+            mock_config.get_server_url.return_value = "https://test.example.com"
+            mock_config.resolve_runtime_target.return_value.resolved_server_url = "https://test.example.com"
+            mock_config.read.return_value = ConfigRead(data={}, fault=None)
+            mock_config_cls.return_value = mock_config
+
+            now = now_utc()
+            session = _make_fake_session(
+                access_expires_at=now + timedelta(days=30),
+                refresh_expires_at=now + timedelta(days=30),
+            )
+            fake_tm = MagicMock()
+            fake_tm.get_current_session.return_value = session
+            mock_get_tm.return_value = fake_tm
+
+            mock_check.return_value = (verdict_status, verdict_note)
+
+            from specify_cli.cli.commands.sync import doctor
+
+            doctor()
+
+            captured = capsys.readouterr()
+            assert "No issues detected" not in captured.out, f"false-green on {verdict_status!r}"
+            assert "Issues found" in captured.out, f"verdict {verdict_status!r} did not reach summary"
+            assert verdict_note in captured.out
+
+    @patch("specify_cli.sync.owner.list_orphan_records", return_value=[])
+    @patch("specify_cli.sync.daemon.scan_sync_daemons")
+    @patch("specify_cli.sync.diagnose.diagnose_body_queue")
+    @patch("specify_cli.sync.body_queue.OfflineBodyUploadQueue")
+    @patch("specify_cli.sync.queue.OfflineQueue")
+    @patch("specify_cli.cli.commands.sync._check_server_connection")
+    @patch("specify_cli.auth.get_token_manager")
+    @patch("specify_cli.sync.config.SyncConfig")
     def test_doctor_full_queue_expired_auth(
         self,
         mock_config_cls: MagicMock,


### PR DESCRIPTION
## Impact

`spec-kitty sync doctor` could print **"No issues detected. Sync is healthy."** while the live server probe was actively failing — so during onboarding a broken first sync looked fine and events silently queued locally with no warning.

## The bug (gate 2 of the #3406 first-sync gauntlet)

The doctor's summary is `healthy iff the issue list is empty`, but the server-reachability block only added to that list when the verdict contained `Unreachable` or `Error`:

```python
if "Unreachable" in connection_status or "Error" in connection_status:
    issues.append(...)
```

So a **`Permission denied` (403)**, a **gateway-down `5xx`**, or any **unexpected status** rendered a coloured row in the diagnostics table but never entered the issue list — and the doctor declared everything healthy.

## The fix

Generalize the condition: every server verdict that is **not** healthy (`Connected` / `Disabled`) and **not** already surfaced by the auth/session block (`Not authenticated` / `Session expired`, to avoid double-reporting one auth fault) now reaches the summary, carrying the probe's own remediation note. Two named marker tuples make the classification explicit and testable:

- `_HEALTHY_CONNECTION_MARKERS = ("Connected", "Disabled")`
- `_AUTH_OWNED_CONNECTION_MARKERS = ("Not authenticated", "Session expired")`

This composes with FR-003 (`#3411`, already on main), which added the gateway-down `Server endpoint down` verdict: the generalized condition catches it automatically.

## Tests

`tests/sync/test_sync_doctor.py::TestDoctorCommand::test_doctor_non_healthy_server_verdict_is_never_reported_healthy` drives three previously-swallowed verdicts (`Permission denied`, `Server endpoint down`, `Unexpected`) with everything else healthy, and asserts each produces an **"Issues found"** summary carrying the note — never **"No issues detected"**. `ruff` + `mypy` clean on the changed module.

## Landing notes

- Rebased onto current `upstream/main` (was 153 commits behind). Two conflicts resolved: the changelog (kept all entries) and a sync.py insertion-point collision with `#3411`'s `_gateway_unavailable_note` (kept both). The `doctor()` block change applied cleanly.
- Red-first verified: the new test fails against the pre-fix `sync.py` (false-green on `Permission denied`) and passes with the fix.
- The `arch-adversarial (arch_shard_3)` red is **pre-existing on main** (the `#3121` `SPEC_KITTY_HOME` pin-census debt, red for every PR); this PR's test adds no new pin, so it doesn't worsen it.

Context: FR-002 of the first-sync preflight mission (`#3406`, spec `first-sync-preflight-01KZZ9Q1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
