### PR TITLE
fix(#3307 P0): emit review-rejection edges force=True to conform to shared events contract

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -108,6 +108,24 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **Review rejections now reach the hosted dashboard instead of being silently
+  dropped by sync (`#3307` P0; `#3444`).** Before, when a reviewer sent a work
+  package back for rework — any backward review-rejection move (`* → planned`,
+  or `in_review → in_progress`) — the CLI stamped the status event `force=False`
+  and, for `in_review → in_progress`, left off the `review_ref`. Those events
+  were accepted on your machine but violated the shared `spec-kitty-events` wire
+  contract the hosted ingestion endpoint enforces, so hosted sync silently
+  rejected them: a rejection that looked applied locally never propagated to the
+  team dashboard (in the reported case a whole batch surfaced 11+ days later as
+  bulk sync failures). Root cause was two same-named `validate_transition`
+  functions giving opposite answers — the emit path consulted only the
+  CLI-local state machine, never the wire contract the server enforces. The
+  emit-force decision now gates on **both**, so the review-rejection family
+  emits `force=True` (still carrying the structured rewind rationale) and threads
+  the `review_ref` on the wire, producing events the project's own vendored
+  contract accepts. Reviewers are now told — at the `move-task` tool surface and
+  in the review skills — that a rejection rationale (`--review-feedback-file` or
+  `--note`) is mandatory, because it travels on the wire as that `review_ref`.
 - **Coordination-topology missions no longer wedge lane allocation by
   committing PRIMARY planning artifacts onto the coordination branch (mission
   `write-path-integrity-01KZZD69`; `#3371` P0, `#2549`, `#3128`, `#3373`;

--- a/src/doctrine/skills/spec-kitty-implement-review/references/rejection-loop-checklist.md
+++ b/src/doctrine/skills/spec-kitty-implement-review/references/rejection-loop-checklist.md
@@ -4,6 +4,7 @@ Operational checklist for handling review rejections and re-implementation cycle
 
 ## On Rejection (WP moved to planned with has_feedback)
 
+- [ ] Reviewer attached a **rationale** to the rejection — a `--review-feedback-file <path>` (or `--note`). This is MANDATORY: it is recorded as the transition's `review_ref` / reason and travels on the event wire. A backward review-rejection edge (`* -> planned`, `in_review -> in_progress`) emitted WITHOUT a rationale is a contract-invalid status event — accepted locally but silently rejected by hosted sync, so the rejection never propagates.
 - [ ] Confirmed WP lane is `planned` with `review_status: has_feedback`
 - [ ] Committed status change from main: `git add kitty-specs/ && git commit -m "chore: Review feedback for WP## from <reviewer> (cycle X/3)"`
 - [ ] Noted current cycle count (1, 2, or 3)
@@ -17,7 +18,7 @@ Operational checklist for handling review rejections and re-implementation cycle
 
 ## Re-Implementation Agent Checklist
 
-- [ ] Read review feedback section in WP file FIRST
+- [ ] Read the review feedback the rejection pointed at FIRST — the referenced feedback file (the rejection's `review_ref`) and the review feedback section in the WP file
 - [ ] Updated `review_status: "acknowledged"` in frontmatter
 - [ ] Addressed EVERY feedback item (treat as mandatory TODOs)
 - [ ] Added regression tests for each issue

--- a/src/doctrine/skills/spec-kitty-runtime-review/SKILL.md
+++ b/src/doctrine/skills/spec-kitty-runtime-review/SKILL.md
@@ -117,6 +117,17 @@ spec-kitty agent tasks move-task WP## --to planned --force \
 
 Every blocking finding must map to a specific, verifiable remediation action.
 
+> **The feedback reference is mandatory, not optional.** A rejection moves the WP
+> along a backward "review-rejection" edge, and the status contract requires that
+> edge to carry a **rationale**: the `--review-feedback-file` (or `--note`) you
+> pass is recorded as the transition's `review_ref` / reason and travels on the
+> event wire. Rejecting a WP to `planned`/`in_progress` **without** a feedback
+> reference or note produces a contract-invalid status event that is accepted
+> locally but silently rejected by hosted sync — so the rejection never
+> propagates. Always attach the feedback file (or a `--note`) when you reject or
+> send a WP back for rework. The rework agent reads exactly that referenced
+> feedback to know what to fix.
+
 ---
 
 ## Step 5: Check Downstream Impact

--- a/src/specify_cli/_completion_manifest.json
+++ b/src/specify_cli/_completion_manifest.json
@@ -133,7 +133,7 @@
      "deprecated": false,
      "commands": {
       "move-task": {
-       "help": "Move task between lanes (planned → doing → for_review → approved → done).\n\nExamples:\n    spec-kitty agent tasks move-task WP01 --to doing --assignee claude --json\n    spec-kitty agent tasks move-task WP02 --to for_review --agent claude --shell-pid $$\n    spec-kitty agent tasks move-task WP03 --to approved --note \"Review passed\"\n    spec-kitty agent tasks move-task WP03 --to done --done-override-reason \"Branch deleted after hotfix merge\"\n    spec-kitty agent tasks move-task WP03 --to planned --review-feedback-file feedback.md",
+       "help": "Move task between lanes (planned → doing → for_review → approved → done).\n\nReview-rejection edges (a backward move out of review — ``--to planned`` from\nin_progress/for_review/in_review/approved, or ``in_review → in_progress``) MUST\ncarry a rationale: pass ``--review-feedback-file`` (or ``--note``). That\nrationale is emitted as the status event's ``review_ref``/reason and is\nrequired by the shared status contract; a rejection emitted without it is\naccepted locally but silently rejected by hosted sync, so it never propagates.\n\nExamples:\n    spec-kitty agent tasks move-task WP01 --to doing --assignee claude --json\n    spec-kitty agent tasks move-task WP02 --to for_review --agent claude --shell-pid $$\n    spec-kitty agent tasks move-task WP03 --to approved --note \"Review passed\"\n    spec-kitty agent tasks move-task WP03 --to done --done-override-reason \"Branch deleted after hotfix merge\"\n    spec-kitty agent tasks move-task WP03 --to planned --review-feedback-file feedback.md",
        "hidden": false,
        "deprecated": false
       },

--- a/src/specify_cli/cli/commands/agent/tasks.py
+++ b/src/specify_cli/cli/commands/agent/tasks.py
@@ -642,7 +642,16 @@ def move_task(
     shell_pid: Annotated[str | None, typer.Option("--shell-pid", help="Shell PID")] = None,
     note: Annotated[str | None, typer.Option("--note", help="History note")] = None,
     review_feedback_file: Annotated[
-        Path | None, typer.Option("--review-feedback-file", help="Path to review feedback file (required for --to planned, including with --force)")
+        Path | None,
+        typer.Option(
+            "--review-feedback-file",
+            help=(
+                "Path to review feedback file. Required for review-rejection edges "
+                "(--to planned, incl. with --force; and in_review->in_progress). "
+                "Recorded as the transition's on-wire review_ref rationale; omitting "
+                "it makes the status event contract-invalid and hosted sync drops it."
+            ),
+        ),
     ] = None,
     approval_ref: Annotated[str | None, typer.Option("--approval-ref", help="Approval reference for approval/done transitions (e.g., PR#42)")] = None,
     reviewer: Annotated[str | None, typer.Option("--reviewer", help="Reviewer name (auto-detected from git if omitted)")] = None,
@@ -701,6 +710,13 @@ def move_task(
     ] = False,
 ) -> None:
     """Move task between lanes (planned → doing → for_review → approved → done).
+
+    Review-rejection edges (a backward move out of review — ``--to planned`` from
+    in_progress/for_review/in_review/approved, or ``in_review → in_progress``) MUST
+    carry a rationale: pass ``--review-feedback-file`` (or ``--note``). That
+    rationale is emitted as the status event's ``review_ref``/reason and is
+    required by the shared status contract; a rejection emitted without it is
+    accepted locally but silently rejected by hosted sync, so it never propagates.
 
     Examples:
         spec-kitty agent tasks move-task WP01 --to doing --assignee claude --json

--- a/src/specify_cli/cli/commands/agent/tasks_transition_core.py
+++ b/src/specify_cli/cli/commands/agent/tasks_transition_core.py
@@ -194,6 +194,47 @@ TransitionOutcome = Emit | RefuseExit1
 # ---------------------------------------------------------------------------
 
 
+def _wire_contract_allows_force_free(
+    old_lane: str,
+    new_lane: str,
+    reason: str | None,
+    review_ref: str | None,
+) -> bool:
+    """Ask the SHARED ``spec-kitty-events`` contract whether this backward edge
+    is legal *without* ``force`` (#3307).
+
+    The emit decision must be governed by the wire contract the SaaS ingestion
+    endpoint enforces — not only the CLI-local FSM. The two historically gave
+    opposite answers for the review-rejection family (``*-> planned`` and
+    ``in_review -> in_progress``): the local FSM accepted them force-free given
+    plan-layer evidence, while the shared package declares them
+    ``force=True``-required, so contract-invalid ``force=False`` events were
+    emitted and queued silently, only to be rejected 11+ days later at sync.
+
+    Fail-closed: if the candidate cannot even be represented as a force-free
+    wire payload, treat the edge as force-required.
+    """
+    from spec_kitty_events import validate_transition as _wire_validate
+    from spec_kitty_events.status import StatusTransitionPayload
+
+    try:
+        candidate = StatusTransitionPayload(
+            mission_slug="_wire_probe",
+            wp_id="_wire_probe",
+            from_lane=old_lane,
+            to_lane=new_lane,
+            actor="cli",
+            force=False,
+            reason=reason,
+            execution_mode="direct_repo",
+            review_ref=review_ref,
+            evidence=None,
+        )
+    except (ValueError, TypeError):
+        return False
+    return bool(_wire_validate(candidate).valid)
+
+
 def build_transition_plan(
     *,
     old_lane: str,
@@ -212,21 +253,28 @@ def build_transition_plan(
     planned-rollback / arbiter side effects (they are ``None`` on the happy path).
 
     FR-015 (force provenance): a backward edge is NOT blindly auto-promoted to
-    ``emit_force=True`` anymore. Instead we **ask the FSM** whether the edge is
-    legal *force-free* given the evidence we actually carry at the plan layer
-    (``reason`` / ``review_ref``, plus ``review_result`` when the caller supplies
-    it) and only promote ``emit_force`` when the FSM genuinely rejects it. This is
-    edge-agnostic — there is deliberately **no hard-coded edge list** (it would rot
-    if the transition matrix changes; ``contracts/emit-force.md``).
+    ``emit_force=True``. We ask the FSM whether the edge is legal *force-free*
+    given the plan-layer evidence (``reason`` / ``review_ref``, plus
+    ``review_result`` when the caller supplies it). This is edge-agnostic — there
+    is deliberately **no hard-coded edge list** (it would rot if the transition
+    matrix changes; ``contracts/emit-force.md``).
+
+    #3307: the FSM verdict alone is NOT sufficient to stay force-free. The wire
+    event we emit is consumed by the SaaS ingestion endpoint, which enforces the
+    **shared** ``spec-kitty-events`` contract — and that contract declares the
+    review-rejection family (``in_progress|for_review|in_review|approved ->
+    planned`` and ``in_review -> in_progress``) ``force=True``-required
+    regardless of evidence. So we gate on BOTH: stay force-free only when the
+    internal FSM *and* the shared wire contract agree (see
+    :func:`_wire_contract_allows_force_free`); otherwise emit ``force=True`` with
+    the structured rewind rationale. This keeps the emitted event conformant with
+    the very package this project vendors, instead of producing ``force=False``
+    events its own dependency rejects.
 
     ``review_result`` is the seam WP06 threads its structured review outcome
-    (reviewer + verdict + reference) into for the two ``in_review -> *`` edges. In
-    the WP02 window it is always ``None``, so those two edges are FSM-rejected
-    force-free and honestly stay ``emit_force=True`` (WP02 supplies no valid
-    evidence for them); WP06 populates it and flips them force-free. The three
-    plan-reachable edges (``in_progress -> planned``, ``approved -> in_progress``,
-    ``approved -> planned``) resolve force-free here from the ``reason`` /
-    ``review_ref`` evidence WP02 already carries.
+    (reviewer + verdict + reference) into for the two ``in_review -> *`` edges; it
+    still feeds the internal FSM verdict, but the shared wire contract is now the
+    binding gate for the family's force flag.
     """
     canonical_lane = resolve_lane_alias(target_lane)
 
@@ -243,6 +291,18 @@ def build_transition_plan(
     # Arbiter override reuses the rejection's review_ref when no base ref applies.
     if arb_review_ref and emit_review_ref is None:
         emit_review_ref = arb_review_ref
+
+    # #3307: the shared wire contract requires a ``review_ref`` on the
+    # review-rollback edges out of ``for_review`` / ``in_review`` / ``approved``
+    # into ``in_progress`` / ``planned`` — and, for ``in_review -> in_progress``,
+    # ``force=True`` does NOT exempt it (that edge is outside the mandatory-force
+    # ``*-> planned`` family). When a structured ``review_result`` carries a
+    # reference, thread it onto the wire so the emitted event conforms instead of
+    # being rejected at sync for a missing ``review_ref``.
+    if emit_review_ref is None and review_result is not None:
+        review_result_ref = getattr(review_result, "reference", None)
+        if isinstance(review_result_ref, str) and review_result_ref.strip():
+            emit_review_ref = review_result_ref
 
     emit_reason: str | None = note_text if note_text else None
     if force and not emit_reason:
@@ -271,7 +331,16 @@ def build_transition_plan(
         legal_force_free, _ = validate_transition(
             old_lane, canonical_lane, ctx_with_evidence
         )
-        emit_force = not legal_force_free
+        # #3307: stay force-free ONLY when the internal FSM *and* the shared
+        # wire contract (the one the SaaS ingestion endpoint enforces) both
+        # accept the edge force-free. When the wire contract requires force —
+        # the review-rejection family does — emit ``force=True`` and carry the
+        # structured rewind rationale below, rather than silently emitting a
+        # contract-invalid ``force=False`` event.
+        wire_allows_force_free = _wire_contract_allows_force_free(
+            old_lane, canonical_lane, emit_reason, emit_review_ref
+        )
+        emit_force = not (legal_force_free and wire_allows_force_free)
         original_reason = (
             None
             if emit_reason is None or emit_reason.startswith("move-task: ")

--- a/src/specify_cli/cli/commands/agent/tasks_transition_core.py
+++ b/src/specify_cli/cli/commands/agent/tasks_transition_core.py
@@ -215,18 +215,18 @@ def _wire_contract_allows_force_free(
     wire payload, treat the edge as force-required.
     """
     from spec_kitty_events import validate_transition as _wire_validate
-    from spec_kitty_events.status import StatusTransitionPayload
+    from spec_kitty_events.status import ExecutionMode, Lane, StatusTransitionPayload
 
     try:
         candidate = StatusTransitionPayload(
             mission_slug="_wire_probe",
             wp_id="_wire_probe",
-            from_lane=old_lane,
-            to_lane=new_lane,
+            from_lane=Lane(old_lane),
+            to_lane=Lane(new_lane),
             actor="cli",
             force=False,
             reason=reason,
-            execution_mode="direct_repo",
+            execution_mode=ExecutionMode("direct_repo"),
             review_ref=review_ref,
             evidence=None,
         )

--- a/tests/integration/test_wp_file_hash_stability.py
+++ b/tests/integration/test_wp_file_hash_stability.py
@@ -265,11 +265,21 @@ def test_sc008_off_axis_emit_lands_at_stored_topology_from_foreign_cwd(
 
 
 # ---------------------------------------------------------------------------
-# Arm 3: SC-007 — the two in_review -> * edges are force-free
+# Arm 3: SC-007 — the in_review -> * rewind edges.
+#
+# #3307 re-point: `in_review -> planned` is a member of the shared
+# `spec-kitty-events` review-rejection family (`* -> planned`), which the wire
+# contract the SaaS ingestion endpoint enforces declares `force=True`-required
+# regardless of local evidence. FR-015/SC-007 formerly asserted it force-free
+# from the CLI-local FSM; emitting `force=False` produced contract-invalid events
+# hosted sync silently dropped, so the emit path now gates on both validators and
+# persists `force=True` (the structured rewind rationale still travels on the
+# wire). `in_review -> in_progress` is NOT in the mandatory-force family and stays
+# force-free (below).
 # ---------------------------------------------------------------------------
 
 
-def test_sc007_in_review_to_planned_is_force_free(
+def test_sc007_in_review_to_planned_is_force_promoted_by_wire_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo, feature_dir = _build_mission(
@@ -290,7 +300,8 @@ def test_sc007_in_review_to_planned_is_force_free(
     last = read_events(feature_dir)[-1]
     assert last.from_lane == Lane.IN_REVIEW
     assert last.to_lane == Lane.PLANNED
-    assert not last.force, "in_review -> planned persisted force=True (SC-007 violated)"
+    # #3307: review-rejection family edge — force=True per the shared wire contract.
+    assert last.force, "in_review -> planned must persist force=True (#3307 wire contract)"
 
 
 def test_sc007_in_review_to_in_progress_is_force_free(

--- a/tests/specify_cli/cli/commands/agent/fixtures/tasks_cli/help/move-task.help
+++ b/tests/specify_cli/cli/commands/agent/fixtures/tasks_cli/help/move-task.help
@@ -1,5 +1,11 @@
 Usage: tasks move-task [OPTIONS] TASK_ID
 Move task between lanes (planned → doing → for_review → approved → done).
+Review-rejection edges (a backward move out of review — ``--to planned`` from
+in_progress/for_review/in_review/approved, or ``in_review → in_progress``) MUST
+carry a rationale: pass ``--review-feedback-file`` (or ``--note``). That
+rationale is emitted as the status event's ``review_ref``/reason and is
+required by the shared status contract; a rejection emitted without it is
+accepted locally but silently rejected by hosted sync, so it never propagates.
 Examples:
 spec-kitty agent tasks move-task WP01 --to doing --assignee claude --json
 spec-kitty agent tasks move-task WP02 --to for_review --agent claude --shell-pid $$
@@ -18,7 +24,7 @@ Options
 --assignee TEXT Assignee name (sets assignee when moving to doing)
 --shell-pid TEXT Shell PID
 --note TEXT History note
---review-feedback-file PATH Path to review feedback file (required for --to planned, including with --force)
+--review-feedback-file PATH Path to review feedback file. Required for review-rejection edges (--to planned, incl. with --force; and in_review->in_progress). Recorded as the transition's on-wire review_ref rationale; omitting it makes the status event contract-invalid and hosted sync drops it.
 --approval-ref TEXT Approval reference for approval/done transitions (e.g., PR#42)
 --reviewer TEXT Reviewer name (auto-detected from git if omitted)
 --self-review-fallback Record that approval is a self-review fallback after the intended reviewer failed.

--- a/tests/specify_cli/cli/commands/agent/test_2684_force_provenance.py
+++ b/tests/specify_cli/cli/commands/agent/test_2684_force_provenance.py
@@ -111,20 +111,23 @@ def _persisted_force(feature_dir: Path, wp_id: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# WP02 slice: the two CLI-reachable evidence-gated edges persist force FALSY
+# #3307: the review-rejection family (`* -> planned`) force-promotes to conform
+# to the shared spec-kitty-events wire contract (the SaaS ingestion authority),
+# which declares these edges force=True-required regardless of local evidence.
+# Emitting force=False here produced contract-invalid events the SaaS silently
+# dropped at sync. The structured rewind rationale still travels on the wire.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "starting_lane, target",
     [
-        ("in_progress", "planned"),  # reason evidence
-        ("approved", "planned"),  # review_ref evidence
-        ("in_review", "planned"),  # WP06 threads review_result -> force-free
-        ("in_review", "in_progress"),  # WP06 threads review_result -> force-free
+        ("in_progress", "planned"),  # review-rejection family
+        ("approved", "planned"),  # review-rejection family
+        ("in_review", "planned"),  # review-rejection family
     ],
 )
-def test_evidence_gated_backward_edge_persists_force_free(
+def test_review_rejection_family_persists_force_true(
     tmp_path: Path, starting_lane: str, target: str
 ) -> None:
     mission_slug = f"prov-{starting_lane}-{target}"
@@ -149,9 +152,47 @@ def test_evidence_gated_backward_edge_persists_force_free(
     result = _invoke(tmp_path, mission_slug, args)
 
     assert result.exit_code == 0, f"move-task failed:\n{result.output}"
+    assert _persisted_force(feature_dir, wp_id) is True, (
+        f"{starting_lane} -> {target}: review-rejection family must persist "
+        f"force=True to conform to the shared spec-kitty-events wire contract"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #3307: `in_review -> in_progress` is NOT in the mandatory-force `* -> planned`
+# family, so the shared contract permits it force-free — but ONLY with a
+# `review_ref` (which WP06 threads from the structured review_result). It stays
+# force-free and carries that reference on the wire.
+# ---------------------------------------------------------------------------
+
+
+def test_in_review_to_in_progress_stays_force_free_with_review_ref(
+    tmp_path: Path,
+) -> None:
+    mission_slug = "prov-in_review-in_progress"
+    wp_id = "WP05"
+    feature_dir = _seed_wp_in_lane(
+        tmp_path, mission_slug=mission_slug, wp_id=wp_id, lane="in_review"
+    )
+
+    result = _invoke(
+        tmp_path,
+        mission_slug,
+        [
+            "move-task",
+            wp_id,
+            "--to",
+            "in_progress",
+            "--mission",
+            mission_slug,
+            "--no-auto-commit",
+        ],
+    )
+
+    assert result.exit_code == 0, f"move-task failed:\n{result.output}"
     assert _persisted_force(feature_dir, wp_id) is False, (
-        f"{starting_lane} -> {target}: persisted force must be falsy "
-        f"(evidence-gated force-free); got a false-force stamp"
+        "in_review -> in_progress is force-free-legal WITH a review_ref; "
+        "it must not be force-promoted"
     )
 
 

--- a/tests/specify_cli/cli/commands/agent/test_tasks_backward_emit.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_backward_emit.py
@@ -180,37 +180,29 @@ def _invoke_move(
 
 
 class TestReviewRejectionFamily:
-    """FR-015 provenance on the backward ``-> planned`` family (re-pointed).
+    """#3307 provenance on the backward ``-> planned`` family.
 
-    Only the emit-force expectation is re-pointed here (SC-007, delete-the-
-    assertion-not-the-test): the ``reason``/lane wire-shape assertions are
-    unchanged. Force provenance is now per-edge, decided by the FSM query:
-
-    * ``in_progress -> planned`` / ``approved -> planned`` — WP02's two
-      plan-reachable evidence-gated edges. With the ``--review-feedback-file``
-      evidence threaded (``reason`` / ``review_ref``) the FSM accepts them
-      force-free, so the persisted ``force`` is now ``False``.
-    * ``for_review -> planned`` — genuine force: ``for_review`` has NO backward
-      edge (rejection routes via ``in_review``), so the FSM rejects it force-free
-      and ``force`` stays truthfully ``True`` (positive control).
-    * ``in_review -> planned`` — WP10 closeout re-point: WP06 now threads the
-      structured ``review_result`` on its two owned ``in_review`` edges, so the
-      FSM accepts the evidence-gated rejection force-FREE and the persisted
-      ``force`` flips to ``False`` (the WP02-window truthful-force this row
-      formerly asserted is superseded).
+    Only the emit-force expectation is re-pointed here (delete-the-assertion-not-
+    the-test): the ``reason``/lane wire-shape assertions are unchanged. Every
+    ``* -> planned`` edge is a member of the shared ``spec-kitty-events``
+    review-rejection family (``in_progress|for_review|in_review|approved ->
+    planned``), which the wire contract the SaaS ingestion endpoint enforces
+    declares ``force=True``-required regardless of local evidence. The CLI-local
+    FSM would accept some of these force-free on ``reason`` / ``review_ref`` /
+    ``review_result`` evidence, but ``build_transition_plan`` now gates on BOTH
+    validators, so the persisted ``force`` is ``True`` for the whole family — no
+    contract-invalid ``force=False`` event the SaaS would silently drop. The
+    structured rewind rationale (and ``review_ref``, when present) still travels
+    on the wire.
     """
 
     @pytest.mark.parametrize(
         "starting_lane, expected_prefix, expected_force",
         [
-            # WP06 threads review_result on in_review -> planned -> force-free.
-            ("in_review", "backward rewind: in_review -> planned", False),
-            # Evidence-gated (review_ref) -> force-free after FR-015.
-            ("approved", "backward rewind: approved -> planned", False),
-            # Genuine force: for_review has no backward edge (structurally illegal).
+            ("in_review", "backward rewind: in_review -> planned", True),
+            ("approved", "backward rewind: approved -> planned", True),
             ("for_review", "backward rewind: for_review -> planned", True),
-            # Evidence-gated (reason) -> force-free after FR-015.
-            ("in_progress", "backward rewind: in_progress -> planned", False),
+            ("in_progress", "backward rewind: in_progress -> planned", True),
         ],
     )
     def test_backward_to_planned_force_provenance(
@@ -444,11 +436,10 @@ class TestBackwardEmitFeedbackRef:
         assert result.exit_code == 0, f"backward emit failed:\n{result.output}"
 
         emitted = _read_latest_events_for_wp(feature_dir, wp_id)[-1]
-        # WP10 closeout re-point: WP06 threads the structured review_result on the
-        # in_review -> planned edge, so the evidence-gated rejection is force-FREE.
-        # The canonical review-cycle URI segment (the assertion this test owns) is
-        # unchanged — only the force provenance flips.
-        assert emitted.force is False
+        # #3307: in_review -> planned is a review-rejection family edge, force=True
+        # per the shared wire contract. The canonical review-cycle URI segment (the
+        # assertion this test owns) is unchanged — only the force provenance is fixed.
+        assert emitted.force is True
         assert emitted.reason is not None
         # Prefix:
         prefix = "backward rewind: in_review -> planned"
@@ -498,8 +489,9 @@ class TestBackwardEmitFeedbackRef:
         assert result.exit_code == 0, f"backward emit with note failed:\n{result.output}"
 
         emitted = _read_latest_events_for_wp(feature_dir, wp_id)[-1]
-        # FR-015 re-point: approved -> planned is force-free with review_ref evidence.
-        assert emitted.force is False
+        # #3307: approved -> planned is a review-rejection family edge, force=True
+        # per the shared wire contract (the review_ref rationale still travels).
+        assert emitted.force is True
         assert emitted.reason is not None
         assert emitted.reason.startswith("backward rewind: approved -> planned")
         assert ": review-cycle://" in emitted.reason
@@ -583,11 +575,11 @@ class TestApprovedRewindWireShape:
 
         # CLI emit wire-shape invariants (independent of the upstream fixture).
         expected_prefix = "backward rewind: approved -> planned"
-        # FR-015 re-point: approved -> planned is now force-free with review_ref
-        # evidence. Mission 1's fixture still encodes the pre-fix force=True — that
-        # is the exact false-force provenance this mission corrects, so the force
-        # bit is deliberately NOT cross-checked against the (stale) fixture below.
-        assert emitted.force is False
+        # #3307: approved -> planned is a review-rejection family edge, force=True
+        # per the shared wire contract. Mission 1's fixture encodes force=True — the
+        # CLI now AGREES with it (FR-015 had wrongly diverged to force=False, which
+        # the SaaS silently rejected). The force bit is cross-checked below.
+        assert emitted.force is True
         assert str(emitted.from_lane) == "approved"
         assert str(emitted.to_lane) == "planned"
         assert emitted.reason is not None
@@ -611,10 +603,15 @@ class TestApprovedRewindWireShape:
         f_from = fp.get("from_lane", fp.get("data", {}).get("from_lane"))
         f_to = fp.get("to_lane", fp.get("data", {}).get("to_lane"))
         f_reason = fp.get("reason", fp.get("data", {}).get("reason"))
+        f_force = fp.get("force", fp.get("data", {}).get("force"))
 
-        # NB: the fixture's ``force`` bit is intentionally NOT cross-checked — it
-        # still carries the pre-FR-015 force=True value the mission corrects. The
+        # #3307: the CLI emit now conforms to the fixture's ``force`` bit. The
         # lane/reason wire shape (FR-009) remains normative and IS cross-checked.
+        if f_force is not None:
+            assert emitted.force == bool(f_force), (
+                f"CLI force must match fixture force; got emitted={emitted.force} "
+                f"fixture={f_force}"
+            )
         if f_from is not None:
             assert str(emitted.from_lane) == f_from == "approved"
         if f_to is not None:

--- a/tests/specify_cli/cli/commands/agent/test_tasks_transition_core.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_transition_core.py
@@ -733,9 +733,13 @@ def test_non_force_backward_without_evidence_stays_forced() -> None:
     assert plan.emit_reason.startswith("backward rewind: approved -> in_progress")
 
 
-def test_in_progress_to_planned_reason_evidence_is_force_free() -> None:
-    """FR-015: ``in_progress -> planned`` is force-free with a ``reason`` (the
-    always-synthesised rewind reason satisfies the FSM's reason-only guard)."""
+def test_in_progress_to_planned_is_force_promoted_for_wire_contract() -> None:
+    """#3307: ``in_progress -> planned`` is a review-rejection family edge that the
+    shared ``spec-kitty-events`` wire contract declares ``force=True``-required
+    regardless of evidence. The CLI-local FSM would accept it force-free on a
+    ``reason``, but ``build_transition_plan`` now gates on BOTH validators, so it
+    emits ``force=True`` with the structured rewind reason (never a contract-invalid
+    ``force=False`` event the SaaS would silently drop)."""
     plan = build_transition_plan(
         old_lane="in_progress",
         target_lane="planned",
@@ -744,14 +748,15 @@ def test_in_progress_to_planned_reason_evidence_is_force_free() -> None:
         arb_review_ref=None,
         note_text=None,
     )
-    assert plan.emit_force is False
+    assert plan.emit_force is True
     assert plan.transition_targets == ["planned"]
     assert plan.emit_reason is not None
     assert plan.emit_reason.startswith("backward rewind: in_progress -> planned")
 
 
-def test_approved_to_planned_review_ref_evidence_is_force_free() -> None:
-    """FR-015: ``approved -> planned`` is force-free with ``review_ref`` evidence
+def test_approved_to_planned_is_force_promoted_and_carries_review_ref() -> None:
+    """#3307: ``approved -> planned`` is force-promoted to conform to the shared
+    wire contract, and still carries the ``review_ref`` rationale on the wire
     (threaded via ``review_feedback_pointer`` on the planned-rollback path)."""
     plan = build_transition_plan(
         old_lane="approved",
@@ -761,7 +766,7 @@ def test_approved_to_planned_review_ref_evidence_is_force_free() -> None:
         arb_review_ref=None,
         note_text=None,
     )
-    assert plan.emit_force is False
+    assert plan.emit_force is True
     assert plan.transition_targets == ["planned"]
     assert plan.emit_review_ref == "feedback://WP01/review-cycle-1.md"
 


### PR DESCRIPTION
## What this fixes for you

When a reviewer sent a work package **back for rework**, the rejection looked
applied on your machine but **never reached the hosted team dashboard**. Every
backward review-rejection move — `* → planned`, or `in_review → in_progress` —
was accepted locally, then **silently dropped by hosted sync**. In the reported
case a whole batch surfaced 11+ days later as bulk sync failures, with the
dashboard showing WPs still sitting in review that had actually been rejected.

This closes **#3307 (P0)** so review rejections propagate to the dashboard like
every other status change.

## Root cause

Two independently-authored `validate_transition` functions with the same name
and **opposite answers**. `build_transition_plan` (the CLI emit path) asked only
the **CLI-local FSM**, which accepted these backward edges force-free given
plan-layer evidence. The **shared, vendored `spec-kitty-events` contract** — the
one the SaaS ingestion endpoint actually enforces — declares the whole
review-rejection family `force=True`-required (and requires a `review_ref` on
`in_review → in_progress`). So the CLI emitted `force=False` events its own
pinned dependency rejects, which queued silently and were only refused later at
sync time.

## The fix

- **Emit-force now gates on both validators** (`tasks_transition_core.py`). A
  backward edge stays force-free only when the CLI-local FSM **and** the shared
  wire contract agree; otherwise it emits `force=True` with the structured rewind
  rationale. Edge-agnostic — no hard-coded edge list. FSM internals untouched (no
  wide blast radius).
- **`review_ref` threaded on `in_review → in_progress`.** That edge isn't in the
  mandatory-force `* → planned` family, but the shared contract requires a
  `review_ref` for it, so the structured `review_result.reference` now travels on
  the wire.
- **Reviewer guidance made explicit** at the tool surface (`move-task
  --review-feedback-file` help + docstring) and in the review skills
  (`spec-kitty-runtime-review` SKILL, `rejection-loop-checklist`): a rejection
  rationale (`--review-feedback-file` / `--note`) is **mandatory** because it
  becomes the on-wire `review_ref`.

## Tests

- Red-first repro `tests/regression/test_issue_3307_*` (already on main as the
  committed P0 reproduction) is now **green** — it drives the real
  `build_transition_plan` and validates the wire payload against the real shared
  contract.
- FR-015 acceptance suite **reversed** to the conformant `force=True` (the old
  assertions encoded exactly the #3307 defect), restoring agreement with the
  events fixture `wp-status-changed-approved-rewind-valid`.
- `in_review → in_progress` stays force-free **with** a `review_ref` (positive
  control).

## Landing notes (maintainer folds)

Rebased onto current `upstream/main` (clean). Two single-purpose folds added
during the landing pass:

1. `fix(landing):` — the new wire-probe helper built its `StatusTransitionPayload`
   from plain `str` lane / execution-mode values, which `spec-kitty-events` types
   as its `Lane` / `ExecutionMode` enums; mypy flagged three `arg-type` errors and
   the `lint` job would have gone red. Wrapped in `Lane(...)` / `ExecutionMode(...)`
   — no behaviour change for valid lanes, and it strengthens the documented
   fail-closed path (an unrepresentable lane now raises `ValueError` at the
   `Lane(...)` call, caught by the existing `except`).
2. `docs(landing):` — `[Unreleased]` changelog entry for this user-facing fix.

Red-first proof re-run during landing: swapping in the pre-fix product file makes
all four review-rejection edges fail the shared contract with exactly the two
reported violations (`requires force=True`, `requires review_ref`); the fix greens
them. `ruff` + `mypy` + terminology guard + docs-freshness (errors=0) clean.

## Related

- Filed **Priivacy-ai/spec-kitty-events#48** for a latent contract-completeness
  gap (the review-rejection family omits the two backward `*→in_progress`
  rewinds) — defense-in-depth, not a blocker.
- A follow-up mission addresses the separate self-review-gate false-positive on
  the review-claim guard surface — tracked separately to keep this PR focused.
- No `__init__.py` change, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
