### PR TITLE
fix: role-aware review-claim gate — allow cross-profile review (folds #2960 write-side, #2861 guard)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -193,6 +193,19 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **A reviewer running a different agent profile than the implementer can now
+  claim a completed work package for review — the false "WP already claimed for
+  review by `<implementer>`" refusal is gone (`#3455`).** Before, claiming a WP
+  for review (`for_review → in_review`) compared the claim holder's identity,
+  which at `for_review` is structurally the *implementer* — so any cross-profile
+  reviewer (e.g. `reviewer-renata` reviewing `python-pedro`'s work) was rejected
+  as a self-review collision, and the block surfaced on the status aggregate
+  seam rather than the `move-task` command. Now the `for_review → in_review` edge
+  is allow-only, and a genuine reviewer-vs-reviewer collision is decided by a
+  single pure predicate at the `in_review` re-claim site (a real second reviewer
+  is still blocked, and the message names the holder). Role is read from the
+  reduced status slot, never by splitting the compact actor string (`#2861`).
+
 - **Coord/primary partition-authority residuals: out-of-loop callers now resolve
   the correct partition surface, so coordination-topology missions stop deadlocking
   and mis-reporting (mission `partition-authority-residuals-01M021K9`; epics `#2160`

--- a/src/specify_cli/coordination/coherence.py
+++ b/src/specify_cli/coordination/coherence.py
@@ -257,7 +257,7 @@ def coord_incoherent_done_wps(
     return [
         wp_id
         for wp_id in candidate_wps
-        if wp_lane_actor_from_events(events, wp_id)[0] == Lane.DONE
+        if wp_lane_actor_from_events(events, wp_id).lane == Lane.DONE
     ]
 
 

--- a/src/specify_cli/coordination/status_service.py
+++ b/src/specify_cli/coordination/status_service.py
@@ -28,7 +28,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from specify_cli.status import EventStream, InnerStateChanged, Lane, StatusEvent
+    from specify_cli.status import (
+        CurrentWpState,
+        EventStream,
+        InnerStateChanged,
+        StatusEvent,
+    )
 
 
 class StatusReadSource(enum.StrEnum):
@@ -256,30 +261,45 @@ def read_event_stream_log(contract: EventLogReadContract) -> EventStream:
 def wp_lane_actor_from_events(
     events: list[StatusEvent],
     wp_id: str,
-) -> tuple[Lane, str | None]:
-    """Reduce already-read events into a WP lane/actor snapshot.
+    annotations: list[InnerStateChanged] | None = None,
+) -> CurrentWpState:
+    """Reduce already-read events into a :class:`CurrentWpState` snapshot.
+
+    Lane and actor come from the transition fold; ``role`` is read from the
+    resolved-binding ``role`` slot of the SAME reduction (C-002: no second
+    reduce, no split-brain reader). ``role`` is annotation-folded, so callers
+    that need it (the in-lock re-claim read) MUST pass ``annotations`` — the
+    ``.lane``-only consumers (coherence / done bookkeeping) omit them and simply
+    see ``role=None``. Role is never derived by splitting the compound actor
+    string (#2861): ``actor`` is projected to its bare tool identity while
+    ``role`` rides its own reduced slot.
 
     An *unseeded* WP (no events at all, or no snapshot entry for wp_id)
     defaults to ``Lane.GENESIS`` — matching the write-side
     ``_derive_from_lane`` behaviour (Contract 3, FR-008).
     """
-    from specify_cli.status import Lane, reduce  # noqa: PLC0415
+    from specify_cli.status import (  # noqa: PLC0415
+        CurrentWpState,
+        Lane,
+        actor_identity_str,
+        reduce,
+    )
 
-    if not events:
-        return Lane.GENESIS, None
-    snapshot = reduce(events)
+    if not events and not annotations:
+        return CurrentWpState(Lane.GENESIS, None, None)
+    snapshot = reduce(events, annotations)
     state = snapshot.work_packages.get(wp_id)
     if not state:
-        return Lane.GENESIS, None
+        return CurrentWpState(Lane.GENESIS, None, None)
     try:
         lane = Lane(str(state.get("lane", Lane.GENESIS)))
     except ValueError:
         lane = Lane.GENESIS
-    from specify_cli.status import actor_identity_str  # noqa: PLC0415
 
     actor = state.get("actor")
     actor_key = actor_identity_str(actor) if actor is not None else ""
-    return lane, actor_key or None
+    role = state.get("role")
+    return CurrentWpState(lane, actor_key or None, role)
 
 
 def append_event_log(

--- a/src/specify_cli/coordination/status_transition.py
+++ b/src/specify_cli/coordination/status_transition.py
@@ -38,6 +38,7 @@ from specify_cli.lanes.branch_naming import (
 from specify_cli.status import emit as _emit
 from specify_cli.status.adapters import fire_dossier_sync
 from specify_cli.status.models import (
+    CurrentWpState,
     DoneEvidence,
     EventStream,
     GuardContext,
@@ -982,8 +983,15 @@ def read_current_wp_state_transactional(
     mission_slug: str,
     wp_id: str,
     repo_root: Path | None = None,
-) -> tuple[Lane, str | None]:
-    """Read current WP lane/actor from the transaction's write target."""
+) -> CurrentWpState:
+    """Read the current WP lane/actor/role from the transaction's write target.
+
+    Reads the full event STREAM (transitions + annotations) so the reduced
+    ``role`` slot is available on the returned :class:`CurrentWpState` from the
+    single in-transaction reduction (C-002). The role rides this value object
+    only to the in-lock re-claim collision site; it is never threaded onto the
+    guard input contract.
+    """
     identity = _identity_for_request(
         TransitionRequest(
             feature_dir=feature_dir,
@@ -995,7 +1003,8 @@ def read_current_wp_state_transactional(
         )
     )
     contract = _read_contract_from_transaction_target(identity, mission_slug)
-    events = read_event_log(contract)
+    stream = read_event_stream_log(contract)
+    events = stream.transitions
     if not events and not _transaction_topology_available(identity, mission_slug):
         from specify_cli.status.lane_reader import (  # noqa: PLC0415
             CanonicalStatusNotFoundError,
@@ -1017,7 +1026,7 @@ def read_current_wp_state_transactional(
             # signals, ...) is a real error and MUST propagate — the former
             # broad ``except Exception`` silently converted genesis-corruption
             # signals into "unseeded WP" (#1736 dormant mask 1).
-            return Lane.GENESIS, None
+            return CurrentWpState(Lane.GENESIS, None, None)
         if resolved_lane == Lane.UNINITIALIZED:
             # #2675/WP05: ``Lane.UNINITIALIZED`` is now a real ``Lane`` member,
             # so ``Lane("uninitialized")`` no longer raises here and the
@@ -1026,11 +1035,11 @@ def read_current_wp_state_transactional(
             # explicitly instead of relying on the now-dead ``ValueError``
             # branch: an absent-from-snapshot WP still means "unseeded" ->
             # GENESIS, per FR-008d/R7.
-            return Lane.GENESIS, None
-        return resolved_lane, None
-    # Local annotation re-narrows the cross-module (``Any``) helper result.
-    lane_actor: tuple[Lane, str | None] = wp_lane_actor_from_events(events, wp_id)
-    return lane_actor
+            return CurrentWpState(Lane.GENESIS, None, None)
+        return CurrentWpState(resolved_lane, None, None)
+    # Single in-transaction reduction (transitions + annotations) surfaces the
+    # reduced role slot alongside lane/actor on the value object (C-002).
+    return wp_lane_actor_from_events(events, wp_id, stream.annotations)
 
 
 def _read_contract_routes_through_coordination(

--- a/src/specify_cli/merge/done_bookkeeping.py
+++ b/src/specify_cli/merge/done_bookkeeping.py
@@ -302,12 +302,12 @@ def _mark_wp_merged_done(
         event_stream.annotations,
     ).work_packages.get(wp_id, {})
 
-    lane, _actor = read_current_wp_state_transactional(
+    lane = read_current_wp_state_transactional(
         feature_dir=feature_dir,
         mission_slug=mission_slug,
         wp_id=wp_id,
         repo_root=repo_root,
-    )
+    ).lane
     coord_lane = lane
     if lane == _Lane.DONE:
         return
@@ -595,7 +595,7 @@ def _durable_done_wps_on_coordination_ref(
         return set()
     done: set[str] = set()
     for wp_id in candidate_wps:
-        lane, _actor = wp_lane_actor_from_events(events, wp_id)
+        lane = wp_lane_actor_from_events(events, wp_id).lane
         if lane == Lane.DONE:
             done.add(wp_id)
     return done

--- a/src/specify_cli/status/__init__.py
+++ b/src/specify_cli/status/__init__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .models import (
     AgentAssignment,
+    CurrentWpState,
     DoneEvidence,
     EventStream,
     GuardContext,
@@ -332,6 +333,7 @@ __all__ = [
     # the facade instead of re-implementing the decode locally (C-002).
     "review_result_from_state",
     "AgentAssignment",
+    "CurrentWpState",
     "actor_identity_str",
     "ALLOWED_TRANSITIONS",
     "EventStream",

--- a/src/specify_cli/status/aggregate.py
+++ b/src/specify_cli/status/aggregate.py
@@ -730,15 +730,16 @@ class MissionStatus:
         """
         from specify_cli.status.models import Lane as _Lane
 
-        from_lane_enum, current_actor = read_current_wp_state_transactional(
+        current = read_current_wp_state_transactional(
             feature_dir=self.read_dir,
             mission_slug=self.mission_slug,
             wp_id=request.wp_id or "",
             repo_root=self.repo_root,
         )
+        from_lane_enum = current.lane
         if from_lane_enum == _Lane.UNINITIALIZED:
             from_lane_enum = lane_unseeded
-        return str(from_lane_enum), current_actor
+        return str(from_lane_enum), current.actor
 
     def _resolve_workspace_context(self, request: TransitionRequest) -> str:
         """Return the workspace context string used by transition guards."""

--- a/src/specify_cli/status/models.py
+++ b/src/specify_cli/status/models.py
@@ -161,6 +161,26 @@ def actor_identity_str(actor: ActorField) -> str:
 
 
 @dataclass(frozen=True)
+class CurrentWpState:
+    """Current WP state resolved from a single in-transaction reduction.
+
+    Returned by ``read_current_wp_state_transactional`` and derived by
+    ``wp_lane_actor_from_events`` from the SAME reduction (C-002: no second
+    reduce, no split-brain identity reader). ``role`` is the already-reduced
+    resolved-binding ``role`` slot — carried, never re-derived by splitting the
+    actor string (#2861). It may be blank/``None`` (a binding-less claim records
+    no role, so collision detection downstream is best-effort).
+
+    An unseeded WP (no events / absent from the snapshot) yields
+    ``CurrentWpState(Lane.GENESIS, None, None)``.
+    """
+
+    lane: Lane
+    actor: str | None
+    role: str | None
+
+
+@dataclass(frozen=True)
 class RepoEvidence:
     """Evidence of code changes in a repository."""
 

--- a/src/specify_cli/status/review_claim_predicate.py
+++ b/src/specify_cli/status/review_claim_predicate.py
@@ -1,0 +1,87 @@
+"""Pure role-aware review-claim collision predicate.
+
+This is the single convergence point for the ``in_review`` re-claim collision
+decision (``work_package_lifecycle.py`` in-lock re-claim). It is a pure leaf:
+it imports nothing from ``wp_state`` / ``work_package_lifecycle`` and performs
+no I/O, so it is trivially unit-testable row-by-row against the contract truth
+table (``contracts/review-claim-predicate.md``).
+
+Design contract (data-model.md):
+
+* The ``for_review -> in_review`` FSM guard is **hard allow-only** and does NOT
+  use this predicate — a stale reviewer role there must still ALLOW.
+* Collision detection is **best-effort**: the reduced ``role`` slot is populated
+  only when a claim carried a resolved binding. A binding-less holder has
+  ``current_role=None`` and therefore degrades to ALLOW (rule 2). This matches
+  the mission's primary goal: never false-block a cross-profile review.
+* Role is read from the reduced ``role`` slot only, never by splitting the actor
+  string (#2861).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Resolved-binding role tokens that mark a holder as an active reviewer. The
+#: token is the ``role`` written at the review-claim seam
+#: (``workflow_executor._REVIEW_CLAIM_ROLE == "reviewer"``); a local frozenset
+#: keeps this predicate a pure leaf with no import into the CLI command layer.
+_REVIEWER_ROLES: frozenset[str] = frozenset({"reviewer"})
+
+
+@dataclass(frozen=True)
+class ReviewClaimDecision:
+    """Outcome of :func:`review_claim_decision`.
+
+    ``allowed=True`` is ALLOW; ``allowed=False`` is COLLISION and always names
+    the current ``holder`` so the caller can build a
+    ``WorkPackageClaimConflict`` message.
+    """
+
+    allowed: bool
+    holder: str | None = None
+
+    @property
+    def is_collision(self) -> bool:
+        return not self.allowed
+
+
+_ALLOW = ReviewClaimDecision(allowed=True, holder=None)
+
+
+def _is_reviewer_role(role: str | None) -> bool:
+    return role is not None and role.strip() in _REVIEWER_ROLES
+
+
+def review_claim_decision(
+    current_actor: str | None,
+    current_role: str | None,
+    requesting_actor: str | None,
+    requesting_role: str | None,
+) -> ReviewClaimDecision:
+    """Decide whether ``requesting_actor`` may re-claim an ``in_review`` WP.
+
+    Rules (contracts/review-claim-predicate.md truth table):
+
+    1. blank/``None`` ``current_actor`` -> ALLOW (never trust a blank identity as
+       a positive collision signal).
+    2. ``current_role`` is not a reviewer-role -> ALLOW (implementer/other holder;
+       also covers the stale-role rework case).
+    3. ``current_actor == requesting_actor`` -> ALLOW (idempotent same-actor
+       re-claim).
+    4. reviewer-role holder AND actors differ -> COLLISION naming the holder.
+    """
+    # ``requesting_role`` completes the symmetric claim-predicate contract
+    # (data-model.md); the documented rules 1-4 key only off the holder's
+    # identity/role, so the requester's role is intentionally not consulted.
+    del requesting_role
+
+    holder = current_actor.strip() if current_actor is not None else ""
+    if not holder:
+        return _ALLOW  # rule 1
+    if not _is_reviewer_role(current_role):
+        return _ALLOW  # rule 2
+    requester = requesting_actor.strip() if requesting_actor is not None else ""
+    if holder == requester:
+        return _ALLOW  # rule 3
+    return ReviewClaimDecision(allowed=False, holder=holder)  # rule 4

--- a/src/specify_cli/status/work_package_lifecycle.py
+++ b/src/specify_cli/status/work_package_lifecycle.py
@@ -13,6 +13,7 @@ from typing import Any, cast
 
 from specify_cli.status.emit import TransitionError
 from specify_cli.status.locking import feature_status_lock
+from specify_cli.status.review_claim_predicate import review_claim_decision
 from specify_cli.status.models import (
     ActorField,
     Lane,
@@ -126,12 +127,14 @@ def start_implementation_status(
     lock_root = _repo_root_for_lock(feature_dir, repo_root)
 
     with feature_status_lock(lock_root, mission_slug):
-        current_lane, current_actor = read_current_wp_state_transactional(
+        current = read_current_wp_state_transactional(
             feature_dir=feature_dir,
             mission_slug=mission_slug,
             wp_id=wp_id,
             repo_root=repo_root,
         )
+        current_lane = current.lane
+        current_actor = current.actor
 
         if current_lane == Lane.GENESIS:
             raise WorkPackageStartRejected(
@@ -268,12 +271,15 @@ def start_review_status(
     lock_root = _repo_root_for_lock(feature_dir, repo_root)
 
     with feature_status_lock(lock_root, mission_slug):
-        current_lane, current_actor = read_current_wp_state_transactional(
+        current = read_current_wp_state_transactional(
             feature_dir=feature_dir,
             mission_slug=mission_slug,
             wp_id=wp_id,
             repo_root=repo_root,
         )
+        current_lane = current.lane
+        current_actor = current.actor
+        current_role = current.role
 
         if current_lane == Lane.FOR_REVIEW:
             event = emit_status_transition_transactional(
@@ -304,8 +310,20 @@ def start_review_status(
             )
 
         if current_lane == Lane.IN_REVIEW:
-            if not _actors_compatible(current_actor, actor):
-                raise WorkPackageClaimConflict(wp_id, current_actor or "unknown", actor, review=True)
+            # Role-aware collision (FR-003): the genuine reviewer-vs-reviewer
+            # gate. Role rides the in-lock ``CurrentWpState`` read (no split-brain
+            # / no guard-path plumbing). Collision is best-effort — a binding-less
+            # holder has ``current_role=None`` and degrades to ALLOW. The requester
+            # role is part of the symmetric predicate contract but is not consulted.
+            requesting_role = actor.get("role") if isinstance(actor, dict) else None
+            decision = review_claim_decision(
+                current_actor,
+                current_role,
+                _actor_key(actor),
+                requesting_role,
+            )
+            if decision.is_collision:
+                raise WorkPackageClaimConflict(wp_id, decision.holder or "unknown", actor, review=True)
             return WorkPackageStartResult(wp_id, Lane.IN_REVIEW, Lane.IN_REVIEW, actor, (), no_op=True, claimed_by=current_actor)
 
     raise WorkPackageStartRejected(f"WP {wp_id} is in '{current_lane}', cannot start review")

--- a/src/specify_cli/status/wp_state.py
+++ b/src/specify_cli/status/wp_state.py
@@ -595,17 +595,22 @@ def _check_in_review_approval(ctx: TransitionInputs) -> tuple[bool, str | None]:
 
 
 def _check_no_review_conflict(ctx: TransitionInputs) -> tuple[bool, str | None]:
-    """Guard: for_review -> in_review rejects a conflicting reviewer claim.
+    """Guard: for_review -> in_review is HARD allow-only (never blocks).
 
-    Permits an idempotent re-claim when ``current_actor`` matches ``actor``.
+    This guard consults actor-presence only (already enforced upstream by
+    :meth:`ForReviewState.guard_for` via ``_has_actor``) and ALWAYS allows. It
+    deliberately has NO reject / ``return False`` branch: the ``for_review``
+    holder is structurally the implementer (or a *stale* reviewer after a rework
+    cycle), so any block-on-actor/role here is either the original
+    cross-profile false-positive ("WP already claimed for review by
+    <implementer>") or the stale-role false-positive. The genuine
+    reviewer-vs-reviewer collision lives solely at the ``in_review`` re-claim
+    (:func:`work_package_lifecycle.start_review_status`, via
+    ``review_claim_decision``); this guard MUST NOT import or evaluate that
+    predicate. A stale reviewer role at ``for_review`` therefore still ALLOWs by
+    construction, not by input shape.
     """
-    current_actor = ctx.current_actor
-    actor = ctx.actor or ""
-    if current_actor and current_actor.strip() and current_actor.strip() != actor.strip():
-        return (
-            False,
-            f"WP already claimed for review by {current_actor.strip()}; cannot be claimed by {actor.strip()}",
-        )
+    del ctx  # allow-only: inputs are intentionally never consulted for a block
     return True, None
 
 

--- a/tests/architectural/test_merge_pipeline_ratchets.py
+++ b/tests/architectural/test_merge_pipeline_ratchets.py
@@ -159,13 +159,13 @@ def _read_state(tmp_path: Path) -> tuple[Lane, str | None]:
 
     feature_dir = tmp_path / "kitty-specs" / "099-mask-test"
     feature_dir.mkdir(parents=True, exist_ok=True)
-    state: tuple[Lane, str | None] = read_current_wp_state_transactional(
+    current = read_current_wp_state_transactional(
         feature_dir=feature_dir,
         mission_slug="099-mask-test",
         wp_id="WP01",
         repo_root=tmp_path,  # not a git repo → transaction topology unavailable
     )
-    return state
+    return current.lane, current.actor
 
 
 def _absent_log_error() -> Exception:

--- a/tests/architectural/test_review_claim_no_frontmatter.py
+++ b/tests/architectural/test_review_claim_no_frontmatter.py
@@ -1,0 +1,160 @@
+"""NFR-001 architectural guard + T006 source guards for the review-claim gate.
+
+Three invariants, each with a *firing* negative control so the gate is a real
+scan, not a tautology:
+
+1. **NFR-001** — actor/role in the claim-resolution surface come ONLY from the
+   canonical reduction, never from WP-file frontmatter (scoped to actor/role;
+   the ``get_wp_lane`` lane-genesis fallback is permitted and out of scope).
+2. **T006(b)** — ``_check_no_review_conflict`` is allow-only: its body contains
+   NO reject / ``return False`` branch (a dormant reject branch is invisible to
+   behavioural tests when ``current_actor`` is ``None``).
+3. **T006(a)** — no guard/FSM test re-asserts the role-free distinct-actor block
+   (the "already claimed for review" message on the ``validate_transition`` /
+   ``can_transition_to`` surface).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.architectural
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _REPO_ROOT / "src" / "specify_cli"
+
+
+# A frontmatter read that sources actor/role: the token ``frontmatter`` within
+# ~40 chars of ``actor``/``role`` in either order. ``lane`` is intentionally NOT
+# matched (the get_wp_lane genesis fallback is permitted).
+_FRONTMATTER_ACTOR_ROLE = re.compile(
+    r"frontmatter[^\n]{0,40}?\b(?:role|actor)\b"
+    r"|\b(?:role|actor)\b[^\n]{0,40}?frontmatter",
+    re.IGNORECASE,
+)
+
+
+def _frontmatter_actor_role_reads(text: str) -> list[str]:
+    return [m.group(0) for m in _FRONTMATTER_ACTOR_ROLE.finditer(text)]
+
+
+def _function_source(path: Path, qualname: str) -> str:
+    """Return the source segment of ``qualname`` (``A.b`` or ``f``) in ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    parts = qualname.split(".")
+
+    def _find(nodes: list[ast.stmt], names: list[str]) -> ast.AST | None:
+        head, rest = names[0], names[1:]
+        for node in nodes:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name == head:
+                if not rest:
+                    return node
+                return _find(list(ast.iter_child_nodes(node)), rest)  # type: ignore[arg-type]
+        return None
+
+    node = _find(list(ast.iter_child_nodes(tree)), parts)
+    assert node is not None, f"{qualname} not found in {path}"
+    return ast.get_source_segment(path.read_text(encoding="utf-8"), node) or ""
+
+
+# The claim-resolution surface: the aggregate seam and the lifecycle re-claim,
+# plus the two reduction-backed reads they delegate to.
+_CLAIM_RESOLUTION_SURFACE: tuple[tuple[str, str], ...] = (
+    ("status/aggregate.py", "MissionStatus.transition"),
+    ("status/aggregate.py", "MissionStatus._resolve_current_lane"),
+    ("status/work_package_lifecycle.py", "start_review_status"),
+    ("coordination/status_service.py", "wp_lane_actor_from_events"),
+    ("coordination/status_transition.py", "read_current_wp_state_transactional"),
+)
+
+
+def test_nfr001_claim_surface_never_reads_actor_role_from_frontmatter() -> None:
+    for rel, qualname in _CLAIM_RESOLUTION_SURFACE:
+        source = _function_source(_SRC / rel, qualname)
+        offenders = _frontmatter_actor_role_reads(source)
+        assert not offenders, (
+            f"{rel}:{qualname} resolves actor/role from frontmatter (NFR-001 violation): {offenders}"
+        )
+
+
+def test_nfr001_detector_fires_on_planted_frontmatter_read() -> None:
+    """Negative control: the detector MUST fire on a planted frontmatter read."""
+    planted = 'self.role = frontmatter.get("role")\nactor = wp_frontmatter["actor"]'
+    assert _frontmatter_actor_role_reads(planted), (
+        "NFR-001 detector is vacuous — it did not fire on a planted frontmatter actor/role read"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T006(b) — _check_no_review_conflict has no reject / return False branch.
+# ---------------------------------------------------------------------------
+
+
+def _check_no_review_conflict_body() -> str:
+    return _function_source(_SRC / "status" / "wp_state.py", "_check_no_review_conflict")
+
+
+def test_check_no_review_conflict_is_allow_only_no_reject_branch() -> None:
+    body = _check_no_review_conflict_body()
+    # Split off the docstring so prose describing the removed behaviour does not
+    # trip the literal scan.
+    module = ast.parse(body)
+    func = module.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    executable = [n for n in func.body if not (isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant))]
+    code = "\n".join(ast.unparse(n) for n in executable)
+    # ``ast.unparse`` renders a tuple return as ``return (True, None)`` — scan for
+    # the bare ``False`` literal (a reject verdict) rather than a source spelling.
+    assert "False" not in code, (
+        f"_check_no_review_conflict must be allow-only (no reject/False branch); found in:\n{code}"
+    )
+    assert "already claimed" not in code, (
+        "_check_no_review_conflict must not carry the old block message"
+    )
+    # It must actually return an allow tuple.
+    assert "True, None" in code
+
+
+def test_allow_only_detector_fires_on_planted_reject_branch() -> None:
+    """Negative control: the reject-branch scan MUST fire on a planted block."""
+    planted = ast.parse(
+        "def f(ctx):\n"
+        "    if ctx.current_actor:\n"
+        "        return False, 'already claimed'\n"
+        "    return True, None\n"
+    )
+    func = planted.body[0]
+    assert isinstance(func, ast.FunctionDef)
+    code = "\n".join(ast.unparse(n) for n in func.body)
+    assert "False" in code and "already claimed" in code
+
+
+# ---------------------------------------------------------------------------
+# T006(a) — no guard/FSM test re-asserts the role-free distinct-actor block.
+# ---------------------------------------------------------------------------
+
+_GUARD_FSM_TEST_FILES: tuple[str, ...] = (
+    "tests/specify_cli/status/test_wp_state.py",
+    "tests/status/test_transitions.py",
+    "tests/unit/status/test_review_claim_transition.py",
+)
+
+
+def test_no_guard_test_reasserts_role_free_distinct_actor_block() -> None:
+    """The guard/FSM surfaces are allow-only; no test may assert the old block.
+
+    The genuine reject lives ONLY at the ``in_review`` re-claim lifecycle test
+    (``WorkPackageClaimConflict``), so the "already claimed" block message must
+    not appear as an expectation on the ``validate_transition`` /
+    ``can_transition_to`` guard surfaces.
+    """
+    for rel in _GUARD_FSM_TEST_FILES:
+        text = (_REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "already claimed" not in text, (
+            f"{rel} re-asserts the role-free distinct-actor block ('already claimed'); "
+            "the guard is allow-only — move reject coverage to the in_review re-claim test"
+        )

--- a/tests/cli/commands/test_merge_status_commit.py
+++ b/tests/cli/commands/test_merge_status_commit.py
@@ -470,7 +470,7 @@ class TestMergeDoneTransitions:
         _write_meta(feature_dir, mission_slug, mission_id=None)
         _write_wp_file(tasks_dir, "WP01")
 
-        from specify_cli.status import Lane
+        from specify_cli.status import CurrentWpState, Lane
 
         with (
             # _mark_wp_merged_done reads the current lane via
@@ -478,7 +478,7 @@ class TestMergeDoneTransitions:
             # it so the WP reads as approved and the lightweight done-emit fires.
             patch(
                 "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-                return_value=(Lane.APPROVED, "reviewer-1"),
+                return_value=CurrentWpState(Lane.APPROVED, "reviewer-1", None),
             ),
             patch("specify_cli.cli.commands.merge._has_transition_to", return_value=False),
             patch("specify_cli.coordination.status_transition.emit_status_transition_transactional") as mock_emit,

--- a/tests/merge/test_done_bookkeeping_seam.py
+++ b/tests/merge/test_done_bookkeeping_seam.py
@@ -20,6 +20,7 @@ import typer
 
 from specify_cli.merge import done_bookkeeping as db
 from specify_cli.status import (
+    CurrentWpState,
     EventStream,
     InnerStateChanged,
     Lane,
@@ -207,7 +208,7 @@ def test_durable_done_reduces_committed_coordination_ref(tmp_path: Path) -> None
         ),
         patch(
             "specify_cli.coordination.status_service.wp_lane_actor_from_events",
-            side_effect=lambda _events, wp_id: (lanes[wp_id], None),
+            side_effect=lambda _events, wp_id: CurrentWpState(lanes[wp_id], None, None),
         ),
     ):
         assert db._durable_done_wps_on_coordination_ref(
@@ -442,7 +443,7 @@ def test_mark_wp_merged_done_noop_when_already_done(tmp_path: Path) -> None:
         ),
         patch(
             "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-            return_value=(Lane.DONE, "merge"),
+            return_value=CurrentWpState(Lane.DONE, "merge", None),
         ),
     ):
         db._mark_wp_merged_done(tmp_path, "m", "WP01", "main")
@@ -464,7 +465,7 @@ def test_mark_wp_merged_done_dedup_skips_when_done_transition_exists(tmp_path: P
         ),
         patch(
             "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-            return_value=(Lane.APPROVED, "merge"),
+            return_value=CurrentWpState(Lane.APPROVED, "merge", None),
         ),
         patch.object(db, "_has_transition_to", return_value=True),
     ):
@@ -490,7 +491,7 @@ def test_mark_wp_merged_done_warns_on_final_transition_error(tmp_path: Path) -> 
         ),
         patch(
             "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-            return_value=(Lane.APPROVED, "merge"),
+            return_value=CurrentWpState(Lane.APPROVED, "merge", None),
         ),
         patch.object(db, "_has_transition_to", return_value=False),
         patch.object(
@@ -525,7 +526,7 @@ def test_mark_wp_merged_done_warns_when_lane_not_approved(tmp_path: Path) -> Non
         ),
         patch(
             "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-            return_value=(Lane.IN_REVIEW, "merge"),
+            return_value=CurrentWpState(Lane.IN_REVIEW, "merge", None),
         ),
         patch.object(db, "_has_transition_to", return_value=False),
         patch.object(
@@ -555,7 +556,7 @@ def test_mark_wp_merged_done_aborts_when_replay_returns_none(tmp_path: Path) -> 
         ),
         patch(
             "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-            return_value=(Lane.FOR_REVIEW, "merge"),
+            return_value=CurrentWpState(Lane.FOR_REVIEW, "merge", None),
         ),
         patch.object(db, "_has_transition_to", return_value=False),
         patch.object(

--- a/tests/merge/test_issue_2367_bake_strand.py
+++ b/tests/merge/test_issue_2367_bake_strand.py
@@ -369,7 +369,7 @@ def _working_coord_events(repo: Path) -> list[StatusEvent]:
 
 
 def _lane_on(events: list[StatusEvent], wp_id: str) -> Lane:
-    lane, _actor = wp_lane_actor_from_events(events, wp_id)
+    lane = wp_lane_actor_from_events(events, wp_id).lane
     return lane
 
 

--- a/tests/merge/test_issue_2711_merge_rollback_resume_coherence.py
+++ b/tests/merge/test_issue_2711_merge_rollback_resume_coherence.py
@@ -458,8 +458,8 @@ def test_rollback_leaves_committed_done_incoherent_with_working_tree(
 
     committed_events = _committed_coord_events(repo, feature_dir)
     working_events = _working_coord_events(repo)
-    committed_lane, _ = wp_lane_actor_from_events(committed_events, WP_ID)
-    working_lane, _ = wp_lane_actor_from_events(working_events, WP_ID)
+    committed_lane = wp_lane_actor_from_events(committed_events, WP_ID).lane
+    working_lane = wp_lane_actor_from_events(working_events, WP_ID).lane
 
     # --- Precondition: the working tree DID roll back to ``approved`` (survives
     # the fix — the working side is coherent both today and post-fix). ---

--- a/tests/merge/test_issue_2786_revert_failure_split_brain.py
+++ b/tests/merge/test_issue_2786_revert_failure_split_brain.py
@@ -137,10 +137,10 @@ def _reduce_coord_lanes(repo: Path, feature_dir: Path) -> tuple[Lane, Lane]:
     reduction of the coordination worktree's rolled-back WORKING-tree event log.
     Both legs are git-reducible — no marker/doctor surface is consulted.
     """
-    committed_lane, _ = wp_lane_actor_from_events(
+    committed_lane = wp_lane_actor_from_events(
         _committed_coord_events(repo, feature_dir), WP_ID
-    )
-    working_lane, _ = wp_lane_actor_from_events(_working_coord_events(repo), WP_ID)
+    ).lane
+    working_lane = wp_lane_actor_from_events(_working_coord_events(repo), WP_ID).lane
     return committed_lane, working_lane
 
 

--- a/tests/merge/test_merge_done_recording.py
+++ b/tests/merge/test_merge_done_recording.py
@@ -219,7 +219,7 @@ def test_mark_wp_merged_done_replays_approved_before_done_for_primary_fallback(
     monkeypatch: Any,
 ) -> None:
     """Primary fallback must replay conforming approved history before done."""
-    from specify_cli.status.models import Lane
+    from specify_cli.status.models import CurrentWpState, Lane
 
     repo_root = tmp_path
     mission_slug = "021-test"
@@ -244,7 +244,7 @@ def test_mark_wp_merged_done_replays_approved_before_done_for_primary_fallback(
     monkeypatch.setattr("specify_cli.coordination.status_transition.emit_status_transition_transactional", emit_mock)
     monkeypatch.setattr(
         "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-        lambda **_kw: (Lane.PLANNED, None),
+        lambda **_kw: CurrentWpState(Lane.PLANNED, None, None),
     )
     monkeypatch.setattr(
         "specify_cli.coordination.status_transition.has_transition_to_transactional",

--- a/tests/specify_cli/coordination/test_status_facade_adoption_wp02.py
+++ b/tests/specify_cli/coordination/test_status_facade_adoption_wp02.py
@@ -202,18 +202,20 @@ def test_f007_lane_state_parity_no_genesis_misread(
     """
     repo, lane = sparse_lane_repo
 
-    primary_lane, primary_actor = read_current_wp_state_transactional(
+    _primary = read_current_wp_state_transactional(
         feature_dir=repo / "kitty-specs" / _MISSION_SLUG,
         mission_slug=_MISSION_SLUG,
         wp_id="WP01",
         repo_root=repo,
     )
-    lane_lane, lane_actor = read_current_wp_state_transactional(
+    primary_lane, primary_actor = _primary.lane, _primary.actor
+    _lane = read_current_wp_state_transactional(
         feature_dir=lane / "kitty-specs" / _MISSION_SLUG,
         mission_slug=_MISSION_SLUG,
         wp_id="WP01",
         repo_root=lane,
     )
+    lane_lane, lane_actor = _lane.lane, _lane.actor
 
     assert primary_lane == Lane.IN_PROGRESS
     assert lane_lane == primary_lane, (

--- a/tests/specify_cli/coordination/test_status_transition.py
+++ b/tests/specify_cli/coordination/test_status_transition.py
@@ -753,12 +753,13 @@ def test_transactional_read_falls_back_to_primary_when_coord_branch_deleted(repo
     _git(repo, "commit", "-q", "-m", "merge mission artifacts to main")
     _git(repo, "branch", "-D", COORD_BRANCH)
 
-    lane, actor = read_current_wp_state_transactional(
+    _state = read_current_wp_state_transactional(
         feature_dir=repo / "kitty-specs" / MISSION_DIRNAME,
         mission_slug=MISSION_SLUG,
         wp_id="WP01",
         repo_root=repo,
     )
+    lane, actor = _state.lane, _state.actor
     assert lane == Lane.PLANNED
     assert actor == "seed"
 
@@ -815,12 +816,13 @@ def test_transactional_wp_state_read_survives_fail_closed_surface_refusal(
 ) -> None:
     _materialize_coord_root_without_mission_dir(repo)
 
-    lane, actor = read_current_wp_state_transactional(
+    _state = read_current_wp_state_transactional(
         feature_dir=repo / "kitty-specs" / MISSION_DIRNAME,
         mission_slug=MISSION_DIRNAME,
         wp_id="WP01",
         repo_root=repo,
     )
+    lane, actor = _state.lane, _state.actor
 
     assert lane == Lane.GENESIS
     assert actor is None

--- a/tests/specify_cli/merge/test_done_evidence_snapshot.py
+++ b/tests/specify_cli/merge/test_done_evidence_snapshot.py
@@ -25,6 +25,7 @@ import pytest
 from mission_runtime import MissionArtifactKind
 from specify_cli.missions._read_path_resolver import resolve_planning_read_dir
 from specify_cli.status import (
+    CurrentWpState,
     Lane,
     ReviewOverride,
     WPInnerStateDelta,
@@ -98,7 +99,7 @@ def _isolate_transactional_lane(monkeypatch: Any, emit_mock: Mock, *, lane: Lane
     )
     monkeypatch.setattr(
         "specify_cli.coordination.status_transition.read_current_wp_state_transactional",
-        lambda **_kw: (lane, "prior-actor"),
+        lambda **_kw: CurrentWpState(lane, "prior-actor", None),
     )
     monkeypatch.setattr(
         "specify_cli.coordination.status_transition.has_transition_to_transactional",

--- a/tests/specify_cli/status/test_wp_state.py
+++ b/tests/specify_cli/status/test_wp_state.py
@@ -471,15 +471,24 @@ class TestGuardEquivalence:
         ctx_no_actor = TransitionContext(actor="")
         assert state.can_transition_to(Lane.IN_REVIEW, ctx_no_actor) is False
 
-    def test_for_review_to_in_review_conflict_detection_rejects_double_claim(self):
-        """for_review -> in_review rejects a second reviewer when another already holds it."""
+    def test_for_review_to_in_review_allows_distinct_reviewer(self):
+        """for_review -> in_review is allow-only: a distinct reviewer ALLOWs.
+
+        Re-pointed (WP01): the guard no longer blocks on ``current_actor``. The
+        holder at ``for_review`` is structurally the implementer (or a stale
+        reviewer after rework), so blocking here is the cross-profile
+        false-positive this mission removes. Role is not on this guard surface,
+        so seeding it would be inert — the genuine reviewer-vs-reviewer reject
+        lives at the ``in_review`` re-claim (see
+        ``tests/status/test_work_package_lifecycle.py::test_start_review_rejects_second_reviewer``).
+        """
         state = wp_state_for("for_review")
 
-        ctx_conflict = TransitionContext(
+        ctx_distinct = TransitionContext(
             actor="reviewer-B",
             current_actor="reviewer-A",
         )
-        assert state.can_transition_to(Lane.IN_REVIEW, ctx_conflict) is False
+        assert state.can_transition_to(Lane.IN_REVIEW, ctx_distinct) is True
 
     def test_for_review_to_in_review_same_actor_reclaim_allowed(self):
         """for_review -> in_review permits idempotent re-claim by the same actor."""
@@ -498,13 +507,17 @@ class TestGuardEquivalence:
         ctx_fresh = TransitionContext(actor="reviewer-A")
         assert state.can_transition_to(Lane.IN_REVIEW, ctx_fresh) is True
 
-    def test_for_review_to_in_review_conflict_detection_guard_equivalence(self):
-        """Guard equivalence: _run_guard and WPState agree on conflict detection."""
+    def test_for_review_to_in_review_guard_equivalence_allow_only(self):
+        """Guard equivalence: _run_guard and WPState agree the guard is allow-only.
+
+        Re-pointed (WP01): a distinct actor at ``for_review`` ALLOWs on both
+        surfaces (the collision guard was removed; role is not on this surface).
+        """
         state = wp_state_for("for_review")
 
-        # Case 1: different actor -> both reject
-        ctx_conflict = TransitionContext(actor="reviewer-B", current_actor="reviewer-A")
-        assert state.can_transition_to(Lane.IN_REVIEW, ctx_conflict) is False
+        # Case 1: different actor -> both ALLOW (allow-only guard)
+        ctx_distinct = TransitionContext(actor="reviewer-B", current_actor="reviewer-A")
+        assert state.can_transition_to(Lane.IN_REVIEW, ctx_distinct) is True
         old_ok, _ = _run_guard(
             "for_review",
             "in_review",
@@ -518,7 +531,7 @@ class TestGuardEquivalence:
             force=False,
             current_actor="reviewer-A",
         )
-        assert old_ok is False
+        assert old_ok is True
 
         # Case 2: same actor -> both accept
         ctx_same = TransitionContext(actor="reviewer-A", current_actor="reviewer-A")

--- a/tests/specify_cli/test_lane_consumer_behavior.py
+++ b/tests/specify_cli/test_lane_consumer_behavior.py
@@ -138,12 +138,13 @@ def test_transactional_read_preserves_genesis_fallback_for_unseeded_wp(
         read_current_wp_state_transactional,
     )
 
-    lane, actor = read_current_wp_state_transactional(
+    _state = read_current_wp_state_transactional(
         feature_dir=feature_dir,
         mission_slug=mission_slug,
         wp_id="WP01",
         repo_root=repo,
     )
+    lane, actor = _state.lane, _state.actor
 
     assert lane == Lane.GENESIS
     assert actor is None

--- a/tests/status/fsm_parity_baseline.jsonl
+++ b/tests/status/fsm_parity_baseline.jsonl
@@ -1275,7 +1275,7 @@
 ["for_review", "in_progress", "ws", false, "Illegal transition: for_review -> in_progress"]
 ["for_review", "in_review", "actor", true, null]
 ["for_review", "in_review", "actor_empty", false, "Transition requires actor identity"]
-["for_review", "in_review", "conflict", false, "WP already claimed for review by rev-A; cannot be claimed by rev-B"]
+["for_review", "in_review", "conflict", true, null]
 ["for_review", "in_review", "done_evidence", true, null]
 ["for_review", "in_review", "empty", false, "Transition requires actor identity"]
 ["for_review", "in_review", "evidence_only", true, null]

--- a/tests/status/test_agent_status_emit_aggregate_wiring.py
+++ b/tests/status/test_agent_status_emit_aggregate_wiring.py
@@ -340,7 +340,7 @@ def test_transition_helper_maps_uninitialized_lane_to_genesis(tmp_path: Path) ->
     """
     from specify_cli.status import TransitionRequest
     from specify_cli.status.aggregate import MissionStatus
-    from specify_cli.status.models import Lane
+    from specify_cli.status.models import CurrentWpState, Lane
 
     ms = MissionStatus(
         mission_slug="017-helper-lane",
@@ -360,7 +360,7 @@ def test_transition_helper_maps_uninitialized_lane_to_genesis(tmp_path: Path) ->
 
     from_lane, current_actor = ms._resolve_current_lane(
         request=request,
-        read_current_wp_state_transactional=lambda **_: ("uninitialized", "codex"),
+        read_current_wp_state_transactional=lambda **_: CurrentWpState(Lane.UNINITIALIZED, "codex", None),
         lane_unseeded=Lane.GENESIS,
     )
 

--- a/tests/status/test_review_claim_role_aware.py
+++ b/tests/status/test_review_claim_role_aware.py
@@ -1,0 +1,336 @@
+"""Acceptance + regression tests for the role-aware review-claim gate (WP01).
+
+Red-first surface (T005): the cross-profile false-block manifests ONLY where the
+holder is resolved from the reduction into the guard — the
+``MissionStatus.transition`` **aggregate seam** (``aggregate.py`` builds a
+``GuardContext(current_actor=...)`` from ``read_current_wp_state_transactional``
+and runs ``validate_transition``). The ``move-task`` command never populates
+``current_actor`` so it is vacuous pre-fix; it is deliberately NOT the repro.
+
+Pre-fix behaviour (captured RED): a distinct reviewer claiming ``in_review`` on a
+WP whose latest ``for_review`` event was authored by an implementer was refused
+with "WP already claimed for review by <implementer>". Post-fix: the guard is
+allow-only and the transition succeeds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kernel.clock import now_utc_iso
+from specify_cli.coordination.status_service import wp_lane_actor_from_events
+from specify_cli.status.aggregate import MissionStatus
+from specify_cli.status.emit import TransitionError
+from specify_cli.status.models import (
+    GuardContext,
+    InnerStateChanged,
+    Lane,
+    StatusEvent,
+    TransitionRequest,
+    WPInnerStateDelta,
+)
+from specify_cli.status.store import append_annotations_atomic_verified, append_event
+from specify_cli.status.transitions import validate_transition
+
+pytestmark = pytest.mark.fast
+
+_SLUG = "099-review-claim-role-aware"
+
+
+def _uid(suffix: str) -> str:
+    """Build a valid 26-char Crockford-base32 ULID (no I/L/O/U) for seeding."""
+    return ("01" + suffix.rjust(24, "0"))[:26]
+
+
+@pytest.fixture(autouse=True)
+def _disable_status_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
+    import specify_cli.status.emit as status_emit
+
+    monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
+    monkeypatch.setattr(status_emit, "fire_dossier_sync", lambda *args, **kwargs: None)
+
+
+def _feature_dir(tmp_path: Path) -> Path:
+    feature_dir = tmp_path / "kitty-specs" / _SLUG
+    feature_dir.mkdir(parents=True)
+    return feature_dir
+
+
+def _transition(
+    event_id: str,
+    *,
+    from_lane: Lane,
+    to_lane: Lane,
+    actor: object,
+    at: str,
+    wp_id: str = "WP01",
+) -> StatusEvent:
+    return StatusEvent(
+        event_id=event_id,
+        mission_slug=_SLUG,
+        wp_id=wp_id,
+        from_lane=from_lane,
+        to_lane=to_lane,
+        at=at,
+        actor=actor,  # type: ignore[arg-type]  -- ActorField accepts str | dict
+        force=False,
+        execution_mode="worktree",
+    )
+
+
+def _legacy_aggregate(feature_dir: Path, repo_root: Path) -> MissionStatus:
+    """Construct a legacy-topology aggregate anchored on ``feature_dir``."""
+    return MissionStatus(
+        mission_slug=_SLUG,
+        mission_id=None,
+        mid8="",
+        topology="legacy",
+        read_dir=feature_dir,
+        repo_root=repo_root,
+        coordination_branch=None,
+    )
+
+
+def _seed_for_review_by_implementer(feature_dir: Path) -> None:
+    """WP01 sits at ``for_review`` with the latest event authored by an implementer."""
+    append_event(
+        feature_dir,
+        _transition(
+            _uid("A1"),
+            from_lane=Lane.IN_PROGRESS,
+            to_lane=Lane.FOR_REVIEW,
+            actor="implementer-ivan",
+            at=now_utc_iso(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# T005 (a) — the aggregate (MissionStatus.transition) seam
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_seam_allows_cross_profile_review_claim(tmp_path: Path) -> None:
+    """A distinct reviewer may claim in_review on an implementer-held for_review WP.
+
+    This is the genuinely red-pre / green-post repro: the aggregate resolves
+    ``current_actor='implementer-ivan'`` from the reduction into the guard, then
+    a reviewer claims ``in_review``. Pre-fix this raised "WP already claimed for
+    review by implementer-ivan"; post-fix the allow-only guard lets it through.
+    """
+    feature_dir = _feature_dir(tmp_path)
+    _seed_for_review_by_implementer(feature_dir)
+
+    aggregate = _legacy_aggregate(feature_dir, tmp_path)
+    event = aggregate.transition(
+        TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug=_SLUG,
+            wp_id="WP01",
+            to_lane=Lane.IN_REVIEW,
+            actor="reviewer-renata",
+            reason="Started review via aggregate seam",
+            review_ref="action-review-claim",
+            repo_root=tmp_path,
+            execution_mode="worktree",
+        )
+    )
+
+    assert event.to_lane == Lane.IN_REVIEW
+    assert event.from_lane == Lane.FOR_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# T005 (b) — validate_transition unit companion (the guard directly)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_transition_allows_reviewer_over_implementer_holder() -> None:
+    """The FSM guard is allow-only: a reviewer claim over an implementer holder ALLOWs."""
+    ok, error = validate_transition(
+        "for_review",
+        "in_review",
+        GuardContext(actor="reviewer-renata", current_actor="implementer-ivan"),
+    )
+    assert ok is True, f"expected allow-only guard, got error={error}"
+
+
+def test_validate_transition_allows_distinct_reviewer_at_for_review() -> None:
+    """Even a distinct reviewer at for_review ALLOWs — the guard never blocks."""
+    ok, error = validate_transition(
+        "for_review",
+        "in_review",
+        GuardContext(actor="reviewer-b", current_actor="reviewer-a"),
+    )
+    assert ok is True, f"guard must be allow-only; error={error}"
+
+
+def test_validate_transition_still_requires_actor() -> None:
+    """Allow-only removes the collision block but keeps the actor-presence guard."""
+    ok, error = validate_transition(
+        "for_review",
+        "in_review",
+        GuardContext(actor=""),
+    )
+    assert ok is False
+    assert error and "actor" in error.lower()
+
+
+# ---------------------------------------------------------------------------
+# T005 — stale reviewer role at for_review still ALLOWs
+# ---------------------------------------------------------------------------
+
+
+def test_stale_reviewer_role_at_for_review_still_allows(tmp_path: Path) -> None:
+    """A rework cycle can leave a stale reviewer role folded on a for_review WP.
+
+    The allow-only guard must never block on it: a fresh reviewer claim ALLOWs.
+    """
+    feature_dir = _feature_dir(tmp_path)
+    # A prior review cycle stamped role="reviewer" (resolved binding), then the
+    # WP was reworked back to for_review by the implementer.
+    append_event(
+        feature_dir,
+        _transition(
+            _uid("A2"),
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+            actor="reviewer-old",
+            at="2026-08-01T10:00:00+00:00",
+        ),
+    )
+    append_annotations_atomic_verified(
+        feature_dir,
+        [
+            InnerStateChanged(
+                event_id=_uid("A3"),
+                wp_id="WP01",
+                at="2026-08-01T10:00:01+00:00",
+                actor="reviewer-old",
+                delta=WPInnerStateDelta(role="reviewer"),
+            )
+        ],
+    )
+    append_event(
+        feature_dir,
+        _transition(
+            _uid("A4"),
+            from_lane=Lane.IN_REVIEW,
+            to_lane=Lane.FOR_REVIEW,
+            actor="implementer-ivan",
+            at=now_utc_iso(),
+        ),
+    )
+
+    aggregate = _legacy_aggregate(feature_dir, tmp_path)
+    event = aggregate.transition(
+        TransitionRequest(
+            feature_dir=feature_dir,
+            mission_slug=_SLUG,
+            wp_id="WP01",
+            to_lane=Lane.IN_REVIEW,
+            actor="reviewer-fresh",
+            reason="Re-review after rework",
+            review_ref="action-review-claim",
+            repo_root=tmp_path,
+            execution_mode="worktree",
+        )
+    )
+    assert event.to_lane == Lane.IN_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# T005 — NFR-004 / FR-007: same-identity self-review claim is ALLOWED (no new
+# hard refusal). Independence remains an advisory-only signal.
+# ---------------------------------------------------------------------------
+
+
+def test_same_identity_self_review_claim_is_allowed(tmp_path: Path) -> None:
+    """The implementer claiming their own WP for review is NOT hard-blocked."""
+    feature_dir = _feature_dir(tmp_path)
+    _seed_for_review_by_implementer(feature_dir)
+
+    aggregate = _legacy_aggregate(feature_dir, tmp_path)
+    # Same identity ("implementer-ivan") that authored for_review now claims review.
+    try:
+        event = aggregate.transition(
+            TransitionRequest(
+                feature_dir=feature_dir,
+                mission_slug=_SLUG,
+                wp_id="WP01",
+                to_lane=Lane.IN_REVIEW,
+                actor="implementer-ivan",
+                reason="Self review claim",
+                review_ref="action-review-claim",
+                repo_root=tmp_path,
+                execution_mode="worktree",
+            )
+        )
+    except TransitionError as exc:  # pragma: no cover - defensive: must not happen
+        pytest.fail(f"same-identity self-review must not be hard-refused: {exc}")
+    assert event.to_lane == Lane.IN_REVIEW
+
+
+# ---------------------------------------------------------------------------
+# T007 — #2861 regression: CurrentWpState.role comes from the reduced role slot,
+# never from splitting the compound actor. Exercises the DERIVATION
+# (wp_lane_actor_from_events), not the pure predicate.
+# ---------------------------------------------------------------------------
+
+
+def test_2861_current_wp_state_role_from_reduced_slot_not_actor_split() -> None:
+    """A compound actor dict must not leak into ``.actor`` or source ``.role``.
+
+    ``.actor`` must be the bare ``tool`` ("claude"), never the compound
+    ``tool:model:profile:role``. ``.role`` must be the reduced ``role`` slot
+    (folded from the binding annotation), not the actor dict's own ``role`` key
+    — proven here by seeding a DIFFERENT value on the actor dict.
+    """
+    compound_actor = {
+        "tool": "claude",
+        "model": "sonnet",
+        "profile": "reviewer-renata",
+        "role": "DECOY-not-the-source",
+    }
+    transitions = [
+        _transition(
+            _uid("A5"),
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+            actor=compound_actor,
+            at="2026-08-05T10:00:00+00:00",
+        )
+    ]
+    annotations = [
+        InnerStateChanged(
+            event_id=_uid("A6"),
+            wp_id="WP01",
+            at="2026-08-05T10:00:01+00:00",
+            actor=compound_actor,  # type: ignore[arg-type]
+            delta=WPInnerStateDelta(role="reviewer"),
+        )
+    ]
+
+    state = wp_lane_actor_from_events(transitions, "WP01", annotations)
+
+    assert state.lane == Lane.IN_REVIEW
+    assert state.actor == "claude"  # bare tool, never the compound string
+    assert state.role == "reviewer"  # from the reduced role slot, not the decoy
+
+
+def test_2861_role_none_when_only_transition_present() -> None:
+    """Without a role annotation, the derivation surfaces role=None (best-effort)."""
+    transitions = [
+        _transition(
+            _uid("A7"),
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+            actor="claude",
+            at="2026-08-05T10:00:00+00:00",
+        )
+    ]
+    state = wp_lane_actor_from_events(transitions, "WP01")
+    assert state.actor == "claude"
+    assert state.role is None

--- a/tests/status/test_review_claim_role_aware.py
+++ b/tests/status/test_review_claim_role_aware.py
@@ -191,6 +191,16 @@ def test_stale_reviewer_role_at_for_review_still_allows(tmp_path: Path) -> None:
     feature_dir = _feature_dir(tmp_path)
     # A prior review cycle stamped role="reviewer" (resolved binding), then the
     # WP was reworked back to for_review by the implementer.
+    #
+    # All three events below are anchored to real "now" (never a hard-coded
+    # absolute literal) so the whole test is a single timestamp kind. The
+    # `_uid(...)` event ids are lexically ordered (A2 < A3 < A4), which is
+    # the reducer's tie-break on `(at, event_id)` -- so even if two
+    # `now_utc_iso()` calls land in the same instant, append order is still
+    # preserved. Mixing a hard-coded literal here with `_transition(...,
+    # at=now_utc_iso())` below is exactly the #3157-class flakiness this
+    # test must not reintroduce (see
+    # tests/architectural/test_no_absolute_event_timestamp_mixture.py).
     append_event(
         feature_dir,
         _transition(
@@ -198,7 +208,7 @@ def test_stale_reviewer_role_at_for_review_still_allows(tmp_path: Path) -> None:
             from_lane=Lane.FOR_REVIEW,
             to_lane=Lane.IN_REVIEW,
             actor="reviewer-old",
-            at="2026-08-01T10:00:00+00:00",
+            at=now_utc_iso(),
         ),
     )
     append_annotations_atomic_verified(
@@ -207,7 +217,7 @@ def test_stale_reviewer_role_at_for_review_still_allows(tmp_path: Path) -> None:
             InnerStateChanged(
                 event_id=_uid("A3"),
                 wp_id="WP01",
-                at="2026-08-01T10:00:01+00:00",
+                at=now_utc_iso(),
                 actor="reviewer-old",
                 delta=WPInnerStateDelta(role="reviewer"),
             )

--- a/tests/status/test_transitions.py
+++ b/tests/status/test_transitions.py
@@ -429,15 +429,20 @@ class TestGuardConditions:
         ok, error = validate_transition("in_progress", "planned", GuardContext(reason="reassigning to other agent"))
         assert ok is True
 
-    def test_conflict_detection_rejects_double_claim(self) -> None:
-        """for_review -> in_review rejects when a different actor already holds the review."""
+    def test_conflict_detection_allows_distinct_actor(self) -> None:
+        """for_review -> in_review is allow-only: a different actor ALLOWs.
+
+        Re-pointed (WP01): the FSM guard carries no role and never invokes the
+        collision predicate, so it cannot express a role-carrying reject — it
+        must ALLOW. The genuine reviewer-vs-reviewer reject is asserted at the
+        ``in_review`` re-claim lifecycle test, not here (NFR-002).
+        """
         ok, error = validate_transition(
             "for_review",
             "in_review",
             GuardContext(actor="reviewer-B", current_actor="reviewer-A"),
         )
-        assert ok is False
-        assert "already claimed" in error.lower()
+        assert ok is True, f"allow-only guard must permit a distinct actor; error={error}"
 
     def test_conflict_detection_allows_same_actor_reclaim(self) -> None:
         """for_review -> in_review permits idempotent re-claim by the same actor."""

--- a/tests/status/test_work_package_lifecycle.py
+++ b/tests/status/test_work_package_lifecycle.py
@@ -9,9 +9,14 @@ import pytest
 
 from kernel.clock import now_utc_iso
 from specify_cli.dashboard.scanner import _KANBAN_COLUMN_FOR_LANE
-from specify_cli.status.models import Lane, StatusEvent, WPInnerStateDelta
+from specify_cli.status.models import InnerStateChanged, Lane, StatusEvent, WPInnerStateDelta
 from specify_cli.status.reducer import materialize_snapshot, reduce
-from specify_cli.status.store import append_event, read_event_stream, read_events
+from specify_cli.status.store import (
+    append_annotations_atomic_verified,
+    append_event,
+    read_event_stream,
+    read_events,
+)
 from specify_cli.status.work_package_lifecycle import (
     WorkPackageClaimConflict,
     WorkPackageStartRejected,
@@ -59,6 +64,32 @@ def _event(
         actor=actor,
         force=False,
         execution_mode="worktree",
+    )
+
+
+def _seed_reviewer_role_annotation(
+    feature_dir: Path, *, actor: str, event_id: str, wp_id: str = "WP01"
+) -> None:
+    """Fold ``role="reviewer"`` onto ``wp_id`` (the resolved-binding review claim).
+
+    The role-aware collision predicate keys off the reduced ``role`` slot, which
+    is populated only when a claim carried a resolved binding
+    (``workflow_executor`` writes ``role="reviewer"`` if ``resolved_binding`` is
+    not None). Seeding it here is what makes the ``in_review`` re-claim collision
+    fire; a binding-less holder (no such annotation) leaves ``role=None`` and
+    degrades to ALLOW (best-effort collision).
+    """
+    append_annotations_atomic_verified(
+        feature_dir,
+        [
+            InnerStateChanged(
+                event_id=event_id,
+                wp_id=wp_id,
+                at=now_utc_iso(),
+                actor=actor,
+                delta=WPInnerStateDelta(role="reviewer"),
+            )
+        ],
     )
 
 
@@ -509,11 +540,17 @@ def test_slow_review_claim_uses_in_review_not_claimed(tmp_path: Path) -> None:
 
 
 def test_start_review_noops_same_reviewer(tmp_path: Path) -> None:
+    """Same reviewer re-claiming an in_review WP is idempotent (predicate rule 3).
+
+    Re-pointed (WP01): the holder's ``role="reviewer"`` is seeded via the binding
+    annotation so the role-aware predicate is exercised; the same actor re-claim
+    resolves to ALLOW (no_op)."""
     feature_dir = _feature_dir(tmp_path)
     append_event(
         feature_dir,
         _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
     )
+    _seed_reviewer_role_annotation(feature_dir, actor="reviewer-a", event_id="01DDDD00000000000000000A4E")
 
     result = start_review_status(
         feature_dir=feature_dir,
@@ -530,11 +567,18 @@ def test_start_review_noops_same_reviewer(tmp_path: Path) -> None:
 
 
 def test_start_review_rejects_second_reviewer(tmp_path: Path) -> None:
+    """Two distinct reviewers on an in_review WP collide (predicate rule 4).
+
+    Re-pointed (WP01): the reject is now role-aware. The holder's
+    ``role="reviewer"`` MUST be seeded via the binding annotation, or the
+    predicate (correctly) degrades to ALLOW. This is the SINGLE genuine reject
+    site — the FSM/guard/parity surfaces carry no role and assert ALLOW."""
     feature_dir = _feature_dir(tmp_path)
     append_event(
         feature_dir,
         _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
     )
+    _seed_reviewer_role_annotation(feature_dir, actor="reviewer-a", event_id="01DDDD00000000000000000A4E")
 
     with pytest.raises(WorkPackageClaimConflict) as exc_info:
         start_review_status(
@@ -548,6 +592,35 @@ def test_start_review_rejects_second_reviewer(tmp_path: Path) -> None:
         )
 
     assert exc_info.value.claimed_by == "reviewer-a"
+
+
+def test_start_review_allows_second_reviewer_when_holder_binding_less(tmp_path: Path) -> None:
+    """Best-effort collision (WP01): a binding-less holder (no reduced role) ALLOWs.
+
+    Records the accepted degradation — when the holder claimed with a bare
+    ``--agent`` (no resolved binding), the reduced ``role`` slot is ``None`` so
+    predicate rule 2 fires and a distinct reviewer's claim is permitted rather
+    than false-blocked. This prevents the mission's primary failure mode (never
+    false-block a cross-profile review) from regressing into a hard block."""
+    feature_dir = _feature_dir(tmp_path)
+    append_event(
+        feature_dir,
+        _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
+    )
+    # NOTE: deliberately NO role annotation -> current_role is None.
+
+    result = start_review_status(
+        feature_dir=feature_dir,
+        mission_slug="099-lifecycle-test",
+        wp_id="WP01",
+        actor="reviewer-b",
+        workspace_context="review:/nonexistent/repo",
+        execution_mode="worktree",
+        repo_root=tmp_path,
+    )
+
+    assert result.no_op is True
+    assert len(read_events(feature_dir)) == 1
 
 
 def test_start_review_rejects_non_review_lane(tmp_path: Path) -> None:

--- a/tests/status/test_work_package_lifecycle.py
+++ b/tests/status/test_work_package_lifecycle.py
@@ -605,7 +605,19 @@ def test_start_review_allows_second_reviewer_when_holder_binding_less(tmp_path: 
     feature_dir = _feature_dir(tmp_path)
     append_event(
         feature_dir,
-        _event("01DDDD0000000000000000004D", from_lane=Lane.FOR_REVIEW, to_lane=Lane.IN_REVIEW, actor="reviewer-a"),
+        _event(
+            "01DDDD0000000000000000004D",
+            from_lane=Lane.FOR_REVIEW,
+            to_lane=Lane.IN_REVIEW,
+            actor="reviewer-a",
+            # Anchored to real "now" (not `_event`'s hard-coded default) so
+            # this test's whole event log is now()-stamped, matching the
+            # `start_review_status` call below -- avoids mixing an absolute
+            # literal with a real-clock event in the same test function
+            # (FR-014 / #3157-class flakiness; see
+            # tests/architectural/test_no_absolute_event_timestamp_mixture.py).
+            at=now_utc_iso(),
+        ),
     )
     # NOTE: deliberately NO role annotation -> current_role is None.
 

--- a/tests/unit/status/test_mission_status_aggregate.py
+++ b/tests/unit/status/test_mission_status_aggregate.py
@@ -497,7 +497,7 @@ class TestTransitionHappyPath:
         """
         from specify_cli.status import TransitionRequest
         from specify_cli.status.aggregate import MissionStatus
-        from specify_cli.status.models import Lane
+        from specify_cli.status.models import CurrentWpState, Lane
 
         ms = MissionStatus(
             mission_slug="034-lane-fallback",
@@ -517,7 +517,7 @@ class TestTransitionHappyPath:
 
         from_lane, current_actor = ms._resolve_current_lane(
             request=request,
-            read_current_wp_state_transactional=lambda **_: ("uninitialized", "claude"),
+            read_current_wp_state_transactional=lambda **_: CurrentWpState(Lane.UNINITIALIZED, "claude", None),
             lane_unseeded=Lane.GENESIS,
         )
 

--- a/tests/unit/status/test_review_claim_predicate.py
+++ b/tests/unit/status/test_review_claim_predicate.py
@@ -1,0 +1,122 @@
+"""Unit tests for the pure review-claim collision predicate (WP01 / T002).
+
+One test per row of the contract truth table
+(``contracts/review-claim-predicate.md``). The predicate is a pure leaf, so
+these run without any filesystem/reduction setup.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.status.review_claim_predicate import (
+    ReviewClaimDecision,
+    review_claim_decision,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_cross_profile_holder_allows() -> None:
+    """Row 1: an implementer holder + reviewer requester -> ALLOW."""
+    decision = review_claim_decision(
+        current_actor="implementer-ivan",
+        current_role="implementer",
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+    assert decision.is_collision is False
+    assert decision.holder is None
+
+
+def test_blank_current_actor_allows() -> None:
+    """Row 2: a blank current_actor is never trusted as a collision -> ALLOW."""
+    decision = review_claim_decision(
+        current_actor="",
+        current_role="",
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+    assert decision.holder is None
+
+
+def test_none_current_actor_allows() -> None:
+    """Row 2 (None variant): a None current_actor -> ALLOW."""
+    decision = review_claim_decision(
+        current_actor=None,
+        current_role=None,
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+
+
+def test_same_reviewer_reclaim_is_idempotent_allow() -> None:
+    """Row 3: the same reviewer re-claiming -> ALLOW (idempotent)."""
+    decision = review_claim_decision(
+        current_actor="reviewer-renata",
+        current_role="reviewer",
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+    assert decision.holder is None
+
+
+def test_distinct_reviewer_collides_and_names_holder() -> None:
+    """Row 4: two distinct reviewers -> COLLISION naming the holder."""
+    decision = review_claim_decision(
+        current_actor="reviewer-bob",
+        current_role="reviewer",
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is False
+    assert decision.is_collision is True
+    assert decision.holder == "reviewer-bob"
+
+
+def test_non_reviewer_role_holder_allows() -> None:
+    """Row 6: a non-reviewer (architect) holder -> ALLOW (rule 2)."""
+    decision = review_claim_decision(
+        current_actor="architect-alphonso",
+        current_role="architect",
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+    assert decision.holder is None
+
+
+def test_binding_less_reviewer_holder_allows_best_effort() -> None:
+    """Best-effort degradation: a reviewer holder with no reduced role
+    (binding-less claim, ``current_role=None``) -> ALLOW (rule 2)."""
+    decision = review_claim_decision(
+        current_actor="reviewer-bob",
+        current_role=None,
+        requesting_actor="reviewer-renata",
+        requesting_role="reviewer",
+    )
+    assert decision.allowed is True
+    assert decision.holder is None
+
+
+def test_requesting_role_does_not_affect_decision() -> None:
+    """The requester's role is not consulted: rule 4 fires regardless of it."""
+    for requesting_role in (None, "", "reviewer", "implementer"):
+        decision = review_claim_decision(
+            current_actor="reviewer-bob",
+            current_role="reviewer",
+            requesting_actor="reviewer-renata",
+            requesting_role=requesting_role,
+        )
+        assert decision.allowed is False
+        assert decision.holder == "reviewer-bob"
+
+
+def test_decision_is_frozen_value_object() -> None:
+    decision = ReviewClaimDecision(allowed=True)
+    with pytest.raises(AttributeError):
+        decision.allowed = False  # type: ignore[misc]

--- a/tests/unit/status/test_review_claim_transition.py
+++ b/tests/unit/status/test_review_claim_transition.py
@@ -21,15 +21,19 @@ class TestReviewClaimTransitionMatrix:
         assert ("for_review", "in_review") in ALLOWED_TRANSITIONS
 
     def test_for_review_to_in_review_is_guarded_by_actor_required(self) -> None:
-        """The guard for the review-claim transition is actor identity +
-        conflict detection (no second reviewer can steal an active claim)."""
+        """The guard for the review-claim transition is actor-presence only.
+
+        Re-pointed (WP01): the ``for_review -> in_review`` guard is allow-only —
+        it enforces actor identity but never blocks a distinct actor (the
+        cross-profile false-positive this mission removes). The reviewer-vs-
+        reviewer reject lives at the ``in_review`` re-claim, not this guard."""
         from specify_cli.status.models import GuardContext, Lane
         from specify_cli.status.wp_state import wp_state_for
 
         state = wp_state_for(Lane.FOR_REVIEW)
         assert state.can_transition_to(Lane.IN_REVIEW, GuardContext(actor=None)) is False
         assert state.can_transition_to(Lane.IN_REVIEW, GuardContext(actor="claude")) is True
-        assert state.can_transition_to(Lane.IN_REVIEW, GuardContext(actor="codex", current_actor="claude")) is False
+        assert state.can_transition_to(Lane.IN_REVIEW, GuardContext(actor="codex", current_actor="claude")) is True
 
 
 class TestReviewClaimGuardBehaviour:
@@ -52,15 +56,17 @@ class TestReviewClaimGuardBehaviour:
         assert not ok
         assert error and "actor" in error.lower()
 
-    def test_validate_transition_rejects_steal_by_second_actor(self) -> None:
-        """A second reviewer must not be able to claim a WP already claimed."""
+    def test_validate_transition_allows_distinct_actor_at_for_review(self) -> None:
+        """Re-pointed (WP01): the allow-only ``for_review`` guard permits a
+        distinct actor. This surface carries no role and never invokes the
+        collision predicate, so no role-carrying reject can be expressed here —
+        the genuine reject is the ``in_review`` re-claim lifecycle test."""
         from specify_cli.status.models import GuardContext
         from specify_cli.status.transitions import validate_transition
 
         ctx = GuardContext(actor="codex", current_actor="claude")
         ok, error = validate_transition("for_review", "in_review", ctx)
-        assert not ok
-        assert error and "claude" in error and "codex" in error
+        assert ok is True, f"allow-only guard must permit a distinct actor; error={error}"
 
     def test_validate_transition_allows_idempotent_re_claim(self) -> None:
         """Same actor re-claiming is benign / idempotent."""


### PR DESCRIPTION
## What changes for you

A reviewer running a **different agent profile than the implementer** can now claim a completed work package for review. Before, claiming a WP for review (`for_review → in_review`) was refused with *"WP already claimed for review by `<implementer>`"* whenever the reviewer's identity differed from the implementer's — which, at `for_review`, it structurally always does. So a cross-profile review (e.g. `reviewer-renata` reviewing `python-pedro`'s work) was rejected as a self-review collision, and the block surfaced confusingly on the status-aggregate seam rather than the `move-task` command.

## The fix

- The `for_review → in_review` guard is now **allow-only** — a stale or cross-profile reviewer role there can never re-block.
- A genuine **reviewer-vs-reviewer** collision is decided by a single pure predicate (`status/review_claim_predicate.py`) at the one `in_review` re-claim site. A real second reviewer is still blocked, and the message names the holder. The implementer-claim path is untouched.
- The holder's role is read from the **reduced status slot**, never by splitting the compact `--agent` actor string (the `#2861` guard).

## Landing note — rescoped onto current `main`

This PR was 59 commits stale-based, and its base predated the partition-residuals status/merge mission. During landing it was **rescoped**:

- **Salvaged** the role-aware gate onto current `main`'s (WP10-restructured, event-sourced) status model: the pure predicate, the `CurrentWpState(lane, actor, role)` read, the hard-allow edge, and the `in_review` collision wiring. `role` turned out to already be a fully-wired reduced slot on `main` (via `#2816`), so the salvage only reads it — no reducer change.
- **Dropped** the original "folds #2960 write-side" hunk: `main`'s WP10 (`#2960`, now closed) already carries a broader blank-clobber guard (write-boundary `"" → None` normalization + reducer truthiness fold + a `status doctor` check). Re-applying the PR's older version would have regressed it. `reducer.py`/`doctor.py` are therefore untouched by this PR.

## Tests

- New: role-aware regression suite (cross-profile allow, genuine collision block, binding-less→allow) + the `#2861` reduced-slot guard test + a no-frontmatter architectural test — all with module `pytestmark`, auto-collected by the glob-based completeness gates.
- Rescoped branch: role-aware suite 22 passed; re-pointed guard/lifecycle/transition/wp_state suite 227 passed; 62 landing/marker/collection-completeness gate tests passed. ruff clean; mypy net-zero-new (the 3 single-file-isolation findings on `work_package_lifecycle.py` are pre-existing and resolve under full-package CI context).
- Reviewed by an independent opus correctness pass + an opus architect pass (the `CurrentWpState` signature ripple was grepped across src+tests — no missed consumer, no tuple-unpack survivor).

## Related

Folds the (already-closed) `#2960` and `#2861`; the write-side of `#2960` is superseded by WP10 on `main` (see landing note). Follow-up `#3445` (configurable-strictness reviewer independence) remains open and out of scope here. Contract note: `Priivacy-ai/spec-kitty-events#48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
