### PR TITLE
fix(bulk-edit): coerce set_change_mode feature_dir str→Path (#3436)

### DIFF
--- a/src/doctrine/skills/spec-kitty-bulk-edit-classification/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-bulk-edit-classification/SKILL.md
@@ -96,8 +96,8 @@ negative is the silent-breakage class of bugs #393 was created to prevent.
    Or via shell after `mission create`:
 
    ```bash
-   python -c "from specify_cli.mission_metadata import set_change_mode; \
-              set_change_mode('<feature_dir>', 'bulk_edit')"
+   python -c "from pathlib import Path; from specify_cli.mission_metadata import set_change_mode; \
+              set_change_mode(Path('<feature_dir>'), 'bulk_edit')"
    ```
 
 3. **Name the target in the spec.** In `spec.md`, state explicitly what's

--- a/src/specify_cli/mission_metadata.py
+++ b/src/specify_cli/mission_metadata.py
@@ -729,12 +729,17 @@ def set_purpose_summary(
 
 
 def set_change_mode(
-    feature_dir: Path,
+    feature_dir: str | Path,
     mode: str,
 ) -> dict[str, Any]:
     """Set ``change_mode`` field.
 
     Validates *mode* is in :data:`VALID_CHANGE_MODES` before writing.
+
+    *feature_dir* accepts a :class:`~pathlib.Path` or a plain ``str``; the
+    latter is coerced to ``Path`` so a caller (e.g. the documented shell
+    one-liner in the bulk-edit classification skill) that passes a bare string
+    does not trip a ``TypeError`` deep inside the path-joining reader (#3436).
 
     Raises:
         ValueError: If *mode* is not a recognized change mode.
@@ -744,6 +749,7 @@ def set_change_mode(
         raise ValueError(
             f"Invalid change_mode {mode!r}; valid values: {sorted(VALID_CHANGE_MODES)}"
         )
+    feature_dir = Path(feature_dir)
     meta = _require_meta(feature_dir)
 
     meta["change_mode"] = mode

--- a/tests/specify_cli/test_mission_metadata_change_mode.py
+++ b/tests/specify_cli/test_mission_metadata_change_mode.py
@@ -77,6 +77,31 @@ def test_set_change_mode_bulk_edit(tmp_path):
     assert reloaded["change_mode"] == "bulk_edit"
 
 
+def test_set_change_mode_accepts_str_path(tmp_path):
+    """A bare ``str`` feature_dir is coerced to Path and behaves identically
+    to a Path argument (regression for #3436 -- the documented shell one-liner
+    passes a string and must not raise ``TypeError``)."""
+    _write_minimal_meta(tmp_path)
+    result = set_change_mode(str(tmp_path), "bulk_edit")
+    assert result["change_mode"] == "bulk_edit"
+    # Round-trip: reload from disk to confirm the write actually landed.
+    reloaded = load_meta(tmp_path)
+    assert reloaded["change_mode"] == "bulk_edit"
+
+
+def test_set_change_mode_str_and_path_equivalent(tmp_path):
+    """str and Path inputs produce identical results."""
+    path_dir = tmp_path / "as_path"
+    str_dir = tmp_path / "as_str"
+    _write_minimal_meta(path_dir)
+    _write_minimal_meta(str_dir)
+
+    via_path = set_change_mode(path_dir, "bulk_edit")
+    via_str = set_change_mode(str(str_dir), "bulk_edit")
+
+    assert via_path["change_mode"] == via_str["change_mode"] == "bulk_edit"
+
+
 def test_set_change_mode_invalid_raises(tmp_path):
     _write_minimal_meta(tmp_path)
     with pytest.raises(ValueError, match="Invalid change_mode"):


### PR DESCRIPTION
## Problem

Fixes #3436.

The bulk-edit classification skill (`src/doctrine/skills/spec-kitty-bulk-edit-classification/SKILL.md`, ~line 100) documents a shell one-liner that calls `set_change_mode('<feature_dir>', 'bulk_edit')` with a **bare string**. `set_change_mode(feature_dir: Path, …)` path-joins its argument — `feature_dir / "meta.json"` in both `_require_meta` (via `load_meta_fail_closed`) and `write_meta` — so a `str` argument raises:

```
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

An agent copying the snippet verbatim hits the error and may abandon the bulk-edit **occurrence-classification gate** entirely — the exact governance guardrail this snippet exists to switch on. (Operator raised this P2→P1 for that reason.)

## Fix — chose coercion (the stronger, recurrence-proof option)

The triage note offered two directions: (a) wrap the doc arg in `Path(...)`, or (b) make the helper coerce `str`→`Path`. I took **(b)** because it prevents recurrence for *every* caller/copy of the snippet, not just the one documented line — and it's clean and low-risk (`Path(Path(...))` is idempotent, one reassignment at the top so both downstream path-joins get a real `Path`). Per the issue's guidance I **also** fixed the doc snippet to model best practice.

- `set_change_mode` now accepts `str | Path` and coerces to `Path` once at the top.
- SKILL.md shell snippet now reads `set_change_mode(Path('<feature_dir>'), 'bulk_edit')`.

Only one SOURCE skill file contained the broken snippet; agent copies under `.claude/`, `.agents/skills/` etc. are generated and were left untouched (they regenerate from the source via `spec-kitty upgrade`).

## Tests

Added two focused regression tests in `tests/specify_cli/test_mission_metadata_change_mode.py`:
- `test_set_change_mode_accepts_str_path` — a bare `str` feature_dir no longer raises and the write round-trips.
- `test_set_change_mode_str_and_path_equivalent` — `str` and `Path` inputs produce identical results.

(The str-path test caught a real gap during development: an early inline coercion left `write_meta` receiving the raw string — the reassignment-at-top form fixes both call sites.)

## Verification

- `pytest tests/specify_cli/test_mission_metadata_change_mode.py` — 11 passed
- `ruff check` on both changed files — All checks passed
- `mypy src/specify_cli/mission_metadata.py` — Success, no issues
- `pytest tests/architectural/test_no_legacy_terminology.py` (doctrine prose touched) — 10 passed

No `__init__.py` change, so no version bump. No Sonar UI follow-up expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789362743&installation_model_id=427282&pr_number=3442&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3442&signature=943d52e86dd91f07c8ab358627d950edbda5dfd1c132c2008cc2e1177cef6e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->