### PR TITLE
chore: add cursor to agent config + record drg-reachability op evidence

### DIFF
--- a/.kittify/config.yaml
+++ b/.kittify/config.yaml
@@ -4,6 +4,7 @@ agents:
   available:
   - claude
   - codex
+  - cursor
   auto_commit: false
   lint_on_edit: true
 project:

--- a/.kittify/evidence/01KZZKZRETNF0RM802ZFM9FEMS/evidence.md
+++ b/.kittify/evidence/01KZZKZRETNF0RM802ZFM9FEMS/evidence.md
@@ -1,0 +1,1 @@
+Closed #2702 (record-analysis write-side confirmed closed+guarded; evidence comment posted). #3372 required no action — already closed COMPLETED by mission #3383 (upgrade-wedge cluster) during this session; our mission drops #3372 accordingly.

--- a/.kittify/evidence/01KZZKZRETNF0RM802ZFM9FEMS/record.json
+++ b/.kittify/evidence/01KZZKZRETNF0RM802ZFM9FEMS/record.json
@@ -1,0 +1,8 @@
+{
+  "event": "completed",
+  "invocation_id": "01KZZKZRETNF0RM802ZFM9FEMS",
+  "completed_at": "2026-08-14T07:53:33.424259+00:00",
+  "outcome": "done",
+  "closed_by": "agent",
+  "evidence_ref": "Closed #2702 (record-analysis write-side confirmed closed+guarded; evidence comment posted). #3372 required no action \u2014 already closed COMPLETED by mission #3383 (upgrade-wedge cluster) during this session; our mission drops #3372 accordingly."
+}


### PR DESCRIPTION
## Summary

Two small housekeeping changes surfaced while syncing the local install to latest `main`:

1. **`.kittify/config.yaml`** — add `cursor` to `agents.available` so its slash-command surface is provisioned alongside `claude` and `codex`.
2. **`.kittify/evidence/01KZZKZRETNF0RM802ZFM9FEMS/`** — invocation evidence for the *DRG Reachability Metric & Orphan Wiring* op: closed #2702 (record-analysis write-side confirmed guarded; evidence comment posted); #3372 dropped as already closed by mission #3383.

## Notes for reviewers

- No code, doctrine, or template changes — config + a mission evidence record only.
- The mission's empty primary `status.json` was **intentionally excluded**: it materializes to `event_count: 0` because this is a coord-topology mission whose real WP state lives on the coord branch. Committing it would introduce the only empty `status.json` on `main`.
- Install-derived manifest churn (`command-skills-manifest.json` rc-version restamp, `agent_profiles_manifest.json` path normalization) was deliberately left uncommitted as machine-local state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C17ftoF9wmnGoNdgz4HxGa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789454217&installation_model_id=427282&pr_number=3492&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3492&signature=0bd18f2f37d45dc919965a40ac592278a4e931e42f595c67e409734d574b23c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->