### PR TITLE
fix(sync): import-history tolerates retired WP frontmatter fields (#3406 FR-011)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -133,6 +133,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   prose equals its `name` field, so this class of identity drift cannot silently
   recur.
 
+- **`sync import-history` now imports legacy work packages that carry retired
+  frontmatter fields, instead of skipping them (mission
+  `first-sync-preflight-01KZZ9Q1` FR-011; `#3406`).** The import scan read WP
+  frontmatter with the strict authoring model (`extra="forbid"`), so a
+  historical WP carrying a field the current schema no longer knows (e.g.
+  `estimated_lines`) raised a validation error, was logged "unreadable", and was
+  degraded to a bare back-fill — losing its real title and dependencies. The
+  import path now uses a lenient reader that drops unrecognised legacy keys
+  while still validating known fields, so genuinely-malformed frontmatter is
+  still skipped fail-loud. Authoring keeps the strict typo guard unchanged.
+
 - **Mission `create` and `next` now run correctly from a caller-owned linked
   git worktree, and each worktree's mission state stays isolated (mission
   `worktree-owned-root-3328-01KZRG01`; `#3346`, closes `#3328`).** Before,

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -136,6 +136,7 @@ from .wp_metadata import (
     WPMetadata,
     _Builder,
     read_authored_wp_frontmatter,
+    read_authored_wp_frontmatter_lenient,
     read_wp_frontmatter,
 )
 from .wp_status_metadata import (
@@ -355,6 +356,7 @@ __all__ = [
     "read_event_stream",
     "read_event_stream_from_text",
     "read_authored_wp_frontmatter",
+    "read_authored_wp_frontmatter_lenient",
     "CoordAuthorityUnavailable",
     "EventLogMergeError",
     "FeatureStatusLockTimeoutError",

--- a/src/specify_cli/status/wp_metadata.py
+++ b/src/specify_cli/status/wp_metadata.py
@@ -12,6 +12,7 @@ before it can be used.
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Any, ClassVar
@@ -19,6 +20,8 @@ from typing import Any, ClassVar
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from specify_cli.status.models import NON_DISPLAY_LANES, AgentAssignment, Lane
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_agent_fallback(
@@ -640,6 +643,44 @@ def read_authored_wp_frontmatter(path: Path) -> tuple[WPMetadata, str]:
     return WPMetadata.model_validate(frontmatter_dict, strict=False), body
 
 
+def read_authored_wp_frontmatter_lenient(path: Path) -> tuple[WPMetadata, str]:
+    """Load WP frontmatter tolerating legacy/unknown fields (historical import).
+
+    The strict :class:`WPMetadata` uses ``extra="forbid"``, so any frontmatter
+    key the current schema does not know raises a ``ValidationError``. That is
+    the right behaviour when *authoring* a WP -- it catches typos and schema
+    drift the moment they are written -- but the wrong behaviour when *importing
+    a historical mission*, whose WP files legitimately carry retired fields
+    (e.g. ``estimated_lines``). Rejecting the whole WP there loses its real
+    title, dependencies, and path, degrading a rich WP to a bare back-fill.
+
+    This reader drops unrecognised top-level keys before validation so every
+    field the current schema still understands is preserved. It does **not**
+    relax validation of known fields: genuinely malformed frontmatter (bad YAML,
+    non-dict, an invalid value for a known field) still raises, so the import
+    scan's fail-loud skip path is unchanged for real corruption. Use it only on
+    the historical-import path -- never for authoring, where ``extra="forbid"``
+    is the intended typo guard.
+
+    FR-011 of the first-sync preflight mission (#3406).
+    """
+    from specify_cli.frontmatter import FrontmatterManager
+
+    frontmatter_dict, body = FrontmatterManager().read(path)
+    if isinstance(frontmatter_dict, dict):
+        known = set(WPMetadata.model_fields)
+        dropped = sorted(key for key in frontmatter_dict if key not in known)
+        if dropped:
+            logger.debug(
+                "wp_metadata: ignoring %d unrecognised legacy field(s) in %s: %s",
+                len(dropped),
+                path,
+                ", ".join(dropped),
+            )
+            frontmatter_dict = {key: value for key, value in frontmatter_dict.items() if key in known}
+    return WPMetadata.model_validate(frontmatter_dict, strict=False), body
+
+
 def read_wp_frontmatter(path: Path) -> tuple[WPMetadata, str]:
     """Load and validate WP frontmatter.
 
@@ -667,4 +708,9 @@ def read_wp_frontmatter(path: Path) -> tuple[WPMetadata, str]:
     return metadata, body
 
 
-__all__ = ["WPMetadata", "read_authored_wp_frontmatter", "read_wp_frontmatter"]
+__all__ = [
+    "WPMetadata",
+    "read_authored_wp_frontmatter",
+    "read_authored_wp_frontmatter_lenient",
+    "read_wp_frontmatter",
+]

--- a/src/specify_cli/sync/history_import/scan.py
+++ b/src/specify_cli/sync/history_import/scan.py
@@ -43,7 +43,7 @@ from specify_cli.status import (
     StatusEvent,
     StoreError,
     mission_event_log_path,
-    read_authored_wp_frontmatter,
+    read_authored_wp_frontmatter_lenient,
     read_events,
     read_lifecycle_events,
 )
@@ -267,7 +267,12 @@ def _wps_from_task_files(mission_dir: Path) -> tuple[tuple[ScannedWorkPackage, .
     skipped: list[str] = []
     for wp_file in sorted(tasks_dir.glob("WP*.md")):
         try:
-            metadata, _ = read_authored_wp_frontmatter(wp_file)
+            # Historical import tolerates retired frontmatter fields (FR-011,
+            # #3406): a legacy WP carrying e.g. `estimated_lines` must import as
+            # a real WP, not degrade to a bare back-fill. The lenient reader
+            # drops unknown keys but still raises on genuinely-malformed docs, so
+            # the fail-loud skip below is unchanged for real corruption.
+            metadata, _ = read_authored_wp_frontmatter_lenient(wp_file)
         except (FrontmatterError, ValidationError, ValueError, TypeError, KeyError, OSError) as exc:
             # A malformed WP doc (bad YAML, non-dict frontmatter, invalid schema)
             # must never abort the whole scan. The catch is broadened past the

--- a/tests/specify_cli/status/test_wp_metadata.py
+++ b/tests/specify_cli/status/test_wp_metadata.py
@@ -308,6 +308,61 @@ class TestWPMetadataExtraFields:
         assert meta.agent_profile == "python-implementer"
 
 
+class TestLenientReaderToleratesLegacyFields:
+    """FR-011 (#3406): historical import must tolerate retired frontmatter keys.
+
+    The strict authoring reader rejects unknown fields (typo guard); the lenient
+    reader used by the import path drops them but still validates known fields.
+    """
+
+    _LEGACY_WP = (
+        "---\n"
+        "work_package_id: WP07\n"
+        "title: Legacy Work Package\n"
+        "dependencies: [WP06]\n"
+        "estimated_lines: 240\n"  # retired field, not on the current schema
+        "some_other_dead_key: whatever\n"
+        "---\n\nBody\n"
+    )
+
+    def test_strict_reader_rejects_legacy_field(self, tmp_path: Path) -> None:
+        from specify_cli.status.wp_metadata import read_authored_wp_frontmatter
+
+        wp_file = tmp_path / "WP07-legacy.md"
+        wp_file.write_text(self._LEGACY_WP, encoding="utf-8")
+        with pytest.raises(ValidationError, match="extra_forbidden"):
+            read_authored_wp_frontmatter(wp_file)
+
+    def test_lenient_reader_drops_legacy_field_and_preserves_known(self, tmp_path: Path) -> None:
+        from specify_cli.status.wp_metadata import read_authored_wp_frontmatter_lenient
+
+        wp_file = tmp_path / "WP07-legacy.md"
+        wp_file.write_text(self._LEGACY_WP, encoding="utf-8")
+
+        meta, body = read_authored_wp_frontmatter_lenient(wp_file)
+
+        assert meta.work_package_id == "WP07"
+        assert meta.display_title == "Legacy Work Package"
+        assert meta.dependencies == ["WP06"]
+        assert body.strip() == "Body"
+        # The dropped key does not become an attribute (frozen model, extra keys gone).
+        assert not hasattr(meta, "estimated_lines")
+
+    def test_lenient_reader_still_raises_on_invalid_known_field(self, tmp_path: Path) -> None:
+        """Tolerance covers unknown keys only -- a bad value for a known field
+        (here an id that violates the WP## pattern) still fails loudly, so the
+        import scan's malformed-skip path is unchanged for real corruption."""
+        from specify_cli.status.wp_metadata import read_authored_wp_frontmatter_lenient
+
+        wp_file = tmp_path / "WPbad.md"
+        wp_file.write_text(
+            "---\nwork_package_id: not-a-wp-id\ntitle: T\nestimated_lines: 5\n---\n\nBody\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValidationError):
+            read_authored_wp_frontmatter_lenient(wp_file)
+
+
 class TestWPMetadataDisplayTitle:
     """display_title property: safe title with fallback to work_package_id."""
 

--- a/tests/sync/test_history_import_scan.py
+++ b/tests/sync/test_history_import_scan.py
@@ -505,6 +505,40 @@ def test_malformed_wp_frontmatter_is_skipped_not_fatal(tmp_path):
     assert [wp.wp_id for wp in scan.work_packages] == ["WP02"]
 
 
+def test_legacy_wp_with_retired_frontmatter_field_imports_not_skipped(tmp_path):
+    """A WP carrying a retired frontmatter field (e.g. `estimated_lines`) must
+    import as a real synthesized WP — with its true title and dependencies —
+    not get rejected by `extra="forbid"` and degraded to a bare back-fill.
+
+    Regression for FR-011 (#3406): historical missions legitimately carry fields
+    the current schema no longer knows; the strict authoring reader rejected the
+    whole WP, so the import lost its title/deps. The lenient import reader drops
+    the unknown key while preserving everything the schema still understands.
+    """
+    mission_dir = tmp_path / "synthetic-legacy-fields-01IIII"
+    tasks = mission_dir / "tasks"
+    tasks.mkdir(parents=True)
+    (tasks / "WP01-legacy.md").write_text(
+        "---\n"
+        "work_package_id: WP01\n"
+        "title: Legacy WP With Retired Fields\n"
+        "dependencies: []\n"
+        "estimated_lines: 240\n"  # retired field — must not sink the WP
+        "some_other_dead_key: whatever\n"
+        "---\nbody\n",
+        encoding="utf-8",
+    )
+
+    scan = scan_mission(mission_dir)  # must not raise
+
+    # Not skipped, not back-filled — imported as a real synthesized WP.
+    assert scan.skipped_wp_files == ()
+    by_id = {wp.wp_id: wp for wp in scan.work_packages}
+    assert "WP01" in by_id
+    assert by_id["WP01"].wp_title == "Legacy WP With Retired Fields"
+    assert by_id["WP01"].source is PrefixSource.SYNTHESIZED
+
+
 def test_malformed_wp_referenced_by_a_lane_transition_is_backfilled_no_orphan(tmp_path):
     """A WP whose task file is malformed (skipped) but which a lane transition
     references must still get a WPCreated via coverage backfill — the exact spot


### PR DESCRIPTION
## What

`sync import-history` skipped legacy work packages whose frontmatter carried a field the current schema no longer knows.

The import scan read WP frontmatter via `read_authored_wp_frontmatter`, which validates against the strict `WPMetadata` model (`extra="forbid"`). A historical WP carrying a retired field — e.g. `estimated_lines` — raised a `ValidationError`, was caught as "unreadable", logged, skipped, and only minimally back-filled by `_ensure_wp_coverage`. The imported WP lost its real title, dependencies, and path.

Strict `extra="forbid"` is correct for **authoring** (it catches typos and schema drift the moment they're written) but wrong for **importing history**, whose files legitimately predate the current schema.

## Change

- Add `read_authored_wp_frontmatter_lenient()` in `status/wp_metadata.py`: drops unrecognised top-level keys before validation (debug-logging what it dropped), while still validating every *known* field. Genuinely-malformed frontmatter (bad YAML, non-dict, invalid value for a known field) still raises.
- Re-export it through the `specify_cli.status` package facade (the status-module-boundary gate).
- Route only the history-import scan (`history_import/scan.py`) through the lenient reader. Authoring paths keep `extra="forbid"` unchanged.

## Test

- `tests/specify_cli/status/test_wp_metadata.py::TestLenientReaderToleratesLegacyFields` — strict reader rejects `estimated_lines`; lenient reader drops it and preserves `work_package_id`/title/dependencies; lenient reader still raises on an invalid **known** field (bad `work_package_id`).
- `tests/sync/test_history_import_scan.py::test_legacy_wp_with_retired_frontmatter_field_imports_not_skipped` — a WP with `estimated_lines` imports as a real `SYNTHESIZED` WP carrying its true title, not skipped, not back-filled.

5 new assertions green; existing malformed-skip test still green; `ruff` + `mypy` clean on the changed modules.

## Context

FR-011 of the first-sync preflight mission (`#3406`, spec `first-sync-preflight-01KZZ9Q1`) — one of the nine first-sync gates. Independent of the other #3406 PRs (#3408/#3409/#3411/#3414); touches the import scan + WP-metadata reader only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789280737&installation_model_id=427282&pr_number=3415&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3415&signature=fcca80cb887d2f6370d329b59b832da3ea98af79383632dbadc6fb5458879c6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->