### PR TITLE
docs(plans): disposition + sequencing for two roadmap blind spots (retrospect surface, consumer-repo layout)

### DIFF
--- a/docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
+++ b/docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR: Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage'
-description: 'Collapses the two divergent pack manifests (counts vs enumerated) onto one canonical pack-manifest schema for every pack type, splits authored lineage/identity from generated constituents, and delegates parent-pack resolution to the existing extends resolver.'
+description: 'Unifies the two divergent pack manifests (counts vs enumerated) onto one canonical pack-manifest schema for every pack type, splitting authored lineage from generated constituents.'
 status: Accepted
 date: '2026-08-16'
 related:

--- a/docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
+++ b/docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
@@ -1,0 +1,133 @@
+---
+title: 'ADR: Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage'
+description: 'Collapses the two divergent pack manifests (counts vs enumerated) onto one canonical pack-manifest schema for every pack type, splits authored lineage/identity from generated constituents, and delegates parent-pack resolution to the existing extends resolver.'
+status: Accepted
+date: '2026-08-16'
+related:
+- docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
+- docs/plans/domains/doctrine-charter-domain-plan.md
+---
+
+# Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage
+
+**Filename:** `2026-08-16-1-pack-metadata-manifest-unification.md`
+
+**Status:** Accepted
+
+**Date:** 2026-08-16
+
+**Deciders:** Maintainer
+
+**Technical Story:** [#2467 (KEYSTONE — split built-in doctrine into packs + compound packs)], corroboration in [`docs/plans/investigations/2026-08-pack-level-metadata-manifest.md`]
+
+---
+
+## Context and Problem Statement
+
+A pack — built-in, org, fetched, or a charter bundle — has no single, first-class
+record of **what it contains** and **where it sits in a lineage** (its parent pack,
+and, for a charter pack, which doctrine pack it accompanies). The information exists,
+but scattered across **two divergent manifest formats that disagree**:
+
+- `pack-manifest.yaml` for org doctrine packs (`src/specify_cli/doctrine/snapshot.py:157-180`)
+  records per-kind **`artifact_counts`** (`:195-212`) — counts, not an enumerated list —
+  carries **no lineage**, and is **not written** for the built-in or git-managed packs
+  (`…/contracts/pack-layout.md:104-107`).
+- `synthesis-manifest.yaml` for charter/project bundles
+  (`src/charter/synthesizer/manifest.py:46-112`) records **enumerated**
+  `artifacts:[{kind, slug, path, content_hash}]` plus a self-integrity `manifest_hash`
+  (`:107`) — the "constituent parts" model — but exists only for charter bundles.
+
+The **built-in reference pack that every org pack extends has no pack-level manifest at
+all** — `packs/built-in/*.graph.yaml` carry only `schema_version`/`generated_by` headers.
+Packs also have **no stable identity** — they are keyed only by config `name`
+(`org_pack_config.py:166`) — and a charter pack's binding to its doctrine pack exists
+only **per-activation** as `doctrine_pack_id` (`src/charter/activations.py:241`), never
+as one pack-level pointer.
+
+Left unaddressed, adding pack metadata would ship a **third** format and deepen the
+fragmentation. The decision is whether to **unify** onto one schema or **bridge** the two.
+
+## Decision Drivers
+
+- **Single canonical authority** (charter governing principle): one description of a
+  pack, not two that drift.
+- **Trust/verifiability:** a `constituents[] + content_hash + manifest_hash` inventory is
+  the substrate for the pack-trust / verified-distribution epic (#2539/#2543); two formats
+  means two things to sign and verify.
+- **Cost asymmetry:** three of the required gaps (built-in manifest, stable `pack_id`, the
+  charter→doctrine binding) are net-new *regardless* of unify-vs-bridge; bridge avoids only
+  the (mechanical, M-sized) migration of `artifact_counts` readers, at the permanent cost of
+  a two-format "add every field twice" tax.
+- **Lossless dominance:** `constituents[]` strictly dominates `artifact_counts` — counts are
+  a derivable projection of the enumerated list, never the reverse.
+
+## Considered Options
+
+1. **Unify** — one `pack-manifest` schema for all pack types; enumerated constituents
+   canonical; counts become a derived view; `synthesis-manifest.yaml` becomes the charter
+   pack's instance (via a charter profile block).
+2. **Bridge** — keep both formats, reconcile behind a read adapter, fill gaps per format.
+
+## Decision Outcome
+
+**Chosen: Unify.** Pack metadata is canonicalized on a single manifest schema for every
+pack type, with two structural rules:
+
+### 1. One schema, enumerated constituents, charter profile
+
+`constituents: [{kind, id, path, content_hash}]` is the canonical inventory across all
+packs. `artifact_counts` is **retired** as stored state and, where still needed, computed
+from `constituents[]`. The charter bundle's extra fields (`mission_id`,
+`bundle_content_hash`, `synthesizer_version`) live in an optional `charter:` **profile
+block** on the same schema — not a forked format. `synthesis-manifest.yaml` becomes the
+charter pack's generated manifest instance.
+
+### 2. Two files: authored identity/lineage vs generated constituents
+
+The pack-layout contract forbids authors editing the generated manifest
+(`pack-layout.md:104`). Rather than fence an authored block inside a generated file, the
+manifest is split:
+
+- **`pack.yaml`** (authored, hand-edited): `pack_id` (stable identity, minted once —
+  mirrors the `mission_id` ULID identity model), `pack_version`, `parent_pack`,
+  `accompanies_doctrine_pack`, human metadata.
+- **`pack.md`** (authored): human-readable pack description.
+- **`pack-manifest.yaml`** (generated, never hand-edited): `schema_version`,
+  `generated_by`/`generated_at`, `manifest_hash`, `constituents[]`, and the optional
+  `charter:` profile block.
+
+This matches the operator's original instinct ("a yaml + markdown pair accompanying a
+pack"): the yaml+md are the *authored* meta + human doc; the generated constituent record
+is their verifiable sibling.
+
+### 3. Lineage delegates, never re-walks
+
+`parent_pack` and `accompanies_doctrine_pack` **store** edges only. Resolution order is
+delegated to the existing `src/charter/org_extends.py::resolve_extends_order` (the
+canonical `extends:` resolver with cycle detection). A second walker is prohibited — it
+trips the C-005 no-parallel-resolver ratchet (`org_extends.py:14-21`).
+
+### Bridge is a migration tactic, not a destination
+
+If the `artifact_counts`-reader migration proves deeper than expected, a bridge-then-unify
+sequence is permitted **only** with a stated unify-by release; two permanent formats are
+not an acceptable end state.
+
+## Consequences
+
+**Positive.** One canonical pack description; a single signing/verification target for
+#2539; stable `pack_id` for trust and lineage keys; the charter→doctrine binding gains a
+pack-level home; every future field is added once.
+
+**Negative / cost.** Requires migrating `artifact_counts` readers to the derived view
+(mechanical, M). Requires a new generator emitting `pack-manifest.yaml` for the built-in
+pack from its per-kind `*.graph.yaml` `nodes:`. Introduces a `pack_id` minting/backfill
+step for existing packs.
+
+**Scope note.** This ADR fixes the *schema and split*; it is the first deliverable of
+#2467's pack-manifest bullet and is sequenced with the pack-trust epic **#2539** (the
+manifest is the verifiability carrier). The broad "compound packs" work in #2467 remains a
+separate slice. Implementation decomposes into: WP-core (unify schema + built-in writer),
+WP-identity (`pack_id`), WP-lineage (`parent_pack` delegation + `accompanies_doctrine_pack`),
+WP-split (authored vs generated files).

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -182,3 +182,4 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-13 | [Gate outcomes carry a typed severity; an operator-configured error-handling strategy decides the CLI effect](2026-08-13-6-gate-outcomes-carry-severity-operator-strategy-decides-effect.md) |
 | 2026-08-13 | [Mission-Type Roster Layering Is the Availability Slice, Not the Kind-Promotion Slice](2026-08-13-1-mission-type-roster-layering-seam.md) |
 | 2026-08-15 | [Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract](2026-08-15-1-handoff-packet-intake-contract.md) |
