### PR TITLE
fix(sync): correct stale `sync enable` consent guidance to `sync opt-in`

### DIFF
--- a/src/specify_cli/cli/commands/sync.py
+++ b/src/specify_cli/cli/commands/sync.py
@@ -1081,7 +1081,7 @@ def _empty_selection_cause(report: PerProjectStoreReport) -> str:
         return (
             f"No project in the event journal has consented to hosted sync{detail}. "
             f"Its {total} retained event(s) stay on this machine and will never be "
-            "delivered until consent is recorded — run `spec-kitty sync enable` in "
+            "delivered until consent is recorded — run `spec-kitty sync opt-in` in "
             "the project that should ship, or `spec-kitty sync doctor` for the full "
             "per-project breakdown."
         )


### PR DESCRIPTION
## What changes

The per-project event-store report (`spec-kitty sync status` / `sync doctor`) told operators to **`run \`spec-kitty sync enable\`** to record hosted-sync consent — but there is no `sync enable` command. The correct command is **`sync opt-in`**. An operator following the message hit a dead end.

This one-line message fix was surfaced while documenting the SaaS sync-drain gates for the Bucket-2 self-documenting-repo mission (`#3464`) — the runbook already documents `sync opt-in` as the consent command; this aligns the in-code guidance with it.

## Known adjacent issue (NOT fixed here — needs sync-domain input)

Several messages still tell operators to **`run \`spec-kitty sync migrate\`** to recover unresolved journal-event identity (`sync.py` ~L1074, ~L1480, ~L2085). But `migrate` is now **retired** — it refuses and redirects to the unrelated `project-store-preview`/`project-store-migrate` (legacy-DB migration, not identity recovery). The correct current identity-recovery command isn't determinable from the code (the #3030 H4 identity-backfill trigger is unclear), so I deliberately did **not** guess a replacement. Flagging for a maintainer with sync-domain context to resolve — happy to fix once the right command is confirmed.

## Tests

Docs/message-only change; `tests/cli/commands/ -k sync` → 211 passed; ruff clean. No `__init__.py` change (no version bump needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789411692&installation_model_id=427282&pr_number=3484&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3484&signature=f55de56850e2238d37905b5be9f44b77a4f914b168bb690bbfd44351fa2a24a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->