### PR TITLE
docs(architecture): accord mission-gates status note with ADR-1 (Accepted) vs the Proposed gate ADRs

### DIFF
--- a/docs/architecture/mission-gates.md
+++ b/docs/architecture/mission-gates.md
@@ -16,9 +16,14 @@ related:
 ---
 # Mission transition gates — declarative, asset-backed, trust-gated
 
-> **Status: design (Proposed).** This page describes the intended model captured across
-> ADRs 2026-08-13-2 … -5. It is being hardened before implementation; treat it as the design
-> of record, not a description of shipped behaviour.
+> **Status: the gate mechanism is design (Proposed); the structural decision it builds on is
+> Accepted.** The declarative gate-mechanism ADRs ([2026-08-13-2](../adr/3.x/2026-08-13-2-gates-are-declarative-asset-backed-doctrine-artefacts.md)
+> … [-6](../adr/3.x/2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md))
+> are **Proposed** — this page is the design of record for them, hardened before implementation, not
+> a description of shipped behaviour. The structural decision underneath it — the built-in mission
+> subtree stays nested and the legacy `MissionStepContract` surface is retired
+> ([ADR 2026-08-13-1](../adr/3.x/2026-08-13-1-built-in-mission-subtree-stays-nested-retire-legacy-step-contracts.md))
+> — is **Accepted**.
 
 A **transition gate** is a deterministic check that runs when a work package crosses a lane
 edge (e.g. `in_progress → for_review`) and returns a pass/fail verdict that can block the


### PR DESCRIPTION
## What

A small docs-only correction to `docs/architecture/mission-gates.md`. The page's status note blanket-labeled the whole design **"Proposed"** and cited "ADRs 2026-08-13-2 … -5". That was inaccurate on two counts:

- **ADR `2026-08-13-1` is `Accepted`** (`status: Accepted` on disk) — the built-in mission subtree stays nested and the legacy `MissionStepContract` surface is retired. It is the *structural decision the gate mechanism builds on*, and the note omitted it entirely.
- The gate-mechanism ADRs run **-2 … -6**, not -5 — ADR-6 (gate outcomes carry severity; operator strategy decides effect) was left out of the cited range.

## Change

One status blockquote reworded to separate:
- the **Proposed** gate mechanism (ADRs -2 … -6), and
- the **Accepted** structural decision underneath it (ADR -1),

with both linked inline. No other content touched.

## Scope / safety

- **Docs-only**, no behaviour change.
- **No frontmatter / `description` change** → no retrieval-index or description-length-gate impact.
- Internal ADR link targets verified to exist.
- No CHANGELOG entry (no shipped behaviour change).

Surfaced during the #3378 design-to-tickets triage pass, which also filed the gate-implementation issues #3416–#3422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8yE9Cvx8sjWyZT32XiwcH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789286280&installation_model_id=427282&pr_number=3423&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3423&signature=22b528e2cce76f5505f2354a0881f5993133979028f682d41bd6c2560d4440a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->