+| 2026-08-16 | [Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage](2026-08-16-1-pack-metadata-manifest-unification.md) |

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2862,6 +2862,20 @@ pages:
     - {slug: "require-a-mandatory-structured-format", text: "Require a mandatory structured format", level: 3}
     - {slug: "encode-producer-specific-vocabulary-in-the-schema", text: "Encode producer-specific vocabulary in the schema", level: 3}
     - {slug: "references", text: "References", level: 2}
+  - path: "docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md"
+    title: "ADR: Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage"
+    divio_type: "none"
+    abstract: "Unifies the two divergent pack manifests (counts vs enumerated) onto one canonical pack-manifest schema for every pack type, splitting authored lineage from generated constituents."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "1-one-schema-enumerated-constituents-charter-profile", text: "1. One schema, enumerated constituents, charter profile", level: 3}
+    - {slug: "2-two-files-authored-identity-lineage-vs-generated-constituents", text: "2. Two files: authored identity/lineage vs generated constituents", level: 3}
+    - {slug: "3-lineage-delegates-never-re-walks", text: "3. Lineage delegates, never re-walks", level: 3}
+    - {slug: "bridge-is-a-migration-tactic-not-a-destination", text: "Bridge is a migration tactic, not a destination", level: 3}
+    - {slug: "consequences", text: "Consequences", level: 2}
   - path: "docs/adr/3.x/README.md"
     title: "3.x ADRs"
     divio_type: "none"
@@ -12085,6 +12099,46 @@ pages:
     - {slug: "open-items-non-blocking-first-pass-findings-retained", text: "Open items (non-blocking, first-pass findings retained)", level: 3}
     - {slug: "open-items-non-blocking-post-restoration", text: "Open items (non-blocking, post-restoration)", level: 3}
     - {slug: "mission-level-assessment", text: "Mission-level assessment", level: 3}
+  - path: "docs/plans/investigations/2026-08-consumer-repo-layout-portability.md"
+    title: "Consumer-repo layout portability: disposition and sequencing"
+    divio_type: "none"
+    abstract: "Planner disposition for the consumer-repo layout blind spot (#3016/#2330): a bounded 3.2.x correctness down-payment now, broad portability deferred to mission-types-as-doctrine."
+    anchors:
+    - {slug: "problem", text: "Problem", level: 2}
+    - {slug: "evidence", text: "Evidence", level: 2}
+    - {slug: "options-considered", text: "Options considered", level: 2}
+    - {slug: "decision", text: "Decision", level: 2}
+    - {slug: "architect-recommendation", text: "Architect recommendation", level: 2}
+    - {slug: "recommended-tracker-actions", text: "Recommended tracker actions", level: 2}
+    - {slug: "sequencing", text: "Sequencing", level: 2}
+    - {slug: "open-questions-for-the-operator", text: "Open questions for the operator", level: 2}
+  - path: "docs/plans/investigations/2026-08-pack-level-metadata-manifest.md"
+    title: "Pack-level metadata manifest: constituent parts + lineage"
+    divio_type: "none"
+    abstract: "Corroborates one pack-level manifest recording each pack's enumerated constituents and parent/lineage — a consolidation of two divergent existing manifests, not a new format."
+    anchors:
+    - {slug: "the-proposal", text: "The proposal", level: 2}
+    - {slug: "verdict-sound-with-one-reframe", text: "Verdict: SOUND, with one reframe", level: 2}
+    - {slug: "what-already-exists-reuse-don-t-reinvent", text: "What already exists (reuse, don't reinvent)", level: 3}
+    - {slug: "the-one-genuinely-thin-spot-the-charter-doctrine-binding", text: "The one genuinely thin spot — the charter↔doctrine binding", level: 3}
+    - {slug: "recommended-design", text: "Recommended design", level: 2}
+    - {slug: "readiness-read", text: "Readiness read", level: 2}
+    - {slug: "gaps-ordered-load-bearing-first", text: "Gaps (ordered, load-bearing first)", level: 2}
+    - {slug: "decision-needed-from-the-operator", text: "Decision needed from the operator", level: 2}
+    - {slug: "open-questions-for-the-operator", text: "Open questions for the operator", level: 2}
+  - path: "docs/plans/investigations/2026-08-retrospective-surface-disposition.md"
+    title: "Retrospective-learning surface: disposition and sequencing"
+    divio_type: "none"
+    abstract: "Planner disposition for the retrospect-surface blind spot (#1239/#2267/#3072): milestone the two orphans now, then mint one lightweight epic on the dual-schema reconciliation."
+    anchors:
+    - {slug: "problem", text: "Problem", level: 2}
+    - {slug: "evidence", text: "Evidence", level: 2}
+    - {slug: "options-considered", text: "Options considered", level: 2}
+    - {slug: "decision", text: "Decision", level: 2}
+    - {slug: "architect-recommendation", text: "Architect recommendation", level: 2}
+    - {slug: "recommended-tracker-actions", text: "Recommended tracker actions", level: 2}
+    - {slug: "sequencing", text: "Sequencing", level: 2}
+    - {slug: "open-questions-for-the-operator", text: "Open questions for the operator", level: 2}
   - path: "docs/plans/investigations/2497-external-observability-endpoints-assessment.md"
     title: "RFC #2497 — External Observability Endpoints: Squad Assessment"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -986,6 +986,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none
@@ -4155,6 +4161,24 @@
   current_target: true
   notes: null
 - path: docs/plans/investigations/2026-04-14-windows-compatibility-hardening-mission-review.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/plans/investigations/2026-08-retrospective-surface-disposition.md
   tag: current
   divio_type: none
   owning_workstream: none

--- a/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
+++ b/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
@@ -1,6 +1,6 @@
 ---
 title: 'Consumer-repo layout portability: disposition and sequencing'
-description: 'Planner disposition for the consumer-repo layout blind spot (#3016/#2330) — a bounded 3.2.x correctness down-payment now, broad portability deferred to a language-neutral extension of mission-types-as-doctrine.'
+description: 'Planner disposition for the consumer-repo layout blind spot (#3016/#2330): a bounded 3.2.x correctness down-payment now, broad portability deferred to mission-types-as-doctrine.'
 doc_status: proposed
 updated: '2026-08-15'
 related:

--- a/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
+++ b/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
@@ -149,6 +149,9 @@ and should not wait on the mechanism decision.
 
 ## Architect recommendation
 
+> **Operator-accepted (2026-08-16).** The recommendation below is adopted as the
+> decision; the ratifying ADR records it rather than re-opening it.
+
 The override-mechanism choice this disposition deferred to architect review has been
 made (architect-alphonso, 2026-08-15):
 

--- a/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
+++ b/docs/plans/investigations/2026-08-consumer-repo-layout-portability.md
@@ -1,0 +1,236 @@
+---
+title: 'Consumer-repo layout portability: disposition and sequencing'
+description: 'Planner disposition for the consumer-repo layout blind spot (#3016/#2330) — a bounded 3.2.x correctness down-payment now, broad portability deferred to a language-neutral extension of mission-types-as-doctrine.'
+doc_status: proposed
+updated: '2026-08-15'
+related:
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/plans/3-2-x-open-core-delivery-plan.md
+- docs/plans/domains/doctrine-charter-domain-plan.md
+- docs/plans/index.md
+---
+
+# Consumer-repo layout portability: disposition and sequencing
+
+**Scope:** a `proposed` investigation on the distil-then-retire working surface —
+**not** a canonical ADR. It records a planner disposition (roadmap-line vs de-scope
+vs fold vs minimal-fix) and sequencing for the consumer-repo layout blind spot. The
+override-*mechanism* choice (config key vs resolver deep-merge) is a real
+architectural call and is deferred to architect review; when settled it belongs in
+an ADR under `docs/adr/3.x/`. This document retires once the down-payment lands and
+the deferred tail has a named home. Evidence base:
+`work/bug-triage-research/blindspot-consumer-layout.md` and
+`categorization-findings.md` §4.
+
+## Problem
+
+`accept` and the path-convention gates assume a Python `src/` + `tests/` layout, so
+first-party non-Python consumer repos fail the gate: **#3016** (P1, Django `apps/`)
+and **#2330** (P1, Go `internal/`+`cmd/`). Supporting arbitrary consumer-repo
+layouts reads as *new capability*, not stabilization.
+
+**Corrected framing (milestone vs epic).** Both #3016 and #2330 **already carry
+milestone `3.2.x`** — "no 3.2.x line owns it" is about **epic/goal-line ownership**,
+not the tag. Sibling **#2329** (same defect) is **closed as duplicate**; **#1892**
+(the `--lenient` ask) is **closed and shipped** — an escape hatch already exists. So
+the decision is the fate of a capability that is *milestone-tagged but
+epic-orphaned, with one escape-hatch increment already delivered* — again an
+**ownership** question, not a scheduling one.
+
+## Evidence
+
+**The primary seam is shallow and already data-driven** — the load-bearing fact.
+
+| Layer | File:line | Role |
+|---|---|---|
+| DATA (root) | `missions/software-dev/mission.yaml:152-153` (`workspace:"src/"`, `tests:"tests/"`; `:110` deliverable `src/`) | the *only* place the shape is asserted for the gate |
+| Model | `mission.py:166-176,183` (`valid_path_keys`) | keys hardcoded, **values free** |
+| Validator (**language-neutral**) | `validators/paths.py:133-215` `validate_mission_paths` | data-driven; reads `mission.config.paths`; **no language literal**; `mkdir -p` remedy at `:81-105` |
+| Gate | `acceptance/summary_core.py:110-148` `evaluate_path_conventions` (wired `acceptance/__init__.py:1013`) | `strict_metadata=True` → hard block; `--lenient` → advisory (the #1892 hatch, `:120-128`) |
+
+**The missing override is the actual gap.** `mission.yaml` is overlayable, but
+resolution is **whole-file precedence, not deep-merge**
+(`src/doctrine/resolver.py:303-361`). To change only `paths:` a project must copy the
+**entire** `mission.yaml` into `.kittify/overrides/` — brittle and drifts on
+`upgrade`. There is no granular `paths` / `path_conventions` knob in
+`.kittify/config.yaml`. **That missing capability is the root ask** — a
+*shallow-seam-plus-missing-override*, not a language assumption buried in the
+validator.
+
+**The correctness wart (independent of portability).** The `mkdir -p src/` remedy
+still prints for a layout where `src/` is inapplicable, converting an inapplicable
+gate check into a **falsely-passing** one — it makes a gate *lie*. That violates the
+charter's *trace-don't-work-around* guidance on its own merits, regardless of the
+roadmap verdict.
+
+**The blast tail.** Beyond the one hard-blocking surface sit **~7** *secondary,
+mostly-non-blocking* hardcodes (the count is **approximate and illustrative** — the
+list below is representative, not an exhaustively re-counted census): `ownership/validation.py:77`
+(`_CODE_PREFIXES=("src/","tests/")`), `policy/risk_scorer.py:190`,
+`lanes/compute.py:76,88`, `review/_dead_code.py:104,133,135`,
+`review/scope_source.py:266`, `post_merge/stale_assertions.py:262,747`,
+`missions/documentation/doc_generators.py:164` + `gap_analysis.py:723`. (Explicitly
+**excluded**: `template/manager.py`, `skills/registry.py`, `compat/doctor.py`, `m_*`
+migrations — those are spec-kitty locating its *own* tree, not consumer layout.)
+Depth verdict: **1 hard-blocking surface (already softened by `--lenient`) + a long,
+shallow, non-blocking tail.**
+
+**Demand + open-core relevance.** Demand is **real but internal/dogfooding-only** —
+two first-party repos (`spec-kitty-saas` Django, `spec-kitty-analyzer` Go); no
+`customer-feedback` label, no external ticket. And this is **orthogonal** to the
+open-core thesis: the open-core "consumer" is a *doctrine-pack consumer*
+(`3-2-x-open-core-delivery-plan.md` §2.2/§3), whereas #3016/#2330's "consumer repo"
+is the *project spec-kitty runs against*. The natural architectural neighbor is
+**mission-types-as-doctrine (#2468/#2721)** — they make `mission.yaml`/`paths:`
+overlayable doctrine — but **neither epic today commits to language-neutral path
+conventions or a granular `paths` override**, and #2721 needs resolver **deep-merge**
+that is not in its scope.
+
+## Options considered
+
+- **(a) New 3.3.x portability line.** — *Reject for now.* Honestly names the
+  capability and keeps 3.2.x pure, but demand is internal-only, `--lenient` already
+  softens urgency, and a standalone epic is net-new scope with no external pull.
+  Revisit only if an external (non-dogfooding) ticket appears.
+- **(b) Fold into mission-types-as-doctrine (#2468/#2721).** — *Accept, but deferred
+  and only for the tail.* Architecturally the correct long-term home (`paths:` is
+  already overlayable doctrine there), but those epics are scoped to
+  ArtifactKind/step-model, and the real fix needs resolver deep-merge not in either
+  epic today. Forcing deep-merge onto a load-bearing G1 epic *now* is scope-creep on
+  a load-bearing epic. Fold **when they mature the granular overlay**, not before.
+- **(c) De-scope as non-goal (Python-first).** — *Reject.* Hard to justify while
+  Priivacy-ai dogfoods its own Go + Django repos, and — decisively — the `mkdir -p
+  src/` wart is a **correctness** bug independent of portability. A Python-first
+  product still must not prescribe an action that makes a gate lie.
+- **(d) Minimal fix: config-driven layout for accept/gates.** — *Accept as the
+  immediate down-payment.* Smallest diff; the validator is already data-driven, so it
+  needs only a granular `paths` override + softening the misleading remedy. Kills the
+  hard-block and the falsely-passing remedy. Its limitation — the ~7 (approximate,
+  illustrative) secondary heuristics stay Python-shaped — is exactly what the deferred
+  (b) tail covers.
+
+## Decision
+
+**Decouple correctness from portability; ship a bounded 3.2.x down-payment now, defer
+broad portability to a matured mission-types-as-doctrine.** Concretely, two tracks:
+
+- **Track 1 — correctness + hard-block down-payment (keep on 3.2.x): option (d).**
+  (i) Soften the `mkdir -p src/` remedy so it does not print an inapplicable action
+  when a convention is *absent* (vs *violated*) — a standalone correctness fix,
+  **dependency-free as a diff**. Its user-visible payoff is **latent** until the
+  granular `paths` override (ii) exists: absent an override, `src/`/`tests/` are
+  always *declared* for every consumer (from the default `mission.yaml`), so the
+  "absent" branch never fires — and for a plain Python repo a missing `src/` is a
+  legitimate *violation* where `mkdir` is the correct remedy. The fix still lands
+  alone, because it closes the trace-don't-work-around violation in the remedy
+  generator regardless of when its payoff becomes observable.
+  (ii) Add a **granular `paths` / `path_conventions` override** so a non-Python
+  project can retarget layout without copying the whole `mission.yaml`. Together these
+  remove the hard-block for Django/Go and stop the gate lying. Bounded to ~2–3
+  surfaces (the validator is already neutral).
+- **Track 2 — broad portability (defer, 3.3.x-shaped): option (b), not (a).** The
+  ~7 secondary heuristics land later as a **language-neutral extension of
+  mission-types-as-doctrine (#2468/#2721)**, once those epics adopt the granular
+  overlay / deep-merge. **Not** a standalone 3.3.x epic (no external demand), **not**
+  a fold *today* (the epics are not scoped for it yet).
+
+**Architectural justification (for architect review).** The portability problem is
+*already* factored the right way: the gate is data-driven and language-neutral
+(`validators/paths.py:133-215`), so the fix is not "de-Python the validator" — it is
+"make the data overridable granularly." That surfaces **one genuine architectural
+choice: a `path_conventions` key in `.kittify/config.yaml` *versus* resolver
+deep-merge (`resolver.py:303-361`).** The config-key is the bounded, 3.2.x-shaped
+down-payment; **deep-merge is the more general change and is the one that naturally
+belongs with mission-types-as-doctrine.** The disposition does **not** pick the
+mechanism — that is the architect's call — but the choice has a roadmap consequence:
+pick deep-merge and Track 1 partially pre-builds Track 2's home; pick the config-key
+and Track 2 stays a clean separate fold. The `mkdir` remedy fix is orthogonal to both
+and should not wait on the mechanism decision.
+
+## Architect recommendation
+
+The override-mechanism choice this disposition deferred to architect review has been
+made (architect-alphonso, 2026-08-15):
+
+**Prefer resolver deep-merge over a `config.yaml` `path_conventions` key — but scope
+the 3.2.x down-payment to a *bounded* merge of the `paths:` subtree only, not a
+general deep-merge and not a config side-channel.**
+
+Path conventions are mission-config data — they already live in
+`mission.config.paths`, and the validator reads them there. The override therefore
+belongs in the **same resolution layer**: one source of truth. A `config.yaml`
+`path_conventions` key introduces a **second competing authority** plus a new
+precedence question (config `apps/` vs `overrides/mission.yaml` `src/` — who wins?),
+and it becomes throwaway once deep-merge lands (a double migration).
+
+A **full, general** deep-merge on `resolve_mission` is a broad, load-bearing change
+that needs its own ADR (list-vs-scalar-vs-null semantics) and belongs with #2721, not
+a G1 epic now. The resolution: for 3.2.x, let the override tier supply a **partial
+that deep-merges over the package default for the `paths:` key specifically** (e.g.
+`.kittify/overrides/missions/<name>/paths.yaml`, or a `paths:`-only partial
+`mission.yaml`). The merge semantics are trivial (flat `str→str`, shallow-merge) — no
+general-deep-merge ADR required — yet forward-compatible: when #2721 generalises
+deep-merge, `paths` is already the right shape.
+
+**Trade-off:** the config key is the smallest diff and ships fastest, but leaves a
+durable second source of truth, precedence ambiguity, and double-migration debt. The
+bounded `paths:`-subtree merge is a slightly larger diff, keeps `mission.yaml` the
+single authority, avoids upgrade drift, and matches the shape #2721 will later
+generalise. **If forced to an either/or: choose deep-merge (bounded to `paths:`), not
+the config key.**
+
+## Recommended tracker actions
+
+- **Keep #3016 and #2330 on 3.2.x** as the Track 1 down-payment (they are
+  stabilization-shaped: unblock the gate + stop it lying, not net-new capability).
+- **File the `mkdir -p src/` remedy fix as its own bounded item** (correctness;
+  ship-alone, no mechanism dependency). Cross-link to #3016 (which explicitly flags
+  the misleading remedy).
+- **Do not mint a standalone 3.3.x portability epic (option a) now.** Instead add a
+  **deferred fold-target note** on #2468/#2721: "language-neutral path conventions +
+  granular `paths` overlay — the ~7 secondary heuristics land here when the overlay
+  matures." Keep it as a **loose 3.3.x line/annotation**, not an active epic.
+- **Close-check** #2329 (dup, already closed) and #1892 (`--lenient`, shipped) so
+  they are not re-triaged.
+- **Do not "fix" portability by widening `--lenient`** — #3016 already rejects it as
+  blunt (it drops other strict checks).
+
+## Sequencing
+
+1. **Now, independent, smallest:** soften the `mkdir -p src/` remedy (absent-vs-
+   violated). Ships alone with no dependency and closes the trace-don't-work-around
+   violation in the remedy generator; its **user-visible payoff is realised once the
+   granular `paths` override (step 2) lets a convention be *absent*** — absent an
+   override, `src/`/`tests/` are always declared, so the "absent" branch never
+   triggers.
+2. **Track 1 core — granular `paths` override.** Depends only on the architect's
+   mechanism ruling (config-key vs deep-merge). Unblocks #3016/#2330's hard-block on
+   3.2.x. Add regression coverage for a non-`src/` layout (Django `apps/`, Go
+   `internal/`) in the same change.
+3. **Track 2 tail (deferred, 3.3.x).** The ~7 secondary heuristics, folded into a
+   language-neutral extension of #2468/#2721 **after** those epics adopt the overlay.
+   Independent of each other; sequence by consumer pain (dogfooding signal), not all
+   at once.
+
+Dependency note: step 1 has **no** dependency and should not be gated behind the
+mechanism decision; steps 2 and 3 both wait on the mechanism ruling, and step 3
+additionally waits on #2468/#2721 maturing.
+
+## Open questions for the operator
+
+- **Keep #3016/#2330 on 3.2.x, or bump to 3.3.x?** *Recommended default: keep on
+  3.2.x* framed as the (d) correctness/hard-block down-payment; the **broad
+  portability capability** (the tail) is what carries the 3.3.x framing, as a fold
+  into #2468/#2721 — not these two tickets. Flagging rather than resolving: keep-vs-
+  bump is an operator call because it reframes what "3.2.x done" means.
+- **Any external (non-dogfooding) demand?** *Recommended default: treat as
+  internal-only* until a `customer-feedback` ticket appears. If external demand
+  surfaces, Track 2 escalates from a deferred fold to a real 3.3.x line (option a).
+- **Override mechanism — answered.** The config `path_conventions` key vs resolver
+  deep-merge question is the architect's decision, and it has been made: prefer
+  resolver deep-merge **bounded to the `paths:` subtree** for 3.2.x — not a general
+  deep-merge, not a `config.yaml` side-channel (see
+  [Architect recommendation](#architect-recommendation)). Retained here only for its
+  roadmap consequence: the bounded `paths:` merge already pre-builds the shape #2721
+  will generalise, so Track 1 lands forward-compatible with Track 2's home rather
+  than throwaway.

--- a/docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
+++ b/docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
@@ -1,6 +1,6 @@
 ---
 title: 'Pack-level metadata manifest: constituent parts + lineage'
-description: 'Design corroboration for a single pack-level manifest recording each pack''s enumerated constituents and its parent/lineage (incl. charter-pack ↔ doctrine-pack binding) — a consolidation of two divergent existing manifests, not a new format.'
+description: 'Corroborates one pack-level manifest recording each pack''s enumerated constituents and parent/lineage — a consolidation of two divergent existing manifests, not a new format.'
 doc_status: proposed
 updated: '2026-08-16'
 related:

--- a/docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
+++ b/docs/plans/investigations/2026-08-pack-level-metadata-manifest.md
@@ -1,0 +1,140 @@
+---
+title: 'Pack-level metadata manifest: constituent parts + lineage'
+description: 'Design corroboration for a single pack-level manifest recording each pack''s enumerated constituents and its parent/lineage (incl. charter-pack ↔ doctrine-pack binding) — a consolidation of two divergent existing manifests, not a new format.'
+doc_status: proposed
+updated: '2026-08-16'
+related:
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/plans/domains/doctrine-charter-domain-plan.md
+- docs/plans/index.md
+---
+
+# Pack-level metadata manifest: constituent parts + lineage
+
+**Scope:** a `proposed` investigation on the distil-then-retire working surface —
+**not** a canonical ADR. It corroborates an operator design proposal (a pack-level
+manifest recording constituent parts + parent/lineage, for doctrine packs and the
+charter pack that accompanies one) against the shipped code, and records the
+readiness read + gap list. The unify-vs-add decision and the manifest schema, once
+settled, belong in an ADR under `docs/adr/3.x/`. Evidence base:
+`work/bug-triage-research/alphonso-pack-metadata-review.md` (architect-alphonso,
+2026-08-16).
+
+## The proposal
+
+> Each **doctrine pack's** meta-information should carry a record of **its
+> constituent parts** and/or its **parent pack**. The same applies to a **charter
+> pack** — a `yaml` + `markdown` pair that *accompanies* a doctrine pack.
+
+I.e. first-class **pack-level metadata**: a manifest recording (a) what a pack
+contains, and (b) lineage (parent pack / which doctrine pack a charter pack
+accompanies).
+
+## Verdict: SOUND, with one reframe
+
+The model is correct, but the load-bearing finding is that **~70% of it already
+exists** — this is a *consolidation*, not a greenfield feature. The real risk is
+shipping a **third** manifest format. Two pack manifests already ship and **disagree**:
+
+| Manifest | Where | What it records | Gap vs. the proposal |
+|---|---|---|---|
+| `pack-manifest.yaml` (org doctrine packs) | `src/specify_cli/doctrine/snapshot.py:157-180` | `pack_version`, `source_*`, **`artifact_counts`** (per-kind counts, `:195-212`); normative per `…/contracts/pack-layout.md:23,102-109` | counts, not enumerated; **no lineage**; not written for built-in or git-managed packs (`pack-layout.md:104-107`) |
+| `synthesis-manifest.yaml` (charter/project bundle) | `src/charter/synthesizer/manifest.py:46-112` | **enumerated `artifacts:[{kind, slug, path, provenance_path, content_hash}]`** + `manifest_hash` self-integrity (`:107`), `bundle_content_hash`, `schema_version`, `mission_id` | already *is* the "constituent parts" model — but charter-only |
+
+**The built-in pack has no pack-level manifest at all** — `packs/built-in/*.graph.yaml`
+carry only `schema_version`/`generated_at`/`generated_by` headers
+(`directive.graph.yaml:1-3`); there is no `references.yaml`, `pack.yaml`, or root
+manifest anywhere.
+
+### What already exists (reuse, don't reinvent)
+
+- **Constituent parts** live implicitly in three places: the DRG `nodes:` URN
+  inventory per kind, the `artifact_counts` bucket (org), and the enumerated
+  `artifacts[]` (charter only). A surfacing/unification problem, not greenfield.
+- **Parent/lineage** is already modeled twice: pack→pack via `extends:` on
+  `OrgCharterPolicy` (`src/specify_cli/doctrine/org_charter.py:147-155`), resolved
+  with cycle detection by `src/charter/org_extends.py::resolve_extends_order`; and
+  profile-level via the `specializes_from` DRG edge
+  (`src/doctrine/drg/validator.py:50-51`). A manifest `parent_pack` field **must
+  delegate** to `org_extends.py` — a second walker trips the C-005 no-parallel-
+  resolver ratchet (`org_extends.py:14-21`).
+
+### The one genuinely thin spot — the charter↔doctrine binding
+
+This is exactly what the proposal names. A charter pack is not a yaml+md pair; it is
+`charter.yaml` + `charter.md` + `graph.yml` + `synthesis-manifest.yaml` +
+`provenance/`. And the binding to a doctrine pack exists only **per-activation** as
+`doctrine_pack_id` in the `(activation_context, doctrine_pack_id, artifact_id,
+artifact_kind)` 4-tuple (`src/charter/activations.py:241,305`). There is **no single
+pack-level "this charter accompanies doctrine pack Y" pointer** — a real, unfilled gap.
+
+## Recommended design
+
+**Extend `pack-manifest.yaml` into the single pack-level manifest for ALL packs**
+(built-in, org, fetched, charter), promoting `synthesis-manifest.yaml`'s
+`ManifestArtifactEntry` as the shared "constituent" sub-schema. Shape:
+
+- `pack_id` — stable identity (**missing today**; org packs are keyed only by config
+  `name`, `org_pack_config.py:166` — mirror the `mission_id` identity model).
+- `pack_version`, `schema_version`, `generated_by`, `generated_at`, `manifest_hash`
+  (self-integrity; reuse `manifest.py:107`).
+- `parent_pack` — **delegate** semantics to `org_extends.resolve_extends_order`.
+- `accompanies_doctrine_pack` — the missing charter→doctrine pack-level binding.
+- `constituents: [{kind, id, path, content_hash}]` — enumerated, superseding
+  `artifact_counts`.
+
+**Authored-vs-generated split (a design decision to settle first).** The pack-layout
+contract forbids authors editing `pack-manifest.yaml` (`pack-layout.md:104-105,138`),
+but `parent_pack` / `accompanies_doctrine_pack` are **authored** data while
+`constituents` / hashes are **generated**. The manifest must carry an authored
+section and a generated section, or the two concerns collide.
+
+## Readiness read
+
+**Closer than it looks on *data*, further on *unification*.** Every ingredient —
+enumerated constituents, per-artifact content hashes, a self-integrity manifest hash,
+pack `extends:` lineage, and a charter→doctrine `doctrine_pack_id` reference — already
+ships, which is what makes it *feel* ready. What makes it *less* ready: the data lives
+in two schemas that disagree (counts vs. enumerated), the built-in reference pack that
+everything extends has no manifest, "parent pack" is an org-charter concern rather than
+a pack-root field, and there is no stable `pack_id` to hang trust on. A naive "add a
+pack manifest" ships a third format and deepens the fragmentation. **Ready to roll only
+*after* the unify-vs-add decision; the engineering after that is modest.**
+
+## Gaps (ordered, load-bearing first)
+
+1. **Unify the two divergent schemas** (counts `snapshot.py:195` vs. enumerated
+   `manifest.py:46`) before adding anything. Skip it → ship a third format. **Size: M**
+   (pick the enumerated shape canonical; migrate `artifact_counts` readers).
+2. **Built-in pack has no pack-level manifest** (`packs/built-in/`). It is the
+   reference every org pack extends — no uniformity without it. **Size: M** (new writer
+   wired into the build/upgrade path).
+3. **No stable `pack_id`** (packs keyed only by config `name`, `org_pack_config.py:166`).
+   Blocks trust/verifiability + lineage keys; mirror the `mission_id` identity model.
+   **Size: S**.
+4. **No single charter→doctrine-pack binding** (only per-activation `doctrine_pack_id`,
+   `activations.py:241`). The proposal's "accompanies" needs one pack-level pointer.
+   **Size: S**.
+5. **`parent_pack` must reuse `org_extends.py`** (`extends:` in `org-charter.yaml`,
+   `org_charter.py:147`) or trip the C-005 no-parallel-resolver ratchet. **Size: S–M**.
+6. **Authored-vs-generated split** in the manifest (contract forbids authoring the
+   generated file, `pack-layout.md:104`). Small code, load-bearing design decision to
+   settle first. **Size: S**.
+
+## Decision needed from the operator
+
+The first move is a **decision, not code**: **unify on `pack-manifest.yaml` with the
+enumerated `constituents[]` shape (recommended), or keep two manifests and bridge.**
+Gaps #1–#2 are the real work; #3–#6 are small once the call is made. The design is
+trust-adjacent — the constituent-parts + content-hash manifest is the natural carrier
+for the pack-trust / verified-distribution epic **#2539** and DIRECTIVE_018 doctrine
+versioning, so it should be sequenced with (or under) that epic rather than as an
+isolated line.
+
+## Open questions for the operator
+
+- **Unify vs. bridge** (above) — the load-bearing call; recommended: unify.
+- **Home** — a member of the pack-trust epic #2539, or its own line? (Recommended:
+  under #2539, since the manifest is the verifiability carrier.)
+- **`pack_id` minting** — reuse the ULID `mission_id` machinery, or a pack-specific
+  scheme? (Recommended: reuse the identity model for consistency.)

--- a/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
+++ b/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
@@ -147,6 +147,9 @@ proposal-application deferred pending the operator input below.
 
 ## Architect recommendation
 
+> **Operator-accepted (2026-08-16).** The recommendation below is adopted as the
+> decision; the epic's first-deliverable ADR ratifies it rather than re-opening it.
+
 The record-contract choice this disposition deferred to architect review has been
 made (architect-alphonso, 2026-08-15):
 

--- a/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
+++ b/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
@@ -1,0 +1,230 @@
+---
+title: 'Retrospective-learning surface: disposition and sequencing'
+description: 'Planner disposition for the retrospect-surface blind spot (#1239/#2267/#3072) — milestone-hygiene the two orphans now, then mint one lightweight epic spined on the dual-schema reconciliation.'
+doc_status: proposed
+updated: '2026-08-15'
+related:
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/architecture/status-model.md
+- docs/plans/index.md
+---
+
+# Retrospective-learning surface: disposition and sequencing
+
+**Scope:** a `proposed` investigation on the distil-then-retire working surface —
+**not** a canonical ADR. It records a planner disposition decision (roadmap-line vs
+de-scope vs fold vs minimal-fix) plus sequencing for the retrospective-learning
+blind spot. The one genuinely architectural call inside it — which record contract
+becomes canonical — is deferred to architect review and, when settled, belongs in
+an ADR under `docs/adr/3.x/`. This document retires once that ADR and the owning
+epic exist. Evidence base: `work/bug-triage-research/blindspot-retrospect.md` and
+`categorization-findings.md` §4.
+
+## Problem
+
+The retrospective-learning surface (`src/specify_cli/retrospective/`, 16 modules +
+runtime hooks + the `spk-gate-retrospective` skill) carries three open defects with
+**no owning epic**: #1239, #2267, #3072. It is the product of four source
+missions plus a perf spike — substantial prior investment, and a `deprecation.py`
+that actively migrates config **forward**, so the surface is *maintained, not
+winding down*.
+
+**Corrected framing (milestone vs epic).** The aggregate `categorization-findings.md`
+§4 called this "no roadmap home." The tracker is more precise: the surface is
+homeless on the **epic** axis, not uniformly on the **milestone** axis.
+
+| Bug | Milestone | State |
+|---|---|---|
+| #1239 | **3.2.x** | P1; pulled onto the critical path by the 2026-07-04 operator ruling (`3-2-x-milestone-roadmap.md:386`). |
+| #3164 | **3.2.x** | P1, reliability — **fixed via #2717 (commit `87b37246c`), closed.** |
+| #2267 | **None** | milestone-hygiene drift. |
+| #3072 | **None** | milestone-hygiene drift. |
+
+So of the three still-open defects one (#1239) is a loose P1 line on 3.2.x with **no
+owning epic**, and two (#2267, #3072) are §3.1 milestone drift. This is an
+**ownership gap, not a scheduling gap** — the distinction that drives the decision
+below.
+
+## Evidence
+
+**The load-bearing fact is a dual top-level record schema** in
+`retrospective/schema.py`: a Pydantic `RetrospectiveRecord` (**`schema.py:380`**,
+`schema_version:"1"`, `extra="forbid"`) sitting beside a dataclass
+`GenRetrospectiveRecord` (**`schema.py:581`**, `schema_version:1` int). Two
+independently-authored contracts, one per source mission, **never reconciled by an
+ADR**. Every consumer is written as "try Pydantic, except → try Gen." That
+split-brain is the parent defect.
+
+- **#1239** (P1, 3.2.x) — `create` writes the **Gen** shape; `synthesize`'s
+  `read_record` uses Pydantic `extra=forbid` and rejects every Gen field; `summary`
+  then counts the record malformed. Fallback readers were bolted on, but
+  `src/specify_cli/cli/commands/agent_retrospect.py:540` still warns *"proposal
+  application not available for generator-shape proposals yet"* — the payoff path
+  (apply learnings to doctrine) is **dead for exactly the shape `create` writes**.
+  Root: the dual schema.
+- **#3164** — **Resolved by #2717 (commit `87b37246c`) and now closed; no longer a
+  member of this epic.** The discovery-source mismatch is fixed: `summary`'s
+  `iter_mission_instance_dirs` (`summary.py:300`) now anchors on `kitty-specs/*` and
+  **excludes** `.kittify/missions/`, so it no longer picks up template/`__pycache__`
+  dirs as pseudo-missions.
+- **#3072** (P2, None) — `generator.py:_TRACE_ENTRY_RE:89` only matches bold-lead
+  list items, but shipped tracer doctrine (`mission-tracer-files.procedure.yaml`,
+  #2203) tells authors to write **prose** → a doctrine-conformant tracer yields zero
+  findings. Two-package root: parser **and** the doctrine procedure.
+- **#2267** (None) — `generator.py:_detect_force_overrides:453` counts any forced
+  transition as a guard-bypass and does not exclude
+  `_is_review_rejection_event:362`, so the state-machine-*required* `--force` on an
+  `in_review→planned` rejection is mislabeled and rejection cycles are
+  double-counted. Sibling of #1734.
+
+**Blast-radius fact (bounds the urgency).** The completion **gate**
+(`retrospective/gate.py:is_completion_allowed`) is **event-driven** against
+`status.events.jsonl`, *schema-independent*. A schema-broken record does **not**
+block `done`; `spk-gate-retrospective` runs post-merge without blocking completed
+work. Net: the three bugs **nullify the analytics/learning output but do not block
+delivery** — high value-erosion, low delivery-risk. The gate sits on the critical
+path; the record/learning flow is an adjacent post-merge analytics layer, and all
+three defects live in that second layer.
+
+## Options considered
+
+Compressed from the brief, with the planner verdict on each.
+
+- **(a) New owning epic "Retrospective-learning surface reliability."** — *Accept, in
+  lightweight form.* Three defects share one structural root and are cohesive; it
+  gives #1239 an epic home and reflects the four-mission investment. The
+  "adds a goal to a ~95%-mapped roadmap" objection is real, which is why the epic is
+  scoped tight (see Decision), not a broad program.
+- **(b) Fold under #3148 (closeout follow-through).** — *Reject.* #3148's charter is
+  *issue-parking for homeless follow-ups*, not *subsystem repair*. Folding a
+  three-defect subsystem with an architectural root under it is the force-fit
+  anti-pattern #3148 itself warns against; it would need an explicit charter
+  amendment to be honest, at which point you have re-created an epic under the wrong
+  name.
+- **(c) De-scope / deprecate.** — *Reject (strongly).* The gate is critical-path and
+  event-driven — you cannot cleanly remove the surface without redesigning `done`.
+  `deprecation.py` shows forward-migration, four missions + skill + profile +
+  synthesizer are sunk value, and the operator already milestoned two defects as P1
+  = an explicit *"fix"* signal, not *"kill."*
+- **(d) Fix-4-bugs-only + milestone the two orphans.** — *Accept the milestone half,
+  reject the fix-only half.* Milestoning #2267/#3072 is a zero-cost hygiene win.
+  But stopping there leaves #1239's dual-schema reconciliation — an architectural
+  decision — unowned, which invites whack-a-field: the next retrospect defect
+  re-orphans and the "try Pydantic except Gen" tax stays.
+
+## Decision
+
+**Hybrid (d)-milestone + (a)-lite epic.** Concretely:
+
+1. **Immediately milestone #2267 and #3072 to 3.2.x** (zero-code hygiene; stops the
+   burn-count leak — these are exactly the §3.1 milestone-drift class the aggregate
+   flagged).
+2. **Mint one lightweight owning epic** spined on the **#1239 dual-schema
+   reconciliation** as its root-cause line, with **#3072 and #2267 as members**.
+   This converts three orphan symptom-lines into one owned root-cause line.
+
+**Architectural justification (for architect review).** The remaining symptoms are
+downstream of a single unmade architecture decision: *which record contract is
+canonical.* #3072 (tracer parser) and #2267 (force classifier) are leaf defects;
+#1239 is the seam. Point-patching the leaves without naming a canonical contract is
+the "point-patch a shared seam" mistake — every consumer keeps its
+`try-Pydantic-except-Gen` branch and the dead proposal-application path
+(`src/specify_cli/cli/commands/agent_retrospect.py:540`) stays dead. The
+reconciliation is a real ADR-shaped choice — **pick one canonical
+`RetrospectiveRecord`, or sanction a single adapter at a named boundary** — and it
+needs a home that a symptom ticket cannot provide. That is the whole reason for an
+epic rather than three milestone lines. The disposition does **not** choose the
+contract here (that is the architect's call and the epic's first deliverable, now
+answered in [Architect recommendation](#architect-recommendation)); it asserts only
+that the decision must be *owned* before the leaves are touched. With #3164 resolved,
+the ADR gates exactly one leaf (#1239's read/create/synthesize path); #3072 and #2267
+are parallelizable from step 1.
+
+Why *lightweight*: the surface is post-merge analytics, not delivery-critical
+(event-driven gate). The epic buys ownership and an ADR home, not a large program;
+its first increment should be scoped to *trustworthy records + summary*, with
+proposal-application deferred pending the operator input below.
+
+## Architect recommendation
+
+The record-contract choice this disposition deferred to architect review has been
+made (architect-alphonso, 2026-08-15):
+
+**Adopt the Pydantic `RetrospectiveRecord` (`schema.py:380`) as the single canonical
+*persisted* contract; demote `GenRetrospectiveRecord` to an internal
+generator-scratch type that is never persisted; sanction exactly one adapter at the
+generator→persist seam.**
+
+The real decision is *which layer is allowed to have two shapes.* The on-disk
+`retrospective.yaml` contract — and every reader of it — must be single. Pydantic
+wins because:
+
+- It is **already the reader contract** (`read_record` / `synthesize` consume it),
+  so canonicalising it leaves the readers untouched and moves the single adapter to
+  the **write** side, where there is exactly one producer — one adapter instead of N
+  `try-Pydantic-except-Gen` branches.
+- `extra="forbid"` gives the **fail-closed** posture the charter expects.
+- The nested `mission: MissionIdentity` shape is DDD-cleaner.
+
+The generator may keep `GenRetrospectiveRecord` internally, but must adapt to the
+canonical shape **before** persistence, at one named seam.
+
+The ADR's real work is the **field mapping** (Gen flat identity → Pydantic nested
+`MissionIdentity`) plus **`schema_version` unification** (string `"1"` wins;
+read-time migration for int-tagged `1` records). Canonicalising also un-deads the
+proposal-application path (`src/specify_cli/cli/commands/agent_retrospect.py:540`).
+
+**Rejected as an end-state:** two persisted contracts behind a single `load()`
+adapter. Acceptable only as a one-release migration bridge — as a permanent design it
+perpetuates two wire formats, double-adds every field, and re-opens version-tag
+divergence.
+
+## Recommended tracker actions
+
+- **Milestone → 3.2.x:** #2267, #3072 (hygiene; do this first, independent of the
+  epic).
+- **Mint epic** — proposed title **"Retrospective-learning surface reliability"**;
+  scope: *reconcile the dual record schema and restore trustworthy
+  create→synthesize→summary output.* Members: **#1239 (root), #3072, #2267.**
+- **First epic deliverable = an ADR** on record-contract ownership (canonical
+  contract vs sanctioned adapter). Do not start the leaf fixes before it lands.
+- **Do not fold under #3148** — cross-link only, with a note that closeout
+  follow-through and subsystem repair are distinct charters.
+- **#2342 perf verdict** — file it into this epic (it currently has no home).
+- Leave #1239 on its existing 3.2.x milestone; the epic is the *epic* axis, not a
+  milestone change. (#3164 is already closed — fixed via #2717.)
+
+## Sequencing
+
+1. **Now, zero-code:** milestone #2267 + #3072 → 3.2.x; mint the epic; parent all
+   three (#1239, #3072, #2267). (No dependencies.)
+2. **Gate item — ADR on the canonical record contract (#1239 root).** Blocks the
+   record-shape-touching fixes below. Owner: architect. (The architect's answer is
+   in [Architect recommendation](#architect-recommendation); the ADR ratifies it.)
+3. **#3072 (parser + tracer procedure)** and **#2267 (force classifier)** — leaf
+   fixes, **independent of the schema decision and of each other**; parallelizable
+   any time after step 1. #3072 must touch *both* the parser regex and
+   `mission-tracer-files.procedure.yaml` in one change (two-package root) or it
+   re-opens.
+4. **Proposal-application path** (the dead
+   `src/specify_cli/cli/commands/agent_retrospect.py:540` warning) — gated on the
+   operator input below; scheduled only if synthesize output is actually consumed.
+
+## Open questions for the operator
+
+- **Record-contract choice — answered.** The "which record contract is canonical"
+  question this disposition deferred to architect review now has an answer: adopt the
+  Pydantic `RetrospectiveRecord` as the single persisted contract, with one write-side
+  adapter (see [Architect recommendation](#architect-recommendation)). The ADR in
+  Sequencing step 2 ratifies it — no further operator input needed on the mechanism.
+- **Does the operator actually consume the `synthesize → doctrine-mutation`
+  output?** *Recommended default: assume yes* (forward-migrating `deprecation.py` +
+  the skill deployed across all agent dirs signal intent) **but** scope the epic's
+  **first** increment to *trustworthy records/summary only* and defer
+  proposal-application (step 4) as a fast-follow. If the answer is **no**, narrow the
+  epic permanently to records/summary and close the proposal-application path rather
+  than fixing it. Flagging rather than silently resolving: this changes epic scope,
+  so it is the operator's call.
+- **Epic weight.** Recommended default: keep it lightweight (one ADR + three fixes).
+  Confirm this is not over-weight for a non-blocking analytics surface, or conversely
+  that the operator wants the full synthesize payoff restored.

--- a/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
+++ b/docs/plans/investigations/2026-08-retrospective-surface-disposition.md
@@ -1,6 +1,6 @@
 ---
 title: 'Retrospective-learning surface: disposition and sequencing'
-description: 'Planner disposition for the retrospect-surface blind spot (#1239/#2267/#3072) — milestone-hygiene the two orphans now, then mint one lightweight epic spined on the dual-schema reconciliation.'
+description: 'Planner disposition for the retrospect-surface blind spot (#1239/#2267/#3072): milestone the two orphans now, then mint one lightweight epic on the dual-schema reconciliation.'
 doc_status: proposed
 updated: '2026-08-15'
 related:


### PR DESCRIPTION
## What

Two `proposed` investigation docs under `docs/plans/investigations/`, resolving the two **roadmap blind spots** surfaced by the 214-open-bug categorization pass — the cases the bug book flagged as having **no owning epic / roadmap line**:

- `2026-08-retrospective-surface-disposition.md`
- `2026-08-consumer-repo-layout-portability.md`

## Why

A governed categorization of all 214 open bugs against the 3.2.x plan found ~95% already map onto the active goals; the residual blind spots were the **retrospective-learning surface** (#1239/#2267/#3072) and **consumer-repo layout portability** (#3016/#2330). Both are *ownership* gaps (no epic), not scheduling gaps. These docs record the disposition decision + sequencing for each.

## Decisions

**Retrospect surface** — not de-scoped, not folded under #3148. Milestone the two orphans (#2267/#3072) to 3.2.x; mint one lightweight epic spined on the **#1239 dual record-schema reconciliation** (`schema.py:380` Pydantic vs `:581` dataclass), with #3072/#2267 as members. **Architect recommendation:** adopt the Pydantic `RetrospectiveRecord` as the single canonical *persisted* contract, one write-seam adapter. *#3164 was verified fixed by #2717 (`87b37246c`) and closed during review — so it is out of the epic.*

**Consumer-repo layout** — decouple correctness from portability. A bounded **3.2.x down-payment** (soften the falsely-passing `mkdir -p src/` remedy + a granular `paths` override; the validator is already language-neutral), and defer the ~7-heuristic tail into a language-neutral extension of **mission-types-as-doctrine (#2468/#2721)** — not a standalone 3.3.x epic. **Architect recommendation:** bounded `paths:`-subtree deep-merge over a `config.yaml` side-channel key.

## Provenance

Produced via **planner-priti** (disposition) → **architect-alphonso** (architectural alignment; both deferred architectural calls answered inline for the ratifying ADRs) → **comms-cleo** (revision). Both docs are `proposed` distil-then-retire investigations; they retire once their ADRs + epic land.

## Notes

- Docs-only change. Terminology guard (`tests/architectural/test_no_legacy_terminology.py`) passes (10/10).
- The **recommended tracker actions** inside each doc (mint the retrospect epic; milestone #2267/#3072; file the `mkdir` remedy fix) are proposals for operator approval — deliberately **not** executed as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URcBSApfoyiD2tYAWbfNyj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789402431&installation_model_id=427282&pr_number=3480&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3480&signature=ca252103e760fe2d6b8d5d2696baf748a2314b35f8ccbf12c7c1098456be8e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->