### PR TITLE
fix(sync): legacy→journal capture cutover — kill #3425 silent-capture (+ #3391/#2846/#3476)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -193,6 +193,22 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **Machines that never ran the layout migration silently captured zero sync
+  events while reporting success — now they capture for real (`#3425`;
+  `#3497`).** Before, an un-migrated machine defaulted to a legacy capture
+  layout where live event/body writes were refused deep in the stack and
+  swallowed — a **silent zero-capture** that never surfaced to the operator. A
+  `#3293` regression compounded this by also refusing authenticated hosts
+  entirely. Now a fresh root resolves to project-only capture *before* any
+  legacy persist; a legacy-with-data root auto-migrates through the canonical
+  `migrate_journal`/`project_store_migration` engines under a deterministic,
+  crash-safe migration id (re-entry never bricks the root); the live emit path
+  completes its cutover via a resolve-before-unit-of-work seam so both emitter
+  swallow sites are observable instead of silent (never-raises contract kept
+  intact); and credential parsing is restored as a pure auth signal (never a
+  physical-store selector), so an already-authenticated host stops being
+  refused.
+
 - **A reviewer running a different agent profile than the implementer can now
   claim a completed work package for review — the false "WP already claimed for
   review by `<implementer>`" refusal is gone (`#3455`).** Before, claiming a WP

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/analysis-report.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/analysis-report.md
@@ -1,0 +1,100 @@
+---
+schema_version: 1
+artifact_type: spec-kitty.analysis-report
+command: /spec-kitty.analyze
+mission_slug: legacy-journal-capture-cutover-01M03BSX
+mission_id: 01M03BSX4RCC07SKHP9H2PFWE5
+generated_at: '2026-08-16T06:33:50.654878+00:00'
+analyzer_agent: unknown
+input_artifacts:
+  spec.md:
+    path: /home/stijn/Documents/_code/SDD/fork/SHADOW_CLONES/spec-kitty_THREE/kitty-specs/legacy-journal-capture-cutover-01M03BSX/spec.md
+    sha256: 9eb228862da80ce763fb9c249bd60229bbef5eed037e11c4965841f2160ec6db
+  plan.md:
+    path: /home/stijn/Documents/_code/SDD/fork/SHADOW_CLONES/spec-kitty_THREE/kitty-specs/legacy-journal-capture-cutover-01M03BSX/plan.md
+    sha256: 598a39ef8e742235f3a7405368c7e66a0ba9faded725055dae74d70005178b29
+  tasks.md:
+    path: /home/stijn/Documents/_code/SDD/fork/SHADOW_CLONES/spec-kitty_THREE/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks.md
+    sha256: e59d8fb8fccc3d5cff74a1e2cdfb97ec36b8d57188b9f3d06b240c72b77507d0
+  charter:
+    path: /home/stijn/Documents/_code/SDD/fork/SHADOW_CLONES/spec-kitty_THREE/.kittify/charter/charter.yaml
+    sha256: b0cb6b6b5a27ca8376c5ef29bfa5c87eb64e6dcaa60e7d2330962341932b26c8
+verdict: ready
+issue_counts:
+  critical: 0
+  high: 0
+  medium: 1
+  low: 2
+  info: 0
+findings:
+- id: C1
+  severity: medium
+  category: coverage
+  summary: 'NFR-004 coordinated LEGACY-flip set: WP06 T029 enumerates 6 known LEGACY-default pins but the full reddened set (~80 LEGACY-referencing files) is finalized only at implementation — risk a reddened non-blocking test is missed and masked by a green blocking gate.'
+- id: L1
+  severity: low
+  category: coverage
+  summary: 'FR numbering intentionally skips the 006 slot (honest sync-now / #3278 deferred to a separate mission per resolved FR-006↔#2750 contradiction); documented in spec Out of Scope — informational, not a defect.'
+- id: I1
+  severity: low
+  category: inconsistency
+  summary: research.md and data-model.md retain historical 'FR-006' mentions after the deferral; harmless since the requirement extractor is scoped to spec.md (validated clean), but a reader may briefly conflate.
+---
+
+## Specification Analysis Report
+
+Mission `legacy-journal-capture-cutover-01M03BSX`. Cross-artifact consistency across
+spec.md ↔ plan.md ↔ tasks.md (+ 6 WP prompts). This mission was hardened by two
+adversarial squads (post-plan: architecture/SSOT, test-strategy, risk/data-safety;
+post-tasks: coverage/anti-laziness, ownership/isolation) whose blockers/majors were all
+folded, so residual findings are low-severity traceability items.
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| C1 | Coverage | MEDIUM | tasks/WP06 T029; spec NFR-003/004 | Full LEGACY-flip reddened set finalized at implement time; only 6 pins pre-enumerated | Implementer must run the enumerated grep and update every reddened `tests/sync`/`event_journal` file; reviewer diffs the non-blocking suites, not just the blocking gate |
+| L1 | Coverage | LOW | spec.md Out of Scope; FR table | FR-006 slot intentionally empty (deferred #3278) | None — documented and correct |
+| I1 | Inconsistency | LOW | research.md, data-model.md | Historical "FR-006" mentions post-deferral | Optional cleanup; no functional impact (extractor scoped to spec.md) |
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+| FR-001 no-silent-success capture | ✅ | T011-T017, T022-T026 | WP03 (writes succeed) + WP05 (both swallow sites + flag) |
+| FR-002 fresh roots journal | ✅ | T011, T015 | WP03 detection-before-persist |
+| FR-003 auto-cutover legacy-with-data | ✅ | T012, T016, T017 | WP03 canonical crash-safe cutover |
+| FR-004 restore credential parsing | ✅ | T001-T005 | WP01 auth-signal |
+| FR-005 single authoritative record | ✅ | T006-T010 | WP02 dedup + ownerless attribution |
+| FR-007 loud cutover/backfill | ✅ | T018-T021, T031 | WP04 (+ deep CutoverResult.error) |
+| FR-008 reproductions assert contract | ✅ | T027, T028 | WP06 rewrite keeps behavioral pins |
+| FR-009 preserve ProjectSyncStore | ✅ | T003, T004, T027 | WP01 (no path revert) + WP06 |
+| FR-010 observable emitter | ✅ | T022-T026, T031 | WP05 mechanism + WP04 boundary consumer |
+| NFR-001 observable failure rate | ✅ | T022, T025, T031 | boundary flag + consumer |
+| NFR-002 zero loss/dup on cutover | ✅ | T006, T012 | conservation red-first |
+| NFR-003 no regression migrated roots | ✅ | T029 | coordinated LEGACY-flip reconcile |
+| NFR-004 blocking CI green on-branch | ✅ | T028, T030 | + coordinated set (see C1) |
+| NFR-005 idempotent cutover | ✅ | T012 | interruption red-first |
+
+**FR-006**: intentionally deferred (#3278 honest sync-now) — out of scope, documented.
+
+**Charter Alignment Issues:** None. The post-plan revision resolved the original
+canonical-sources violation (cutover now reuses `migrate_journal`/`project_store_migration`
+rather than reinventing them). ATDD-first, single-authority, terminology-canon, and
+ownership-boundary principles are satisfied.
+
+**Unmapped Tasks:** None. All 31 subtasks map to a requirement.
+
+**Metrics:**
+- Total Requirements: 9 FR (FR-006 deferred) + 5 NFR + 5 C = 19
+- Total Tasks: 31 subtasks across 6 WPs
+- Coverage: 100% of active FRs and NFRs have ≥1 task
+- Ambiguity Count: 0 (no vague-adjective / placeholder findings)
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+Verdict **READY** — no CRITICAL/HIGH findings. The single MEDIUM (C1) is an
+implementation-time diligence item already encoded in WP06 T029, not a spec/plan defect.
+Proceed to `/spec-kitty.implement` (or the implement-review loop). Reviewer for WP06 must
+verify the coordinated LEGACY-flip set is complete by diffing the non-blocking `tests/sync`
+and `event_journal` suites, not only the `regression tests (blocking)` gate.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/checklists/requirements.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Legacy→Journal Capture Cutover
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — *bug-fix mission necessarily names affected capability surfaces (layout mode, capture stores) but avoids code/framework specifics*
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Requirement types are separated (Functional / Non-Functional / Constraints)
+- [x] IDs are unique across FR-###, NFR-###, and C-### entries
+- [x] All requirement rows include a non-empty Status value
+- [x] Non-functional requirements include measurable thresholds
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic — *outcome-framed (capture %, refusal count, event-count preservation); CI-job name retained as the one verifiable release gate*
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (explicit Out of Scope: #2750, emitter contract)
+- [x] Dependencies and assumptions identified (C-001 #3391-first; Assumptions section)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (P1 capture + auth, P2 dedup/stranded/cutover/tests)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification (beyond unavoidable capability naming)
+
+## Notes
+
+- Items marked incomplete require spec updates before `/spec-kitty.plan`.
+- All items pass on first authoring iteration; spec derived from a prior research
+  squad (root-cause + related-bugs + PR-conflict scans) and three confirmed scope
+  decisions (fold #3476/#3278/#2846; land #3391 first; auto-cutover legacy-with-data).

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/contracts/README.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/contracts/README.md
@@ -1,0 +1,9 @@
+# Contracts
+
+This mission is an internal-CLI bug-fix cluster (sync layout / event-journal capture).
+It introduces **no external API, webhook, or network contract** — all surfaces are
+in-process Python (layout resolution, cutover engine reuse, emitter capture flag,
+backfill command). The behavioral contracts live in `data-model.md` (layout state
+machine + invariants INV-1..6) and the per-WP acceptance scenarios in `spec.md`.
+
+No OpenAPI/GraphQL/schema artifacts apply.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/data-model.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: Legacy→Journal Capture Cutover
+
+Behavioral / state model for the capture surface (revised post-squad). No new persistent
+schema; this documents entities, the layout state machine, and the invariants the
+implementation must preserve. Cutover **reuses** `migrate_journal` /
+`project_store_migration` — this model describes the states around those engines, not a
+new copy engine.
+
+## Entities
+
+### LayoutState (per repository-root checkout)
+
+- **`.initialized` marker** (`marker_path`): durable "this root has been initialized"
+  signal. **Its presence does NOT mean "migrated"** — a greenfield root gets it written
+  on first read.
+- **`.layout-generation.json` record** (`record_path`): `generation`, `mode`
+  (`LEGACY` | `CUTOVER_PENDING` | `PROJECT_ONLY`), `migration_id`, `updated_at`.
+- **Current bug**: `_read_locked` on a fresh root writes `_initial_state()` = `LEGACY`
+  + marker, so the "never migrated" signal self-destructs on first emit.
+- **Target**: the no-legacy-data decision runs **before** that LEGACY write, so a
+  greenfield root is published `PROJECT_ONLY` and never persists LEGACY.
+
+### LegacyQueue (source, preserved)
+
+- **Store**: legacy `queue.db` + scoped `queue-<digest>.db`, discovered via
+  `migrate_journal.discover_source_dbs`.
+- **Role**: migration input only; **rows never deleted** (C-002, #2750 out of scope).
+  Consequence: honest `sync now` convergence (#3278) is **deferred** — copy-without-delete
+  cannot converge the legacy-row boundary (documented at `migrate_journal.py:40-52`).
+
+### EventJournal / ProjectSyncStore (authoritative destination)
+
+- **Store**: per-project event journal selected by ProjectSyncStore (#3293 — kept).
+- **Guard**: `_require_project_destination` (`journal.py:117-119`,
+  `ProjectLayoutRequiredError`) — live writes require `PROJECT_ONLY`.
+- **Dedup**: `append` idempotence keys on `event_id`; cutover dedup keys on
+  `(event_id, source_digest)` (IC-00).
+
+### Credentials → auth signal (not a path)
+
+- `read_queue_scope_from_credentials` yields a boolean "authenticated?" for the setup-plan
+  gate. It must NOT drive `scope_db_path(...)` at `preflight.py`/`target_authority.py`
+  (C-003/FR-009 revert-risk).
+
+## Layout State Machine
+
+```
+   marker/record absent
+          │
+          ▼  detect legacy data (real reader: discover_source_dbs + row counts)
+   ┌──────────────┐   no legacy data      ┌──────────────┐
+   │ (unresolved) │ ────────────────────▶ │ PROJECT_ONLY │  live writes land (terminal)
+   └──────────────┘   (decided BEFORE      └──────────────┘
+          │            any LEGACY persist)        ▲
+          │ legacy data present                   │ migrate_journal / project_store_migration
+          ▼                                        │ (stable migration_id, dedup, attribution)
+   ┌──────────────┐  begin_cutover   ┌──────────────────┐  publish_project_only
+   │    LEGACY    │ ───────────────▶ │  CUTOVER_PENDING │ ─────────────────────▶ PROJECT_ONLY
+   │(migration    │                  │ live writes:     │
+   │  input)      │                  │ block-and-retry, │  crash here ⇒ re-enter same
+   └──────────────┘                  │ then loud (never │  migration_id, complete/retry
+          ▲                          │ silent LEGACY)   │  (never brick)
+          │ SPEC_KITTY_NO_AUTO_CUTOVER└──────────────────┘
+          │ ⇒ stay LEGACY, surface loud actionable refusal (manual migrate)
+```
+
+## Invariants (must always hold)
+
+- **INV-1 (no silent success)**: no capture path returns success while journaling zero
+  events (FR-001/NFR-001).
+- **INV-2 (conservation)**: after cutover, every pre-existing legacy event appears in the
+  authoritative store exactly once — 0 loss, 0 duplication, incl. ownerless rows
+  (FR-003/FR-005/NFR-002). Guaranteed by reusing the engines' copy-verify-under-lock.
+- **INV-3 (idempotence / crash-safety)**: an interrupted cutover re-enters the same
+  `migration_id` and converges with no extra/divergent writes; a crash never bricks the
+  root (NFR-005).
+- **INV-4 (source preservation)**: legacy rows are read, never deleted (C-002). (Verified:
+  the current engine only unlinks temp scratch files.)
+- **INV-5 (no mid-cutover drop)**: a live write arriving during `CUTOVER_PENDING` must not
+  silently route to LEGACY-and-swallow — it blocks-and-retries, then surfaces loudly.
+  *(Replaces the deferred honest-sync-now invariant.)*
+- **INV-6 (selection preserved)**: ProjectSyncStore-owned queue selection is unchanged
+  (#3293 kept — C-003/FR-009); restoring credential parsing does not change which physical
+  store a live write lands in.
+
+## Cutover Transitions (auto, reusing canonical engines)
+
+1. On first live write, resolve layout (before any LEGACY persist).
+2. `PROJECT_ONLY` → write (done).
+3. Unresolved + no legacy data (real reader) → publish `PROJECT_ONLY` → write.
+4. Legacy data present + escape hatch unset → `begin_cutover` (deterministic
+   root-derived `migration_id`) → **copy via `migrate_journal`/`project_store_migration`**
+   (dedup `(event_id, source_digest)`, attribute `project_uuid` to ownerless rows,
+   quarantine divergent payloads; **source retained**) → `publish_project_only` → write.
+   Live writes during `CUTOVER_PENDING`: block-and-retry, else loud. Re-entrant on crash.
+5. Legacy data present + `SPEC_KITTY_NO_AUTO_CUTOVER` set → do not mutate; surface a loud,
+   actionable refusal pointing at `sync project-store-migrate` (never silent).

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/issue-matrix.json
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/issue-matrix.json
@@ -1,0 +1,137 @@
+{
+ "rows": {
+  "#2144": {
+   "evidence_ref": "Architectural parent (event durability); partially advanced by WP03 capture fix. Follow-up: #2144 remains open.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": null,
+   "title": null,
+   "verdict": "deferred-with-followup",
+   "wp": "WP03"
+  },
+  "#2688": {
+   "evidence_ref": "Auto-migration direction realized by WP03 lazy cutover; full closure tied to #2750 (out of scope). Follow-up: #2688 remains open.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "deferred-with-followup",
+   "wp": "WP03"
+  },
+  "#2750": {
+   "evidence_ref": "Retire legacy queue.db write path is out of scope (spec Out of Scope). Follow-up: #2750 remains open (parent #2144).",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "deferred-with-followup",
+   "wp": "WP03"
+  },
+  "#2846": {
+   "evidence_ref": "Divergent-duplicate dedup + quarantine (not last-write-win): WP02 4c1879813e.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "fixed",
+   "wp": "WP02"
+  },
+  "#3262": {
+   "evidence_ref": "Closed epic \u2014 the per-project consent program that #3293 implemented; already terminal upstream.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": null,
+   "title": null,
+   "verdict": "verified-already-fixed",
+   "wp": "WP02"
+  },
+  "#3278": {
+   "evidence_ref": "Honest sync-now convergence needs legacy-row cleanup (#2750, out of scope), per research Decision 7. Follow-up: #3278 remains open.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "deferred-with-followup",
+   "wp": "WP06"
+  },
+  "#3293": {
+   "evidence_ref": "Introducer of the regression, already merged (cd3d6a91d2); ProjectSyncStore selection kept, not reverted.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": null,
+   "title": null,
+   "verdict": "verified-already-fixed",
+   "wp": "WP01"
+  },
+  "#3300": {
+   "evidence_ref": "Draft PR (per-project sync consent), separate/related work not modified here. Follow-up: #3300.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": null,
+   "title": null,
+   "verdict": "deferred-with-followup",
+   "wp": "WP02"
+  },
+  "#3391": {
+   "evidence_ref": "Both emitter swallow sites observable + process-level flag (never-raises intact): WP05 f9b67d250a.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "fixed",
+   "wp": "WP05"
+  },
+  "#3425": {
+   "evidence_ref": "Silent-capture fixed end-to-end: WP01 credentials + WP03 layout/cutover + WP05 live-path seam + WP06 repro; squash 3e77ab22bd; integration 75 passed.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "fixed",
+   "wp": "WP03"
+  },
+  "#3476": {
+   "evidence_ref": "Loud cutover/backfill failures (write-cannot-land surfaced): WP04 694262097c.",
+   "fr": null,
+   "nfr": null,
+   "repo": null,
+   "sc": null,
+   "scope": null,
+   "source_file": "spec.md",
+   "title": "<fill at WP-implementation time>",
+   "verdict": "fixed",
+   "wp": "WP04"
+  }
+ },
+ "schema_version": 1
+}

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/meta.json
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/meta.json
@@ -1,0 +1,30 @@
+{
+  "acceptance_history": [
+    {
+      "acceptance_mode": "pr",
+      "accepted_at": "2026-08-16T09:02:31.462939+00:00",
+      "accepted_by": "stijn",
+      "accepted_from_commit": "8533c3a94d521c5ffb64581554f0a8c649d51588"
+    }
+  ],
+  "acceptance_mode": "pr",
+  "accepted_at": "2026-08-16T09:02:31.462939+00:00",
+  "accepted_by": "stijn",
+  "accepted_from_commit": "8533c3a94d521c5ffb64581554f0a8c649d51588",
+  "coordination_branch": "kitty/mission-legacy-journal-capture-cutover-01M03BSX",
+  "created_at": "2026-08-15T18:44:01.816982+00:00",
+  "flattened": false,
+  "friendly_name": "Legacy→Journal Capture Cutover",
+  "mission_id": "01M03BSX4RCC07SKHP9H2PFWE5",
+  "mission_number": null,
+  "mission_slug": "legacy-journal-capture-cutover-01M03BSX",
+  "mission_type": "software-dev",
+  "pr_bound": true,
+  "purpose_context": "A cluster of P0 bugs means machines that never ran the layout migration silently journal zero events while reporting success, and a recent credentials regression refuses genuinely-authenticated hosts. This mission fixes the silent-capture root cause, restores credential parsing, auto-migrates legacy roots (including those with real data), and folds the related duplicate/stranded-event bugs — building on the observable-failure emitter surface landed first by #3391.",
+  "purpose_tldr": "Stop the event journal from silently capturing nothing on un-migrated machines and make SaaS sync reliable.",
+  "slug": "legacy-journal-capture-cutover-01M03BSX",
+  "target_branch": "fix/legacy-journal-capture-cutover",
+  "topology": "coord",
+  "vcs": "git",
+  "vcs_locked_at": "2026-08-16T06:42:35.257940+00:00"
+}

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/plan.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/plan.md
@@ -1,0 +1,193 @@
+# Implementation Plan: Legacy→Journal Capture Cutover
+
+**Branch**: `fix/legacy-journal-capture-cutover` | **Date**: 2026-08-15 (rev. post-squad) | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `kitty-specs/legacy-journal-capture-cutover-01M03BSX/spec.md`
+
+## Summary
+
+Un-migrated machines default to a legacy capture layout, so live event/body writes are
+refused and swallowed — silent zero-capture while reporting success (#3425). A #3293
+regression also narrowed credential parsing so authenticated hosts are refused. This
+mission restores credential parsing (auth-signal only, no path-derivation revert),
+resolves fresh roots to `project_only` **before** any LEGACY write is persisted,
+auto-migrates legacy-with-data roots by **reusing the canonical migration engines**
+(`migrate_journal` / `project_store_migration`) — never a bespoke drain — deduplicating
+the copy (#2846), surfaces cutover/backfill failures loudly (#3476), and makes capture
+failure observable at the command boundary via the emitter (folds #3391). It rewrites
+the mis-built #3425 reproductions to the real contract and keeps #3293's ProjectSyncStore
+selection (no revert). **Honest `sync now` convergence (#3278) is deferred** (it requires
+legacy-row cleanup / #2750, out of scope).
+
+> This plan was revised after a post-plan adversarial squad (architecture/SSOT,
+> test-strategy, risk/data-safety). Findings + remediations:
+> `work/3425-legacy-layout-research/post-plan-squad/` (gitignored).
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: existing only — SQLite (`sqlite3`), `filelock`; **canonical migration engines reused, not added**: `src/specify_cli/sync/migrate_journal.py` (`migrate_queues_to_journal`, `discover_source_dbs`, `(event_id, source_digest)` provenance, divergent-duplicate quarantine) and `src/specify_cli/sync/project_store_migration.py` (`MigrationPhase` state machine, snapshot/fingerprint, `project_uuid` attribution). **No dependency add/upgrade/removal.**
+**Storage**: SQLite (event journal + legacy `queue.db` / `queue-<digest>.db`), filesystem markers (`.layout-generation.initialized` marker + `.layout-generation.json` record) per checkout
+**Testing**: pytest, red-first (C-011). **Isolation is mandatory** — all cutover/layout tests run against temp roots via `SPEC_KITTY_HOME`/`HOME` fixtures; **never** the real machine-global `~/.spec-kitty` (this dev box is itself a live legacy root — see Risk note)
+**Target Platform**: Linux, macOS, Windows 10+ CLI
+**Project Type**: single (`src/specify_cli/`)
+**Performance Goals**: cutover runs at most once per root; lock-hold bounded to the copy; no measurable hot-path cost on already-migrated roots
+**Constraints**: zero event loss/duplication incl. ownerless legacy rows (NFR-002); lock-safe + idempotent + crash-recoverable, never bricking a root (NFR-005); emitter fix stays non-fatal while becoming boundary-observable (FR-010); keep ProjectSyncStore selection (C-003); legacy write path not retired, source rows never deleted (C-002)
+**Scale/Scope**: per-machine roots; bounded event counts
+
+### Supply-Chain Security (advisory — issue 051)
+
+No dependency add/upgrade/removal. All changes are first-party `src/specify_cli/sync/**`,
+`src/specify_cli/event_journal/**`, `src/specify_cli/cli/commands/agent/**`, and tests.
+Registry/lifecycle/freshness checks N/A. Explicit examination, not silence.
+
+## Charter Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Note |
+|-----------|--------|------|
+| Single canonical authority | ✅ (fixed) | Cutover **reuses** `migrate_journal`/`project_store_migration` rather than re-deriving dedup/provenance/quarantine — the post-squad correction of the original plan's canonical-source violation. |
+| Use canonical sources, never improvise | ✅ (fixed) | Prior draft reinvented the migration engines; now cites the canonical entry points as the copy mechanism. |
+| ATDD-first / red-first (C-011) | ✅ | Red-first tests for idempotence-under-interruption, zero-loss/dup conservation, mid-cutover concurrency, and the escape hatch — not just happy-path integration. Test A rewritten but keeps its behavioral pins. |
+| Regression vigilance | ✅ | Fixes the real #3293 credential regression; NFR-004 pins on-branch green **including** the ~80 LEGACY-referencing files outside the blocking selection (coordinated-update set enumerated in tasks). |
+| Ownership boundaries for mutating flows | ✅ | Auto-cutover is idempotent, crash-recoverable (defined `CUTOVER_PENDING`/`FAILED` recovery), non-destructive; emitter fix (#3391) coordinated with assignee (MOES-Media). |
+| Pre-existing failure reporting | ✅ | Distinguishes the real #3293 regression from CI-env auth artifacts (research.md). |
+
+**No charter violations after revision.**
+
+## Project Structure
+
+### Documentation (this mission)
+
+```
+kitty-specs/legacy-journal-capture-cutover-01M03BSX/
+├── plan.md · research.md · data-model.md · quickstart.md
+└── tasks.md   # /spec-kitty.tasks — NOT created here
+```
+
+### Source Code (repository root)
+
+```
+src/specify_cli/sync/
+├── layout_generation.py        # resolve BEFORE persisting LEGACY on greenfield; CUTOVER_PENDING window (IC-02)
+├── migrate_journal.py          # REUSED copy engine — discover_source_dbs, (event_id,source_digest) dedup, quarantine (IC-00/02/03)
+├── project_store_migration.py  # REUSED — MigrationPhase, project_uuid attribution for ownerless rows (IC-00/02)
+├── queue.py                    # read_queue_scope_from_credentials (IC-01); detectors detect_legacy_rows_for_scope (stub→real, IC-02)
+├── preflight.py                # credential→scope consumers split("|") / scope_db_path (IC-01, revert-risk seam)
+├── target_authority.py         # _read_cached_scope / build_queue_scope → scope_db_path (IC-01, revert-risk seam)
+├── consent.py                  # per-project consent (touch only if scope-derivation requires)
+└── emitter.py                  # BOTH swallow sites: _capture_to_journal (~2114) + _emit_for_project_context (~2334-2336); process-level captured-failure flag (IC-05)
+src/specify_cli/event_journal/journal.py   # _require_project_destination guard; append() event_id idempotence (IC-02/03)
+src/specify_cli/cli/commands/agent/mission_setup_plan.py  # FR-011 auth gate: consume boolean auth-signal, not a derived path (IC-01)
+
+tests/
+├── regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py  # rewritten, attribution corrected (IC-06)
+├── sync/                       # layout resolution, credential parsing, cutover concurrency/idempotence/conservation, escape hatch
+└── event_journal/              # journal guard + dedup
+```
+
+**Structure Decision**: Single CLI project, confined to the sync + event-journal surface
+changed by #3293 plus the setup-plan auth gate. No new packages.
+
+## Complexity Tracking
+
+*No Charter Check violations after revision — table intentionally empty.*
+
+## Engineering Alignment (confirmed + post-squad revisions)
+
+- **Scope** (user-confirmed): fix #3425 (silent-capture) + credentials regression + #2846
+  dedup + #3391 emitter + #3476 loud cutover. **Deferred:** #3278 honest sync-now (needs
+  legacy-row cleanup / #2750). **Out:** retiring legacy `queue.db` (#2750).
+- **Auto-cutover — reuse canonical engines, stable id, crash-safe (BLOCKER-1/2, risk-1)**:
+  the lazy first-write cutover calls `migrate_journal.migrate_queues_to_journal` /
+  `project_store_migration` with a **deterministic, root-derived `migration_id`** and
+  **auto-discovered source** (`discover_source_dbs`), not operator-supplied args. Recovery
+  is defined: a `CUTOVER_PENDING` root re-enters and completes the same migration_id
+  (idempotent); a `FAILED` manifest is cleared/retried under a documented rule — a crash
+  between begin and publish must never brick the root.
+- **Close the mid-cutover drop window (BLOCKER-2)**: live writes arriving while
+  `mode == CUTOVER_PENDING` must NOT resolve to LEGACY-and-swallow. Chosen model:
+  **block-and-retry within a bounded wait**, and if cutover cannot complete, route to the
+  loud emitter surface (IC-05) — never silent. A red-first test emits *during* an
+  in-progress cutover and asserts zero loss.
+- **Detection before LEGACY persist (MAJOR-5)**: the "no-legacy-data ⇒ `project_only`"
+  decision happens **before** `_initial_state` writes LEGACY in `_read_locked`, so a
+  greenfield root never persists LEGACY on first emit. Detection uses the real reader
+  (`migrate_journal.discover_source_dbs` + queued-row counts), not the stub
+  `detect_legacy_rows_for_scope`. Data-model corrected to the `.initialized` marker.
+- **Emitter observability (MAJOR-3, FR-010)**: fix **both** swallow sites; deliver
+  boundary observability via a **process-level captured-failure flag/counter** the command
+  epilogue inspects (and non-zero-exits or reports on), threaded without changing the ~30
+  `emit_*` signatures or `_emit`'s never-raises contract. Coordinate the seam with #3391.
+- **IC-01 auth-signal vs path derivation (MAJOR-4)**: the setup-plan gate needs a boolean
+  "authenticated?", not a live scope→path. Restoring parsing must NOT re-introduce
+  credential→`scope_db_path` derivation at `preflight.py`/`target_authority.py` (that is
+  the C-003/FR-009 revert). A test asserts restoring parsing does not change which physical
+  store a live write lands in.
+- **Dedup identity is foundational (MAJOR-6)**: ownerless legacy rows must acquire a
+  `project_uuid` (via `project_store_migration` attribution) before/at copy; dedup keys on
+  `(event_id, source_digest)`. This precedes the cutover copy (IC-00), inverting the
+  original IC-02→IC-03 order.
+- **Test isolation (risk MINOR-8)**: this dev box's `~/.spec-kitty` is a live machine-global
+  legacy root; every cutover/layout test MUST use isolated temp roots. No test or manual
+  step may run cutover against the real store.
+
+## Implementation Concern Map
+
+> Concerns are NOT work packages. `/spec-kitty.tasks` translates these into WPs.
+
+### IC-00 — Dedup identity + ownerless-row attribution (foundation)
+
+- **Purpose**: Pin the stable copy identity so the cutover copy cannot duplicate or drop, including legacy rows that predate per-project ownership.
+- **Relevant requirements**: FR-005 (#2846); NFR-002.
+- **Affected surfaces**: `migrate_journal.py` (`(event_id, source_digest)` provenance, quarantine), `project_store_migration.py` (`project_uuid` attribution), `journal.py` `append` idempotence, `queue.py` `queue_event` owner check (346-348).
+- **Sequencing/depends-on**: none — precedes IC-02 copy.
+- **Risks**: ownerless legacy rows raise "project UUID does not match store owner" on naïve copy — attribution must run first.
+
+### IC-01 — Restore credential→scope parsing as an AUTH SIGNAL (no path revert)
+
+- **Purpose**: Stop the auth gate refusing authenticated hosts, WITHOUT re-introducing credential→path derivation (C-003/FR-009).
+- **Relevant requirements**: FR-004, FR-009; NFR-004, SC-002.
+- **Affected surfaces**: `queue.py` `read_queue_scope_from_credentials`; `mission_setup_plan.py` gate; **`preflight.py:480/516`, `target_authority.py:401/466`** (revert-risk consumers); possibly `consent.py`.
+- **Sequencing/depends-on**: none (independent un-redder).
+- **Risks**: the pre-#3293 `server|user|team` piped form flows into `scope_db_path` — must gate to auth-signalling only; test physical-store invariance.
+
+### IC-02 — Layout resolution + canonical, crash-safe auto-cutover
+
+- **Purpose**: Fresh→`project_only` before any LEGACY persist; legacy-with-data→cutover via the canonical engine with stable id, closed drop window, and defined recovery.
+- **Relevant requirements**: FR-002, FR-003; NFR-002, NFR-005; SC-001, SC-004, SC-005.
+- **Affected surfaces**: `layout_generation.py` (`_read_locked` order, `_destination`, `begin_cutover`/`publish_project_only`, `CUTOVER_PENDING` write routing), `migrate_journal`/`project_store_migration` (invoked), `queue.py` real detector.
+- **Sequencing/depends-on**: IC-00 (identity), IC-01 (scope signal).
+- **Risks**: bricking on crash mid-cutover; concurrency at the first-write trigger; the LEGACY default is heavily test-pinned.
+
+### IC-03 — Divergent-duplicate elimination (#2846)
+
+- **Purpose**: Guarantee the cutover copy yields exactly one authoritative record per event; quarantine genuine divergent payloads rather than dropping.
+- **Relevant requirements**: FR-005 (#2846); NFR-002.
+- **Affected surfaces**: reuse `migrate_journal` quarantine; `journal.py` idempotence. (No `sync now` change — #3278 deferred.)
+- **Sequencing/depends-on**: IC-00, IC-02.
+- **Risks**: divergent-payload conflicts must quarantine, not silently last-write-win.
+
+### IC-04 — Loud cutover / backfill failures (#3476)
+
+- **Purpose**: Cutover/backfill writes that cannot land surface the failure, distinguishable from a legitimate already-migrated no-op.
+- **Relevant requirements**: FR-007; NFR-001.
+- **Affected surfaces**: backfill-runtime-state path + `layout_generation.py` cutover write.
+- **Sequencing/depends-on**: IC-02.
+- **Risks**: must not flag a legitimate no-op as failure.
+
+### IC-05 — Observable emitter capture failure (folds #3391)
+
+- **Purpose**: No silent-success capture: fix **both** swallow sites and surface a genuinely-unrecoverable failure at the command boundary via a process-level flag — non-fatal.
+- **Relevant requirements**: FR-001, FR-010; NFR-001.
+- **Affected surfaces**: `emitter.py` `_capture_to_journal` (~2114) + `_emit_for_project_context` (~2334-2336); a captured-failure flag/counter + command-epilogue inspection.
+- **Sequencing/depends-on**: IC-02, IC-03.
+- **Risks**: must not break `_emit`'s never-raises contract (~30 callers); rate-limit so the loud path can't warning-storm; coordinate with #3391 assignee (MOES-Media).
+
+### IC-06 — Rewrite #3425 reproductions to the real contract (+ hard-invariant coverage)
+
+- **Purpose**: Turn the mis-built red-first tests green against the real ProjectSyncStore contract while KEEPING the behavioral pins (journal conservation + warning-absence); add the missing red-first invariant tests; un-red the blocking gate.
+- **Relevant requirements**: FR-008, FR-009; NFR-003, NFR-004; SC-003.
+- **Affected surfaces**: `tests/regression/test_issue_3425_*` (correct attribution to `journal.py:119 ProjectLayoutRequiredError`, drop retired no-arg queue API, keep end-to-end assertions); new red-first tests for idempotence-under-interruption, zero-loss/dup conservation, mid-cutover concurrency, escape hatch; enumerate + update the ~80 LEGACY-referencing files (`tests/sync`, `event_journal`) outside the blocking selection; pin auth tests on `SPEC_KITTY_HOME` (not just `HOME`).
+- **Sequencing/depends-on**: IC-01, IC-02.
+- **Risks**: a green blocking gate can mask NFR-003/004 reds in the non-blocking suites — the coordinated-update set must be explicit; rewritten tests must stay behavioral, not permit-enum assertions.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/quickstart.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Legacy→Journal Capture Cutover
+
+How to reproduce the bugs and verify the mission is green. Commands assume the shadow
+venv is on PATH (`export PATH="$PWD/.venv/bin:$PATH"`) and
+`SPEC_KITTY_SYNC_DISABLE=1` for fast local runs.
+
+## Reproduce (red, on `main` today)
+
+The blocking-CI reproduction:
+
+```bash
+PWHEADLESS=1 .venv/bin/python -m pytest \
+  tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py -q
+# Expect (pre-fix): 3 failed, 4 passed
+#   - test_authenticated_setup_plan_lands_in_scoped  → LegacyQueueMigrationRequiredError
+#   - test_setup_plan_refuses_on_daemon_owner_mismatch → wrong (auth) refusal
+#   - test_setup_plan_authenticated_coherent_succeeds  → exit 2 (spurious auth refusal)
+```
+
+Live dogfood reproduction (this repo is an un-migrated legacy root): any
+`spec-kitty agent mission create …` prints `Warning: Explicit-context event capture
+failed: live payload writes require the project_only layout; legacy state is migration
+input only` — silent zero-capture.
+
+## Verify (green, post-fix)
+
+Per-slice acceptance:
+
+- **IC-01 credential parsing (FR-004 / SC-002)**: a coherent authenticated host passes
+  setup-plan preflight (exit 0), scope derived from the supported credential format.
+- **IC-02 layout + auto-cutover (FR-002/003 / SC-001/004/005)**: on a fresh temp root,
+  emitted events land in the journal (was 0); on a legacy-with-data temp root, capture
+  resumes and the pre-existing event count is preserved exactly once (snapshot diff);
+  re-running an interrupted cutover adds nothing (idempotent).
+- **IC-03 single record + honest sync (FR-005/006)**: each event appears once; `sync
+  now` does not report success while events remain in the legacy queue.
+- **IC-04 loud cutover/backfill (FR-007)**: a cutover write that cannot land surfaces a
+  non-silent failure.
+- **IC-05 observable emitter (FR-001/010, #3391)**: an unrecoverable capture failure is
+  surfaced (not stderr-swallowed) and stays non-fatal (host command does not crash).
+- **IC-06 reproductions (FR-008 / SC-003)**: the rewritten `test_issue_3425_*` suite is
+  fully green.
+
+Blocking gate (the release-authority check):
+
+```bash
+# The regression-blocking selection must be green on this branch (NFR-004):
+PWHEADLESS=1 .venv/bin/python -m pytest tests/regression/ -q
+```
+
+Escape hatch check:
+
+```bash
+# With the escape hatch set, a legacy-with-data root is NOT auto-mutated; it surfaces a
+# loud, actionable refusal pointing at `sync project-store-migrate` (never silent):
+SPEC_KITTY_NO_AUTO_CUTOVER=1 <driver that emits an event on a legacy-with-data root>
+```
+
+## Rebase note
+
+Before landing, rebase `fix/legacy-journal-capture-cutover` onto current
+`upstream/main`. All target files were last touched by merged #3293 (`cd3d6a91d2`);
+nothing has re-touched them since, so conflicts are unlikely (research finding 03).

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/research.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/research.md
@@ -1,0 +1,136 @@
+# Research: Legacy→Journal Capture Cutover
+
+Phase 0 consolidation. Source: pre-mission research squad (gitignored
+`work/3425-legacy-layout-research/` — `01-root-cause-and-fix-options.md`,
+`02-related-p0-bugs-same-surface.md`, `03-open-pr-conflict-scan.md`) plus live
+dogfood evidence (mission `create` emitted the #3425 warning five times).
+
+## Decision 1 — #3425 is two distinct bugs; the reproductions are mis-attributed
+
+- **Decision**: Treat the credential/queue regression and the layout silent-capture as
+  separate defects with separate fixes (IC-01 and IC-02).
+- **Rationale**: The three red-first tests never reach the layout silent-capture path.
+  Test A fails at `default_queue_db_path()` (`sync/queue.py:195`), which raises
+  *unconditionally* (not layout-gated — the test docstring is wrong) and asserts a
+  retired no-arg `OfflineBodyUploadQueue().db_path` API. Tests B & C fail because
+  `read_queue_scope_from_credentials` (`sync/queue.py:175`) was rewritten JSON-only and
+  no longer derives a scope from the TOML credentials the tests write, so the FR-011
+  auth gate (`mission_setup_plan.py:1043-1075`, runs before the boundary preflight)
+  refuses an authenticated host with exit 2.
+- **Correction recorded**: the two "SAAS auth refusal" failures are a **real #3293
+  credentials-parser regression**, NOT CI-env artifacts (PR #3467's body and the first
+  triage mislabeled them). This satisfies the charter Pre-existing Failure Reporting rule.
+- **Alternatives considered**: (a) treat all three as CI-env noise — rejected, they
+  fail deterministically on a coherent host; (b) revert #3293 — rejected (C-003).
+
+## Decision 2 — Fresh roots resolve to `project_only`; legacy-with-data auto-cutover
+
+- **Decision**: `_initial_state()`/resolution returns `project_only` for a root with no
+  `.layout-generation.json` **and** no legacy data; a root with real legacy data is
+  auto-migrated (lazy, on first live write).
+- **Rationale**: The `LayoutMode.LEGACY` default (`sync/layout_generation.py:129-136`)
+  is correct only for a root that actually holds legacy data awaiting migration; a
+  greenfield root has none and is stuck LEGACY forever because leaving LEGACY is
+  manual-only (`sync project-store-migrate` → `begin_cutover` → `publish_project_only`).
+- **Non-destructive**: because retiring `queue.db` (#2750) is out of scope, cutover
+  *reads* the legacy store and never deletes it — the source is preserved as migration
+  input, making the mutation recoverable and low-risk (no heavyweight backup needed).
+- **Alternatives considered**: (a) keep manual, just make failure loud (detect-and-refuse)
+  — rejected by user (they chose auto-cutover); (b) eager cutover at startup — rejected
+  as more invasive than lazy-on-first-write with equal safety.
+
+## Decision 3 — Fold #3391: make the emitter capture failure observable
+
+- **Decision (updated per user)**: FOLD #3391 into this mission. The common-case write
+  is made to *succeed* (Decision 2), and the emitter swallow site
+  (`sync/emitter.py:2114`, `_capture_to_journal`) is fixed to surface a genuinely-
+  unrecoverable failure loud-but-non-fatal — closing #3391.
+- **Rationale**: #3391 is an assigned *issue* with no PR/active work, and FR-001's
+  "no silent-success capture" guarantee has a real gap for unrecoverable cases without
+  the loud backstop. Depending on someone else's unstarted issue is fragile; folding it
+  in makes the mission self-contained. Coordinate with the assignee (MOES-Media) so the
+  fix lands once. Constraint: must stay **non-fatal** — a capture failure must not crash
+  the host command; and must not warning-storm (IC-02 fixes the common case, so the loud
+  path is exceptional).
+- **Alternatives considered**: (a) depend on #3391 landing first — rejected (unstarted
+  issue, fragile); (b) leave the emitter swallow untouched and rely only on writes
+  succeeding — rejected (leaves the unrecoverable-case silent-success gap in FR-001).
+
+## Decision 4 — Keep ProjectSyncStore-owned queue selection; rewrite Test A
+
+- **Decision**: Preserve #3293's ProjectSyncStore selection; rewrite Test A to assert
+  that contract (drop the retired no-arg queue API) while still pinning the no-silent-
+  capture behavior.
+- **Rationale**: #3293 was a deliberate recent landing closing #3262; reverting it is
+  out of scope and would regress the per-project consent work.
+
+## Decision 5 — Fold the same-root cluster (minus #3278)
+
+- **Decision**: Fold #3476 (backfill cutover silent no-op — IC-04) and #2846 (divergent
+  duplicate legacy↔journal events — IC-03). **#3278 (honest `sync now`) is DEFERRED.**
+- **Rationale**: all share the legacy↔journal split root surface. #2750 (retire legacy
+  path) is out of scope; #2688 auto-migration direction is partially realized by Decision 2.
+  Nearest architectural parent: #2144 (event durability, stijn-dejongh).
+
+## Decision 7 (post-squad, user) — Drop #3278 to resolve the FR-006 ↔ #2750 contradiction
+
+- **Decision**: Defer honest `sync now` convergence (#3278, was FR-006) to a separate mission.
+- **Rationale**: the post-plan architecture lens surfaced a documented, code-level
+  contradiction — `migrate_journal.py:40-52` records that *import-alone never converges the
+  legacy-row boundary* (`sync now` refuses forever) because the convergence/cleanup step was
+  retired (`OfflineQueue` has no source-path constructor). Honest sync-now therefore requires
+  DELETING migrated legacy rows, which reopens #2750 (kept out of scope). Rather than reopen
+  #2750 or invent new "migrated-retained" state semantics, the user chose the smallest
+  coherent scope: keep #2750 out, defer #3278. #2846 dedup still applies (the copy must not
+  duplicate); only sync-now reporting is deferred.
+
+## Decision 8 (post-squad) — Reuse the canonical migration engines
+
+- **Decision**: Auto-cutover calls `migrate_journal.migrate_queues_to_journal` /
+  `project_store_migration` (dedup by `(event_id, source_digest)`, `project_uuid`
+  attribution for ownerless rows, divergent-payload quarantine, documented idempotence) —
+  never a bespoke drain/copy.
+- **Rationale**: charter "use canonical sources"; the engines already implement exactly the
+  copy semantics the original plan proposed to rebuild, and their reuse is required for
+  INV-2 conservation and ownerless-row handling (arch BLOCKER-1, MAJOR-6). Deterministic
+  root-derived `migration_id` + auto source discovery (`discover_source_dbs`) replace the
+  operator-supplied `--migration-id`/`--source` the engine otherwise needs.
+
+## Decision 9 (post-squad) — Close the CUTOVER_PENDING drop window; crash-safe recovery
+
+- **Decision**: While `mode == CUTOVER_PENDING`, live writes block-and-retry within a bounded
+  wait; if cutover cannot complete they route to the loud emitter surface (never silent). A
+  crash between begin and publish leaves a re-enterable `CUTOVER_PENDING`/`FAILED` state that
+  the next run completes/retries under a documented rule — never bricking the root.
+- **Rationale**: `_destination` returns LEGACY for `CUTOVER_PENDING` (268-272) → both write
+  guards raise → swallowed → the exact P0, made permanent (arch BLOCKER-2, risk BLOCKER-1).
+
+## Decision 10 (post-squad) — Emitter observability mechanism; detection order; auth-signal seam
+
+- **Emitter (MAJOR-3)**: fix BOTH swallow sites (`_capture_to_journal` ~2114 and
+  `_emit_for_project_context` ~2334-2336 — the latter is the live-reproduced one); deliver
+  boundary observability via a process-level captured-failure flag the command epilogue
+  inspects, not by raising (`_emit` never-raises across ~30 callers).
+- **Detection (MAJOR-5)**: decide `project_only` for no-legacy-data roots BEFORE `_read_locked`
+  persists LEGACY; use the real reader (`discover_source_dbs`), not the stub
+  `detect_legacy_rows_for_scope`; data-model corrected to the `.initialized` marker.
+- **Auth-signal (MAJOR-4)**: IC-01 restores parsing to yield a boolean "authenticated?" for
+  the gate; it must NOT re-introduce credential→`scope_db_path` derivation at
+  `preflight.py`/`target_authority.py` (the C-003/FR-009 revert).
+- **Test isolation (MINOR-8)**: cutover/layout tests use isolated temp roots; never the live
+  machine-global `~/.spec-kitty` (this dev box is itself a legacy root).
+
+## Decision 6 — Conflict posture
+
+- **Decision**: Proceed on `fix/legacy-journal-capture-cutover`; rebase before landing.
+- **Rationale (squad finding 03)**: 0 of 25 open PRs touch the six target files
+  (LOW risk); no open PR addresses #3425. Watch draft #3300 (per-project sync consent)
+  — same family, currently no `src/` edits. All target files were last modified by
+  merged #3293 (`cd3d6a91d2`); nothing has re-touched them since.
+
+## Adversarial Evidence
+
+No security-impacting dependency decision (no dependency changes). A pre-`tasks`
+adversarial-squad pass is not required by the supply-chain contract here; a squad may
+still be run at the post-tasks anti-laziness point-cut per campsite discipline. No
+contested finding outstanding.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/spec.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/spec.md
@@ -1,0 +1,224 @@
+# Mission Specification: Legacy→Journal Capture Cutover
+
+**Mission Branch**: `fix/legacy-journal-capture-cutover`
+**Created**: 2026-08-15
+**Status**: Draft
+**Input**: Fix P0 #3425 (un-migrated machines silently journal nothing) and fold the same-root cluster (#3476, #3278, #2846), auto-migrating legacy roots. Builds on #3391 (observable emitter failure), which lands first.
+
+## Context & Motivation
+
+Machines that have never run the layout migration default to a **legacy** capture
+layout. On such a root, every event-journal / body-queue write is refused deep in
+the stack and the refusal is swallowed into a stderr warning — so the command
+reports success while capturing **zero** events. The absence of data is visible only
+to someone reading stderr. A separate regression introduced with the per-project
+consent work refuses genuinely-authenticated hosts at the setup-plan auth gate,
+because credential parsing was narrowed and can no longer derive a sync scope from
+the supported credential format.
+
+This is not hypothetical: **creating this very mission reproduced the bug live** —
+`mission create` emitted `Warning: Explicit-context event capture failed: live
+payload writes require the project_only layout; legacy state is migration input
+only` five times. This repository is itself an un-migrated legacy root.
+
+The two defects share a root surface (layout resolution + queue selection + journal
+capture) with three other open bugs: divergent duplicate events between the two
+stores, `sync now` reporting success while events stay stranded in the legacy queue,
+and the backfill/cutover write hitting the same guard silently. This mission fixes
+them as one coherent change.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reliable capture on an un-migrated machine (Priority: P1)
+
+An operator (or agent) runs `setup-plan` (or any command that emits events) on a
+machine that never ran the layout migration. Today the events are silently dropped.
+After this mission, capture succeeds: a fresh root with no prior data resolves to a
+journaling layout automatically, and a root that holds real legacy data is
+auto-migrated so capture resumes without losing or duplicating existing events.
+
+**Why this priority**: This is the P0 (#3425). Silent zero-capture corrupts every
+downstream dashboard, sync, and audit trail without any error signal.
+
+**Independent Test**: On a fresh temp root, emit events via the real command entry
+point and assert the journal contains them (currently zero). On a root seeded with
+legacy data, run the command and assert capture resumes and the pre-existing legacy
+events are preserved exactly once.
+
+**Acceptance Scenarios**:
+
+1. **Given** a greenfield root with no `.layout-generation.json` and no legacy data, **When** a command emits an event, **Then** the event is captured to the journal and no capture-failure warning is produced.
+2. **Given** an un-migrated root that holds real legacy queue data, **When** a command emits an event, **Then** the root is auto-migrated, capture resumes, and every pre-existing legacy event survives exactly once (no loss, no duplication).
+3. **Given** any un-migrated root, **When** a capture attempt cannot succeed, **Then** the failure is observable at the command surface (never a swallowed stderr-only warning).
+
+---
+
+### User Story 2 - Authenticated host is not spuriously refused (Priority: P1)
+
+An operator with valid credentials runs `setup-plan`. Today the auth gate refuses a
+genuinely-authenticated host because credential parsing was narrowed. After this
+mission, the supported credential format is parsed again and a coherent
+authenticated host passes preflight.
+
+**Why this priority**: This is the regression that actually reddens the blocking CI
+suite on `main` today; it also blocks real authenticated operators.
+
+**Independent Test**: Write credentials in the supported format, run the real
+setup-plan entry point on a coherent host, and assert exit 0 (not a preflight
+refusal), with a sync scope correctly derived from the credentials.
+
+**Acceptance Scenarios**:
+
+1. **Given** valid credentials in the supported format, **When** setup-plan runs on a coherent authenticated host, **Then** preflight passes (exit 0) and a sync scope is derived.
+2. **Given** a daemon-owner mismatch, **When** setup-plan runs, **Then** the boundary-preflight refusal is the one surfaced (not masked by a spurious auth-unavailable refusal).
+
+---
+
+### User Story 3 - One capture record, no divergent duplicates (Priority: P2)
+
+An operator's captured events can today be duplicated across the legacy and journal
+stores. After this mission the one-time cutover copy deduplicates by stable event
+identity so each event exists exactly once in the authoritative store.
+
+**Why this priority**: Folds #2846 (divergent duplicates) — same root surface; the
+cutover copy must not create duplicates. (Honest `sync now` convergence, #3278, is
+**deferred to a separate mission** — see Out of Scope — because it requires cleaning up
+migrated legacy rows, which reopens #2750.)
+
+**Independent Test**: Seed a root that would previously diverge; run capture + cutover;
+assert exactly one authoritative record per event (dedup by `event_id`/provenance),
+including for ownerless legacy rows.
+
+**Acceptance Scenarios**:
+
+1. **Given** a root with events reachable by both stores, **When** cutover copies legacy events, **Then** each event appears exactly once in the authoritative store (no divergent duplicate).
+
+---
+
+### User Story 4 - Cutover/backfill writes fail loud, not silent (Priority: P2)
+
+An operator runs the backfill/cutover path. Today it can hit the same legacy-layout
+guard and silently no-op. After this mission, a cutover write that cannot land
+surfaces the failure.
+
+**Why this priority**: Folds #3476 — the backfill cutover write is the intended
+remediation path for #3425; if it too fails silently, the fix is unobservable.
+
+**Independent Test**: Drive the backfill/cutover path against a legacy layout that
+cannot accept the write; assert a surfaced failure rather than a silent success.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cutover write that cannot land on the current layout, **When** the backfill path runs, **Then** the failure is surfaced (non-zero / explicit error), never a silent success.
+
+---
+
+### User Story 5 - Regression reproductions pin the real contract (Priority: P2)
+
+The existing `#3425` red-first reproduction tests currently assert a retired queue
+API and mis-attribute the failure. After this mission, the reproductions assert the
+current ProjectSyncStore-owned contract and turn green, and the `regression tests
+(blocking)` job is green on this branch.
+
+**Why this priority**: Un-reds `main`'s blocking CI signal and prevents the mis-built
+test from masking future regressions.
+
+**Independent Test**: Run the (rewritten) `tests/regression/test_issue_3425_*` suite
+and assert all pass; run the `regression tests (blocking)` selection and assert green.
+
+**Acceptance Scenarios**:
+
+1. **Given** the rewritten reproductions, **When** the regression suite runs on this branch, **Then** the three previously-failing tests pass and no new reds appear.
+
+---
+
+### Edge Cases
+
+- **Interrupted / partial cutover**: a crash mid-migration must leave a recoverable
+  state; re-running completes it without loss or duplication (idempotent).
+- **Root with both legacy data and partial project-store state**: cutover must
+  reconcile, not double-count.
+- **Concurrent writers during cutover**: the "project sync store is locked"
+  contention observed during `mission create` must not corrupt or silently drop.
+- **Credentials present but no derivable scope**: must produce a clear, actionable
+  refusal — not a masked or misattributed one.
+- **Greenfield root with zero events emitted yet**: resolving to the journaling
+  layout must be a no-op-safe default, not an error.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+| ID | Title | User Story | Priority | Status |
+|----|-------|------------|----------|--------|
+| FR-001 | No silent-success capture | As an operator, I want any command that cannot capture an event to fail observably, so that success never means zero-capture. | High | Open |
+| FR-002 | Fresh roots journal by default | As an operator on a greenfield machine, I want capture to work without a manual migration step, so that events are never silently lost. | High | Open |
+| FR-003 | Auto-cutover legacy-with-data roots | As an operator whose machine holds real legacy data, I want the root auto-migrated so capture resumes, preserving every existing event exactly once. | High | Open |
+| FR-004 | Restore credential parsing | As an authenticated operator, I want a coherent host to pass the setup-plan auth gate, so that valid credentials are not spuriously refused. | High | Open |
+| FR-005 | Single authoritative record | As an operator, I want each event stored exactly once during cutover copy (dedup by stable identity, incl. ownerless legacy rows), so that dashboards are not double-counted. | Medium | Open |
+| FR-007 | Loud cutover/backfill failures | As an operator, I want backfill/cutover writes that cannot land to surface the failure rather than silently no-op. | Medium | Open |
+| FR-008 | Reproductions assert current contract | As a maintainer, I want the #3425 reproductions to assert the ProjectSyncStore contract and pass, so CI signal is honest. | Medium | Open |
+| FR-009 | Preserve ProjectSyncStore selection | As a maintainer, I want the per-project ProjectSyncStore-owned queue selection kept (no revert of the prior consent work). | High | Open |
+| FR-010 | Observable emitter capture failure | As an operator, I want a genuinely-unrecoverable capture failure surfaced loud-but-non-fatal at the emitter, so no failure is swallowed to a stderr-only warning (folds #3391). | High | Open |
+
+### Non-Functional Requirements
+
+| ID | Title | Requirement | Category | Priority | Status |
+|----|-------|-------------|----------|----------|--------|
+| NFR-001 | Observable failure rate | 100% of capture failures are surfaced at the command boundary; 0 swallowed to stderr-only. | Reliability | High | Open |
+| NFR-002 | Zero data loss/dup on cutover | Auto-cutover preserves 100% of pre-existing legacy events with 0 duplicates (verified event-count + identity diff before/after). | Data Safety | High | Open |
+| NFR-003 | No regression for migrated roots | Existing already-migrated (project_only) roots see 0 behavior change; the pre-existing status/sync/journal test suites stay green. | Compatibility | High | Open |
+| NFR-004 | Blocking CI green on-branch | The `regression tests (blocking)` selection returns green on this mission branch with 0 new reds attributable to the diff. | Quality | High | Open |
+| NFR-005 | Idempotent cutover | Re-running an interrupted cutover converges to the same state with no additional writes; safe under a held store lock. | Reliability | Medium | Open |
+
+### Constraints
+
+| ID | Title | Constraint | Category | Priority | Status |
+|----|-------|------------|----------|----------|--------|
+| C-001 | Folds #3391 (emitter) | Issue #3391 (assigned, same emitter swallow shape) is FOLDED IN: this mission makes the emitter capture-failure observable (FR-010). Coordinate with the #3391 assignee (MOES-Media) so the fix closes #3391 rather than colliding. | Coordination | High | Open |
+| C-002 | Legacy write path not retired | Retiring the legacy `queue.db` write path (#2750) is OUT of scope; the legacy store remains readable as migration input. | Scope | High | Open |
+| C-003 | No consent-work revert | Keep the ProjectSyncStore-owned queue selection from the prior per-project consent work; fixes are additive, not a partial revert. | Governance | High | Open |
+| C-004 | Emitter contract owned externally | `emitter.py` observable-failure contract is owned by #3391 (external contributor); coordinate, do not collide. | Coordination | Medium | Open |
+| C-005 | Migration safety | Auto-cutover must be idempotent, lock-safe, and recoverable from partial/interrupted runs. | Technical | High | Open |
+
+### Key Entities
+
+- **Layout mode**: the per-root capture layout — legacy (migration-input only) vs project-scoped (live-journaling). Resolved from a durable per-root marker.
+- **Layout-generation marker**: the durable per-root record whose absence currently yields the legacy default.
+- **Capture stores**: the legacy queue and the event journal — the two destinations that must reconcile to a single authoritative record.
+- **Queue/store selector**: the ProjectSyncStore-owned selection that decides where a live write lands (kept, not reverted).
+- **Credentials → sync scope**: the operator credential material from which the auth gate derives a sync scope (parsing to be restored).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a fresh un-migrated root, 100% of emitted events are captured to the journal (currently 0%).
+- **SC-002**: A coherent authenticated host passes setup-plan preflight (exit 0) with 0 spurious refusals across the credential-format test matrix.
+- **SC-003**: The three `#3425` regression reproductions pass and the `regression tests (blocking)` selection is green on-branch with 0 new reds.
+- **SC-004**: After auto-cutover of a legacy-with-data root, pre-existing event count is preserved exactly (0 loss, 0 duplicates) versus a pre-cutover snapshot.
+- **SC-005**: Re-running an interrupted cutover produces no additional or divergent records (idempotent convergence).
+
+## Assumptions
+
+- **#3391 is folded into this mission** (C-001, FR-010). The primary layout/cutover fix makes the common-case write succeed (nothing to swallow); FR-010 adds the loud-but-non-fatal emitter surface as the backstop for genuinely-unrecoverable cases, closing #3391. Coordinate with the assignee (MOES-Media) so the change lands once, not twice.
+- The supported credential format whose parsing regressed is the one the existing
+  reproductions write; restoring derivation for it is sufficient for FR-004.
+- Auto-cutover of legacy-with-data roots (#2688 direction) is desired even though the
+  legacy write path is not retired (#2750) — the two are decoupled here: migrate
+  forward, keep the old path readable.
+- "ProjectSyncStore-owned queue selection" (prior consent work) is the intended
+  end-state; the mis-built reproduction (Test A) is rewritten to it rather than the
+  code reverted to it.
+
+## Out of Scope
+
+- Retiring the legacy `queue.db` write path (#2750).
+- **Honest `sync now` convergence (#3278) — deferred to a separate mission.**
+  The code proves it requires cleaning up (deleting) migrated legacy rows, which reopens
+  #2750; keeping #2750 out of scope means #3278 cannot be honestly closed here. This
+  mission still deduplicates the cutover copy (#2846) so no divergent duplicates are
+  created; it just does not change `sync now`'s convergence reporting. (The functional-
+  requirement numbering skips one slot between FR-005 and FR-007 to keep IDs stable after
+  this deferral; that gap is intentional.)
+- Broader sync/tracker or dashboard changes beyond making capture honest.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Legacy→Journal Capture Cutover
+
+**Mission**: `legacy-journal-capture-cutover-01M03BSX`
+**Plan**: [plan.md](./plan.md) (post-squad revision) · **Spec**: [spec.md](./spec.md)
+**Branch**: `fix/legacy-journal-capture-cutover` → merges to `fix/legacy-journal-capture-cutover`
+
+6 work packages, 30 subtasks. Completion is event-sourced — record with
+`spec-kitty agent tasks mark-status Txxx --status done`, not by ticking boxes.
+
+## Ownership map (no overlap — finalize-tasks validated)
+
+| WP | Concern | Authoritative surface | Owns (core) |
+|----|---------|----------------------|-------------|
+| WP01 | Credential auth-signal (IC-01) | `src/specify_cli/sync/` | `queue.py`, `preflight.py`, `target_authority.py`, `mission_setup_plan.py` |
+| WP02 | Dedup identity + ownerless attribution (IC-00/IC-03) | `src/specify_cli/sync/` | `migrate_journal.py`, `project_store_migration.py`, `event_journal/journal.py` |
+| WP03 | Layout resolution + crash-safe cutover (IC-02) | `src/specify_cli/sync/` | `layout_generation.py` |
+| WP04 | Loud cutover/backfill (IC-04, #3476) | `src/specify_cli/cli/commands/` | `migrate_cmd.py` |
+| WP05 | Observable emitter (IC-05, #3391) | `src/specify_cli/sync/` | `emitter.py` |
+| WP06 | Repro rewrite + LEGACY-flip reconcile (IC-06) | `tests/` | `test_issue_3425_*`, `test_layout_generation.py` |
+
+## Dependency graph
+
+```
+WP01 (credentials)   WP02 (identity/attribution)      ← both independent, parallel
+        │                     │
+        └─────────┬───────────┘
+                  ▼
+              WP03 (layout + cutover)                  ← depends WP01, WP02
+                  │
+      ┌───────────┼───────────┐
+      ▼           ▼           ▼
+    WP04        WP05        WP06                        ← depend WP03 (WP06 also WP01)
+  (backfill)  (emitter)  (repro/reconcile)
+```
+
+## Subtask Index
+
+| ID | Description | WP | Parallel |
+|----|-------------|----|----------|
+| T001 | red-first: coherent authenticated host passes setup-plan preflight (SPEC_KITTY_HOME-isolated) | WP01 | |
+| T002 | restore `read_queue_scope_from_credentials` to parse supported creds → auth signal | WP01 | |
+| T003 | setup-plan gate consumes boolean "authenticated?", not a derived path | WP01 | |
+| T004 | red-first: physical-store invariance — restoring parsing does not change which store a live write lands in | WP01 | |
+| T005 | green B/C; keep JSON-path parsing working | WP01 | |
+| T006 | red-first: cutover conservation — one authoritative record per event incl ownerless rows (0 loss/dup) | WP02 | [P] |
+| T007 | red-first: divergent-payload quarantine (not last-write-win) | WP02 | [P] |
+| T008 | wire `(event_id, source_digest)` provenance dedup via `migrate_journal` | WP02 | |
+| T009 | ownerless-row `project_uuid` attribution via `project_store_migration` | WP02 | |
+| T010 | confirm/harden `journal.append` `event_id` idempotence | WP02 | |
+| T011 | red-first: greenfield root → project_only, never persists LEGACY, captures events (was 0) | WP03 | |
+| T012 | red-first: idempotence-under-interruption — crash between begin/publish → re-enter same migration_id, no brick | WP03 | |
+| T013 | red-first: emit during CUTOVER_PENDING → zero loss (block-and-retry, else loud) | WP03 | |
+| T014 | red-first: SPEC_KITTY_NO_AUTO_CUTOVER → loud actionable refusal, no mutation | WP03 | |
+| T015 | detection-before-persist: decide project_only before `_initial_state` LEGACY write; real detector via `discover_source_dbs` | WP03 | |
+| T016 | lazy auto-cutover: invoke canonical engines with deterministic root-derived migration_id + auto source discovery; CUTOVER_PENDING/FAILED recovery | WP03 | |
+| T017 | CUTOVER_PENDING write routing (block-and-retry bounded, else loud) + escape-hatch impl | WP03 | |
+| T018 | red-first: backfill/cutover write that cannot land surfaces failure (not silent no-op) | WP04 | |
+| T019 | red-first: legitimate already-migrated no-op is NOT flagged as failure | WP04 | |
+| T020 | impl loud failure path in `backfill-runtime-state` | WP04 | |
+| T021 | distinguish no-op from failure; actionable message | WP04 | |
+| T022 | red-first: unrecoverable capture failure observable at command boundary, non-fatal | WP05 | |
+| T023 | fix `_capture_to_journal` swallow (~2114) | WP05 | |
+| T024 | fix `_emit_for_project_context` swallow (~2334-2336) — the live-reproduced site | WP05 | |
+| T025 | process-level captured-failure flag/counter + command-epilogue inspection (no `emit_*` signature change) | WP05 | |
+| T026 | rate-limit loud path (no warning-storm); coordinate #3391 seam | WP05 | |
+| T027 | rewrite Test A: correct attribution to `journal.py:119 ProjectLayoutRequiredError`, drop retired no-arg queue API, KEEP behavioral pins | WP06 | |
+| T028 | green the 3 `#3425` reproductions end-to-end (conservation + warning-absence) | WP06 | |
+| T029 | enumerate + update the coordinated LEGACY-flip set (existing `tests/sync`/`event_journal` LEGACY-default pins outside the blocking selection) | WP06 | |
+| T030 | pin auth-adjacent tests on `SPEC_KITTY_HOME` (not just `HOME`); verify `regression tests (blocking)` green on-branch | WP06 | |
+| T031 | deep honest `CutoverResult.error` (runtime_state_cutover/backfill_runtime_state) + consume WP05 capture-failure flag at the cutover epilogue (FR-010 boundary consumer) | WP04 | |
+
+---
+
+## WP01 — Restore credential parsing as an auth signal (IC-01)
+
+**Goal**: Stop the setup-plan auth gate refusing authenticated hosts (the real #3293 regression reddening blocking CI) WITHOUT re-introducing credential→path derivation (C-003/FR-009).
+**Priority**: P1 (un-redder) · **Dependencies**: none · **Requirements**: FR-004, FR-009 · **Est.**: ~320 lines
+**Independent test**: a coherent authenticated host passes setup-plan preflight (exit 0), scope derived; and a live write lands in the same physical store before/after the change.
+**Subtasks**: T001 T002 T003 T004 T005
+**Risks**: the pre-#3293 `server|user|team` piped form flows into `scope_db_path` at `preflight.py:480/516` and `target_authority.py:401/466` — restore parsing to auth-signalling only; do not revert path derivation. Prompt: `tasks/WP01-credential-auth-signal.md`
+
+## WP02 — Dedup identity + ownerless-row attribution foundation (IC-00 / IC-03)
+
+**Goal**: Pin the copy identity so cutover cannot duplicate/drop, incl. legacy rows predating per-project ownership; quarantine divergent payloads (#2846).
+**Priority**: P1 (foundation) · **Dependencies**: none · **Requirements**: FR-005 · **Est.**: ~300 lines
+**Independent test**: seed a temp root with duplicate + ownerless legacy rows; run the copy; assert exactly one authoritative record each, divergent payloads quarantined.
+**Subtasks**: T006 T007 T008 T009 T010
+**Risks**: naïve copy of an ownerless row raises "project UUID does not match store owner" (`queue.py:346-348`) — attribute first. Prompt: `tasks/WP02-dedup-identity-attribution.md`
+
+## WP03 — Layout resolution + canonical, crash-safe auto-cutover (IC-02)
+
+**Goal**: Fresh roots → project_only before any LEGACY persist; legacy-with-data roots auto-migrate via the canonical engines with stable id, closed drop window, and crash recovery — never bricking a root.
+**Priority**: P1 (core) · **Dependencies**: WP01, WP02 · **Requirements**: FR-002, FR-003 · **Est.**: ~480 lines
+**Independent test**: greenfield temp root captures events (was 0); interrupted cutover re-enters and converges; emit during CUTOVER_PENDING loses nothing; escape hatch refuses loudly.
+**Subtasks**: T011 T012 T013 T014 T015 T016 T017
+**Risks**: `_destination` returns LEGACY for CUTOVER_PENDING → swallow → P0 made permanent; bricking on crash; heavily test-pinned LEGACY default. ALL tests use temp roots — never the live machine-global `~/.spec-kitty`. Prompt: `tasks/WP03-layout-resolution-cutover.md`
+
+## WP04 — Loud cutover / backfill failures (IC-04, #3476)
+
+**Goal**: `backfill-runtime-state` cutover writes that cannot land surface the failure, distinguishable from a legitimate already-migrated no-op.
+**Priority**: P2 · **Dependencies**: WP03, WP05 · **Requirements**: FR-007, FR-010 · **Est.**: ~300 lines
+**Independent test**: a cutover write that cannot land surfaces a non-silent failure (populated `CutoverResult.error`); a legitimate no-op does not; a recorded unrecoverable capture failure is surfaced at the epilogue non-fatally.
+**Owns (post-tasks fold)**: also `migration/runtime_state_cutover.py` + `migration/backfill_runtime_state.py` (deep honest error) — resolves post-tasks MAJOR-2. WP04 is the boundary consumer of WP05's capture-failure flag — resolves MAJOR-1.
+**Subtasks**: T018 T019 T020 T021 T031
+**Risks**: must not flag legitimate no-op as failure. Confirm the exact backfill surface in `migrate_cmd.py`. Prompt: `tasks/WP04-loud-cutover-backfill.md`
+
+## WP05 — Observable emitter capture failure (IC-05, folds #3391)
+
+**Goal**: No silent-success capture: fix BOTH swallow sites and surface a genuinely-unrecoverable failure at the command boundary via a process-level flag — non-fatal.
+**Priority**: P2 · **Dependencies**: WP03 · **Requirements**: FR-001, FR-010 · **Est.**: ~360 lines
+**Independent test**: an unrecoverable capture failure is observable at the command boundary (epilogue) and the host command does not crash.
+**Subtasks**: T022 T023 T024 T025 T026
+**Risks**: `_emit` is "never raises" across ~30 `emit_*` callers — do not raise; thread a flag. Rate-limit to avoid warning-storm. Coordinate #3391 (MOES-Media). Prompt: `tasks/WP05-observable-emitter.md`
+
+## WP06 — Rewrite #3425 reproductions + coordinated LEGACY-flip reconcile (IC-06)
+
+**Goal**: Turn the mis-built red-first tests green against the real contract while KEEPING behavioral pins; update the existing LEGACY-default pins outside the blocking selection so a green blocking gate cannot mask NFR-003/004 regressions.
+**Priority**: P2 · **Dependencies**: WP01, WP03 · **Requirements**: FR-008, FR-009 · **Est.**: ~340 lines
+**Independent test**: the 3 `#3425` reproductions pass end-to-end; `regression tests (blocking)` + the coordinated `tests/sync`/`event_journal` set are green on-branch.
+**Subtasks**: T027 T028 T029 T030
+**Risks**: rewritten tests must stay behavioral (conservation + warning-absence), not permit-enum assertions; the ~80 LEGACY-referencing files sit OUTSIDE the blocking selection — enumerate the reddened subset explicitly. Prompt: `tasks/WP06-repro-rewrite-reconcile.md`

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/README.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/README.md
@@ -1,0 +1,64 @@
+# Tasks Directory
+
+This directory contains work package (WP) prompt files.
+
+## Directory Structure (v0.9.0+)
+
+```
+tasks/
+├── WP01-setup-infrastructure.md
+├── WP02-user-authentication.md
+├── WP03-api-endpoints.md
+└── README.md
+```
+
+All WP files are stored flat in `tasks/`. Status is tracked in `status.events.jsonl`, not in WP frontmatter.
+
+## Work Package File Format
+
+Each WP file **MUST** use YAML frontmatter:
+
+```yaml
+---
+work_package_id: "WP01"
+title: "Work Package Title"
+dependencies: []
+planning_base_branch: "fix/legacy-journal-capture-cutover"
+merge_target_branch: "fix/legacy-journal-capture-cutover"
+branch_strategy: "Planning artifacts were generated on fix/legacy-journal-capture-cutover; completed changes must merge back into fix/legacy-journal-capture-cutover."
+subtasks:
+  - "T001"
+  - "T002"
+phase: "Phase 1 - Setup"
+assignee: ""
+agent: ""
+shell_pid: ""
+history:
+  - timestamp: "2025-01-01T00:00:00Z"
+    agent: "system"
+    action: "Prompt generated via /spec-kitty.tasks"
+---
+
+# Work Package Prompt: WP01 – Work Package Title
+
+[Content follows...]
+```
+
+## Status Tracking
+
+Status is tracked via the canonical event log (`status.events.jsonl`), not in WP frontmatter.
+Use `spec-kitty agent tasks move-task` to change WP status:
+
+```bash
+spec-kitty agent tasks move-task <WPID> --to <lane>
+```
+
+Example:
+```bash
+spec-kitty agent tasks move-task WP01 --to doing
+```
+
+## File Naming
+
+- Format: `WP01-kebab-case-slug.md`
+- Examples: `WP01-setup-infrastructure.md`, `WP02-user-auth.md`

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP01-credential-auth-signal.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP01-credential-auth-signal.md
@@ -1,0 +1,349 @@
+---
+work_package_id: WP01
+title: Restore credential parsing as an auth signal
+dependencies: []
+requirement_refs:
+- FR-004
+- FR-009
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T001
+- T002
+- T003
+- T004
+- T005
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/sync/
+create_intent:
+- tests/sync/test_credential_scope_signal.py
+execution_mode: code_change
+owned_files:
+- src/specify_cli/sync/queue.py
+- src/specify_cli/sync/preflight.py
+- src/specify_cli/sync/target_authority.py
+- src/specify_cli/cli/commands/agent/mission_setup_plan.py
+- tests/sync/test_credential_scope_signal.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+**Before reading any code or editing any file, run:**
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+This loads your identity, ownership boundaries, and the governance context that binds
+this work package (charter principles, red-first C-011, the "use canonical sources"
+rule, and the terminology canon). Do not skip it: the profile tells you which files you
+may mutate (`owned_files` above), which surfaces are off-limits (everything else), and
+the ATDD-first discipline this WP is built around. Only after the profile is loaded and
+you have confirmed your boundaries should you proceed to the Objective.
+
+---
+
+## Objective
+
+Fix the **#3293 credential regression** (research.md Decision 1; spec US2 / FR-004) so a
+genuinely-authenticated host is no longer refused at the setup-plan auth gate — **without
+reverting #3293's ProjectSyncStore-owned queue selection** (FR-009 / C-003).
+
+The regression narrowed `read_queue_scope_from_credentials` (`src/specify_cli/sync/queue.py:175-180`)
+to a JSON-only read of an explicit `queue_scope` field. The supported credential format
+the existing reproductions write no longer yields a scope, so the FR-011 auth gate in
+`mission_setup_plan.py:1043-1075` treats an authenticated host as unauthenticated and
+exits 2.
+
+The fix is an **auth signal only**. Restoring parsing must let the gate answer the boolean
+question "is this host authenticated?" — it must NOT re-introduce a credential→`scope_db_path`
+derivation at `preflight.py` / `target_authority.py`. Deriving a live physical store path
+from credentials is exactly the C-003/FR-009 revert this WP must avoid (research.md Decision
+10, "Auth-signal (MAJOR-4)"; data-model.md "Credentials → auth signal (not a path)").
+
+This WP is IC-01 in the plan (plan.md:147-153). It is the independent un-redder: it has no
+dependencies and does not touch the layout/cutover surface.
+
+---
+
+## Context
+
+**The two-bug split.** #3425 is really two defects on one root surface (research.md Decision
+1). This WP owns the *credential* half — the one that reddens the blocking CI suite on `main`
+today (spec US2 "Why this priority"). The layout silent-capture half is a separate WP.
+
+**The revert-risk seam.** The restored parse value flows through several consumers that feed
+`scope_db_path(...)`, which resolves a live legacy queue DB path:
+
+- `preflight.py:480-484` — `read_queue_scope_from_credentials()` result is split on `"|"`
+  (`credentials_scope.split("|")`, expecting the canonical `server|user|team` form).
+- `preflight.py:516-519` — `_read_queue_scope_local_only()` result is passed to
+  `scope_db_path(scope)` to choose the physical queue DB the preflight reports on
+  (`_read_queue_scope_local_only` itself, at `preflight.py:397-416`, falls back to
+  `read_queue_scope_from_credentials`).
+- `target_authority.py:391-404` — `_read_cached_scope()` reads
+  `read_queue_scope_from_credentials()`, but only as a **diagnostic** (`_diagnose_scope_status`
+  at 407-418 explicitly reports, never selects — see the docstring "never used to pick a queue
+  or DB path").
+- `target_authority.py:465-466` — the authoritative `queue_db_path` is derived from
+  `_derive_queue_scope(...)` → `scope_db_path(...)`, and does **not** read credentials.
+
+So the trap is real for `preflight.py:516` (which would change which physical store a live
+write lands in) and cosmetic for `target_authority.py` (diagnostic-only). The gate itself
+(`mission_setup_plan.py:1059`) needs only a **boolean** "authenticated?", not a path.
+
+**The gate.** `_enforce_saas_sync_auth_refusal` (`mission_setup_plan.py:1043-1075`) is
+short-circuited by `SPEC_KITTY_ENABLE_SAAS_SYNC != "1"`, then computes
+`read_queue_scope_from_session() or read_queue_scope_from_credentials()` and exits 2 with
+`SAAS_SYNC_UNAUTHENTICATED` when that is falsy. Restoring parsing makes that truthy for an
+authenticated host — which is all the gate needs.
+
+---
+
+## Subtasks
+
+### T001 — Red-first: authenticated coherent host passes preflight (exit 0)
+
+**Purpose.** Pin the FR-004 / SC-002 contract with a failing test *before* any production
+change (C-011). The test proves that, with credentials written in the supported format on a
+coherent authenticated host, `setup-plan`'s auth gate passes (exit 0) rather than refusing
+with exit 2.
+
+**Concrete steps.**
+1. Create `tests/sync/test_credential_scope_signal.py` (declared in `create_intent`).
+2. Add a fixture that isolates BOTH home roots to a temp dir: set `HOME` **and**
+   `SPEC_KITTY_HOME` (and `XDG_*`/`APPDATA` as the sibling tests do) via `monkeypatch.setenv`
+   pointing at `tmp_path`. This dev box's real `~/.spec-kitty` is a live legacy root
+   (plan.md:131-133) — pinning only `HOME` is insufficient because scope/credential paths key
+   off `SPEC_KITTY_HOME`.
+3. Write credentials in the supported format the reproductions use (the `server|user|team`
+   piped scope form the pre-#3293 parser accepted — see `preflight.py:479` "Canonical scope is
+   `server|user|team`").
+4. Set `SPEC_KITTY_ENABLE_SAAS_SYNC=1` so the gate at `mission_setup_plan.py:1052` does not
+   short-circuit.
+5. Drive `_enforce_saas_sync_auth_refusal(json_output=True)` (or the real setup-plan entry
+   point) and assert it does **not** raise `typer.Exit(code=2)` — i.e. the authenticated host
+   is accepted.
+
+**Files touched.** `tests/sync/test_credential_scope_signal.py` (new).
+
+**Validation checklist.**
+- [ ] Test FAILS before T002 (currently `read_queue_scope_from_credentials` returns `None` for
+      the piped form → gate exits 2).
+- [ ] Test pins BOTH `HOME` and `SPEC_KITTY_HOME` to a temp root.
+- [ ] No ambient auth is consulted (no network, no real credentials file).
+
+**Edge cases.** Ensure `SPEC_KITTY_ENABLE_SAAS_SYNC` is restored/unset by the fixture so the
+gate short-circuit state does not leak to other tests.
+
+### T002 — Restore `read_queue_scope_from_credentials` parsing to yield an auth signal
+
+**Purpose.** Make `read_queue_scope_from_credentials` (`queue.py:175-180`) recognise the
+supported credential format again so it returns a truthy scope string for an authenticated
+host — turning T001 green — while remaining a pure, side-effect-free read.
+
+**Concrete steps.**
+1. In `queue.py:175-180`, extend the parse so that, in addition to the current JSON
+   `queue_scope` field, the supported on-disk credential form (the `server|user|team` piped
+   scope the pre-#3293 code produced, and that `preflight.py:482` still splits on `"|"`) is
+   recognised and returned as a scope string.
+2. Keep the function pure: no migration side effect, no SaaS round-trip, no path resolution.
+   It returns `str | None` exactly as today (the signature and `__all__` export at
+   `queue.py:527` stay unchanged).
+3. Do NOT change `scope_db_path` (`queue.py:148-149`) or `build_queue_scope`
+   (`queue.py:143-145`). This WP only restores the *read*, never the path derivation.
+
+**Files touched.** `src/specify_cli/sync/queue.py`.
+
+**Validation checklist.**
+- [ ] T001 now passes.
+- [ ] `read_queue_scope_from_credentials` still returns `None` for genuinely-absent/garbage
+      credentials (no false positives).
+- [ ] Function performs no I/O beyond the existing credentials-file read; no migration call.
+- [ ] `ruff` + `mypy` clean on `queue.py`.
+
+**Edge cases.** Corrupt/partial credentials must yield `None`, not raise (preserve the
+`_read_json`-style defensive posture at `queue.py:167-172`). A JSON `queue_scope` explicit
+value must still win where present (do not regress the current behavior).
+
+### T003 — Gate consumes the boolean auth signal
+
+**Purpose.** Confirm the FR-011 gate at `mission_setup_plan.py:1043-1075` treats the restored
+scope purely as a boolean "authenticated?" — it already does (`if _scope: return` at line
+1060), so this subtask is a *verification-and-lock* step, not a rewrite.
+
+**Concrete steps.**
+1. Read `_enforce_saas_sync_auth_refusal` (`mission_setup_plan.py:1043-1075`). Confirm line
+   1059 (`_scope = read_queue_scope_from_session() or read_queue_scope_from_credentials()`)
+   and line 1060 (`if _scope: return`) consume the value only as a truthiness signal — the
+   scope string is never passed to `scope_db_path` or any store selector here.
+2. If (and only if) any code on this gate path passes the credential-derived scope into a
+   physical path, refactor it so the gate keeps a boolean signal. Expected outcome: **no code
+   change needed** in `mission_setup_plan.py` beyond a clarifying comment that the value is an
+   auth signal, not a path.
+3. Add a focused assertion in `tests/sync/test_credential_scope_signal.py` that the gate accepts
+   the host **without** materializing or touching any queue DB file (assert no
+   `queue-*.db`/`queue.db` is created under the isolated `SPEC_KITTY_HOME` by the gate call).
+
+**Files touched.** `src/specify_cli/cli/commands/agent/mission_setup_plan.py` (comment only,
+if anything), `tests/sync/test_credential_scope_signal.py`.
+
+**Validation checklist.**
+- [ ] Gate path never calls `scope_db_path` with the credential-derived value.
+- [ ] Test asserts no physical queue DB is created by the gate.
+- [ ] If `mission_setup_plan.py` is edited, it is comment-only; no behavioral change to the
+      gate ordering (it still runs before project-root resolution — line 1044-1050).
+
+**Edge cases.** The daemon-owner-mismatch scenario (spec US2 acceptance #2): the boundary
+preflight refusal must remain the one surfaced; the auth signal must not mask it by
+short-circuiting a legitimate later refusal.
+
+### T004 — Red-first: physical-store invariance (INV-6)
+
+**Purpose.** Guarantee that restoring credential parsing does NOT change which physical store
+a live write lands in (data-model.md INV-6; plan.md:124-126). This is the test that catches an
+accidental C-003/FR-009 revert. Write it red-first against the pre-T002 behavior *or* as a
+before/after invariant.
+
+**Concrete steps.**
+1. In `tests/sync/test_credential_scope_signal.py`, under the same BOTH-home-pinned isolation,
+   capture the physical store selection the sync surface resolves for a live write.
+2. Assert via `preflight.py` / `target_authority.py`, not via a private helper: e.g. call the
+   read-only path resolver `_resolve_queue_db_path_readonly()` (`preflight.py:488-519`) — which
+   routes through `_read_queue_scope_local_only()` → `scope_db_path` — and assert the resolved
+   DB path is the **same** whether or not the restored credential parse is active. Equivalently,
+   assert `resolve_sync_target(...)` (`target_authority.py:426-478`) yields the same
+   `queue_db_path` (derived from `_derive_queue_scope`, `target_authority.py:465-466`, which
+   does not read credentials) regardless of the credential parse.
+3. The invariant to pin: the ProjectSyncStore-owned selection is authoritative; the credential
+   read is an auth signal that must be *inert* for physical-store selection.
+
+**Files touched.** `tests/sync/test_credential_scope_signal.py`.
+
+**Validation checklist.**
+- [ ] Test asserts the resolved physical DB path is unchanged by the credential-parse restore.
+- [ ] Assertion goes through `preflight.py` / `target_authority.py` public-ish surfaces, not a
+      re-implementation of path logic in the test.
+- [ ] BOTH `HOME` and `SPEC_KITTY_HOME` pinned; deterministic, no ambient auth.
+
+**Edge cases.** If restoring parsing at `queue.py` *would* have changed `preflight.py:516`'s
+`scope_db_path(scope)` result (because the piped scope now flows there), the fix must ensure
+the ProjectSyncStore selection still wins — the test must FAIL loudly if credential parsing
+starts steering the physical store. That failure signal is the whole point of this subtask.
+
+### T005 — Green the B/C reproductions; keep the JSON path
+
+**Purpose.** Turn the two credential-regression reproductions (research.md Decision 1 "Tests B
+& C") green, and confirm the existing JSON `queue_scope` behavior is preserved (no regression
+of #3293's explicit-scope handling).
+
+**Concrete steps.**
+1. Identify the B/C reproductions that fail because `read_queue_scope_from_credentials` no
+   longer derives a scope from the TOML/piped credentials (research.md Decision 1 names
+   `sync/queue.py:175` and the gate at `mission_setup_plan.py:1043-1075`). Run them and confirm
+   they now pass after T002.
+2. Add/keep an assertion in `tests/sync/test_credential_scope_signal.py` that a JSON credentials
+   file with an explicit `queue_scope` still returns that scope (guards against T002
+   accidentally dropping the current path).
+3. Do NOT modify the B/C reproduction files themselves if they already assert the correct
+   contract — only the credential *parser* and the new signal test are in scope here. (Rewriting
+   the mis-built #3425 reproductions is a different WP / IC-06.)
+
+**Files touched.** `tests/sync/test_credential_scope_signal.py` (assertions); no production
+change beyond T002.
+
+**Validation checklist.**
+- [ ] B/C reproductions pass on-branch.
+- [ ] JSON explicit-`queue_scope` path still works (regression assertion green).
+- [ ] No B/C reproduction file is edited unless it asserts a retired contract (out of scope
+      here — flag it for IC-06 instead of editing).
+
+**Edge cases.** If a B/C reproduction is red for a *layout* reason rather than the credential
+reason, it belongs to the other WP — do not "fix" it here; note it and move on.
+
+---
+
+## Branch Strategy
+
+- **Planning / base branch:** `fix/legacy-journal-capture-cutover`.
+- **Merge target:** `fix/legacy-journal-capture-cutover` (same branch — this is a fix mission,
+  not a `main` PR from the WP).
+- **Execution:** `branch_strategy: lane`. The execution worktree is allocated per the computed
+  lane from `lanes.json` — do NOT hand-construct a worktree path.
+- **The only supported command to prepare the workspace:**
+
+  ```
+  spec-kitty agent action implement WP01 --agent <name>
+  ```
+
+  Consume the resolved workspace path the resolver returns; never reconstruct it.
+
+---
+
+## Test Strategy
+
+- **Red-first (C-011).** T001 and T004 are authored to FAIL before the corresponding production
+  change and pass after. Do not write the production fix first.
+- **Auth-test isolation is mandatory.** Every auth/credential test pins BOTH `SPEC_KITTY_HOME`
+  and `HOME` (plus `XDG_*`/`APPDATA` per the sibling tests) to an isolated temp root. This dev
+  box's real `~/.spec-kitty` is a live legacy root (plan.md:131-133) — pinning only `HOME` is a
+  known footgun. Scope/credential resolution keys off `SPEC_KITTY_HOME`.
+- **Deterministic, no ambient auth.** Tests must not read the real credentials file, contact
+  SaaS, or depend on the machine's login state. All roots are temp roots.
+- **Fast, targeted runs only.** Do not run the full suite (it hangs the session and takes ~1h);
+  CI is the release authority. Run:
+
+  ```
+  PWHEADLESS=1 .venv/bin/python -m pytest tests/sync/test_credential_scope_signal.py -q
+  ```
+
+  Prepend `.venv/bin` to `PATH` (shadow-venv footgun) — a bare `spec-kitty`/`python` runs the
+  wrong interpreter.
+
+---
+
+## Definition of Done
+
+- [ ] T001 red-first test passes: authenticated coherent host passes the gate (exit 0),
+      `SPEC_KITTY_HOME` + `HOME` isolated.
+- [ ] The B/C credential-regression reproductions pass on-branch (FR-004 / SC-002).
+- [ ] T004 physical-store invariance test is green — restoring parsing does NOT change which
+      physical store a live write lands in (INV-6 / FR-009 / C-003).
+- [ ] JSON explicit-`queue_scope` path still works (no #3293 regression).
+- [ ] `ruff check` and `mypy` clean on all owned production files (`queue.py`, `preflight.py`,
+      `target_authority.py`, `mission_setup_plan.py`) — zero issues, zero suppressions added.
+- [ ] **No #3293 revert:** `scope_db_path` and `build_queue_scope` are unchanged; the
+      ProjectSyncStore-owned selection is preserved.
+- [ ] Only `owned_files` are modified; no other file touched. No commit made by the implementer.
+
+---
+
+## Risks & Reviewer Guidance
+
+- **The C-003 / FR-009 revert trap (primary risk).** Restoring `read_queue_scope_from_credentials`
+  makes a real scope flow into consumers that call `scope_db_path` — notably
+  `preflight.py:516` (`scope_db_path(scope)` via `_read_queue_scope_local_only`). If that changes
+  which physical DB a live write lands in, it is a partial revert of #3293's ProjectSyncStore
+  selection, which is forbidden (FR-009 / C-003; plan.md:124-126; data-model.md INV-6).
+- **Reviewer must confirm:**
+  1. `scope_db_path` (`queue.py:148-149`) and `build_queue_scope` (`queue.py:143-145`) are
+     byte-for-byte unchanged.
+  2. The credential-derived scope is consumed **only** as a boolean auth signal at the gate
+     (`mission_setup_plan.py:1059-1060`) — never passed into a store selector on the live-write
+     path.
+  3. `target_authority.py:465-466` still derives `queue_db_path` from `_derive_queue_scope`
+     (not from credentials) — the credential read at `_read_cached_scope` (401-404) remains
+     diagnostic-only (`_diagnose_scope_status`, 407-418).
+  4. The T004 invariance test genuinely asserts through `preflight.py` / `target_authority.py`
+     and would fail if credential parsing started steering the physical store.
+- **Isolation drift risk.** A test that pins only `HOME` can silently pass by reading this box's
+  live legacy root. Reviewer should confirm every test in the new file pins `SPEC_KITTY_HOME`
+  as well.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP02-dedup-identity-attribution.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP02-dedup-identity-attribution.md
@@ -1,0 +1,304 @@
+---
+work_package_id: WP02
+title: Dedup identity + ownerless-row attribution foundation
+dependencies: []
+requirement_refs:
+- FR-005
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T006
+- T007
+- T008
+- T009
+- T010
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/sync/
+create_intent:
+- tests/sync/test_cutover_conservation.py
+execution_mode: code_change
+owned_files:
+- src/specify_cli/sync/migrate_journal.py
+- src/specify_cli/sync/project_store_migration.py
+- src/specify_cli/event_journal/journal.py
+- tests/sync/test_cutover_conservation.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+Before doing anything else, load your governance profile:
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+This binds your identity, boundaries, and the doctrine context (red-first / ATDD,
+canonical-sources, ownership boundaries) that governs every step below. Do not begin
+reading or editing until the profile is loaded.
+
+## Objective
+
+Pin the **copy identity** so the legacy→journal cutover can never duplicate or drop an
+event — **including ownerless legacy rows that predate per-project ownership**. This work
+package is the FOUNDATION (Implementation Concern **IC-00** in
+[`plan.md`](../plan.md)) that WP03's cutover copy consumes: WP03 invokes the copy engine,
+but only *after* this WP has guaranteed that (a) dedup keys deterministically on
+`(event_id, source_digest)` provenance, (b) ownerless rows carry a `project_uuid` before
+they hit any owner check, and (c) genuine divergent-payload collisions **quarantine**
+rather than last-write-win (#2846).
+
+**REUSE the canonical engines — do not reinvent dedup, provenance, or attribution.** The
+copy semantics already live in `migrate_journal.py` (provenance + quarantine) and
+`project_store_migration.py` (`project_uuid` attribution). Your job is to *confirm, wire,
+and harden* those entry points and lock the conservation invariant (INV-2 in
+[`data-model.md`](../data-model.md)) behind red-first tests — not to author a new drain or
+copy path. Any bespoke copy loop is a charter "canonical sources" violation and an
+automatic reviewer rejection.
+
+Satisfies **FR-005** (single authoritative record, dedup by stable identity incl.
+ownerless legacy rows) and underwrites **NFR-002** (zero loss / zero dup on cutover).
+
+## Context
+
+- **Ownerless legacy rows are the trap.** Rows written before per-project ownership have
+  no `project_uuid` that matches the destination store. A naïve copy therefore trips the
+  owner guard: `queue.py:346-348` computes `owner = _owner_from_event(event)` and raises
+  `ValueError("event project UUID does not match store owner")` when `owner !=
+  self.project_uuid`. The journal side has the twin guard at
+  `journal.py:170-171` (`event.project_uuid != self.project_uuid` →
+  `ValueError("event-declared project UUID does not match store owner")`). Attribution
+  (assigning the canonical `project_uuid` to an ownerless row) MUST run **before** either
+  check — this is the whole reason IC-00 precedes the IC-02 copy.
+- **Dedup keys on `(event_id, source_digest)`.** The provenance ledger in
+  `migrate_journal.py` is keyed exactly this way — see the `migration_provenance` table
+  (`PRIMARY KEY (event_id, source_digest)`, migrate_journal.py:175) and
+  `MigrationAudit.record_provenance` (migrate_journal.py:240-244), which does an
+  `INSERT OR IGNORE` so re-runs never double-count. `event_id` is carried through
+  verbatim, never rewritten (module docstring, migrate_journal.py:27).
+- **Divergent payloads QUARANTINE, not last-write-win (#2846).** A same-`event_id`
+  collision whose canonical payload *differs* is parked for an operator via
+  `MigrationAudit.quarantine_conflict` (migrate_journal.py:317-335, idempotent on
+  `(event_id, source_digest)`). Silently keeping the last write is the #2846 bug this WP
+  must prevent regressing.
+- **Idempotence backstop.** `EventJournal.append` short-circuits on a prior assignment for
+  the same `event_id` (`existing = self._existing_assignment(event.event_id)` /
+  `if existing is not None: return existing`, journal.py:172-173) — the last line of
+  defense so a replayed copy is a no-op, not a duplicate.
+
+## Subtasks
+
+### T006 — Red-first conservation test (0 loss / 0 dup, incl. ownerless rows)
+
+- **File**: create `tests/sync/test_cutover_conservation.py` (declared in
+  `create_intent`).
+- **Write RED first.** Seed a temp `spec_kitty_dir` (via `tmp_path` /
+  `SPEC_KITTY_HOME` — see Test Strategy) with a legacy `queue.db` plus at least one scoped
+  `queue-<digest>.db`, holding a known set of events where **some rows are ownerless**
+  (no `project_uuid`, or a `None`/empty one). Snapshot the pre-cutover event-id multiset so
+  the assertion is a before/after diff, not a fixed literal.
+- **Drive the real engine.** Build the destination `EventJournal` against the temp root and
+  call `migrate_journal.migrate_queues_to_journal(spec_kitty_dir, journal=<journal>)`
+  (migrate_journal.py:677). Enumerate sources with `discover_source_dbs`
+  (migrate_journal.py:144) so the fixture matches exactly what the engine walks — do not
+  hand-list paths the engine would not discover.
+- **Assert conservation (INV-2)**: every pre-existing `event_id` appears in the destination
+  **exactly once** — assert BOTH count equality (destination event count ==
+  distinct-source event count) AND identity-set equality (the set of destination
+  `event_id`s == the set of source `event_id`s). Ownerless rows are included in both sides.
+- **Validation**: run only this file; confirm it is RED against `main`'s behavior for the
+  ownerless leg (the owner guard rejects the un-attributed row today), then GREEN after
+  T008/T009 wiring. The count-and-identity assertion is what pins NFR-002.
+- **Edge cases**:
+  - Empty legacy store → no-op, no error, destination stays empty.
+  - Identical duplicate rows spanning two source digests collapse to ONE destination
+    record while accumulating BOTH provenance rows (assert via `provenance_for`,
+    migrate_journal.py:267).
+  - A scoped `queue-<digest>.db` with zero queued rows is skipped, not errored.
+  - Re-running the copy a second time adds no rows (idempotent) — assert the destination
+    multiset is unchanged after a second `migrate_queues_to_journal`.
+
+### T007 — Red-first divergent-payload quarantine test
+
+- **File**: same `tests/sync/test_cutover_conservation.py` (new test function).
+- **Write RED first.** Seed two source DBs that carry the **same `event_id`** but
+  **divergent canonical payloads** (different `payload_sha`). This is the #2846 shape: the
+  legacy and journal stores disagree on the body for one identity.
+- **Assert the copy does NOT last-write-win.** Exactly one authoritative record lands for
+  the shared `event_id`, and the divergence is parked as a quarantined conflict:
+  - Assert a conflict row exists for that `(event_id, source_digest)` via the
+    `MigrationAudit` conflict surface — `quarantine_conflict` (migrate_journal.py:317) and
+    the conflict iterator (`iter_conflicts`, migrate_journal.py:299-306).
+  - Assert `MigrationResult.blocked` is truthy / `exit_code` is non-zero while the conflict
+    is unresolved (cleanup is blocked — see the `migrate_queues_to_journal` docstring,
+    migrate_journal.py:684-695).
+- **Validation**: RED before T008 confirms the quarantine path is genuinely exercised (not
+  bypassed by a silent overwrite); GREEN after. This test is the standing #2846 regression
+  guard — without it, a future "simplification" back to last-write-win passes CI.
+- **Edge cases**:
+  - Identical payloads under the same `event_id` are DEDUP (one record, both provenance
+    rows), NOT quarantine — assert the conflict table is empty in that case.
+  - Quarantine is idempotent — a second `migrate_queues_to_journal` does not add a second
+    conflict row for the same `(event_id, source_digest)` (`INSERT OR IGNORE`,
+    migrate_journal.py:333-334).
+  - The authoritative destination record is deterministic (stable choice), not
+    run-order-dependent — assert it does not flip between the two payloads across re-runs.
+
+### T008 — Wire `(event_id, source_digest)` provenance dedup via `migrate_journal`
+
+- **File**: `src/specify_cli/sync/migrate_journal.py`.
+- **Confirm and, only where missing, wire** that the copy path routes every source event
+  through `MigrationAudit.record_provenance` (migrate_journal.py:240-244) keyed on
+  `(event_id, source_digest)`, and that a same-`event_id` divergent payload is sent to
+  `quarantine_conflict` (migrate_journal.py:317-335) rather than overwriting. Do NOT add a
+  parallel dedup mechanism — thread the existing audit ledger. If the plumbing is already
+  correct, the deliverable is the T006/T007 tests that pin it plus any narrowly-scoped
+  hardening the tests expose.
+- **Validation**: T006 and T007 both GREEN; `provenance_for(event_id)`
+  (migrate_journal.py:267-273) returns every contributing `source_digest` for a
+  multi-source event (provenance accumulates, dedup does not lose sources). Confirm the
+  `migration_provenance` PRIMARY KEY `(event_id, source_digest)` (migrate_journal.py:175)
+  is what enforces the once-per-source ledger — do not add a second keying scheme.
+- **Edge cases**:
+  - A locked/corrupt source DB isolates to a per-source failure and does not abort the
+    whole run (module docstring guarantee, migrate_journal.py:25-26).
+  - `event_id` is carried through verbatim, never rewritten (migrate_journal.py:27) — assert
+    a copied event keeps its exact source `event_id`.
+  - `record_provenance` is `INSERT OR IGNORE` (migrate_journal.py:243) so a replayed source
+    row does not create a second provenance entry.
+
+### T009 — Ownerless-row `project_uuid` attribution via `project_store_migration`
+
+- **File**: `src/specify_cli/sync/project_store_migration.py` (+ the call seam in
+  `migrate_journal.py` if the attribution is invoked from there).
+- **Ensure ownerless rows acquire a canonical `project_uuid` before the owner check.** Do
+  NOT invent a new attribution routine — reuse the existing canonicalization surface:
+  - `_canonical_project` (project_store_migration.py:406) normalizes a raw uuid to
+    `(canonical, reason)`.
+  - The extraction helpers `_project_uuid_value` (project_store_migration.py:375) and
+    `_payload_project_uuid` (project_store_migration.py:392) read the uuid from the row and
+    from the payload respectively.
+  - Attribution is driven through the `MigrationPhase` state machine
+    (project_store_migration.py:90) via `LegacyProjectStoreMigration.migrate`
+    (project_store_migration.py:1236), whose durable monotonic phases keep the operation
+    idempotent and crash-recoverable.
+- **Attribution must resolve to the destination store's owner** so the row then passes the
+  owner guards at `journal.py:170-171` and `queue.py:346-348` on copy. This ordering — attribute
+  first, THEN copy — is the entire reason IC-00 precedes the IC-02 copy: an un-attributed
+  ownerless row raises the "project UUID does not match store owner" `ValueError`.
+- **Validation**: the ownerless-row leg of T006 goes GREEN. Add a focused unit assertion
+  that a row with a `None`/missing `project_uuid` is attributed to the canonical owner (not
+  dropped, not quarantined) and afterward satisfies the owner check.
+- **Edge cases**:
+  - A row whose payload `project_uuid` **conflicts** with the store owner is a genuine
+    conflict, NOT free attribution — it maps to `CONFLICTING_PROJECT_UUID`
+    (project_store_migration.py:121).
+  - Preserve the three distinct reasons: `MISSING_PROJECT_UUID`
+    (project_store_migration.py:118), `NIL_PROJECT_UUID` (project_store_migration.py:120),
+    and `CONFLICTING_PROJECT_UUID` (project_store_migration.py:121). Collapsing them into one
+    is a regression — `MISSING`/`NIL` are attributable, `CONFLICTING` is not.
+
+### T010 — Confirm / harden `journal.append` `event_id` idempotence
+
+- **File**: `src/specify_cli/event_journal/journal.py`.
+- **Confirm the idempotence backstop holds and is covered.** `append`
+  (journal.py:163) must return the existing assignment for a replayed `event_id` without a
+  second write — the `existing = self._existing_assignment(event.event_id)` /
+  `if existing is not None: return existing` guard (journal.py:172-173), backed by
+  `_existing_assignment` (journal.py:148). Do NOT weaken the owner guard at
+  journal.py:170-171 — attribution (T009) runs upstream; the guard stays.
+- **Validation**: a test appends the same `Event` twice and asserts one row / identical
+  receipt (no duplicate `capture_sequence`). Fold this assertion into
+  `tests/sync/test_cutover_conservation.py` so the conservation file owns the end-to-end
+  idempotence pin — the replayed-copy no-op is what makes a re-run of
+  `migrate_queues_to_journal` safe (T006's second-run assertion leans on this backstop).
+- **Do not weaken the owner guard.** `journal.py:170-171` (`event.project_uuid !=
+  self.project_uuid → ValueError`) stays exactly as-is. Attribution (T009) is the upstream
+  fix; the guard is the invariant that keeps a mis-attributed event out of the wrong store.
+  Any change that relaxes this guard to "fix" ownerless rows is the wrong layer and a
+  reviewer rejection.
+- **Edge cases**:
+  - A suppressing coalesce strategy still returns a stable receipt for the collapsed event
+    (journal.py:176-185) — do not regress that contract.
+  - `_existing_assignment` (journal.py:148) is the single lookup; the replay no-op must go
+    through it, not a new parallel dedup check.
+  - Only harden the `event_id`-replay no-op if the tests expose a genuine gap; if the
+    backstop already holds, the deliverable is the covering test, not a code change.
+
+## Branch Strategy
+
+- **Base branch**: `fix/legacy-journal-capture-cutover`.
+- **Merge target**: `fix/legacy-journal-capture-cutover` (mission integration branch; this
+  is NOT `main`).
+- **Lane worktree**: per-lane worktree materialized from `lanes.json` — do not hand-build
+  or reconstruct the path.
+- **Prepare the workspace only via the resolver**:
+
+  ```
+  spec-kitty agent action implement WP02 --agent <name>
+  ```
+
+  Consume the resolved workspace path; never `cd` into a reconstructed
+  `.worktrees/...` directory.
+
+## Test Strategy
+
+- **Red-first (C-011).** Every subtask that adds behavior lands its failing test first
+  (T006, T007 especially), then the wiring that turns it green.
+- **Temp roots ONLY — never the real `~/.spec-kitty`.** This dev box is itself a live
+  machine-global legacy root; a cutover test run against it would mutate real data. Every
+  test MUST resolve its `spec_kitty_dir` from an isolated temp root — `tmp_path` plus the
+  `SPEC_KITTY_HOME` / `HOME` fixtures — so `discover_source_dbs`
+  (migrate_journal.py:144) sees only the seeded fixtures. No test or manual step may point
+  the engine at the real store (plan Risk MINOR-8 / research Decision 10).
+- **Run targeted, not the full suite** (the full suite hangs the session):
+
+  ```
+  PWHEADLESS=1 pytest tests/sync/test_cutover_conservation.py -q
+  ```
+
+## Definition of Done
+
+- `tests/sync/test_cutover_conservation.py` exists and is GREEN: conservation
+  (0 loss / 0 dup incl. ownerless rows) AND divergent-payload quarantine (#2846) both
+  pinned red-first then green.
+- Ownerless legacy rows are attributed a canonical `project_uuid` before any owner check;
+  divergent-uuid rows quarantine under the correct distinct reason.
+- `event_id` idempotence backstop in `journal.append` is confirmed and test-covered.
+- **Canonical engines REUSED — cite the entry points in the PR**: dedup/provenance/
+  quarantine via `migrate_journal.migrate_queues_to_journal` (migrate_journal.py:677) +
+  `MigrationAudit` (migrate_journal.py:214, `record_provenance` :240,
+  `quarantine_conflict` :317); attribution via `project_store_migration` (`MigrationPhase`
+  :90, `_canonical_project` :406, `LegacyProjectStoreMigration.migrate` :1236). **No
+  bespoke drain/copy loop.**
+- `ruff check .` and `mypy` clean on the touched files — zero new issues, zero
+  suppressions.
+- No file outside `owned_files` is modified.
+
+## Risks & Reviewer Guidance
+
+- **Reviewer: confirm there is NO bespoke drain/copy.** The single most likely failure
+  mode is an agent re-implementing dedup or attribution inline instead of threading the
+  canonical `migrate_journal` / `project_store_migration` entry points. Reject any parallel
+  copy loop; require the cited entry points.
+- **Attribution must run BEFORE the owner check.** Verify ordering: an ownerless row is
+  assigned its canonical `project_uuid` upstream of `queue.py:346-348` and
+  `journal.py:170-171`. If the "project UUID does not match store owner" `ValueError` can
+  still fire for a legitimately-attributable legacy row, the ordering is wrong.
+- **Quarantine, not last-write-win.** Confirm T007 actually exercises the
+  `quarantine_conflict` path (a real conflict row lands, `MigrationResult.blocked` is set)
+  and that identical payloads dedup rather than quarantine — the two must not be conflated.
+- **Distinct quarantine reasons preserved.** `MISSING_` / `NIL_` / `CONFLICTING_PROJECT_UUID`
+  (project_store_migration.py:118-121) are semantically different; a fix that maps all
+  three to one reason is a regression.
+- **Isolation.** Confirm no test touches the real `~/.spec-kitty`; a fixture that leaks the
+  real `HOME`/`SPEC_KITTY_HOME` is a data-safety defect on this box.
+- **Foundation contract for WP03.** WP03 depends on the guarantees pinned here; a weak or
+  skipped conservation/quarantine test silently degrades WP03's cutover safety.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP03-layout-resolution-cutover.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP03-layout-resolution-cutover.md
@@ -1,0 +1,464 @@
+---
+work_package_id: WP03
+title: Layout resolution + canonical crash-safe auto-cutover
+dependencies:
+- WP01
+- WP02
+requirement_refs:
+- FR-002
+- FR-003
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T011
+- T012
+- T013
+- T014
+- T015
+- T016
+- T017
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/sync/
+create_intent:
+- tests/sync/test_layout_cutover.py
+execution_mode: code_change
+owned_files:
+- src/specify_cli/sync/layout_generation.py
+- tests/sync/test_layout_cutover.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+Before reading anything else, load your operating profile:
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+This binds your identity, boundaries, and governance scope for the whole work
+package. Do not begin editing code or tests before the profile is loaded — the
+profile carries the red-first (C-011) and canonical-source discipline this WP
+lives or dies by. If the load fails, stop and surface it; do not improvise a
+substitute role.
+
+## Objective
+
+This is the **P0 core** of the mission (IC-02 in `plan.md:155-161`). It closes the
+silent zero-capture defect (#3425) at its origin: the layout-resolution state machine
+in `src/specify_cli/sync/layout_generation.py`.
+
+Deliver three behaviors, in this exact ordering of concern:
+
+1. **Fresh roots journal by default (FR-002).** A greenfield repository-root checkout
+   — no `.layout-generation.json` record and **no legacy data** — must resolve to
+   `PROJECT_ONLY` **before** any `LEGACY` state is persisted. Today `_read_locked`
+   (`layout_generation.py:176-188`) writes `_initial_state()` = `LEGACY` on the very
+   first read, so the "never migrated" signal self-destructs and the root is stuck
+   `LEGACY` forever (leaving `LEGACY` is manual-only). The greenfield decision must be
+   made and published *ahead of* that write, so a fresh root emits its first event and
+   the journal actually contains it (currently: zero).
+
+2. **Legacy-with-data roots auto-migrate via the canonical engines (FR-003).** A root
+   that holds real legacy queue data is auto-migrated lazily on first live write by
+   **reusing** `migrate_journal.migrate_queues_to_journal` (`migrate_journal.py:677`)
+   and the `project_store_migration` engine (`MigrationPhase`,
+   `project_store_migration.py:90-100`) — never a bespoke drain/copy (Decision 8,
+   `research.md:87-97`). Source discovery is automatic via
+   `discover_source_dbs` (`migrate_journal.py:144`); the migration identity is a
+   **deterministic, root-derived `migration_id`** (not operator-supplied), so re-entry
+   after a crash targets the *same* migration.
+
+3. **Close the `CUTOVER_PENDING` drop window with crash-safe recovery (NFR-005, INV-3,
+   INV-5).** A crash between `begin_cutover` (`layout_generation.py:339-362`) and
+   `publish_project_only` (`layout_generation.py:364-390`) must leave a re-enterable
+   state that the next run completes — never bricking a root. Live writes arriving while
+   `mode == CUTOVER_PENDING` must not silently route to `LEGACY` and swallow.
+
+The mission-critical property: **no state of the layout machine may return
+capture-success while journaling zero events** (INV-1, `data-model.md:68-70`).
+
+## Context
+
+Read `plan.md` (IC-02, Engineering Alignment lines 96-133), `spec.md` (FR-002/FR-003,
+US1, Edge Cases lines 135-146, NFR-002/NFR-005), `research.md` (Decisions 2, 8, 9, 10),
+and `data-model.md` (state machine lines 46-65, INV-1..6, Cutover Transitions lines
+86-97). Then internalize **the three hazards** — each is a concrete line in
+`layout_generation.py` that will silently defeat the fix if handled naïvely:
+
+### Hazard (a) — `_destination` returns LEGACY for CUTOVER_PENDING
+
+`_destination` (`layout_generation.py:268-272`) maps `PROJECT_ONLY → PROJECT_STORE` and
+**everything else → LEGACY**. So while a migration is in flight (`CUTOVER_PENDING`), the
+issued write permit points at `LEGACY`; `journal.py:117-119`
+(`_require_project_destination` → `ProjectLayoutRequiredError`) then refuses the live
+write, the emitter swallows it, and the exact P0 is made **permanent** for the duration
+of the window (Decision 9, `research.md:99-106`). The write routing for
+`CUTOVER_PENDING` must change: block-and-retry within a bounded wait, and if the
+migration cannot complete, route to the loud emitter surface — **never** silent LEGACY.
+
+### Hazard (b) — the "never migrated" marker self-destructs
+
+`_read_locked` (`layout_generation.py:176-188`) on a fresh root writes
+`_initial_state()` = `LEGACY` (`layout_generation.py:129-136`) **and** the durable
+`.initialized` marker (`_write_marker_locked`, path set at `layout_generation.py:407`)
+on the first read. After that single read the greenfield signal is gone — the root looks
+"initialized-as-LEGACY" indistinguishably from a real legacy root. Therefore the
+no-legacy-data decision must run **before** that persist (Decision 10 / MAJOR-5,
+`research.md:114-116`). Note `peek_state` (`layout_generation.py:256-266`) is the
+existing **non-mutating** snapshot reader — the greenfield detection path must be
+snapshot-shaped like it, not `_read_locked`-shaped.
+
+### Hazard (c) — the real engine needs `migration_id` + source; derive them, define re-entry
+
+`migrate_queues_to_journal` and `project_store_migration` were built for an
+operator-driven `sync project-store-migrate` (explicit `--migration-id` / `--source`).
+Auto-cutover has no operator, so:
+
+- **`migration_id`** is derived deterministically from the root identity (e.g. the
+  store's canonical `project_uuid` / runtime root), so a crash-and-retry re-enters the
+  *same* migration. `begin_cutover` (`layout_generation.py:347-350`) already treats a
+  re-entered `CUTOVER_PENDING` with a matching `migration_id` as idempotent and a
+  mismatched one as "another migration owns cutover" — lean on that, do not fight it.
+- **source** is discovered via `discover_source_dbs` (`migrate_journal.py:144`) — the
+  **real reader**. Do **NOT** use the `queue.py` stub `detect_legacy_rows_for_scope`
+  (`queue.py:204`): it `raise`s `LegacyQueueMigrationRequiredError` unconditionally, as
+  does `default_queue_db_path` (`queue.py:195`). Detection and copy both go through the
+  real `migrate_journal` surface.
+- **re-entry contract**: a `CUTOVER_PENDING` record whose migration cannot yet publish
+  re-enters on the next run and completes; a `FAILED` `MigrationPhase`
+  (`project_store_migration.py:100`) manifest is cleared/retried under a documented rule.
+  The invariant: a crash between `begin_cutover` and `publish_project_only` **always**
+  converges on a later run and **never** bricks the root.
+
+Legacy source rows are **read, never deleted** (INV-4, C-002; #2750 out of scope) — the
+copy is non-destructive, so the mutation is inherently recoverable.
+
+## Subtasks
+
+Each subtask is red-first where marked: write the failing test in
+`tests/sync/test_layout_cutover.py` **first**, watch it fail for the right reason, then
+implement in `layout_generation.py`. All tests use isolated temp roots (see Test
+Strategy) — **never** the live `~/.spec-kitty`.
+
+### T011 — RED-FIRST: greenfield → PROJECT_ONLY, never persists LEGACY, captures
+
+- **File**: `tests/sync/test_layout_cutover.py` (new), then `layout_generation.py`.
+- **Red test**: build a `LayoutGenerationAuthority` (via
+  `_new_layout_generation_authority`, `layout_generation.py:393-409` — the direct
+  constructor at `layout_generation.py:103-108` raises by design) over a temp runtime
+  root with **no** `.layout-generation.json` record, **no** `.initialized` marker, and
+  **no** legacy queue DBs under the discovered `queues/` dir. Drive the first-write
+  resolution path and assert:
+  1. the published record `mode` is `PROJECT_ONLY` with `migration_id is None`;
+  2. at **no point** was a record with `mode == LEGACY` written to `record_path`
+     (`layout_generation.py:405`) — assert on the persisted JSON on disk, not merely on
+     the returned `LayoutGenerationState`. A record that flickered LEGACY→PROJECT_ONLY
+     between two writes still fails this assertion (spy on `_write_locked` or diff the
+     file after each step);
+  3. the issued permit's `destination` is `PROJECT_STORE` (`_destination`,
+     `layout_generation.py:270-271`), so a subsequent live write is authorized by
+     `_require_project_destination` (`journal.py:117-119`) and the journal count goes
+     from 0 → 1 (SC-001, US1 acceptance scenario 1, `spec.md:50`).
+- **Validation — why it is red today**: `_read_locked`
+  (`layout_generation.py:181-184`) on a fresh root unconditionally writes
+  `_initial_state()` = LEGACY (`layout_generation.py:129-136`) plus the marker, so
+  assertion (2) fails immediately and (1)/(3) never reach PROJECT_ONLY (leaving LEGACY is
+  manual-only). Watch it fail here before implementing.
+- **Implement**: introduce a greenfield-resolution step that runs the real detector
+  (T015) **before** the LEGACY persist and, on no-legacy-data, publishes `PROJECT_ONLY`
+  directly (generation 1, `migration_id=None`). Keep the detection read snapshot-safe —
+  shaped like `peek_state` (`layout_generation.py:256-266`), which reads without
+  materializing the marker (`materialize_marker=False`, `layout_generation.py:265`) —
+  so detection itself never trips Hazard (b).
+- **Edge case**: a fresh root with **zero events emitted yet** must resolve
+  `PROJECT_ONLY` as a no-op-safe default, not an error (`spec.md:145-146`). Assert that
+  merely constructing the authority and reading state on a greenfield root does not error
+  and does not persist LEGACY even before any write is attempted.
+- **Regression guard**: assert an **already-migrated** (`PROJECT_ONLY`) root is untouched
+  by the new path — read it, confirm the record bytes are unchanged and generation does
+  not advance (NFR-003: zero behavior change for migrated roots).
+
+### T012 — RED-FIRST: idempotence under interruption (crash between begin/publish)
+
+- **File**: test first, then `layout_generation.py`.
+- **Red test**: seed a temp root with real legacy data. Begin cutover (deterministic
+  `migration_id` from T016), then simulate a crash **after** `begin_cutover`
+  (`layout_generation.py:339-362`) advanced the record to `CUTOVER_PENDING` but
+  **before** `publish_project_only` (`layout_generation.py:364-390`) ran. Re-enter the
+  resolution path and assert: the same `migration_id` is reused (no "another migration
+  owns cutover" from `layout_generation.py:350`), the migration converges to
+  `PROJECT_ONLY`, the journal holds each pre-existing legacy event **exactly once** (0
+  loss, 0 dup — INV-2/NFR-002/SC-004/SC-005), and **no additional writes** beyond
+  convergence occur.
+- **Validation**: assert an event-count **and** identity diff of the journal
+  before/after re-entry equals the pre-crash snapshot — a pure count check would miss a
+  drop masked by an equal-count duplicate. Prove convergence is a **no-op** when already
+  `PROJECT_ONLY` (re-running a completed cutover writes nothing new — spy on
+  `_write_locked` and assert zero calls on the second pass). Assert the re-entry does
+  **not** raise `LayoutAuthorityError("another migration owns cutover")`
+  (`layout_generation.py:350`), which would prove the `migration_id` was
+  non-deterministic — the classic bricking bug (see Risks).
+- **Implement**: the deterministic `migration_id` (T016) plus the re-entry rule (T016).
+  `begin_cutover` already short-circuits a re-entered `CUTOVER_PENDING` whose
+  `migration_id` matches (`layout_generation.py:347-349`, returns `current`
+  unchanged) — the implementation must feed it the *same* id after a crash so this branch
+  is taken, then resume the copy + `publish_project_only`.
+- **Edge case**: root with both legacy data **and** partial project-store state must
+  reconcile, not double-count (`spec.md:139-140`). The engine's
+  `(event_id, source_digest)` provenance primary key (`migrate_journal.py:175`,
+  `INSERT OR IGNORE`, `migrate_journal.py:243`) guarantees idempotent copy; the test
+  seeds one already-copied event, re-runs, and asserts it is not re-copied (dedup, not
+  duplicate).
+- **Edge case**: a `MigrationPhase.FAILED` (`project_store_migration.py:100`) manifest
+  from a prior failed attempt must be cleared and retried under the deterministic id, not
+  left wedging the root — assert a FAILED-then-retry path converges to `PROJECT_ONLY`.
+
+### T013 — RED-FIRST: emit during CUTOVER_PENDING → zero loss
+
+- **File**: test first, then `layout_generation.py`.
+- **Red test**: drive the machine to `CUTOVER_PENDING` and hold it there (a migration
+  that has not yet published). Issue a **live write** while in that state. Assert the
+  write is **not** silently routed to LEGACY-and-swallowed (INV-5,
+  `data-model.md:79-81`): it blocks-and-retries within a bounded wait and, once cutover
+  publishes, lands in the project store; if cutover cannot complete inside the bound, the
+  write surfaces **loudly** (routed to the loud emitter surface, WP owned by IC-05), not
+  silent. Zero events lost across the window.
+- **Validation — why it is red today**: `_destination`
+  (`layout_generation.py:268-272`) returns `LEGACY` for any non-`PROJECT_ONLY` mode, so
+  `issue_write_permit` (`layout_generation.py:274-281`) hands out a LEGACY-destination
+  permit while `CUTOVER_PENDING`; `execute_write` (`layout_generation.py:299-337`) then
+  invokes the writer against LEGACY, `_require_project_destination`
+  (`journal.py:117-119`) raises `ProjectLayoutRequiredError`, and the emitter swallows it.
+  The test must fail on exactly that swallow first, asserting the dropped event is
+  observable nowhere.
+- **Implement**: T017 (CUTOVER_PENDING write routing: block-and-retry, else loud). The
+  bounded wait must be deterministic in tests — inject the bound and use a synchronization
+  hook shaped like `LayoutTestHooks.before_revalidate` (`layout_generation.py:75-79`,
+  wired through `execute_write`'s `test_hooks` param at `layout_generation.py:304`), never
+  wall-clock-flaky.
+- **Edge case**: if the migration publishes `PROJECT_ONLY` *during* the retry window, the
+  write must proceed to the project store on the next revalidation — assert the event
+  lands exactly once (not dropped, not double-written) when publish races the retry.
+- **Edge case**: if the bounded wait elapses with the migration still pending, the write
+  routes to the loud emitter surface (IC-05, owned by another WP) — assert the WP03 code
+  raises/signals a distinguishable "cutover-not-yet-complete" condition rather than
+  returning success, so the loud surface has something to report.
+
+### T014 — RED-FIRST: SPEC_KITTY_NO_AUTO_CUTOVER → loud actionable refusal, no mutation
+
+- **File**: test first, then `layout_generation.py`.
+- **Red test**: seed a legacy-with-data root, set `SPEC_KITTY_NO_AUTO_CUTOVER` in the
+  environment, and drive first-write resolution. Assert: (1) the layout is **not**
+  mutated — the record stays `LEGACY`, no `begin_cutover` occurs, no `migration_id`
+  written; (2) a **loud, actionable** refusal is surfaced pointing at
+  `sync project-store-migrate` (Cutover Transition 5, `data-model.md:96-97`); (3) the
+  refusal is **never** a silent LEGACY swallow.
+- **Validation**: assert `record_path` (`layout_generation.py:405`) is byte-identical
+  before/after (no mutation — no `begin_cutover` generation bump), and that the refusal
+  message names the manual `sync project-store-migrate` command so an operator can act on
+  it. The refusal is loud (raised/routed), never a silent LEGACY swallow.
+- **Implement**: read the escape hatch from the environment (T017) and gate the
+  auto-cutover branch; when set on a legacy-with-data root, skip the mutation entirely and
+  raise/route the actionable refusal. The check must read the env at resolution time (not
+  import time) so tests can toggle it per-case.
+- **Edge case**: the escape hatch must still allow a **greenfield** (no legacy data) root
+  to resolve `PROJECT_ONLY` — the hatch suppresses *auto-cutover of legacy data*, not
+  greenfield journaling. Add an assertion covering that split: hatch set + no legacy data
+  ⇒ `PROJECT_ONLY` and a captured event; hatch set + legacy data ⇒ loud refusal, no
+  capture, no mutation.
+- **Edge case**: a root already in `CUTOVER_PENDING` (crash mid-migration) with the hatch
+  set — decide and document: recovery of an in-flight migration should still complete
+  (the migration was already authorized), i.e. the hatch gates *initiating* auto-cutover,
+  not *finishing* one that was already begun. Assert the in-flight case converges rather
+  than wedging.
+
+### T015 — Detection-before-persist + real detector via discover_source_dbs
+
+- **File**: `layout_generation.py` (+ test coverage folded into T011/T012).
+- **Implement**: a detection helper that answers "does this root hold legacy data?" using
+  the **real reader** `discover_source_dbs` (`migrate_journal.py:144`) plus queued-row
+  counts — **not** the stub `detect_legacy_rows_for_scope` (`queue.py:204`, raises). The
+  helper runs **before** any LEGACY persist in the resolution path (Hazard (b)), so a
+  no-legacy-data root never writes LEGACY.
+- **Validation**: unit-test the helper directly on (a) an empty/absent `queues/` dir → no
+  legacy data → greenfield; (b) a dir with a real scoped `queue-<digest>.db`; (c) the
+  legacy `queue.db`; (d) both. `discover_source_dbs` returns `[]` for an absent/empty
+  queue dir with no error (`migrate_journal.py:150-151`), so greenfield detection is
+  clean and never raises. The legacy `queue.db` is included only when it is an actual
+  file (`migrate_journal.py:160-162`).
+- **Row-count nuance**: a *present but empty* source DB (file exists, zero queued rows)
+  is **not** legacy data awaiting migration — the detector must consult queued-row counts
+  through the real `migrate_journal` read surface, not merely the existence of a `.db`
+  file, or a stale empty queue would trigger a pointless cutover. Test the empty-DB case
+  explicitly resolves greenfield.
+- **Edge case**: a malformed queue filename (does not match the hex-digest shape) is
+  skipped by `discover_source_dbs` (`migrate_journal.py:156-158`, `_parse_digest` →
+  `None` → `continue`), so it must not be misread as legacy data. Seed a
+  `queue-notahex.db` and assert greenfield.
+- **Boundary discipline**: the helper must **not** import or call the `queue.py` stubs
+  `detect_legacy_rows_for_scope` (`queue.py:204`) or `default_queue_db_path`
+  (`queue.py:195`) — both raise `LegacyQueueMigrationRequiredError` unconditionally
+  (`queue.py:196`, `queue.py:206`) and exist only as retired shims. A grep of the diff
+  for those symbols must come back empty.
+
+### T016 — Lazy auto-cutover invoking canonical engines + deterministic id + recovery
+
+- **File**: `layout_generation.py`.
+- **Implement**: on first live write to a legacy-with-data root (escape hatch unset),
+  derive a **deterministic root-derived `migration_id`** (stable across process
+  restarts — from the store's canonical `project_uuid` / runtime root, **not** `uuid4`),
+  call `begin_cutover(migration_id)` (`layout_generation.py:339-362`), run the copy via
+  `migrate_queues_to_journal` (`migrate_journal.py:677`) with auto-discovered source and
+  `project_store_migration` attribution, then `publish_project_only(migration_id, verify_exact=...)`
+  (`layout_generation.py:364-390`). The `verify_exact` callback is the engine's
+  copy-verify (conservation), so publication only happens after the copy is proven exact.
+- **Recovery rule (document inline)**: a re-entered `CUTOVER_PENDING` with the matching
+  `migration_id` resumes and completes (idempotent — `layout_generation.py:347-349`); a
+  `MigrationPhase.FAILED` (`project_store_migration.py:100`) manifest is cleared and
+  retried against the same deterministic `migration_id`. A crash between begin and
+  publish **always** converges on a later run; the root is **never** bricked.
+- **Validation**: covered by T012 (crash/idempotence) + a focused unit test asserting the
+  derived `migration_id` is identical across two constructions of the authority over the
+  same root (determinism), and distinct across two different roots.
+- **Canonical-source discipline**: do **not** reimplement dedup, provenance, quarantine,
+  or attribution — those live in the engines (`migrate_journal.py:175` provenance PK,
+  `project_store_migration.py` `project_uuid` attribution). Reuse only. The copy call is
+  `migrate_queues_to_journal(spec_kitty_dir, journal=..., audit=..., resolved_target=...)`
+  (`migrate_journal.py:677-683`); its `MigrationResult.exit_code`/`blocked`
+  (`migrate_journal.py:693-694`) stay non-zero/True while any conflict is unresolved —
+  the cutover drive must treat a blocked result as "do not publish", surfacing it loudly
+  (IC-04) rather than publishing over an unresolved conflict.
+- **verify_exact wiring**: `publish_project_only`'s `verify_exact` callback
+  (`layout_generation.py:368,379-380`) must return `True` only when the engine has proven
+  the copy exact (every discovered source event present in the journal exactly once).
+  A `False`/non-`True` return raises `LayoutVerificationError`
+  (`layout_generation.py:380`) and correctly refuses to publish — assert that a
+  deliberately-incomplete copy does **not** publish `PROJECT_ONLY`.
+
+### T017 — CUTOVER_PENDING write routing + escape-hatch implementation
+
+- **File**: `layout_generation.py`.
+- **Implement (write routing)**: change how a live write behaves when the current state is
+  `CUTOVER_PENDING`. Instead of `_destination` silently yielding `LEGACY`
+  (`layout_generation.py:272`) and `execute_write` (`layout_generation.py:299-337`)
+  handing the writer a LEGACY permit, the `CUTOVER_PENDING` path blocks-and-retries within
+  a bounded, injectable wait for the migration to publish `PROJECT_ONLY`; on success it
+  proceeds to the project store; on timeout it routes to the loud emitter surface (IC-05)
+  — **never** a silent LEGACY write. Preserve `execute_write`'s existing under-lock
+  revalidation and single-redirect semantics (`layout_generation.py:317-337`); the new
+  behavior is a `CUTOVER_PENDING`-specific branch, not a rewrite of the permit machinery.
+- **Implement (escape hatch)**: `SPEC_KITTY_NO_AUTO_CUTOVER` gates the auto-cutover branch
+  in T016; when set on a legacy-with-data root, no mutation, loud actionable refusal
+  (T014).
+- **Validation**: T013 (zero loss under CUTOVER_PENDING) + T014 (escape hatch). Assert the
+  bounded wait is deterministic via an injected hook, not wall-clock.
+- **Edge case**: concurrent writers during cutover — the "project sync store is locked"
+  contention observed live during `mission create` (`spec.md:141-142`) must not corrupt or
+  drop; the block-and-retry runs under the existing `FileLock` (`layout_generation.py:319`)
+  discipline.
+
+## Branch Strategy
+
+- **Base branch**: `fix/legacy-journal-capture-cutover`.
+- **Merge target**: `fix/legacy-journal-capture-cutover` (lane strategy — this WP lands
+  back onto the mission branch, not `main`).
+- **Worktree**: per-lane, allocated from `lanes.json`. Do **not** hand-construct the
+  worktree path — let the resolver create it.
+- **Command** (only supported way to prepare the workspace):
+
+  ```
+  spec-kitty agent action implement WP03 --agent <name>
+  ```
+
+- **Dependency gate**: WP01 and WP02 must be `approved` or `done` before WP03 can be
+  claimed (`dependencies: ["WP01","WP02"]`). WP01 supplies the restored credential
+  auth-signal / detection groundwork and WP02 the identity/attribution foundation this
+  cutover copy depends on (IC-00 precedes IC-02, `plan.md:139-161`). Do not attempt to
+  claim WP03 until both are green — the dependency-readiness gate will refuse it.
+
+## Test Strategy
+
+- **Red-first (C-011).** For T011–T014, the failing test lands and is observed failing for
+  the correct reason **before** any implementation. Do not write the fix first and
+  back-fill a test.
+- **⚠️ Isolation is mandatory — non-negotiable.** **ALL** tests use isolated temp roots
+  via `SPEC_KITTY_HOME` / `HOME` fixtures. **NEVER** run cutover against the live
+  machine-global `~/.spec-kitty`. This dev box is **itself a live legacy root** — running
+  cutover against it would migrate the whole machine's real queue data (risk MINOR-8,
+  `plan.md:131-133`, `research.md:120-121`). Every test constructs its own temp runtime
+  root, points the authority's `record_path` / `marker_path` /
+  `queues/` dir inside it, and asserts nothing touches the real home.
+- **Determinism.** No wall-clock sleeps in the block-and-retry tests — inject the bound and
+  use a synchronization hook shaped like `LayoutTestHooks`
+  (`layout_generation.py:75-79`, `before_revalidate`). Race behavior must be reproducible.
+- **Conservation assertions.** T012 asserts a before/after event-count **and** identity
+  diff (not just a count), so a drop that is masked by an equal-count duplicate is caught.
+- **Real engines, not stubs.** Detection and copy go through `discover_source_dbs` /
+  `migrate_queues_to_journal`; a test that reaches `detect_legacy_rows_for_scope`
+  (`queue.py:204`) or `default_queue_db_path` (`queue.py:195`) is wired wrong — both
+  raise unconditionally.
+- **Run**:
+
+  ```
+  PWHEADLESS=1 .venv/bin/python -m pytest tests/sync/test_layout_cutover.py -q
+  ```
+
+  (Use the hand-built `.venv`; a bare `uv run` re-syncs and can destroy it.)
+
+## Definition of Done
+
+- All four red-first tests (T011, T012, T013, T014) are green, each having first failed
+  for the documented reason.
+- **No silent-capture window remains in any layout state** — including `CUTOVER_PENDING`.
+  INV-1 (no silent success) and INV-5 (no mid-cutover drop) hold under test.
+- Greenfield roots resolve `PROJECT_ONLY` **before** any LEGACY persist; a fresh root's
+  first event lands in the journal (SC-001).
+- Crash-recovery is proven: an interrupted cutover (crash between `begin_cutover` and
+  `publish_project_only`) re-enters the same deterministic `migration_id` and converges,
+  with zero additional/divergent writes (INV-3/NFR-005/SC-005), never bricking the root.
+- Auto-cutover copy is performed **only** by the canonical engines
+  (`migrate_queues_to_journal` + `project_store_migration`) — no bespoke drain, no
+  re-derived dedup/provenance/quarantine (Decision 8).
+- `SPEC_KITTY_NO_AUTO_CUTOVER` yields a loud, actionable, non-mutating refusal (T014).
+- `ruff check .` and `mypy` are clean on the touched files with zero new issues and zero
+  new suppressions. Any function touched stays at complexity ≤ 15 — extract helpers for
+  the detection / cutover-drive / write-routing phases rather than growing one method.
+- No files outside `owned_files` are modified in this WP.
+
+## Risks & Reviewer Guidance
+
+- **Bricking (highest risk).** The failure mode to hunt: a crash mid-cutover that leaves a
+  `CUTOVER_PENDING` record no later run can complete (e.g. a non-deterministic
+  `migration_id`, so re-entry hits "another migration owns cutover",
+  `layout_generation.py:350`). Reviewer: verify the `migration_id` is derived
+  deterministically from stable root identity and that T012 genuinely simulates the
+  crash *between* `begin_cutover` and `publish_project_only`, not around the whole flow.
+- **Concurrency at the first-write trigger.** Two writers racing to trigger auto-cutover
+  on the same root must not double-begin or corrupt. The block-and-retry and cutover drive
+  run under the existing `FileLock` (`layout_generation.py:319`); reviewer confirms no new
+  unlocked read-decide-write gap was introduced ahead of the LEGACY-persist decision.
+- **The LEGACY default is heavily test-pinned.** Roughly ~80 files across `tests/sync` and
+  `tests/event_journal` assert the current LEGACY-default behavior. **Do not fight those
+  pins in this WP** — WP06 (IC-06) owns reconciling the external pins. If a pre-existing
+  test outside `owned_files` goes red purely because the greenfield default flipped, that
+  is expected and is WP06's remit; note it, do not edit it here.
+- **No silent LEGACY-swallow window may survive.** The reviewer's primary acceptance
+  check: walk every layout state (`LEGACY`, `CUTOVER_PENDING`, `PROJECT_ONLY`) and confirm
+  none returns write-success while the event is journaled to nowhere. `CUTOVER_PENDING` is
+  the trap — confirm it block-and-retries then goes loud, and never silently issues a
+  LEGACY permit via `_destination` (`layout_generation.py:268-272`).
+- **Canonical-source discipline.** Reviewer confirms the copy is the engine's, not a
+  hand-rolled loop — grep the diff for any re-implementation of `(event_id, source_digest)`
+  dedup or `project_uuid` attribution; there must be none.
+- **Scope discipline.** Only `layout_generation.py` and the new
+  `tests/sync/test_layout_cutover.py` change here. The emitter observability surface
+  (IC-05), the credential auth-signal (IC-01/WP01), and the regression-test rewrite
+  (IC-06/WP06) are **other** WPs — do not reach into them.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP04-loud-cutover-backfill.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP04-loud-cutover-backfill.md
@@ -1,0 +1,284 @@
+---
+work_package_id: WP04
+title: Loud cutover / backfill failures (#3476)
+dependencies:
+- WP03
+- WP05
+requirement_refs:
+- FR-007
+- FR-010
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T018
+- T019
+- T020
+- T021
+- T031
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/cli/commands/
+create_intent:
+- tests/sync/test_backfill_loud_failure.py
+execution_mode: code_change
+owned_files:
+- src/specify_cli/cli/commands/migrate_cmd.py
+- src/specify_cli/migration/runtime_state_cutover.py
+- src/specify_cli/migration/backfill_runtime_state.py
+- tests/sync/test_backfill_loud_failure.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+Before touching any file, load the implementer profile so identity, boundaries,
+and governance scope are in force for this work package:
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+Do not begin the subtasks until the profile is loaded.
+
+## Objective
+
+Make the `backfill-runtime-state` cutover path **loud** when a write cannot land
+(#3476). The backfill command is the intended remediation path for the #3425
+silent-zero-capture defect: it seeds legacy runtime state into the event log and
+flips `status_phase` to snapshot-authority. Today, on a legacy capture layout the
+seed write is refused deep in the stack and the refusal is swallowed — the command
+reports success while backfilling nothing, so the fix for #3425 is itself
+unobservable.
+
+This WP closes IC-04 / FR-007: a cutover write that **cannot land** must surface
+the failure at the command boundary (non-zero exit + an actionable message),
+while a **legitimate already-migrated no-op** (nothing to seed, or a re-run that
+is byte-stable) must stay quiet and continue to exit `0`. The load-bearing work
+is the *distinction* between those two states — not just "exit non-zero more
+often."
+
+## Context
+
+WP03 (dependency) lands the layout-resolution + crash-safe auto-cutover work
+(IC-02): fresh roots resolve to `project_only` before any LEGACY persist, and
+legacy-with-data roots auto-migrate via the canonical engines. This WP04 sits
+downstream at the operator-facing `backfill-runtime-state` command boundary.
+
+Confirmed today, the seed write flows:
+
+- `backfill_runtime_state_cmd` (`src/specify_cli/cli/commands/migrate_cmd.py:816`)
+  drives `cutover_mission` / `cutover_repo` from
+  `specify_cli.migration.runtime_state_cutover` (`:235` / `:371`).
+- Each mission's seed events are appended by
+  `backfill_runtime_state` → `append_events_atomic_verified`
+  (`src/specify_cli/migration/backfill_runtime_state.py:99`).
+- On a legacy layout that append is refused by `_require_project_destination`
+  (`ProjectLayoutRequiredError`, `src/specify_cli/event_journal/journal.py:117-119`
+  per data-model.md), which can be swallowed rather than propagated into
+  `CutoverResult.error`.
+- The command epilogue (`migrate_cmd.py:882-883`) only exits non-zero when
+  `_cutover_failed(...)` (`migrate_cmd.py:965-978`) is True — i.e. a real
+  `result.error` or a live not-ok verify. A swallowed "write did not land" leaves
+  `error is None` and can leave verify looking ok, so the command exits `0` on a
+  genuine failure: **the exact #3476 silent no-op.**
+
+The discriminator that must NOT regress: `_cutover_failed` already treats a
+`--dry-run` preview (seeds intentionally unwritten → verify "not ok" pre-seed) as
+a healthy would-seed state, and a re-run as byte-stable. Those legitimate no-ops
+must remain quiet.
+
+## Surface confirmation
+
+- **Command / function located:** `backfill_runtime_state_cmd`, decorated
+  `@app.command(name=_RUNTIME_STATE_CMD)` where `_RUNTIME_STATE_CMD =
+  "backfill-runtime-state"`, at **`src/specify_cli/cli/commands/migrate_cmd.py:816`**.
+  It is in `migrate_cmd.py` as the frontmatter `owned_files` assumes — no path
+  mismatch on the command itself.
+- **Command-boundary seam (in-scope, owned):** the loud-vs-quiet decision is
+  concentrated in `_cutover_failed` (`migrate_cmd.py:965-978`), `_cutover_detail`
+  (`:981-987`), and the epilogue exit (`:882-883`). Surfacing a
+  "write-cannot-land" as a genuine failure at the boundary can and should be done
+  here, in the owned file.
+- **⚠ Scope-boundary flag (root signal may originate deeper):** IC-04's affected
+  surfaces are recorded as "backfill-runtime-state path **+ `layout_generation.py`
+  cutover write**", and the swallowed-refusal originates below `migrate_cmd.py` —
+  in `runtime_state_cutover.py` / `backfill_runtime_state.py`'s append, or the
+  `journal.py` guard. `owned_files` intentionally scopes this WP to
+  `migrate_cmd.py` + the new test. If, once red-first tests exist, surfacing the
+  failure honestly **requires** propagating a "write did not land" signal into
+  `CutoverResult.error` from `runtime_state_cutover.py` (a file this WP does not
+  own), do **not** silently edit it: raise a scope note and coordinate with WP03
+  (IC-02 owns the layout/cutover write). Prefer a fix that reads the existing
+  `CutoverResult` signals at the command boundary; only widen scope with an
+  explicit hand-off.
+
+## Subtasks
+
+### T018 — Red-first: write-cannot-land surfaces as a failure
+
+Author a failing test in `tests/sync/test_backfill_loud_failure.py` that drives
+the backfill/cutover path against a layout where the seed write **cannot land**
+(a legacy layout that refuses the journal append via `ProjectLayoutRequiredError`,
+`journal.py:117-119`). Invoke the real command entry point
+(`backfill_runtime_state_cmd`, `migrate_cmd.py:816`) — via the Typer app / a
+`CliRunner`, not by calling internal helpers — against an **isolated temp root**
+(see Test Strategy). Assert:
+
+- the command **exits non-zero** (the write could not be persisted), and
+- the operator-facing output names the failing mission and the reason (an
+  actionable message, not a bare traceback).
+
+This test MUST be red against the pre-fix code (it will currently exit `0` /
+report success while capturing nothing). Record in the test docstring the exact
+#3476 shape it pins: "seed write refused on a legacy layout is swallowed and the
+command reports success." Keep the assertion behavioral (exit code + surfaced
+detail), not an assertion over internal enum values, so the fix cannot be gamed
+by re-labeling.
+
+### T019 — Red-first: a legitimate no-op is NOT flagged
+
+Author the companion failing/guard test that pins the false-positive boundary: a
+**legitimate already-migrated no-op** must stay quiet. Two shapes, both against
+isolated temp roots:
+
+1. an **already-migrated** mission (`status_phase` already snapshot-authority /
+   nothing left to seed) — a re-run seeds zero, flips nothing, and the command
+   exits `0` with no failure surfaced; and
+2. a **`--dry-run` preview** over a healthy legacy corpus — verify is "not ok"
+   only because seeds are intentionally unwritten (`_cutover_failed` dry-run
+   branch, `migrate_cmd.py:976-977`), and the command still exits `0`.
+
+Assert exit `0` **and** the absence of any "failed" / loud-failure signal in the
+output for both. This test guards NFR-001's inverse: the loud path must not
+warning-storm on healthy roots. It should pass today for the no-op shapes and
+must **stay** passing after T020/T021 — it is the regression fence around the
+distinction, so any T020 change that reddens a legitimate no-op is a defect.
+
+### T020 — Implement the loud-failure path
+
+Make a cutover/backfill write that cannot land surface as a genuine failure at
+the command boundary, turning T018 green. Work within `owned_files`
+(`migrate_cmd.py`) first:
+
+- Ensure a swallowed / refused seed write is reflected as a real failure the
+  epilogue can see — either because `CutoverResult.error` is now populated
+  (preferred; if this requires a deeper-file change, follow the Surface
+  confirmation scope-flag and coordinate with WP03), or because `_cutover_failed`
+  (`migrate_cmd.py:965-978`) is taught to treat a "seeded but did-not-land" result
+  as a failure on a live run.
+- Route the surfaced failure through the existing epilogue (`migrate_cmd.py:882-883`)
+  so it `raise typer.Exit(1)`s, and through `_cutover_detail` (`:981-987`) so the
+  message is actionable (mission slug + reason).
+
+Do not weaken the never-raises contract of the underlying emitter/append (IC-05
+owns that seam); surface at the command boundary, do not crash the host. Keep
+`ruff` + `mypy` clean; if `_cutover_failed` grows a branch, keep the function's
+complexity ≤ 15 by extracting a small predicate rather than nesting.
+
+### T021 — Distinguish no-op vs failure + actionable message
+
+Cement the discriminator so T019 stays green while T018 goes green. Confirm the
+three states are cleanly separated at the boundary and each carries the right
+signal:
+
+- **legitimate no-op** (already-migrated / byte-stable re-run) → exit `0`, no
+  loud failure, no misleading "would seed" noise;
+- **dry-run preview** (seeds intentionally unwritten) → exit `0`, reported as a
+  preview, never as a failure (preserve the `_cutover_failed` dry-run branch);
+- **write-cannot-land** (refused on the current layout) → exit non-zero with an
+  actionable message naming the mission and telling the operator what to do
+  (e.g. that the root needs the layout cutover / WP03 auto-migration to complete
+  first, per data-model.md's state machine).
+
+Hoist any repeated message literal to a module constant (Sonar S1192) if it
+appears ≥ 3 times. Add focused assertions in the test for the message content so
+the "actionable" requirement is executed, not merely asserted structurally.
+
+### T031 — Deep honest error + consume WP05's capture-failure flag at the boundary (FR-010)
+
+This subtask closes the two post-tasks ownership seams. WP04 now **owns** the
+deeper cutover files, so make the honest signal originate where the write actually
+fails, and consume WP05's process-level flag at the cutover command boundary:
+
+- **Populate `CutoverResult.error` at the source** in `src/specify_cli/migration/runtime_state_cutover.py` / `backfill_runtime_state.py`: when the runtime-state cutover write cannot land (the `journal.py:117-119 ProjectLayoutRequiredError` / refusal path), record the real reason on the result object instead of returning a bland success. `cutover_mission` today catches only `MigrationOrderingError` — widen it to carry the layout-refusal reason so `_cutover_failed`/`_cutover_detail` in `migrate_cmd.py` can surface it (T018/T020 consume this).
+- **Consume WP05's capture-failure flag at the cutover epilogue** (`migrate_cmd.py`, the epilogue near `:882-883`): after the command body runs, query WP05's public capture-failure summary helper (from `emitter.py`); if any genuinely-unrecoverable capture failure was recorded, surface it at the boundary (report + non-zero where appropriate) — **non-fatal to the command's own success semantics**. This is the concrete command-boundary consumer for FR-010/NFR-001 (the mechanism is WP05; the demonstrated consumer is here). Because WP04 now `depends_on` WP05, the helper exists when this runs.
+- **Isolation**: red-first coverage in `tests/sync/test_backfill_loud_failure.py` uses temp roots (`SPEC_KITTY_HOME`+`HOME`), never the live `~/.spec-kitty`.
+
+Validation: (a) a cutover write that cannot land yields a populated `CutoverResult.error` and a non-zero, actionable boundary exit; (b) a run with a recorded unrecoverable capture failure surfaces it at the epilogue without crashing the command; (c) a clean run stays silent.
+
+## Branch Strategy
+
+- **Base branch:** `fix/legacy-journal-capture-cutover`.
+- **Merge target:** `fix/legacy-journal-capture-cutover` (this mission's integration
+  branch — NOT `main`; the operator lands the mission branch to origin/main via PR
+  later).
+- **Lane execution:** `branch_strategy: lane` — per-lane worktree, resolved by the
+  runtime resolver. Do not hand-construct the worktree path.
+- **Prepare the workspace with the canonical command** (the only supported way):
+
+  ```
+  spec-kitty agent action implement WP04 --agent <name>
+  ```
+
+- **Dependency gate:** WP04 depends on **WP03**. WP03 must be `approved` or `done`
+  before WP04 can be claimed/implemented (dependency-readiness gating). Do not
+  start until `spec-kitty agent tasks status` shows WP03 satisfied.
+
+## Test Strategy
+
+- **Red-first (C-011):** T018 and the write-cannot-land shape of T019 must be
+  authored and observed **red** before any `migrate_cmd.py` change (T020/T021).
+  Capture the red output in the WP notes.
+- **Isolation is mandatory (plan Testing note / risk MINOR-8):** every test runs
+  against an **isolated temp root** via `SPEC_KITTY_HOME` / `HOME` fixtures. This
+  dev box's real `~/.spec-kitty` is a live machine-global legacy root — a test or
+  step that runs cutover against it is a defect. Seed legacy layout state and
+  refusal conditions inside the temp root only.
+- **Drive the real entry point:** invoke `backfill-runtime-state` through the
+  Typer app (`CliRunner`) so exit code and surfaced output are exercised as an
+  operator sees them — not by calling `_cutover_failed` in isolation (that may be
+  a helper unit test in addition, but the behavioral pin is the command boundary).
+- **New test file:** `tests/sync/test_backfill_loud_failure.py` (create-intent).
+- **Targeted runs only** (full suite is ~1h and off-limits in-session):
+  `PWHEADLESS=1 .venv/bin/python -m pytest tests/sync/test_backfill_loud_failure.py -q`.
+
+## Definition of Done
+
+- `backfill-runtime-state` **exits non-zero with an actionable message** when a
+  cutover/backfill write cannot land on the current layout (FR-007 / #3476).
+- A **legitimate already-migrated no-op** and a **`--dry-run` preview** remain
+  **quiet and exit `0`** — no false-positive loud failure (NFR-001 inverse).
+- T018 (write-cannot-land) and T019 (no-op-not-flagged) both green; both authored
+  red-first where applicable.
+- All tests run against isolated temp roots; the real `~/.spec-kitty` is never
+  touched.
+- `ruff check .` and `mypy` clean on the diff — zero new issues, no new
+  `# noqa` / `# type: ignore`; `_cutover_failed` (and any extracted helper) stays
+  ≤ 15 complexity.
+- If honest surfacing required a change outside `owned_files`, that scope widening
+  was raised as an explicit note and coordinated with WP03 — not slipped in.
+
+## Risks & Reviewer Guidance
+
+- **Primary risk — false positive on a legitimate no-op.** The single most likely
+  regression is making the command loud on a healthy already-migrated / byte-stable
+  re-run, or on a `--dry-run` preview. Reviewer: run T019 and confirm both no-op
+  shapes still exit `0` with no "failed" signal; confirm the `_cutover_failed`
+  dry-run branch (`migrate_cmd.py:976-977`) is untouched or preserved in intent.
+- **Scope creep into a non-owned file.** If the fix reached into
+  `runtime_state_cutover.py` / `backfill_runtime_state.py` / `journal.py` /
+  `layout_generation.py`, verify it was a coordinated hand-off with WP03 and
+  flagged per Surface confirmation — not a silent edit of a file this WP does not
+  own.
+- **Never-raises contract (IC-05).** Confirm the loud path surfaces at the command
+  boundary (epilogue exit + message) and does **not** make the underlying emitter/
+  append start raising into ~30 callers; that seam belongs to IC-05, not WP04.
+- **Actionable message.** Confirm the surfaced text names the mission and tells the
+  operator the recovery (layout cutover must complete first), rather than dumping a
+  raw `ProjectLayoutRequiredError` traceback.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP05-observable-emitter.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP05-observable-emitter.md
@@ -1,0 +1,350 @@
+---
+work_package_id: WP05
+title: 'Observable emitter capture failure (folds #3391)'
+dependencies:
+- WP03
+requirement_refs:
+- FR-001
+- FR-010
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T022
+- T023
+- T024
+- T025
+- T026
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: src/specify_cli/sync/
+create_intent:
+- tests/sync/test_emitter_observability.py
+execution_mode: code_change
+owned_files:
+- src/specify_cli/sync/emitter.py
+- tests/sync/test_emitter_observability.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+Before touching any code, load your operating profile:
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+The profile carries your identity, boundaries, and the ATDD/red-first discipline
+this WP is built around. Do not proceed on default behavior — the emitter contract
+below is a footgun the profile's boundaries are meant to keep you inside of.
+
+---
+
+## Objective
+
+Eliminate **silent-success capture** at the event emitter. Today a capture that
+cannot land is swallowed into a stderr-only `[yellow]Warning:[/yellow]` and the host
+command still reports success — the exact P0 shape of #3425, and the standing
+grievance of #3391.
+
+This WP delivers IC-05 (plan.md:179-185) / FR-001 + FR-010:
+
+1. Fix **both** swallow sites in `src/specify_cli/sync/emitter.py`:
+   - `_capture_to_journal` (`emitter.py:2114-2115`, `"Warning: event journal capture failed"`).
+   - `_emit_for_project_context` (`emitter.py:2334-2335`, `"Warning: Explicit-context event
+     capture failed"`) — **the live-reproduced site** (`mission create` printed this five
+     times authoring this very mission; spec.md:19-23).
+2. Surface a genuinely-unrecoverable capture failure at the **command boundary** via a
+   **process-level captured-failure flag/counter** the command epilogue inspects and reports
+   on (or non-zero-exits from).
+3. Keep the surface **NON-FATAL** — a capture failure must never crash the host command.
+4. Rate-limit the loud path so an exceptional failure cannot become a per-event
+   warning-storm.
+
+This folds #3391 (INV-1 "no silent success", data-model.md:69-71).
+
+---
+
+## Context
+
+**CRITICAL — do NOT make `_emit` raise.** `_emit` (`emitter.py:2117`) is contractually
+documented "Non-blocking: never raises" (`emitter.py:2130`) and is the **sole body behind
+~30 public `emit_*` methods** (`emit_build_registered`, `emit_wp_status_changed`,
+`emit_mission_created`, … — every `def emit_*` from `emitter.py:1012` onward). Those callers
+ignore the return value and assume emission can never throw. Raising out of `_emit`, or out of
+either helper it drives, would turn a swallowed warning into a crash across the entire status /
+build / mission surface. That is a **regression, not a fix**. The observability signal must be
+**out-of-band** (a process-level flag/counter), never an exception that escapes to a caller.
+
+**The common case is already fixed upstream in this mission.** WP03 makes live writes on a
+greenfield / cutover root actually succeed (fresh roots resolve `project_only` before any
+LEGACY persist; legacy-with-data roots auto-migrate). So after WP03 there is normally **nothing
+to swallow** — the loud path here is genuinely **exceptional** (a truly unrecoverable capture
+failure). This is exactly why rate-limiting matters and why raising is the wrong lever: the
+loud surface is a backstop for the residual unrecoverable case (research.md Decision 3, lines
+43-57; Decision 10, lines 109-113), not the hot path.
+
+**Coordinate with #3391 (assignee MOES-Media) — do NOT duplicate.** The emitter swallow shape
+is #3391's territory (C-001/C-004, spec.md:178-181). This mission folds it (FR-010). Leave a
+coordination note on #3391 stating that the observable-failure surface lands here so the fix
+closes once, not twice — do not re-implement a competing surface. Use `unset GITHUB_TOKEN` for
+`gh` if scopes are missing (CLAUDE.md GitHub CLI note).
+
+**Depends on WP03.** WP03 (layout resolution / cutover) must be `approved`/`done` before this
+WP is claimed — the loud path is only correct once the common case is already succeeding. If
+WP03 is not yet satisfied, the dependency gate refuses the claim; do not force past it. Building
+this surface before WP03 lands would make the flag fire on the *common* case (every greenfield
+emit), which is precisely the storm this WP is designed to avoid.
+
+**Only the `except` handlers change.** This WP is deliberately narrow: it rewrites the two
+swallow `except` blocks and adds the process-level surface + epilogue read. It does not touch
+`_emit`'s routing, the validation pipeline, `_queue_event_locally`, or the ProjectSyncStore
+selection (owned elsewhere in the mission / kept per C-003).
+
+---
+
+## Subtasks
+
+### T022 — Red-first: unrecoverable capture failure is boundary-observable AND non-fatal
+
+Author `tests/sync/test_emitter_observability.py` (new file; `create_intent`). Write these
+tests **red first** — they must fail against the current `emitter.py` before any production
+change. This subtask pins the two orthogonal guarantees the rest of the WP must not violate:
+non-fatal (no exception escapes) and observable (a process-level signal is set). It maps
+directly to US1 acceptance scenario 3 (spec.md:52) and INV-1 (data-model.md:69-71).
+
+- **Non-fatal pin**: drive an emit through a public `emit_*` method (e.g. `emit_history_added`,
+  `emitter.py:1756`, or `emit_wp_status_changed`, `emitter.py:1109`) with the underlying queue
+  append forced to raise — monkeypatch `_queue_event_locally` (called from `_capture_to_journal`,
+  `emitter.py:2112`) to throw a representative `RuntimeError`. Assert **no exception escapes** —
+  the `emit_*` call returns normally (`None` or the event, per the method). This locks the
+  never-raises contract (`emitter.py:2130`) so T023/T024/T025 cannot regress it.
+- **Observable pin**: after that failed capture, assert the **process-level captured-failure
+  flag is set / counter incremented** (the surface T025 introduces). Assert the signal is
+  readable **without a filesystem rescan** — an in-process module/class attribute queried via
+  the T025 read API (e.g. `captured_failures()`), mirroring the `skipped_profiles`
+  no-rescan-diagnostics pattern (CLAUDE.md Profile Load Diagnostics).
+- **Both sites**: parametrize or duplicate so **both** swallow sites drive the flag when their
+  inner write fails — `_capture_to_journal` (`emitter.py:2095`) and `_emit_for_project_context`
+  (`emitter.py:2265`, whose inner `OfflineQueue(...).queue_event` refusal raises the
+  `RuntimeError` at `emitter.py:2330`). Since this is red-first, these assertions FAIL now
+  (today both sites only `_console.print`).
+- **Reset/isolation pin**: assert the read/reset API leaves a clean slate between cases so one
+  test's failure count does not bleed into the next (drives the T025 `reset_captured_failures()`
+  design).
+- Use isolated temp roots via `SPEC_KITTY_HOME` / `HOME` fixtures — **never** the live
+  machine-global `~/.spec-kitty` (this dev box is itself a legacy root; plan.md:30,
+  research.md:120-121). Confirm each test is red against current `emitter.py` before moving on.
+
+File anchors: `src/specify_cli/sync/emitter.py:2095`, `:2114`, `:2265`, `:2334`; new test at
+`tests/sync/test_emitter_observability.py`.
+
+### T023 — Fix `_capture_to_journal` swallow (`emitter.py:2114-2115`)
+
+Replace the silent `except Exception as exc: _console.print(... "event journal capture
+failed" ...)` at `emitter.py:2114-2115` so that, in addition to the (rate-limited) warning, the
+failure **records into the process-level captured-failure surface** from T025.
+
+- Keep the method's `-> None` signature (`_capture_to_journal`, `emitter.py:2095-2103`) and its
+  non-raising behavior unchanged — callers of `_capture_to_journal` still see no exception.
+- Do NOT re-raise; do NOT change the docstring's capture-is-local contract
+  (`emitter.py:2104-2109`) — capture stays independent of hosted consent (FR-006 note there).
+- The recorded entry should carry enough to be actionable at the epilogue (site name +
+  `repr(exc)`/summary) **without leaking the full envelope** (no payload, no credential
+  material) — the emitter handles identity-bearing data.
+- Order of operations inside the `except`: record into the surface first (so the count is
+  always exact even if the console print is throttled/suppressed by T026), then emit the
+  human warning.
+
+Verify the T022 "both sites" pin for this site now goes green while the non-fatal pin stays
+green. Ties to FR-001 (no silent-success capture) and NFR-001 (0 swallowed to stderr-only).
+
+### T024 — Fix `_emit_for_project_context` swallow (`emitter.py:2334-2335`) — live-reproduced site
+
+Replace the silent `except Exception as exc: ... "Explicit-context event capture failed" ...;
+return None` at `emitter.py:2334-2335` so the failure **records into the same process-level
+surface** from T025, then still `return None` (preserving the explicit-context contract that a
+refused capture yields `None`, `emitter.py:2329-2331`).
+
+- This is the site `mission create` hit five times while authoring this very mission
+  (spec.md:19-23) — it is the highest-value fix in the WP; call that out in the commit body and
+  the PR description.
+- Keep it non-fatal: `_emit_for_project_context` (`emitter.py:2265`) must not raise out to its
+  caller; the internal `RuntimeError("canonical project outbox refused dossier event capture")`
+  at `emitter.py:2330` must stay **caught** at `emitter.py:2334` — it is the refusal signal —
+  now routed to the loud surface instead of stderr-only, then still `return None`.
+- Preserve the other guards in the `try` body untouched: the identity-override `ValueError`
+  (`emitter.py:2319`), `_validate_event` short-circuit returning `None` (`emitter.py:2326`),
+  and `validate_outbound_payload` — this WP only changes the `except` handler, not the
+  validation flow.
+- Same record-then-warn ordering as T023 so the count is exact under T026 throttling.
+
+Verify the T022 pin for this site goes green; the non-fatal pin stays green. Ties to US1
+scenario 3 (spec.md:52) and FR-010.
+
+### T025 — Process-level captured-failure flag/counter threaded to the command epilogue
+
+Introduce a **process-level captured-failure surface** — a module-level (or `EventEmitter`
+class-level, `emitter.py:853`) flag + counter/record list — that both swallow sites (T023,
+T024) record into. The **command epilogue inspects it and reports / non-zero-exits** on a
+genuinely-unrecoverable failure. This is the mechanism the plan mandates (plan.md:119-121,
+183; research.md Decision 10, lines 109-113): boundary observability delivered *by inspecting
+a flag*, not by raising.
+
+- **Do NOT change the ~30 `emit_*` method signatures** and **do NOT change `_emit`'s
+  never-raises contract** (`emitter.py:2130`). The signal is strictly out-of-band: every
+  `emit_*` caller (from `emitter.py:1012` onward) keeps calling exactly as today and still
+  ignores the return; only the epilogue reads the flag afterward. Any diff that threads a new
+  parameter or return channel through `_emit` or the `emit_*` surface is out of contract —
+  the whole point is that the ~30 callers are untouched.
+- Expose a small read/reset API on the surface — e.g. `captured_failures()` returning the
+  recorded failures (site name + exception summary, no full envelope) and
+  `reset_captured_failures()` clearing them — so the epilogue can inspect at command end and so
+  tests (T022/T026) can assert and isolate between cases. Reset at command **entry** so the
+  flag is per-invocation and never leaks across a long-lived process or across missions.
+- Wire the epilogue inspection at the command boundary — the CLI command wrapper that runs an
+  emit-bearing command. Keep the behavior **non-fatal by default** but **observable**: at
+  minimum a surfaced end-of-command summary of unrecoverable captures; a non-zero exit is
+  acceptable for the unrecoverable case *as long as it is the epilogue, not `_emit`, that
+  decides it* — the emitter never crashes the command mid-flight.
+- Keep the module-level `_console` (`emitter.py:98`, a stderr `Console`) for the human-readable
+  warning; the flag/counter is the machine-observable half. The two are complementary — the
+  warning is throttled (T026), the counter is exact.
+- **Boundary consumer ownership (resolved post-tasks):** WP05 delivers the mechanism entirely
+  inside `emitter.py` — both swallow sites fixed + the `captured_failures()`/`reset_captured_failures()`
+  read API. The concrete command-boundary **consumer** is delivered by **WP04's T031** at the
+  cutover-command epilogue (`migrate_cmd.py`), which now `depends_on` WP05. Do NOT reach across
+  the boundary from here into command files you do not own; expose the read API and let WP04
+  consume it. (This closes post-tasks finding MAJOR-1/O-2.)
+
+Anchors: `emitter.py:98` (`_console`), `:853` (`EventEmitter`), `:1012` (first `emit_*`),
+`:2114`, `:2334`.
+
+### T026 — Rate-limit the loud path (no per-event warning-storm)
+
+Guard both sites so a burst of unrecoverable failures does not emit one warning per event.
+
+- Deduplicate/throttle the `_console.print` (e.g. print-once-per-distinct-failure keyed on
+  site + exception type, or a bounded count with an "N more suppressed" summary surfaced at the
+  epilogue) while still **counting every failure** in the T025 counter — suppression is for the
+  human warning only, never for the machine signal (INV-1 must still see the true count, so the
+  epilogue's non-zero/report decision is on real data).
+- Apply the throttle at **both** sites (`emitter.py:2114`, `:2334`) via the shared surface, so
+  a mixed burst across the two sites is still bounded, not doubled.
+- Add a red-first test in `tests/sync/test_emitter_observability.py`: force many consecutive
+  capture failures (e.g. 50), assert the warning is emitted at most once (or the bounded cap)
+  **and** the counter equals the true failure count (50). Capture console output via the test
+  harness rather than asserting on the live terminal.
+- Rationale: WP03 makes the common case succeed, so a storm here means a real systemic fault —
+  it should be loud once and counted fully, not drown the console (plan.md:185,
+  research.md:52-54). A per-event flood is a reviewer-reject shape.
+
+---
+
+## Branch Strategy
+
+- **Planning base / merge target**: `fix/legacy-journal-capture-cutover` (both). This WP lands
+  on the mission branch, not `main`.
+- **Lane worktree**: `branch_strategy: lane` — a per-lane worktree is allocated by the runtime;
+  do not hand-construct the path.
+- **Prepare the workspace via the resolver — the only supported entry point**:
+
+  ```
+  spec-kitty agent action implement WP05 --agent <name>
+  ```
+
+- **Dependency gate**: WP03 must be `approved` or `done` before WP05 can be claimed
+  (dependency readiness; CLAUDE.md Status Model). Do not start against an unmet dependency.
+- Do NOT modify files outside `owned_files`. Do NOT commit from this authoring step.
+
+---
+
+## Test Strategy
+
+- **Red-first (C-011)**: every subtask that changes behavior lands its failing test first
+  (T022 before T023/T024; T026's storm test before its throttle). Confirm red against current
+  `emitter.py`, then green.
+- **Isolation is mandatory**: all tests use isolated temp roots via `SPEC_KITTY_HOME` / `HOME`
+  fixtures. Never touch the live machine-global `~/.spec-kitty` — this box is a live legacy root
+  (plan.md:30, research.md:120-121).
+- **Two independent assertions per failure path**:
+  1. **Non-fatal** — no exception escapes any public `emit_*` call when the inner write raises.
+  2. **Observable** — the process-level flag is set / counter incremented, and the epilogue
+     surfaces it.
+- Run the new file green and confirm no collateral red in the emitter suite:
+
+  ```
+  SPEC_KITTY_SYNC_DISABLE=1 PWHEADLESS=1 .venv/bin/python -m pytest \
+    tests/sync/test_emitter_observability.py -q
+  ```
+
+  (`SPEC_KITTY_SYNC_DISABLE=1` avoids the pre-review full-suite hang; use `.venv/bin/python`,
+  not bare `uv run`, per CLAUDE.md.)
+- Do NOT run the full suite in-session (≈1h, breaks the session). Targeted only; CI is the
+  release authority.
+
+---
+
+## Definition of Done
+
+- [ ] **Both** swallow sites fixed: `_capture_to_journal` (`emitter.py:2114-2115`) and
+      `_emit_for_project_context` (`emitter.py:2334-2335`) record into the process-level
+      captured-failure surface.
+- [ ] A genuinely-unrecoverable capture failure is **boundary-observable** — the command
+      epilogue inspects the flag/counter and reports (or non-zero-exits).
+- [ ] **Non-fatal preserved**: `_emit`'s never-raises contract (`emitter.py:2130`) is intact;
+      no exception escapes any `emit_*` caller; the ~30 `emit_*` signatures are unchanged.
+- [ ] The loud path is **rate-limited** — no per-event warning-storm; the counter still reflects
+      the true failure count.
+- [ ] New `tests/sync/test_emitter_observability.py` is green (non-fatal + observable + throttle
+      pins), authored red-first, temp-root isolated.
+- [ ] `ruff check .` and `mypy` clean on the changed files — no new `# noqa` / `# type: ignore`
+      / per-file ignores.
+- [ ] Coordination note left on #3391 (fold, do not collide).
+
+---
+
+## Risks & Reviewer Guidance
+
+- **Breaking the never-raises contract (highest risk).** The tempting-but-wrong fix is to
+  re-raise from `_emit` / the helpers so the failure "propagates". That crashes ~30 `emit_*`
+  call sites that assume emission never throws. **Reviewer action**: grep the `emit_*` callers
+  and confirm none can now receive an exception —
+  `grep -rn "\.emit_" src/specify_cli | head` plus a read of `_emit`'s docstring
+  (`emitter.py:2130`). Confirm the observability signal is out-of-band (flag/counter), not an
+  exception. The T022 non-fatal pin is the regression guard; it must exist and be green.
+- **Warning-storm.** Because WP03 makes the common case succeed, a residual failure is
+  systemic — one loud-once warning plus a full count is correct; a per-event flood is a
+  reviewer reject. Confirm T026's throttle test asserts both the bounded warning count and the
+  true counter.
+- **#3391 coordination.** The swallow shape belongs to #3391 (MOES-Media). Confirm a
+  coordination note exists and that this WP folds — not duplicates — the fix (C-001/C-004,
+  spec.md:178-181). Do not ship a second competing surface.
+- **Scope discipline.** Only `emitter.py` + the new test file are `owned_files`. The command
+  epilogue wiring must consume the emitter's flag API without widening the blast radius into
+  other packages; if the epilogue truly needs an edit outside `owned_files`, flag it for a
+  sibling WP rather than reaching across the boundary here.
+- **Record content leakage.** Reviewer should confirm the recorded failure entries carry only
+  a site label and an exception summary — no event payload, correlation ids, or credential
+  material. The emitter is the identity-selection surface; the captured-failure record must not
+  become an accidental exfiltration channel at the epilogue.
+- **Reset hygiene.** Confirm `reset_captured_failures()` runs at command entry so a long-lived
+  process (or a mission that emits across many commands) does not accumulate a stale count that
+  makes a later, clean command non-zero-exit on someone else's failure.
+
+## Reviewer Checklist (quick)
+
+- [ ] `grep -rn "\.emit_" src/specify_cli | head` — no `emit_*` caller can now receive an
+      exception; signatures unchanged.
+- [ ] `_emit` docstring at `emitter.py:2130` still reads "Non-blocking: never raises" and is
+      still true.
+- [ ] Both `except` handlers (`emitter.py:2114`, `:2334`) record into the surface AND warn
+      (throttled), in that order.
+- [ ] T022 non-fatal + observable pins and T026 throttle+count pin are present and green.
+- [ ] Coordination note on #3391 present; no duplicate surface shipped.

--- a/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP06-repro-rewrite-reconcile.md
+++ b/kitty-specs/legacy-journal-capture-cutover-01M03BSX/tasks/WP06-repro-rewrite-reconcile.md
@@ -1,0 +1,331 @@
+---
+work_package_id: WP06
+title: 'Rewrite #3425 reproductions + coordinated LEGACY-flip reconcile'
+dependencies:
+- WP01
+- WP03
+requirement_refs:
+- FR-008
+- FR-009
+planning_base_branch: fix/legacy-journal-capture-cutover
+merge_target_branch: fix/legacy-journal-capture-cutover
+branch_strategy: Planning artifacts for this mission were generated on fix/legacy-journal-capture-cutover. During /spec-kitty.implement this WP may branch from a dependency-specific base, but completed changes must merge back into fix/legacy-journal-capture-cutover unless the human explicitly redirects the landing branch.
+subtasks:
+- T027
+- T028
+- T029
+- T030
+history:
+- at: '2026-08-15T00:00:00Z'
+  actor: claude
+  note: WP authored by tasks phase
+agent_profile: implementer-ivan
+authoritative_surface: tests/
+create_intent: []
+execution_mode: code_change
+owned_files:
+- tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py
+- tests/sync/test_layout_generation.py
+role: implementer
+tags: []
+tracker_refs: []
+---
+
+## ⚡ Do This First: Load Agent Profile
+
+Before doing anything else, load your governance profile:
+
+```
+/ad-hoc-profile-load implementer-ivan
+```
+
+This binds your identity, boundaries, and the doctrine context (red-first / ATDD,
+canonical-sources, ownership boundaries, campsite discipline) that governs every step
+below. Do not begin reading or editing until the profile is loaded.
+
+## Objective
+
+Turn the **mis-built #3425 reproductions** green against the **real ProjectSyncStore
+contract** while *keeping* their behavioral pins — end-to-end journal conservation and
+capture-failure-warning absence — and reconcile the existing **LEGACY-default** test pins
+that WP03's default-flip reddens, so a green `regression tests (blocking)` gate cannot mask
+an **NFR-003 / NFR-004** regression hiding in the non-blocking `tests/sync` / `tests/event_journal`
+suites.
+
+This is Implementation Concern **IC-06** in [`plan.md`](../plan.md). It satisfies **FR-008**
+(reproductions assert the current contract and pass) and **FR-009** (preserve the
+ProjectSyncStore-owned queue selection — the rewrite asserts that contract, it does **not**
+revert the code to the retired API). It underwrites **NFR-003** (already-migrated roots see
+0 behavior change; the pre-existing suites stay green), **NFR-004** (blocking CI green
+on-branch with 0 new reds attributable to the diff), and **SC-003** (the three #3425
+reproductions pass and `regression tests (blocking)` is green on-branch).
+
+**Do NOT hollow the tests into permit-enum assertions.** The rewrite corrects *attribution*
+and *drops a retired API call*; it must keep driving the real `setup_plan` entry point end
+to end and keep asserting the observable outcome (events land in the journal, the legacy
+store is untouched, no swallowed capture-failure warning). A test that only asserts
+`permit.destination is LayoutDestination.PROJECT_STORE` and stops there is a hollowed
+behavioral pin and an automatic reviewer rejection.
+
+## Context
+
+- **Test A mis-attributes the failure to a RETIRED API.** The current
+  `test_authenticated_setup_plan_lands_in_scoped`
+  ([`tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py:288`](../../../tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py))
+  asserts `default_queue_db_path() == expected_scoped_path` and later instantiates a
+  **no-arg** `OfflineBodyUploadQueue()` (line 372) then asserts `.db_path == expected_scoped_path`.
+  That `default_queue_db_path()` (`src/specify_cli/sync/queue.py:195-196`) now raises
+  `LegacyQueueMigrationRequiredError` **unconditionally** — it is not layout-gated, so the
+  test's docstring root-cause narrative (that `LayoutMode.LEGACY` makes it "fail closed") is
+  wrong. The no-arg `.db_path` resolution is a **retired** queue API under the
+  ProjectSyncStore-owned selection (FR-009 / C-003).
+- **The ACTUAL swallowed error on the reproduced path is the journal guard, not the queue.**
+  The live #3425 shape — the warning `mission create` emitted five times — is
+  `ProjectLayoutRequiredError("live payload writes require the project_only layout; legacy
+  state is migration input only")` raised by `_require_project_destination`
+  (`src/specify_cli/event_journal/journal.py:117-119`, class defined at `journal.py:42`).
+  Correct attribution points at `journal.py:119`, not `queue.py:195`.
+- **The LEGACY-default pins sit OUTSIDE the regression-blocking selection.** ~15 files under
+  `tests/sync` / `tests/event_journal` reference `LEGACY`; roughly a half-dozen assert the
+  greenfield LEGACY default as a **hard** pin (enumerated in T029). WP03 flips that default to
+  `project_only` for no-legacy-data roots, so those hard pins go RED — but they are **not** in
+  the `regression tests (blocking)` selection, so a green blocking gate would mask them.
+  Reconciling them here is the NFR-004 guarantee.
+- **Auth-adjacent tests pin `HOME` but the runtime root honors `SPEC_KITTY_HOME` first.**
+  Test A sets only `HOME` (line 254); `_scope_home_classmethod` (line 147) pins
+  `Path.home` + `HOME` / `USERPROFILE` / `LOCALAPPDATA` but **not** `SPEC_KITTY_HOME`. Yet
+  `get_runtime_root()` (`src/specify_cli/paths/windows_paths.py:60`) and `runtime/home.py:39`
+  both resolve `SPEC_KITTY_HOME` **before** any HOME-derived path ("always wins regardless of
+  platform", `runtime/home.py:36`). On this dev box — itself a live machine-global legacy root
+  — an ambient or leaked `SPEC_KITTY_HOME` therefore escapes the temp-root isolation. The sibling
+  `tests/sync/test_layout_generation.py:31` already pins `SPEC_KITTY_HOME`; the #3425 file must too.
+
+## Subtasks
+
+### T027 — Rewrite Test A to the real contract, KEEP the behavioral pins
+
+- **File**: `tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py`
+  (owned).
+- **Correct the attribution.** Rewrite the module docstring and Test A so the root cause is
+  the journal guard `ProjectLayoutRequiredError` (`journal.py:119`), not the unconditional
+  `default_queue_db_path()` (`queue.py:195-196`). Remove the wrong "LayoutMode.LEGACY makes
+  `default_queue_db_path()` fail closed" narrative.
+- **Drop the retired no-arg queue API.** Delete the assertions that call `default_queue_db_path()`
+  with no arguments (lines 288-289) and the no-arg `OfflineBodyUploadQueue()` `.db_path`
+  equality (lines 372-373). Under the ProjectSyncStore-owned selection (FR-009) the live
+  write path is resolved through the store, not a module-level default-path helper — assert
+  the store-owned contract instead.
+- **KEEP the end-to-end behavioral assertions.** Continue driving the **real** `setup_plan`
+  entry point (`specify_cli.cli.commands.agent.mission.setup_plan`) end to end, then assert:
+  (a) **journal conservation** — the emitted event lands in the project journal exactly once;
+  (b) the **legacy store is untouched** — the existing `legacy_body_rows == 0` /
+  `legacy_event_rows == 0` pins (lines 397-404) stay; (c) **warning-absence** — assert
+  `capsys` shows **no** capture-failure warning (no "live payload writes require the
+  project_only layout" / "event journal capture failed" / "Explicit-context event capture
+  failed" on stderr). This warning-absence pin is the load-bearing #3425 assertion — it is
+  what proves the silent-success shape is gone.
+- **Do NOT hollow.** The test must still exercise capture through the command boundary. A
+  rewrite that deletes the enqueue/count/warning assertions and substitutes only a
+  permit-enum check fails the Objective and must be rejected.
+- **Validation**: run only this test post-WP03; it must be GREEN, and removing the WP03 fix
+  (mentally / on the base) must make the warning-absence assertion RED — i.e. the pin still
+  detects the P0.
+- **Edge cases**: some environments skip the dossier helper (SaaS sync disabled / no project
+  UUID) — the existing test already guards the `created_queues` loop for that (lines 362-366);
+  preserve a path that still exercises a real capture through the command boundary rather than
+  asserting on an empty list. The `expected_scope` / `scope_db_path` derivation (lines 274-279)
+  is fine to keep for computing *where* the journal should land — the change is that you assert
+  the row landed there via the store contract, not that a retired no-arg helper returns that
+  path.
+
+### T028 — Green all three #3425 reproductions end-to-end
+
+- **File**: same owned regression file (Test A plus the two WP04 preflight tests).
+- **`test_setup_plan_refuses_on_daemon_owner_mismatch`** (line 426): with credential parsing
+  restored (WP01 / IC-01) the FR-011 auth gate no longer short-circuits, so the **boundary
+  preflight** daemon-owner-mismatch refusal is the one that fires. Keep the `exit_code == 2`
+  and `"Refusing" in combined` assertions (lines 489-498) and the post-refusal "no queue
+  rows" pins (lines 501-504) — they now pass because the intended gate, not the auth
+  cascade, is exercised.
+- **`test_setup_plan_authenticated_coherent_succeeds`** (line 506): a coherent authenticated
+  host must get **past** the preflight — keep the `code != 2` assertion (line 555). Post-WP01
+  the auth gate confirms authentication instead of refusing.
+- **All three end to end** — do not stub the capture path out of existence. The tests drive
+  `setup_plan` for real (the `_patches_for_setup_plan` seam only stubs git / project-root
+  discovery, lines 206-235); keep that seam, keep the real queue-write / journal path live.
+- **Do NOT weaken the daemon-owner-mismatch semantics.** The `exit 2` there is the boundary
+  preflight refusal, a *different* gate from the FR-011 auth refusal the old test tripped
+  first. Keep the `"Refusing"` banner assertion so a regression that reintroduces the auth
+  short-circuit (masking the boundary diagnostic) is still caught — do not relax it to a bare
+  `exit_code == 2` that either gate could satisfy.
+- **Edge cases**: the coherent-host test tolerates a non-2 downstream exit (no real plan
+  template in `tmp_path`, lines 546-558) — keep that tolerance; the assertion is specifically
+  `code != 2`, i.e. "did not refuse at preflight", not "exit 0". Do not tighten it to `exit 0`
+  and reintroduce flakiness on the absent-template path.
+- **Validation**: `pytest tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py -q`
+  → 3 passed, on-branch, with the WP01 + WP03 fixes present. Confirm each of the three passes
+  for the *intended* reason (capture lands / boundary preflight refuses / preflight not
+  refused), not because a gate was stubbed away.
+
+### T029 — ENUMERATE + reconcile the coordinated LEGACY-flip set (checklist)
+
+- **The default flip (WP03) reddens every test that HARD-asserts the greenfield LEGACY
+  default.** Update each so it asserts the post-flip contract (fresh/no-legacy-data root →
+  `project_only`; only a root actually seeded with legacy data → `LEGACY`). Reconcile — do
+  **not** delete a pin to make it pass. Work this explicit checklist:
+
+  - [ ] `tests/sync/test_layout_generation.py:59` — `assert state.mode is LayoutMode.LEGACY`
+        (peek on an **absent** authority = greenfield). Post-flip a no-legacy-data root
+        resolves `project_only`; re-pin to the new default, or seed legacy data first if the
+        test's intent is the legacy branch. **(owned file)**
+  - [ ] `tests/sync/test_layout_generation.py:92` — `assert legacy.destination is
+        LayoutDestination.LEGACY` (`issue_write_permit()` on a fresh store). **(owned file)**
+  - [ ] `tests/sync/test_layout_generation.py:243` — `assert inserts[0].destination is
+        LayoutDestination.LEGACY` (mid-cutover writer barrier). Verify whether the permit is
+        issued before any legacy seed; if the barrier test still means to exercise the LEGACY
+        insert, seed legacy data so the destination stays LEGACY intentionally. **(owned file)**
+  - [ ] `tests/sync/test_migration_writer_barrier.py:215` — `assert permit.destination is
+        LayoutDestination.LEGACY`.
+  - [ ] `tests/sync/test_legacy_queue_guard_3030.py:50` — `assert
+        store.layout_generation().peek_state().mode is LayoutMode.LEGACY`.
+  - [ ] `tests/event_journal/test_project_store_journal.py:112` — `assert
+        observed_destinations == [LayoutDestination.LEGACY]`.
+
+- **Also audit the conditional `if ... is LayoutMode.LEGACY:` guards** — they branch rather
+  than hard-assert, so most will not redden, but each must be re-read to confirm the branch it
+  guards (seed / skip) is still correct post-flip; adjust the seed if the guard silently
+  becomes dead:
+
+  - [ ] `tests/sync/test_final_sync_diagnostics.py:52`
+  - [ ] `tests/sync/test_project_store_cross_platform.py:248` and `:267`
+  - [ ] `tests/sync/test_body_integration.py:55`
+  - [ ] `tests/sync/test_spec_kitty_home_paths.py:145`
+  - [ ] `tests/sync/test_issue_598_hang_fixes.py:82`
+  - [ ] `tests/sync/tracker/test_origin_integration.py:714`
+  - [ ] `tests/sync/tracker/test_tracker_egress_refusal_3108.py:1718`
+
+- **Regenerate the checklist from source, do not trust this snapshot alone.** Re-run the grep
+  on the WP03-merged branch to catch any file the flip newly reddens:
+
+  ```
+  grep -rn "is LayoutMode.LEGACY\|LayoutDestination.LEGACY\|== LayoutMode.LEGACY" tests/sync/ tests/event_journal/
+  ```
+
+- **Validation**: every enumerated file GREEN on-branch after reconcile; no LEGACY-default
+  hard pin left red, no pin deleted to dodge the flip.
+
+### T030 — Pin auth-adjacent tests on `SPEC_KITTY_HOME` + verify both gates green
+
+- **File**: `tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py`
+  (owned) — plus any coordinated-set file from T029 that resolves a runtime root.
+- **Set `SPEC_KITTY_HOME`, not just `HOME`.** In Test A (line 254) and in
+  `_scope_home_classmethod` (line 147) add `monkeypatch.setenv("SPEC_KITTY_HOME", str(<temp
+  root>))` so the runtime root resolves inside the temp tree. Rationale: `get_runtime_root()`
+  (`src/specify_cli/paths/windows_paths.py:60`) and `runtime/home.py:39` resolve
+  `SPEC_KITTY_HOME` **before** any HOME-derived path ("always wins", `runtime/home.py:36`) —
+  pinning only `HOME` leaves an ambient/leaked `SPEC_KITTY_HOME` able to escape isolation onto
+  this box's live legacy root. Mirror the sibling `tests/sync/test_layout_generation.py:31`.
+- **Verify BOTH gates green on-branch**: (a) the `regression tests (blocking)` selection —
+  the three reproductions plus whatever else that job selects — is GREEN with 0 new reds
+  attributable to this diff (NFR-004 / SC-003); and (b) the reconciled
+  `tests/sync` / `tests/event_journal` set from T029 is GREEN. The second gate is the point of
+  this WP: a green blocking gate alone must not certify the change.
+- **Validation**:
+
+  ```
+  PWHEADLESS=1 SPEC_KITTY_SYNC_DISABLE=1 .venv/bin/python -m pytest \
+    tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py \
+    tests/sync/test_layout_generation.py tests/sync/test_migration_writer_barrier.py \
+    tests/sync/test_legacy_queue_guard_3030.py tests/event_journal/test_project_store_journal.py -q
+  ```
+
+## Branch Strategy
+
+- **Base branch**: `fix/legacy-journal-capture-cutover`.
+- **Merge target**: `fix/legacy-journal-capture-cutover` (mission integration branch; this is
+  **NOT** `main`).
+- **Lane worktree**: per-lane worktree materialized from `lanes.json` — do not hand-build or
+  reconstruct the `.worktrees/...` path.
+- **Dependencies gate first**: `WP01` (credential parsing / IC-01, un-reds the auth gate) and
+  `WP03` (layout resolution + default flip / IC-02, reddens the LEGACY pins) must be
+  `approved` or `done` before this WP is claimed — this WP reconciles against *their* landed
+  behavior. If either is not yet satisfied the reconcile targets a moving contract.
+- **Prepare the workspace only via the resolver**:
+
+  ```
+  spec-kitty agent action implement WP06 --agent <name>
+  ```
+
+  Consume the resolved workspace path; never `cd` into a reconstructed worktree directory.
+
+## Test Strategy
+
+- **This WP IS tests.** There is no `create_intent`; every deliverable is an edit to an
+  existing test file that turns red-or-mis-built into green-and-behavioral.
+- **Run targeted, never the full suite** (the full suite hangs the session). Always with the
+  sync gate disabled so the pre-review full-suite hang does not fire:
+
+  ```
+  PWHEADLESS=1 SPEC_KITTY_SYNC_DISABLE=1 .venv/bin/python -m pytest <paths> -q
+  ```
+
+  Use `.venv/bin/python -m pytest` — never a bare `uv run`, which re-syncs and destroys the
+  hand-built `.venv`.
+- **Temp roots ONLY — never the real `~/.spec-kitty`.** This dev box is itself a live
+  machine-global legacy root; a layout/cutover test run against it mutates real data. Every
+  test resolves its root from an isolated temp tree via `tmp_path` + `SPEC_KITTY_HOME` /
+  `HOME` (plan Risk MINOR-8 / research Decision 10). T030 exists precisely to close the
+  `SPEC_KITTY_HOME` leak.
+- **The coordinated set is broad and only two files are `owned_files`.** A small, targeted
+  edit to an additional reddened test file discovered by the T029 grep (outside the two owned
+  files) is **acceptable** when it carries a one-line rationale in the diff/PR noting it is a
+  coordinated LEGACY-flip reconcile. The real guard is **no overlap** with another WP's
+  `owned_files` — keep edits confined to test files the default-flip reddens, and never touch
+  a `src/` file (that is WP01 / WP03 territory).
+
+## Definition of Done
+
+- The three #3425 reproductions
+  (`tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py`) are GREEN
+  end-to-end on-branch **and still behavioral**: journal conservation, legacy-store-untouched,
+  and capture-failure-**warning-absence** all asserted; attribution corrected to
+  `journal.py:119 ProjectLayoutRequiredError`; the retired no-arg `default_queue_db_path()` /
+  `OfflineBodyUploadQueue().db_path` assertions removed (FR-008, FR-009, SC-003).
+- The coordinated LEGACY-flip set is **enumerated** (T029 checklist, regenerated from the
+  source grep) and **GREEN** — every hard LEGACY-default pin reconciled to the post-flip
+  contract, no pin deleted to dodge the flip, conditional guards audited (NFR-003, NFR-004).
+- `regression tests (blocking)` is GREEN on-branch with 0 new reds attributable to the diff
+  (NFR-004), **and** the reconciled `tests/sync` / `tests/event_journal` set is GREEN — both
+  verified, not just the blocking gate.
+- Auth-adjacent tests pin `SPEC_KITTY_HOME` (not only `HOME`); isolation holds on this live
+  legacy box.
+- `ruff check .` clean on the touched files — zero new issues, zero suppressions.
+- No file outside `owned_files` is modified **except** coordinated LEGACY-flip test-file
+  reconciles, each carrying a one-line rationale; **no `src/` file touched**; no overlap with
+  another WP's `owned_files`.
+
+## Risks & Reviewer Guidance
+
+- **Hollowing the behavioral pin is the primary risk.** The easy wrong move is to "fix" Test
+  A by deleting the enqueue / row-count / warning assertions and replacing them with a bare
+  `permit.destination is LayoutDestination.PROJECT_STORE`. **Reviewer: confirm the rewritten
+  reproductions still (a) count the journaled event, (b) assert the legacy store stays at 0
+  rows, and (c) assert the absence of a capture-failure warning via `capsys`.** If any of the
+  three is gone, the #3425 pin no longer detects the P0 — reject.
+- **A green blocking gate can MASK a reddened non-blocking file.** The whole reason IC-06
+  enumerates the coordinated set is that `regression tests (blocking)` does not select the
+  `tests/sync` / `tests/event_journal` LEGACY pins. **Reviewer: re-run the T029 grep on the
+  branch and confirm no LEGACY-default hard assert is left red** — a missed file passes the
+  blocking gate and ships an NFR-003/004 regression silently.
+- **Reconcile, do not delete.** A LEGACY pin turned green by removing the assertion (rather
+  than re-pinning it to the post-flip contract, or seeding legacy data where the LEGACY branch
+  is the genuine intent) is a coverage regression dressed as a fix.
+- **Attribution must name the journal guard.** If the rewritten docstring or assertion still
+  blames `default_queue_db_path()` / `queue.py:195` for the silent capture, the correction did
+  not land — the reproduced swallow is `journal.py:119 ProjectLayoutRequiredError`.
+- **Isolation on a live legacy box.** Confirm no test resolves the runtime root without
+  `SPEC_KITTY_HOME` pinned to a temp tree; a leaked `SPEC_KITTY_HOME` is a data-safety defect
+  here, not a flake.
+- **Dependency ordering.** This WP reconciles against WP01's restored auth gate and WP03's
+  flipped default. If claimed before both are `approved`/`done`, the target contract is still
+  moving and the reconcile will churn.

--- a/scripts/canonical_producer_lint_baseline.txt
+++ b/scripts/canonical_producer_lint_baseline.txt
@@ -25,6 +25,8 @@ tests/sync/test_background.py::CP001
 tests/sync/test_batch_error_surfacing.py::CP001
 tests/sync/test_diagnose.py::CP001
 tests/sync/test_edge_cases.py::CP001
+tests/sync/test_emitter_observability.py::CP001
+tests/sync/test_emitter_observability.py::CP002
 tests/sync/test_envelope_id_formats.py::CP001
 tests/sync/test_events.py::CP001
 tests/sync/test_final_sync_diagnostics.py::CP001

--- a/src/specify_cli/cli/commands/agent/mission_setup_plan.py
+++ b/src/specify_cli/cli/commands/agent/mission_setup_plan.py
@@ -1056,6 +1056,11 @@ def _enforce_saas_sync_auth_refusal(*, json_output: bool) -> None:
         read_queue_scope_from_session,
     )
 
+    # ``_scope`` is consumed purely as a boolean **auth signal** ("is this host
+    # authenticated?") — it is never passed to ``scope_db_path`` or any store
+    # selector here. The credential parse (queue.read_queue_scope_from_credentials)
+    # is deliberately inert for physical-store selection (FR-009 / C-003); the
+    # authoritative queue DB is owned by ProjectSyncStore via ``_derive_queue_scope``.
     _scope = read_queue_scope_from_session() or read_queue_scope_from_credentials()
     if _scope:
         return

--- a/src/specify_cli/cli/commands/migrate_cmd.py
+++ b/src/specify_cli/cli/commands/migrate_cmd.py
@@ -70,6 +70,13 @@ _LABEL_WOULD_SEED = "Would seed (verify pending)"
 _LABEL_SKIPPED = "Skipped (already migrated)"
 _LABEL_FAILED = "Failed"
 
+#: Header for the FR-010 boundary consumer of WP05's process-level capture-failure
+#: flag (``specify_cli.sync.emitter.captured_failures``). Surfaced at the cutover
+#: epilogue when the emitter swallowed an unrecoverable capture failure during the
+#: run — observable (report + non-zero), non-fatal to the command's own success
+#: computation (it never crashes the command or rewrites the cutover verdict).
+_CAPTURE_FAILURE_HEADER = "Unrecoverable capture failure(s) recorded during this run:"
+
 
 @app.callback(invoke_without_command=True)
 def migrate(  # noqa: C901
@@ -853,6 +860,12 @@ def backfill_runtime_state_cmd(
         cutover_mission,
         cutover_repo,
     )
+    from specify_cli.sync.emitter import reset_captured_failures
+
+    # FR-010 boundary consumer (WP05): the capture-failure flag is process-level.
+    # Reset it at entry so what we surface at the epilogue is this invocation's own
+    # signal — never a leftover from a prior command in a long-lived process.
+    reset_captured_failures()
 
     repo_root = locate_project_root()
     if repo_root is None:
@@ -879,7 +892,16 @@ def backfill_runtime_state_cmd(
     # --dry-run is a non-mutating preview: an unseeded corpus verifies "not ok"
     # only because the seeds are not yet written, so a preview never fails the
     # command — the counts + any mismatch are reported for the operator.
-    if not dry_run and any(_cutover_failed(r, dry_run=dry_run) for r in results):
+    cutover_failed = not dry_run and any(_cutover_failed(r, dry_run=dry_run) for r in results)
+
+    # FR-010 boundary consumer: surface any unrecoverable capture failure WP05's
+    # emitter recorded during this run. Independent of the cutover verdict and
+    # non-fatal to it (it only ever *adds* a non-zero reason; it never rewrites a
+    # cutover failure into success), so a genuinely-swallowed capture failure is
+    # observable at the boundary instead of silently lost (#3391 / NFR-001).
+    capture_failed = _surface_capture_failures()
+
+    if cutover_failed or capture_failed:
         raise typer.Exit(1)
 
 
@@ -960,6 +982,29 @@ def rebaseline_dossier_hashes(
 def _error(message: str) -> None:
     """Print an error message to stderr via Rich console."""
     err_console.print(f"[red]Error:[/red] {message}")
+
+
+def _surface_capture_failures() -> bool:
+    """FR-010 boundary consumer: report WP05's recorded capture failures.
+
+    Queries the emitter's process-level capture-failure surface
+    (:func:`specify_cli.sync.emitter.captured_failures`). When one or more
+    unrecoverable failures were swallowed during the run, prints an actionable
+    report naming each ``site`` + ``summary`` and returns ``True`` so the caller
+    can add a non-zero exit reason. Returns ``False`` (silent) on a clean run —
+    the NFR-001 inverse: a healthy root never warning-storms. This never raises:
+    surfacing the flag must not crash the command it is diagnosing.
+    """
+    from specify_cli.sync.emitter import captured_failures
+
+    failures = captured_failures()
+    if not failures:
+        return False
+
+    err_console.print(f"\n[red]{_CAPTURE_FAILURE_HEADER}[/red]")
+    for failure in failures:
+        err_console.print(f"  [red]{failure.site}:[/red] {failure.summary}")
+    return True
 
 
 def _cutover_failed(result: Any, *, dry_run: bool) -> bool:

--- a/src/specify_cli/migration/backfill_runtime_state.py
+++ b/src/specify_cli/migration/backfill_runtime_state.py
@@ -101,6 +101,7 @@ from specify_cli.status import (
     read_event_stream,
     reduce,
 )
+from specify_cli.event_journal.journal import ProjectLayoutRequiredError
 from specify_cli.workspace import canonicalize_feature_dir
 
 from .mission_state import deterministic_ulid
@@ -109,6 +110,19 @@ logger = logging.getLogger(__name__)
 
 #: Actor recorded on seed events (migration provenance, not a live agent).
 BACKFILL_ACTOR = "migration:backfill_runtime_state"
+
+#: Honest ``BackfillResult.reason`` for the #3476 loud-failure path: the seed
+#: write was refused because the project layout has not been cut over, so a live
+#: event write cannot land (``journal.py`` ``_require_project_destination`` ->
+#: :class:`~specify_cli.event_journal.journal.ProjectLayoutRequiredError`). The
+#: message is actionable — it names what could not happen AND the recovery — so
+#: the CLI boundary (``_cutover_detail``) surfaces a fix, not a bare traceback.
+LAYOUT_REFUSAL_REASON = (
+    "runtime-state cutover seed write could not land on the current layout: the "
+    "project layout cutover must complete first (a legacy layout refuses live "
+    "event writes; legacy state is migration input only). Complete the layout "
+    "auto-cutover for this root, then re-run backfill-runtime-state"
+)
 
 #: Distinct provenance for append-only repairs of persisted pre-floor seeds.
 COMPATIBILITY_REPAIR_ACTOR = f"{BACKFILL_ACTOR}:compatibility"
@@ -1503,13 +1517,49 @@ def backfill_runtime_state(
     if dry_run:
         return BackfillResult(feature_dir=feature_dir, slug=slug, action="wrote", seeded_count=seeded_count, reason="dry-run (no write)", warnings=warnings)
 
-    if new_transitions:
-        append_events_atomic_verified(feature_dir, new_transitions)
-    if new_annotations:
-        append_annotations_atomic_verified(feature_dir, new_annotations)
+    try:
+        if new_transitions:
+            append_events_atomic_verified(feature_dir, new_transitions)
+        if new_annotations:
+            append_annotations_atomic_verified(feature_dir, new_annotations)
+    except (ProjectLayoutRequiredError, StoreError) as exc:
+        # #3476 loud-failure path: the seed write was refused because the layout
+        # has not been cut over (``ProjectLayoutRequiredError`` direct, or wrapped
+        # in a store persistence error ``from`` it). Record the honest reason at
+        # the source rather than swallowing the refusal into a bland success.
+        if not _is_layout_refusal(exc):
+            raise
+        return BackfillResult(
+            feature_dir=feature_dir,
+            slug=slug,
+            action="error",
+            seeded_count=seeded_count,
+            reason=LAYOUT_REFUSAL_REASON,
+            warnings=warnings,
+        )
 
     logger.info("Backfilled %d runtime seed event(s) for %s", seeded_count, slug)
     return BackfillResult(feature_dir=feature_dir, slug=slug, action="wrote", seeded_count=seeded_count, warnings=warnings)
+
+
+def _is_layout_refusal(exc: BaseException) -> bool:
+    """True iff *exc* (or any cause in its chain) is a layout-cutover refusal.
+
+    The store re-raises an append refusal as a :class:`StoreError` subclass
+    ``from`` the original
+    :class:`~specify_cli.event_journal.journal.ProjectLayoutRequiredError`, so the
+    layout signal survives on ``__cause__``. Walk the chain so both the direct and
+    the wrapped forms are recovered — a non-layout persistence error (disk fault)
+    is NOT a layout refusal and propagates unchanged (IC-05 owns that seam).
+    """
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        if isinstance(current, ProjectLayoutRequiredError):
+            return True
+        seen.add(id(current))
+        current = current.__cause__
+    return False
 
 
 def backfill_runtime_state_repo(

--- a/src/specify_cli/migration/runtime_state_cutover.py
+++ b/src/specify_cli/migration/runtime_state_cutover.py
@@ -51,7 +51,10 @@ from specify_cli.core.utils import ensure_within_any
 from specify_cli.mission_metadata import load_meta, write_meta
 from specify_cli.workspace import canonicalize_feature_dir
 
+from specify_cli.event_journal.journal import ProjectLayoutRequiredError
+
 from .backfill_runtime_state import (
+    LAYOUT_REFUSAL_REASON,
     BackfillResult,
     MigrationOrderingError,
     VerifyResult,
@@ -293,6 +296,13 @@ def cutover_mission(
         seed = _seed_phase(status_dir, read_dir=feature_dir, dry_run=dry_run)
     except MigrationOrderingError as exc:
         return CutoverResult(slug=slug, flipped=False, error=str(exc))
+    except ProjectLayoutRequiredError:
+        # #3476: a seed write refused because the layout is not cut over must be
+        # a genuine, honest failure on the result — never a bland success. The
+        # backfill library already translates the refusal to an ``error`` result;
+        # this widens the catch for a direct raise that bypasses that seam so the
+        # CLI boundary (``_cutover_failed`` / ``_cutover_detail``) surfaces it.
+        return CutoverResult(slug=slug, flipped=False, error=LAYOUT_REFUSAL_REASON)
 
     slug = seed.slug
     if seed.action == "error":

--- a/src/specify_cli/sync/emitter.py
+++ b/src/specify_cli/sync/emitter.py
@@ -97,6 +97,98 @@ if TYPE_CHECKING:
 
 _console = Console(stderr=True)
 
+# --- Process-level captured-failure surface (WP05, IC-05 / FR-001 + FR-010) ---
+#
+# The machine-observable half of the emitter's non-fatal capture contract. ``_emit``
+# still never raises (its ~30 ``emit_*`` callers assume emission cannot throw); a
+# capture that cannot land is recorded here, out-of-band, so the command epilogue
+# (WP04's consumer) can inspect it WITHOUT a filesystem rescan — mirroring
+# ``AgentProfileRepository.skipped_profiles``. The human-readable warning is the
+# complementary, throttled half (a residual systemic fault is loud-once-and-counted,
+# never a per-event storm). The signal is strictly a flag/counter — never an
+# exception threaded back through the ``emit_*`` surface.
+_SITE_JOURNAL_CAPTURE = "event journal capture"
+_SITE_EXPLICIT_CONTEXT_CAPTURE = "Explicit-context event capture"
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedFailure:
+    """One unrecoverable capture failure, safe to surface at the command epilogue.
+
+    Carries only a ``site`` label and an exception ``summary`` — never the event
+    envelope, payload, correlation ids, or credential material. The emitter is the
+    identity-selection surface; this record must not become an exfiltration channel.
+    """
+
+    site: str
+    summary: str
+
+
+class _CapturedFailureRegistry:
+    """Per-invocation record of swallowed capture failures + warning throttle.
+
+    ``record`` counts every failure (INV-1 must see the true count) and returns
+    whether the human warning should print — at most once per distinct
+    ``(site, exception-type)`` key so a burst cannot become a per-event storm.
+    Recording happens before the console decision so the count stays exact even
+    when the warning is throttled or the console is suppressed.
+    """
+
+    __slots__ = ("_records", "_warned_keys")
+
+    def __init__(self) -> None:
+        self._records: list[CapturedFailure] = []
+        self._warned_keys: set[str] = set()
+
+    def record(self, site: str, exc: BaseException) -> bool:
+        self._records.append(CapturedFailure(site=site, summary=repr(exc)))
+        key = f"{site}:{type(exc).__name__}"
+        if key in self._warned_keys:
+            return False
+        self._warned_keys.add(key)
+        return True
+
+    def snapshot(self) -> tuple[CapturedFailure, ...]:
+        return tuple(self._records)
+
+    def reset(self) -> None:
+        self._records.clear()
+        self._warned_keys.clear()
+
+
+_captured_failures_registry = _CapturedFailureRegistry()
+
+
+def captured_failures() -> tuple[CapturedFailure, ...]:
+    """Return the capture failures recorded since the last reset (no rescan)."""
+    return _captured_failures_registry.snapshot()
+
+
+def reset_captured_failures() -> None:
+    """Clear the process-level capture-failure surface.
+
+    Call at command entry so the flag is per-invocation and never leaks across a
+    long-lived process or across missions — a later clean command must not report
+    someone else's failure.
+    """
+    _captured_failures_registry.reset()
+
+
+def _record_capture_failure(site: str, exc: BaseException) -> None:
+    """Record a swallowed capture failure, then warn (throttled) — record first.
+
+    Record-then-warn ordering keeps the counter exact even when the warning is
+    suppressed by the throttle. Both swallow sites route through here so a mixed
+    burst across the two sites is bounded (one warning per distinct site), never
+    doubled or per-event.
+    """
+    should_warn = _captured_failures_registry.record(site, exc)
+    if should_warn:
+        _console.print(
+            f"[yellow]Warning: {site} failed: {exc} "
+            f"(repeats suppressed; see the end-of-command capture summary)[/yellow]"
+        )
+
 
 def _get_project_identity() -> ProjectIdentity:
     """Lazily load and resolve project identity.
@@ -2112,7 +2204,10 @@ class EventEmitter:
         try:
             self._queue_event_locally(event)
         except Exception as exc:
-            _console.print(f"[yellow]Warning: event journal capture failed: {exc}[/yellow]")
+            # Record into the process-level surface first (so the count is exact
+            # even when the console warning is throttled), then warn. Stays
+            # non-fatal + capture-is-local: no re-raise, no consent coupling.
+            _record_capture_failure(_SITE_JOURNAL_CAPTURE, exc)
 
     def _emit(
         self,
@@ -2332,7 +2427,12 @@ class EventEmitter:
                 raise RuntimeError("canonical project outbox refused dossier event capture")
             return event
         except Exception as exc:
-            _console.print(f"[yellow]Warning: Explicit-context event capture failed: {exc}[/yellow]")
+            # Live-reproduced swallow (``mission create`` hit this five times while
+            # authoring this mission). Record into the same process-level surface
+            # first, then still ``return None`` (explicit-context contract: a refused
+            # capture yields ``None``). The internal refusal ``RuntimeError`` stays
+            # caught here — now observable, never stderr-only.
+            _record_capture_failure(_SITE_EXPLICIT_CONTEXT_CAPTURE, exc)
             return None
 
     def _get_team_slug(self) -> str | None:
@@ -2538,6 +2638,17 @@ class EventEmitter:
             logger.debug("Event %s has no project-owned outbox", event.get("event_id"))
             return False
         store = ProjectSyncStore(project_uuid)
+        # Resolve/drive the machine layout cutover BEFORE opening this write's
+        # unit-of-work (WP03 live-path completion, IC-05 / FR-003). The layout
+        # lock is not re-entrant: driven from inside an open UoW the cutover copy
+        # contends on the held store lock and cannot land, which surfaced
+        # ``LayoutCutoverIncompleteError`` on the live emit path. Out here the lock
+        # is free, so a legacy-with-data root completes its cutover to PROJECT_ONLY
+        # and the write below lands in the project store. Greenfield / already-
+        # migrated roots return in a single peek; only legacy data drives a copy.
+        # A genuinely-unrecoverable resolution (escape hatch, foreign migration)
+        # propagates to the caller's now-observable capture site, never silently.
+        store.layout_generation().resolve_layout_for_write()
         with store.unit_of_work() as unit:
             return OfflineQueue(unit, store.layout_generation()).queue_event(event)
 

--- a/src/specify_cli/sync/layout_generation.py
+++ b/src/specify_cli/sync/layout_generation.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import json
 import os
-from collections.abc import Callable
+import sqlite3
+import threading
+from collections.abc import Callable, Iterator
 from dataclasses import asdict, dataclass
 from kernel.clock import now_utc_iso
 from enum import StrEnum
@@ -15,6 +19,39 @@ from uuid import uuid4
 from filelock import FileLock, Timeout
 
 from specify_cli.sync.project_identity import CanonicalProjectUUID
+
+#: Operator escape hatch: when set, a legacy-with-data root is NOT auto-migrated on
+#: first write. Read at resolution time (never import time) so tests toggle per case.
+NO_AUTO_CUTOVER_ENV = "SPEC_KITTY_NO_AUTO_CUTOVER"
+
+#: The manual command an operator runs when the escape hatch refuses auto-cutover.
+_MANUAL_MIGRATE_COMMAND = "sync project-store-migrate"
+
+#: Bounded, deterministic retry budget for a live write that arrives while a
+#: migration is in flight (``CUTOVER_PENDING``). Iterations — never wall-clock — so
+#: the block-and-retry is reproducible; the ``before_revalidate`` hook is the sync
+#: point a test uses to publish (or not) mid-wait.
+_CUTOVER_WAIT_ATTEMPTS = 8
+
+#: Thread-local marker set while THIS thread is driving the auto-cutover copy. A
+#: migrating writer is authorized to write into the project store during
+#: ``CUTOVER_PENDING``; every other (live) writer blocks-and-retries instead.
+_drive_state = threading.local()
+
+
+def _in_cutover_drive() -> bool:
+    return bool(getattr(_drive_state, "active", False))
+
+
+@contextlib.contextmanager
+def _cutover_drive() -> Iterator[None]:
+    """Mark the current thread as the authorized migrating writer for its duration."""
+    previous = getattr(_drive_state, "active", False)
+    _drive_state.active = True
+    try:
+        yield
+    finally:
+        _drive_state.active = previous
 
 
 class LayoutMode(StrEnum):
@@ -50,6 +87,19 @@ class LayoutVerificationError(LayoutAuthorityError):
 
 class StaleLayoutWritePermitError(LayoutAuthorityError):
     """A permit no longer matches the current machine layout generation."""
+
+
+class LayoutAutoCutoverRefusedError(LayoutAuthorityError):
+    """Auto-cutover was refused by ``SPEC_KITTY_NO_AUTO_CUTOVER`` on a legacy root."""
+
+
+class LayoutCutoverIncompleteError(LayoutAuthorityError):
+    """A live write arrived while cutover was in flight and could not yet publish.
+
+    Distinguishable from a silent LEGACY swallow: the write is surfaced loudly so
+    the caller (the emitter observability surface, IC-05) has something to report,
+    rather than being routed to LEGACY and dropped (INV-5).
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -269,16 +319,39 @@ class LayoutGenerationAuthority:
     def _destination(state: LayoutGenerationState) -> LayoutDestination:
         if state.mode is LayoutMode.PROJECT_ONLY:
             return LayoutDestination.PROJECT_STORE
+        # The migrating writer copies legacy rows INTO the project store while the
+        # machine is CUTOVER_PENDING; a silent LEGACY route here would defeat cutover.
+        if state.mode is LayoutMode.CUTOVER_PENDING and _in_cutover_drive():
+            return LayoutDestination.PROJECT_STORE
         return LayoutDestination.LEGACY
 
     def issue_write_permit(self) -> LayoutWritePermit:
-        """Issue a generation-bound permit for this store's canonical UUID."""
-        state = self.read_state()
+        """Resolve the layout for a first live write, then issue a bound permit.
+
+        Resolution (greenfield → ``PROJECT_ONLY`` before any LEGACY persist; legacy
+        data → auto-cutover; escape hatch → loud refusal) runs here because this is
+        the sole write-path seam the journal/outbox invoke. A migrating writer
+        re-entering during its own copy skips resolution and reads the live state.
+        """
+        state = self.read_state() if _in_cutover_drive() else self._resolved_state_for_write()
         return LayoutWritePermit(
             project_uuid=self._project_uuid,
             generation=state.generation,
             destination=self._destination(state),
         )
+
+    def _resolved_state_for_write(self) -> LayoutGenerationState:
+        """Resolve layout for a write; a still-pending cutover is not fatal here.
+
+        A ``LayoutCutoverIncompleteError`` (contention or a foreign in-flight
+        migration) is caught so ``execute_write`` can block-and-retry then surface
+        it loudly — never a silent LEGACY write. The escape-hatch refusal and an
+        exact-verification failure propagate (they are the loud outcome themselves).
+        """
+        try:
+            return self.resolve_layout_for_write()
+        except LayoutCutoverIncompleteError:
+            return self.read_state()
 
     def _permit_matches(
         self,
@@ -310,6 +383,11 @@ class LayoutGenerationAuthority:
         """
         if permit.project_uuid != self._project_uuid:
             raise ValueError("layout permit project UUID does not match this store")
+        if not _in_cutover_drive():
+            # INV-5: a live write arriving during CUTOVER_PENDING blocks-and-retries
+            # for the migration to publish, then surfaces loudly on timeout — it is
+            # never handed a silent LEGACY permit via _destination.
+            self._await_publish_or_loud(permit, test_hooks)
         if test_hooks is not None and test_hooks.before_revalidate is not None:
             test_hooks.before_revalidate(permit)
 
@@ -389,6 +467,235 @@ class LayoutGenerationAuthority:
 
         return self._under_lock(publish)
 
+    # --- layout resolution + canonical crash-safe auto-cutover (WP03/IC-02) ----
+
+    def _spec_kitty_dir(self) -> Path:
+        """The machine runtime root that holds the legacy ``queues/`` + ``queue.db``.
+
+        ``record_path`` is ``<runtime_root>/projects/.layout-generation.json`` — the
+        legacy sources ``discover_source_dbs`` reads sit one level up, at the root.
+        """
+        return self._record_path.parent.parent
+
+    def auto_migration_id(self) -> str:
+        """Deterministic, root-derived migration identity for lazy auto-cutover.
+
+        Stable across process restarts (a crash-and-retry re-enters the SAME
+        migration, so ``begin_cutover``'s idempotent branch is taken) and distinct
+        across roots. Never ``uuid4`` — a fresh id per run would brick a crashed
+        root by tripping "another migration owns cutover".
+        """
+        # noqa rationale: this is a deterministic, non-cryptographic identifier
+        # derivation from a stable root path — not content integrity or a charter
+        # digest — so charter.hasher.hash_content() does not apply (cf. the same
+        # correlation-hash pattern in project_store_migration._safe_failure).
+        digest = hashlib.sha256(str(self._spec_kitty_dir()).encode("utf-8")).hexdigest()  # noqa: TID251
+        return f"auto-cutover-{digest[:32]}"
+
+    def has_legacy_data(self) -> bool:
+        """Answer "does this root hold legacy data?" via the real reader.
+
+        Uses ``discover_source_dbs`` + queued-row counts (never the retired
+        ``queue.py`` stubs, which raise). A present-but-empty source DB is NOT
+        legacy data awaiting migration; a malformed queue filename is skipped by
+        the discoverer. An unreadable source fails closed as legacy-present so a
+        root that may hold un-migrated data is never silently greenfielded.
+        """
+        from specify_cli.sync.migrate_journal import _read_queued_rows, discover_source_dbs
+
+        for source in discover_source_dbs(self._spec_kitty_dir()):
+            try:
+                if _read_queued_rows(source.path):
+                    return True
+            except sqlite3.Error:
+                return True
+        return False
+
+    @staticmethod
+    def _auto_cutover_disabled() -> bool:
+        """Read the escape hatch at resolution time (never import time)."""
+        return bool(os.environ.get(NO_AUTO_CUTOVER_ENV))
+
+    def resolve_layout_for_write(
+        self,
+        *,
+        cutover_copy: Callable[[str], bool] | None = None,
+    ) -> LayoutGenerationState:
+        """Resolve the machine layout for a first live write.
+
+        The mission-critical property (INV-1): no state returns capture-success
+        while journaling zero events. A greenfield root publishes ``PROJECT_ONLY``
+        *before* any LEGACY persist; a legacy-with-data root auto-migrates via the
+        canonical engines under a deterministic id; the escape hatch refuses loudly.
+        """
+        if _in_cutover_drive():
+            return self.peek_state()
+        snapshot = self.peek_state()
+        if snapshot.mode is LayoutMode.PROJECT_ONLY:
+            return snapshot  # already migrated — no write, bytes untouched (NFR-003)
+        if snapshot.mode is LayoutMode.CUTOVER_PENDING:
+            return self._resume_pending(snapshot, cutover_copy)
+        if not self.has_legacy_data():
+            return self._publish_greenfield()
+        if self._auto_cutover_disabled():
+            raise LayoutAutoCutoverRefusedError(
+                f"legacy queue data is present and auto-cutover is disabled "
+                f"({NO_AUTO_CUTOVER_ENV}); run `{_MANUAL_MIGRATE_COMMAND}` to migrate it explicitly"
+            )
+        return self._begin_and_drive(cutover_copy)
+
+    def _resume_pending(
+        self,
+        snapshot: LayoutGenerationState,
+        cutover_copy: Callable[[str], bool] | None,
+    ) -> LayoutGenerationState:
+        """Re-enter a CUTOVER_PENDING root; complete OUR migration, defer a foreign one.
+
+        The escape hatch gates *initiating* auto-cutover, not *finishing* one already
+        authorized — so an in-flight cutover still converges even with the hatch set.
+        """
+        if snapshot.migration_id != self.auto_migration_id():
+            return snapshot  # an operator-owned migration holds cutover; do not interfere
+        return self._drive(self.auto_migration_id(), cutover_copy)
+
+    def _begin_and_drive(
+        self,
+        cutover_copy: Callable[[str], bool] | None,
+    ) -> LayoutGenerationState:
+        migration_id = self.auto_migration_id()
+        self.begin_cutover(migration_id)
+        return self._drive(migration_id, cutover_copy)
+
+    def _drive(
+        self,
+        migration_id: str,
+        cutover_copy: Callable[[str], bool] | None,
+    ) -> LayoutGenerationState:
+        """Copy via the canonical engine, then publish only after exact verification.
+
+        Never bricks the root: a store-lock contention (e.g. driven from inside a
+        live write's own unit of work) or an unresolved copy conflict leaves the
+        record CUTOVER_PENDING so a later run re-enters the same id and completes.
+        """
+        from specify_cli.sync.project_store import ProjectStoreLockedError
+
+        copy = cutover_copy if cutover_copy is not None else self._default_cutover_copy
+        try:
+            with _cutover_drive():
+                blocked = copy(migration_id)
+        except ProjectStoreLockedError:
+            return self.read_state()  # contended — re-enter later, never brick
+        if blocked:
+            return self.read_state()  # unresolved conflict — do not publish over it
+        self.publish_project_only(migration_id, verify_exact=self._conservation_ok)
+        return self.read_state()
+
+    def _publish_greenfield(self) -> LayoutGenerationState:
+        """Publish PROJECT_ONLY on a no-legacy-data root WITHOUT persisting LEGACY.
+
+        Closes Hazard (b): the greenfield decision is made and published ahead of
+        ``_read_locked``'s LEGACY persist, so a fresh root's "never migrated" signal
+        never self-destructs and its first event lands in the journal (FR-002).
+        """
+
+        def advance() -> LayoutGenerationState:
+            initialized = self._read_marker_locked()
+            if self._record_path.exists():
+                current = self._read_existing_record_locked(
+                    initialized=initialized,
+                    materialize_marker=False,
+                )
+                if current.mode is LayoutMode.PROJECT_ONLY:
+                    return current
+                if current.mode is not LayoutMode.LEGACY:
+                    raise LayoutAuthorityError("greenfield publish requires an unresolved or legacy record")
+                generation = current.generation + 1
+            else:
+                generation = 1
+            updated = LayoutGenerationState(
+                generation=generation,
+                mode=LayoutMode.PROJECT_ONLY,
+                migration_id=None,
+                updated_at=_utc_now(),
+            )
+            self._write_locked(updated)
+            self._write_marker_locked()
+            return updated
+
+        return self._under_lock(advance)
+
+    def _default_cutover_copy(self, migration_id: str) -> bool:
+        """Copy legacy queues into the journal via the canonical engine (reuse only).
+
+        Returns ``True`` iff the migration is blocked (an unresolved divergent-payload
+        conflict), in which case the drive must NOT publish. Dedup, provenance,
+        quarantine, and ownerless-row attribution all live in the engine — never
+        re-derived here.
+        """
+        del migration_id  # the engine keys provenance on (event_id, source_digest)
+        from specify_cli.event_journal.journal import EventJournal
+        from specify_cli.sync.migrate_journal import (
+            AUDIT_DB_NAME,
+            MigrationAudit,
+            migrate_queues_to_journal,
+        )
+        from specify_cli.sync.project_store import ProjectSyncStore
+
+        spec_kitty_dir = self._spec_kitty_dir()
+        store = ProjectSyncStore(self._project_uuid)
+        audit = MigrationAudit(spec_kitty_dir / AUDIT_DB_NAME)
+        try:
+            with store.unit_of_work() as unit:
+                journal = EventJournal(unit, store.layout_generation())
+                result = migrate_queues_to_journal(spec_kitty_dir, journal=journal, audit=audit)
+            return bool(result.blocked)
+        finally:
+            with contextlib.suppress(sqlite3.Error):
+                audit.close()
+
+    def _conservation_ok(self) -> bool:
+        """Exact-copy verification: every queued legacy event is present exactly once.
+
+        The ``verify_exact`` callback ``publish_project_only`` gates on — a non-exact
+        copy refuses publication (``LayoutVerificationError``) and the root stays
+        CUTOVER_PENDING for a later, converging run.
+        """
+        from specify_cli.event_journal.journal import EventJournal
+        from specify_cli.sync.migrate_journal import _read_queued_rows, discover_source_dbs
+        from specify_cli.sync.project_store import ProjectSyncStore
+
+        expected: set[str] = set()
+        for source in discover_source_dbs(self._spec_kitty_dir()):
+            with contextlib.suppress(sqlite3.Error):
+                expected.update(row.event_id for row in _read_queued_rows(source.path))
+        store = ProjectSyncStore(self._project_uuid)
+        with store.unit_of_work() as unit:
+            present = {event.event_id for event in EventJournal(unit, store.layout_generation()).read_all()}
+        return expected <= present
+
+    def _await_publish_or_loud(
+        self,
+        permit: LayoutWritePermit,
+        test_hooks: LayoutTestHooks | None,
+    ) -> None:
+        """Block-and-retry a live write while CUTOVER_PENDING, then surface loudly.
+
+        Deterministic (bounded iterations, never wall-clock): the ``before_revalidate``
+        hook is the synchronization point a test uses to publish (or withhold) the
+        migration mid-wait. On timeout the write is routed to the loud surface via
+        ``LayoutCutoverIncompleteError`` — never a silent LEGACY swallow (INV-5).
+        """
+        for _ in range(_CUTOVER_WAIT_ATTEMPTS):
+            if self.read_state().mode is not LayoutMode.CUTOVER_PENDING:
+                return
+            if test_hooks is not None and test_hooks.before_revalidate is not None:
+                test_hooks.before_revalidate(permit)
+        if self.read_state().mode is LayoutMode.CUTOVER_PENDING:
+            raise LayoutCutoverIncompleteError(
+                "machine layout cutover did not publish within the bounded wait; "
+                "the event is routed to the loud surface rather than dropped to legacy"
+            )
+
 
 def _new_layout_generation_authority(
     *,
@@ -410,6 +717,9 @@ def _new_layout_generation_authority(
 
 
 __all__ = [
+    "NO_AUTO_CUTOVER_ENV",
+    "LayoutAutoCutoverRefusedError",
+    "LayoutCutoverIncompleteError",
     "LayoutDestination",
     "LayoutMode",
     "LayoutTestHooks",

--- a/src/specify_cli/sync/migrate_journal.py
+++ b/src/specify_cli/sync/migrate_journal.py
@@ -66,6 +66,11 @@ from typing import TYPE_CHECKING, Any
 
 from kernel.clock import from_epoch, now_utc_iso
 from specify_cli.event_journal import Event, EventJournal, JournalTransaction
+from specify_cli.sync.project_store_migration import (
+    QuarantineReason,
+    _canonical_project,
+    _payload_project_uuid,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only (avoid the queue<->authority cycle)
     from specify_cli.sync.project_identity import IdentityBackfillResult
@@ -450,6 +455,43 @@ def _payload_sha(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()  # noqa: TID251
 
 
+# --- ownerless-row attribution (IC-00) ------------------------------------
+
+
+def _attribute_owner(data: str, owner_uuid: str) -> tuple[str | None, QuarantineReason | None]:
+    """Resolve the ``project_uuid`` an attributable legacy row acquires on copy.
+
+    The queue→journal copy lands every source event into ONE UUID-owned
+    destination journal, whose :meth:`EventJournal.append` refuses any event that
+    does not already declare that owner (``journal.py`` owner guard). Legacy rows
+    written before per-project ownership carry no ``project_uuid`` and would trip
+    that guard, so IC-00 attributes them **before** the copy — reusing
+    ``project_store_migration``'s canonicalization surface
+    (:func:`_payload_project_uuid` + :func:`_canonical_project`) rather than
+    re-deriving identity here.
+
+    Returns ``(attributed_uuid, reason)``:
+
+    * **missing / nil** declared uuid → ``(owner_uuid, MISSING|NIL)`` — an
+      ownerless row is attributed to the destination owner. The distinct reason is
+      preserved (never collapsed) so an operator can tell *why* it was ownerless.
+    * **matches** the destination owner → ``(owner_uuid, None)`` — passes through.
+    * **conflicts** with the destination owner (a different, or malformed, declared
+      uuid) → ``(None, CONFLICTING|MALFORMED)`` — refused, **never** force-attributed
+      into the wrong store. A ``None`` first element is the copy path's signal to
+      quarantine rather than append.
+    """
+    declared = _payload_project_uuid({"data": data})
+    canonical, reason = _canonical_project(declared)
+    if reason in (QuarantineReason.MISSING_PROJECT_UUID, QuarantineReason.NIL_PROJECT_UUID):
+        return owner_uuid, reason  # ownerless legacy row → attribute destination owner
+    if reason is not None:
+        return None, reason  # malformed declared identity — refuse, do not force it
+    if canonical != owner_uuid:
+        return None, QuarantineReason.CONFLICTING_PROJECT_UUID
+    return canonical, None
+
+
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name = ?", (table,))
     return cur.fetchone() is not None
@@ -488,8 +530,13 @@ def _row_to_queued(row: tuple[Any, ...], has_coalesce: bool) -> _QueuedRow:
     )
 
 
-def _build_event(row: _QueuedRow, payload: bytes) -> Event:
-    """Build a journal :class:`Event`, carrying ``event_id`` verbatim (C-005)."""
+def _build_event(row: _QueuedRow, payload: bytes, project_uuid: str) -> Event:
+    """Build a journal :class:`Event`, carrying ``event_id`` verbatim (C-005).
+
+    ``project_uuid`` is the destination store owner resolved by
+    :func:`_attribute_owner` — set here (never inside the payload bytes, which stay
+    the canonical dedup key) so the event satisfies the ``append`` owner guard.
+    """
     when = from_epoch(row.timestamp).isoformat() if row.timestamp is not None else now_utc_iso()
     return Event(
         event_id=row.event_id,
@@ -498,6 +545,7 @@ def _build_event(row: _QueuedRow, payload: bytes) -> Event:
         occurred_at=when,
         created_at=when,
         coalesce_key=row.coalesce_key,
+        project_uuid=project_uuid,
     )
 
 
@@ -565,21 +613,38 @@ class _SourceStaging:
 
 
 def _classify_and_apply(row: _QueuedRow, txn: JournalTransaction, source_digest: str) -> _RowImport:
-    """Append/dedupe/quarantine one row against the staged journal batch.
+    """Attribute/append/dedupe/quarantine one row against the journal.
 
-    * unseen ``event_id`` → stage the canonical payload (``imported``);
+    * ownerless / owner-matching ``event_id`` → attribute the destination owner
+      (IC-00) then, for an unseen id, append the canonical payload (``imported``);
     * identical canonical payload → no second row (``deduped``);
     * divergent canonical payload → never overwrite; emit a conflict so the
-      existing journal payload stays immutable (FR-018, C-005).
+      existing journal payload stays immutable (FR-018, C-005);
+    * a foreign / malformed declared owner → never force-attribute; emit a
+      conflict so the row is quarantined rather than landed in the wrong store.
 
-    The append is *staged* on *txn* (not committed); the source loop commits the
-    whole batch alongside provenance, so a later provenance failure rolls the
-    staged row back rather than orphaning it (atomicity).
+    The append targets the store-owned unit of work (:meth:`EventJournal.append`
+    persists within the outer transaction); provenance is recorded per row and the
+    audit store is committed once the whole source loop succeeds.
     """
     payload = _canonical_payload(row.data)
+    attributed_uuid, _reason = _attribute_owner(row.data, txn.project_uuid)
+    if attributed_uuid is None:
+        # Foreign/malformed declared owner — refuse rather than mis-attribute.
+        # ``existing_sha``/``incoming_sha`` carry the two conflicting owner tokens
+        # for this reason class (the payload is not what diverges); ``detail``
+        # names the closed reason so the distinct causes stay legible.
+        conflict = MigrationConflict(
+            event_id=row.event_id,
+            source_digest=source_digest,
+            existing_sha=txn.project_uuid,
+            incoming_sha=_payload_sha(payload),
+            detail=f"{_reason}: legacy row owner does not match destination store owner",
+        )
+        return _RowImport(action="conflict", event_id=row.event_id, conflict=conflict)
     existing = txn.read_by_id(row.event_id)
     if existing is None:
-        txn.append(_build_event(row, payload))
+        txn.append(_build_event(row, payload, attributed_uuid))
         return _RowImport(action="imported", event_id=row.event_id)
     if existing.payload == payload:
         return _RowImport(action="deduped", event_id=row.event_id)
@@ -602,21 +667,19 @@ def _import_source(
     result: MigrationResult,
     is_known: bool,
 ) -> SourceOutcome:
-    """Migrate one source DB **atomically** (T058); collect per-row outcomes.
+    """Migrate one source DB (T058); collect per-row outcomes.
 
-    The journal rows and their provenance are written as one all-or-nothing unit
-    per source: every append is *staged* on a deferred journal transaction and
-    every provenance/conflict row is staged on the audit store, then **both** are
-    committed only after the whole source loop succeeds. On any
-    :class:`sqlite3.Error` (e.g. a provenance write failing) **both** are rolled
-    back — the staged journal batch is dropped and ``audit.rollback()`` discards
-    the provenance — so a provenance failure can never leave an orphan committed
-    journal row with no matching provenance (atomicity guarantee).
+    The destination journal is a view over the caller's store-owned unit of work
+    (:meth:`EventJournal.transaction` is a grouping seam only — the outer
+    ``unit_of_work`` owns the SQLite transaction and commits on clean exit), so
+    each :meth:`EventJournal.append` persists as it runs. Provenance/conflict rows
+    are recorded on the separate audit store and committed once the whole source
+    loop succeeds; on a :class:`sqlite3.Error` the audit writes for this source are
+    rolled back and the source is reported as errored without aborting the run.
 
-    Provenance is committed *before* the journal batch so that a committed
-    journal row always implies its provenance is already durable. Both writes are
-    idempotent (journal ``INSERT OR IGNORE`` on ``event_id``; audit keyed on
-    ``(event_id, source_digest)``), so an interrupted source re-runs cleanly with
+    Both writes are idempotent — the journal short-circuits a replayed ``event_id``
+    (``append`` returns the existing assignment) and the audit is keyed on
+    ``(event_id, source_digest)`` — so an interrupted source re-runs cleanly with
     no duplication (NFR-005). The source DB is opened read-only and is untouched.
     """
     outcome = SourceOutcome(digest=source.digest, is_legacy=source.is_legacy)
@@ -630,13 +693,11 @@ def _import_source(
         try:
             for row in rows:
                 _apply_row(row, source, txn, audit, target_id, staging, is_known)
-            audit.commit()  # provenance durable first …
-            txn.commit()  # … then the journal batch (no orphan journal row)
-        except sqlite3.Error as exc:  # roll BOTH back: drop staged journal + provenance
-            txn.rollback()
+            audit.commit()  # provenance/conflicts durable alongside the journal writes
+        except sqlite3.Error as exc:  # drop this source's provenance; report, do not abort
             audit.rollback()
             outcome.error = str(exc)
-            return outcome  # discard staging — nothing was committed for this source
+            return outcome  # discard staging — provenance rolled back for this source
     staging.merge_into(result, outcome)
     return outcome
 
@@ -658,6 +719,16 @@ def _apply_row(
     imported = _classify_and_apply(row, txn, source.digest)
     if imported.conflict is not None:
         audit.record_conflict(imported.conflict)
+        # Archive the superseded/refused source payload before its row is ever
+        # cleaned up, so keep-journal resolution never loses data (idempotent on
+        # ``(event_id, source_digest)``).
+        audit.quarantine_conflict(
+            event_id=imported.conflict.event_id,
+            source_digest=imported.conflict.source_digest,
+            payload=_canonical_payload(row.data),
+            existing_sha=imported.conflict.existing_sha,
+            incoming_sha=imported.conflict.incoming_sha,
+        )
         staging.conflicts.append(imported.conflict)
         return
     audit.record_provenance(

--- a/src/specify_cli/sync/queue.py
+++ b/src/specify_cli/sync/queue.py
@@ -172,12 +172,63 @@ def _read_json(path: Path) -> Mapping[str, Any] | None:
     return value if isinstance(value, Mapping) else None
 
 
-def read_queue_scope_from_credentials(credentials_path: Path | None = None) -> str | None:
-    data = _read_json(credentials_path or _credentials_path())
-    if data is None:
+def _piped_scope_from_toml_credentials(path: Path) -> str | None:
+    """Build the canonical ``server|user|team`` scope from a TOML credentials file.
+
+    This is an **auth/identity signal**, not a physical-store selector: the
+    returned string is split back into ``(user, team)`` by
+    ``preflight._read_scope_identity_local_only`` (which expects the
+    ``server|user|team`` order) and is used by the FR-011 gate purely as a
+    truthiness test. It never derives a queue DB path — the authoritative store
+    is selected by ProjectSyncStore via ``_derive_queue_scope`` (FR-009 / C-003).
+
+    Defensive by contract: a missing/corrupt/incomplete file yields ``None``
+    rather than raising, mirroring the ``_read_json`` posture above.
+    """
+    try:
+        data = toml.load(path)
+    except (toml.TomlDecodeError, OSError, TypeError):
         return None
-    explicit = data.get("queue_scope")
-    return str(explicit) if isinstance(explicit, str) and explicit.strip() else None
+    if not isinstance(data, Mapping):
+        return None
+    user_data = data.get("user")
+    server_data = data.get("server")
+    if not isinstance(user_data, Mapping) or not isinstance(server_data, Mapping):
+        return None
+    username = user_data.get("username")
+    server_url = server_data.get("url")
+    if not isinstance(username, str) or not username.strip():
+        return None
+    if not isinstance(server_url, str) or not server_url.strip():
+        return None
+    team_slug = user_data.get("team_slug")
+    team = team_slug if isinstance(team_slug, str) and team_slug.strip() else "no-team"
+    return f"{server_url}|{username}|{team}"
+
+
+def read_queue_scope_from_credentials(credentials_path: Path | None = None) -> str | None:
+    """Return a queue-scope **auth signal** from the on-disk credentials, or ``None``.
+
+    Two supported forms, JSON-explicit winning where present (preserves #3293):
+
+    1. JSON with an explicit ``queue_scope`` string — returned verbatim.
+    2. The supported TOML credential form (``[user]`` / ``[server]`` tables) —
+       parsed back into the canonical ``server|user|team`` piped scope that
+       ``preflight._read_scope_identity_local_only`` splits on (preflight.py:479).
+
+    Restoring form (2) fixes the #3425 credential regression (FR-004): a
+    genuinely-authenticated host again yields a truthy scope so the FR-011 auth
+    gate stops refusing it. This function stays a pure, side-effect-free read: no
+    migration, no SaaS round-trip, no path resolution. The value is an auth signal
+    only — it must never steer physical-store selection (FR-009 / C-003).
+    """
+    path = credentials_path or _credentials_path()
+    data = _read_json(path)
+    if data is not None:
+        explicit = data.get("queue_scope")
+        if isinstance(explicit, str) and explicit.strip():
+            return str(explicit)
+    return _piped_scope_from_toml_credentials(path)
 
 
 def read_queue_scope_from_session(*, allow_rehydrate: bool = True) -> str | None:

--- a/tests/architectural/_golden_count_baseline.json
+++ b/tests/architectural/_golden_count_baseline.json
@@ -17,7 +17,7 @@
     "tests/runtime": 11,
     "tests/specify_cli": 265,
     "tests/status": 36,
-    "tests/sync": 74,
+    "tests/sync": 75,
     "tests/test_dashboard": 13,
     "tests/unit": 17
   }

--- a/tests/architectural/test_no_dead_symbols.py
+++ b/tests/architectural/test_no_dead_symbols.py
@@ -817,8 +817,11 @@ _CATEGORY_C_EVENT_SYNC_RETENTION_DELIVERY: frozenset[SymbolKey] = frozenset(
         SymbolKey("SourceDb", "359bad378deef3920559bea9d89645c9a7aa2d84ff0c14ae315047fb9e5a3e22"),  # specify_cli.sync.migrate_journal::SourceDb
         SymbolKey("SourceOutcome", "e5222067e3eba9771531b0a8364d898136c13fbfa5757cbd3b40a50cf8ce30a2"),  # specify_cli.sync.migrate_journal::SourceOutcome
         SymbolKey("UNKNOWN_PREFIX", "8f1aac4b29244ee6faa6b237b3fdbe471d1ea66cdd9afd0370727053535c2791"),  # specify_cli.sync.migrate_journal::UNKNOWN_PREFIX
-        # specify_cli.sync.migrate_journal::discover_source_dbs
-        SymbolKey("discover_source_dbs", "b62fbc49144c13965d68cc210612005523d6b3fdf2cb224737ab11bfb035197d"),
+        # discover_source_dbs REMOVED (#3497 landing): now has a real external
+        # caller -- layout_generation.py's has_legacy_data()/_conservation_ok()
+        # import and call it directly (the "real reader", not a retired stub) --
+        # so the allowlist grant is stale and must be removed (reverse
+        # containment: a symbol with a caller cannot stay allowlisted).
         # specify_cli.sync.migrate_journal::migration_target_token
         SymbolKey("migration_target_token", "bce7a50af7aefac52a1f1b1319dba5f0ba128f8d67ac449c16e9cf1986cbf6a0"),
     }
@@ -836,6 +839,36 @@ _CATEGORY_C_SYNC_RESET_RESULT_ENTRIES: frozenset[SymbolKey] = frozenset(
         SymbolKey("FailedEntry", "0e1aa316dd07e92dedc924494897d393b9e8410bb718b8884698933da58900e9"),  # specify_cli.sync.orphan_sweep::FailedEntry
         SymbolKey("SkippedEntry", "d55962bfd4eb368c36e7204231f5dd79c7c677768ca27db70fc0c0d21950547f"),  # specify_cli.sync.orphan_sweep::SkippedEntry
         SymbolKey("SweptEntry", "e74ae7b75e826cf7e213e08728c1ef15d7ba42dad631136512d9ed2527f1304f"),  # specify_cli.sync.orphan_sweep::SweptEntry
+    }
+)
+
+
+# ---------- C. legacy->journal capture cutover mission (#3425/#3497) ----------
+# ``layout_generation.py``'s machine layout-generation authority (WP01/WP03)
+# introduces this small public error/config surface for a genuinely-
+# unrecoverable resolution: ``NO_AUTO_CUTOVER_ENV`` names the operator
+# escape-hatch env var read internally by ``_auto_cutover_disabled()`` and
+# echoed into the refusal message; ``LayoutAutoCutoverRefusedError`` and
+# ``LayoutCutoverIncompleteError`` are raised by ``resolve_layout_for_write``.
+# Both errors propagate to ``emitter.py``'s ``_route_event`` catch-all
+# (deliberately generic per the "never silently swallow" contract -- see the
+# comment at ``emitter.py:_queue_event_locally``) rather than being caught by
+# name anywhere else in src/, so no other src/ file imports these symbols by
+# name. All three are exercised directly by
+# ``tests/sync/test_layout_cutover.py`` (T014 escape-hatch /
+# ``pytest.raises(LayoutAutoCutoverRefusedError)`` /
+# ``pytest.raises(LayoutCutoverIncompleteError)``) and
+# ``tests/sync/test_emitter_observability.py`` (Part B resolve-before-UoW).
+# Follow-up tracker: #3497.
+
+_CATEGORY_C_LAYOUT_CUTOVER_AUTHORITY_SURFACE: frozenset[SymbolKey] = frozenset(
+    {
+        # specify_cli.sync.layout_generation::NO_AUTO_CUTOVER_ENV
+        SymbolKey("NO_AUTO_CUTOVER_ENV", "42000b4d43af2be0fe49519580844ae591d5d1757bdd182da765aad0e1098434"),
+        # specify_cli.sync.layout_generation::LayoutAutoCutoverRefusedError
+        SymbolKey("LayoutAutoCutoverRefusedError", "4e1aab01c345a9525ac411f202313dfdaa3f3f83711f0d87912e26ce7f235249"),
+        # specify_cli.sync.layout_generation::LayoutCutoverIncompleteError
+        SymbolKey("LayoutCutoverIncompleteError", "b8ea000a40231fd78125c048552b171d12b7ef0d94ddfbcd1954beac76f20505"),
     }
 )
 
@@ -1267,6 +1300,7 @@ _SYMBOL_ALLOWLIST: frozenset[SymbolKey] = (
     | _CATEGORY_C_MERGE_DECOMP_SHIM_REEXPORT_2057
     | _CATEGORY_C_EVENT_SYNC_RETENTION_DELIVERY
     | _CATEGORY_C_SYNC_RESET_RESULT_ENTRIES
+    | _CATEGORY_C_LAYOUT_CUTOVER_AUTHORITY_SURFACE
     | _CATEGORY_C_RUNTIME_BRIDGE_DEGOD_COMPAT_SURFACE
     | _CATEGORY_C_MISSION_TYPE_DRG_EDGES_FACADE_REEXPORT
     | _CATEGORY_C_URN_RESOLUTION_LANE

--- a/tests/cli/commands/test_sync_status_drain_blockers.py
+++ b/tests/cli/commands/test_sync_status_drain_blockers.py
@@ -74,13 +74,29 @@ def test_drain_blocked_counts_zero_when_all_ready() -> None:
     assert "Drain Blockers" not in output
 
 
-def test_queue_get_drain_blocked_counts_persists_through_drain_round_trip(tmp_path: Path) -> None:
+def test_queue_get_drain_blocked_counts_persists_through_drain_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``get_drain_blocked_counts`` reflects what's currently durable on disk.
 
     Drives the real queue (not a mock) to prove the JSON scan that powers
     ``sync status`` works against the actual SQLite envelope shape that
     ``EventEmitter._emit`` writes.
+
+    The machine layout-generation record this test drives directly
+    (``begin_cutover`` / ``publish_project_only``) is scoped to
+    ``SPEC_KITTY_HOME`` as a WHOLE, not to this test's project UUID (see
+    ``layout_generation.LayoutGenerationAuthority`` — the record lives at
+    ``<runtime_root>/projects/.layout-generation.json``). Without pinning
+    ``SPEC_KITTY_HOME`` to this test's own ``tmp_path``, it shares the
+    per-worker home other ``tests/cli`` and ``tests/sync`` cases reuse across
+    the whole pytest session; an earlier test that auto-resolves the machine
+    layout to ``PROJECT_ONLY`` would make this test's own ``begin_cutover``
+    call fail with "layout is already project-only". Pin the home explicitly
+    (matching ``tests/sync/test_layout_cutover.py``'s ``_isolate`` pattern) so
+    this test always starts from a fresh LEGACY record.
     """
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "home"))
     store = ProjectSyncStore("aaaaaaaa-0000-0000-8000-000000000107")
     authority = store.layout_generation()
     authority.begin_cutover("status-drain-blockers")

--- a/tests/event_journal/test_project_store_journal.py
+++ b/tests/event_journal/test_project_store_journal.py
@@ -93,14 +93,21 @@ def test_stale_legacy_permit_redirects_once_before_capture(
     monkeypatch.setenv("SPEC_KITTY_HOME", str(runtime))
     store = ProjectSyncStore(PROJECT_A)
     authority = store.layout_generation()
+    # Hold the machine CUTOVER_PENDING under a *foreign* (operator-owned) migration
+    # id so the live capture resolves to a LEGACY (pending) permit that must wait
+    # for publication. Post cutover-flip (WP03/IC-02) a first write on an
+    # unencumbered root resolves straight to project_only, so this pending hold is
+    # how we still exercise the stale-legacy-permit → redirect-once seam.
+    authority.begin_cutover("operator-owned-race")
     observed_destinations: list[LayoutDestination] = []
 
     def publish_cutover_between_issue_and_revalidate(
         permit: LayoutWritePermit,
     ) -> None:
+        if observed_destinations:
+            return
         observed_destinations.append(permit.destination)
-        authority.begin_cutover("wp04-race")
-        authority.publish_project_only("wp04-race", verify_exact=lambda: True)
+        authority.publish_project_only("operator-owned-race", verify_exact=lambda: True)
 
     with store.unit_of_work() as unit:
         receipt = EventJournal(unit, authority).append(

--- a/tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py
+++ b/tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py
@@ -1,59 +1,53 @@
-"""Red-first reproduction of #3425 — un-migrated machines stay in
-``LayoutMode.LEGACY`` after #3293, so the event journal silently captures
-nothing.
+"""Regression contract for #3425 — a fresh, un-migrated host must journal its
+setup-plan capture instead of silently swallowing it.
 
 Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3425
 
-Root cause (verified against the issue's own mechanism section):
+Correct root cause (the swallowed error is the **journal guard**, not a queue
+default-path helper):
 
-* ``LayoutGenerationAuthority._initial_state()``
-  (``src/specify_cli/sync/layout_generation.py:130-135``) defaults to
-  ``LayoutMode.LEGACY`` when ``.layout-generation.json`` is absent — the
-  state of any runtime root that has never run the WP10 migration.
-* ``_require_project_destination()``
-  (``src/specify_cli/event_journal/journal.py:117-119``) then raises
-  ``LegacyQueueMigrationRequiredError: live payload queues are selected by
-  ProjectSyncStore; legacy paths are WP10 migration inputs`` — the same
-  fail-closed shape backs ``default_queue_db_path()``
-  (``src/specify_cli/sync/queue.py:195-196``), which every setup-plan
-  queue-write call site resolves through.
-* ``src/specify_cli/sync/emitter.py:2115`` catches the raised error and
-  prints ``Warning: event journal capture failed: ...`` to stderr only —
-  the command itself reports no error. The event is never journaled.
+* On a runtime root that has never run the WP10 cutover the machine layout mode
+  is ``LayoutMode.LEGACY``. Under the ProjectSyncStore-owned queue selection
+  (FR-009 / C-003) a live writer is then handed a non-``project_only`` permit and
+  ``_require_project_destination()``
+  (``src/specify_cli/event_journal/journal.py:117-119``) raises
+  ``ProjectLayoutRequiredError("live payload writes require the project_only
+  layout; legacy state is migration input only")``.
+* ``src/specify_cli/sync/emitter.py:2115`` catches that and prints
+  ``Warning: event journal capture failed: ...`` to stderr only — the command
+  reports success while the event is never journaled (a silent-success shape).
+* The retired no-arg ``default_queue_db_path()``
+  (``src/specify_cli/sync/queue.py:195-196``) is a **red herring** for this
+  reproduction: it now raises ``LegacyQueueMigrationRequiredError``
+  *unconditionally* (it is not layout-gated), so it is not what makes the
+  reproduced setup-plan path fail closed. Attribution belongs to
+  ``journal.py:119``.
 
-On an un-migrated machine this is a silent-success shape: no error surfaces
-to the caller, and the absence of captured data is visible only to someone
-reading stderr. These three tests drive the real ``setup_plan`` entry point
-(``specify_cli.cli.commands.agent.mission.setup_plan``) end to end and prove
-the silent-failure / cascading-refusal consequences:
+Post-fix (WP03 / IC-02) a fresh root auto-publishes ``project_only`` *before* any
+legacy persist, so the live capture lands in the project store journal and no
+swallowed-capture warning is printed; WP01 restores credential parsing so the
+FR-011 auth gate confirms authentication instead of spuriously refusing. These
+three tests drive the real ``setup_plan`` entry point
+(``specify_cli.cli.commands.agent.mission.setup_plan``) end to end:
 
-1. ``test_authenticated_setup_plan_lands_in_scoped`` — an authenticated,
-   un-migrated host cannot resolve ``default_queue_db_path()`` at all; it
-   raises ``LegacyQueueMigrationRequiredError`` before any queue write is
-   attempted.
-2. ``test_setup_plan_refuses_on_daemon_owner_mismatch`` — the boundary
-   preflight (daemon-owner mismatch refusal) never gets a chance to run: the
-   FR-011 auth-refusal gate fires first with "SaaS sync cannot be
-   guaranteed", because scope resolution on an un-migrated host cannot
-   confirm authentication, masking the boundary-preflight diagnostic this
-   test expects.
-3. ``test_setup_plan_authenticated_coherent_succeeds`` — even a fully
-   coherent, authenticated host is refused with exit code 2 by the same
-   auth gate, because the underlying scope/layout resolution the gate
-   depends on is broken by the ``LayoutMode.LEGACY`` default.
-
-Desired post-fix outcome (either maintainer resolution turns this green, per
-the issue's own suggested direction): either default un-migrated roots to a
-layout mode that still journals, or make the capture failure loud at the
-command surface instead of a swallowed stderr warning. This test pins the
-conformance contract (setup-plan must not silently produce zero SaaS
-capture / must not spuriously refuse a coherent host), not the chosen
-mechanism.
+1. ``test_authenticated_setup_plan_journals_without_silent_capture_failure`` —
+   an authenticated, un-migrated host drives setup-plan without a swallowed
+   capture-failure warning; a live journal capture on the resolved project store
+   lands exactly once (auto-cutover to ``project_only``) and the legacy store is
+   never touched.
+2. ``test_setup_plan_refuses_on_daemon_owner_mismatch`` — with credential parsing
+   restored (WP01) the FR-011 auth gate no longer short-circuits, so the boundary
+   preflight's daemon-owner-mismatch "Refusing" banner is the gate that fires.
+3. ``test_setup_plan_authenticated_coherent_succeeds`` — a fully coherent,
+   authenticated host (resolvable project identity + migrated ``project_only``
+   store) gets past the boundary preflight (exit code != 2) instead of being
+   spuriously refused.
 """
 
 from __future__ import annotations
 
 import contextlib
+import json
 import pathlib
 import sqlite3
 import sys
@@ -145,11 +139,22 @@ def _build_minimal_repo(tmp_path: Path, mission_slug: str) -> Path:
 
 
 def _scope_home_classmethod(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Pin ``Path.home()`` and env vars to *tmp_path* (C-008 cross-platform)."""
+    """Pin ``Path.home()`` and env vars to *tmp_path* (C-008 cross-platform).
+
+    ``SPEC_KITTY_HOME`` must be pinned too, not just ``HOME``: ``get_runtime_root``
+    (``paths/windows_paths.py:60`` / ``runtime/home.py:39``) resolves
+    ``SPEC_KITTY_HOME`` **before** any HOME-derived path ("always wins"), so a
+    leaked/ambient ``SPEC_KITTY_HOME`` on this live legacy box would otherwise
+    escape the temp-root isolation and resolve credentials/queues against real
+    machine-global state. The runtime root is ``<base>`` directly and the
+    credential/queue files this test writes live under ``tmp_path/.spec-kitty``
+    (see ``_write_credentials``), so point ``SPEC_KITTY_HOME`` there.
+    """
     monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / ".spec-kitty"))
 
 
 def _write_daemon_owner_record(
@@ -188,7 +193,54 @@ def _write_daemon_owner_record(
         or str(Path.home() / ".spec-kitty" / "queues" / "queue-test.db"),
         started_at="2026-05-18T08:00:00+00:00",
     )
-    return write_owner_record(record)
+    owner_record_path: Path = write_owner_record(record)
+    return owner_record_path
+
+
+_COHERENT_PROJECT_UUID = "aaaaaaaa-0000-0000-0000-00000000000a"
+
+
+def _seed_project_identity(root: Path) -> str:
+    """Write a resolvable project identity into *root* — nothing else.
+
+    ``resolve_checkout_sync_routing_readonly`` (and the emitter's project-store
+    selection) resolve the canonical project UUID from
+    ``<root>/.kittify/config.yaml``. This seeds only the identity, leaving the
+    machine layout at its ``LayoutMode.LEGACY`` in-memory default (an un-migrated
+    root) so the WP03 auto-cutover-on-first-write path is what is exercised.
+    """
+    kittify = root / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "config.yaml").write_text(
+        "project:\n"
+        f"  uuid: {_COHERENT_PROJECT_UUID}\n"
+        "  slug: wp04-coherent\n"
+        "  node_id: coherent-node\n",
+        encoding="utf-8",
+    )
+    return _COHERENT_PROJECT_UUID
+
+
+def _seed_coherent_project_store(root: Path) -> str:
+    """Give *root* a resolvable project identity **and** a migrated project_only store.
+
+    The WP04 boundary preflight (FR-002 / FR-009) refuses a checkout that has no
+    resolvable project identity, or whose machine layout is not yet
+    ``project_only``. Post-WP01 the FR-011 auth gate no longer masks that refusal,
+    so a genuinely coherent authenticated host must now present both. Mirrors the
+    canonical coherent-host fixture in
+    ``tests/sync/test_sync_boundary_preflight.py`` (``_scoped_home``).
+    """
+    project_uuid = _seed_project_identity(root)
+    from specify_cli.sync.project_store import ProjectSyncStore
+
+    store = ProjectSyncStore(project_uuid)
+    authority = store.layout_generation()
+    authority.begin_cutover("wp04-coherent-migration")
+    authority.publish_project_only("wp04-coherent-migration", verify_exact=lambda: True)
+    with store.unit_of_work():
+        pass
+    return project_uuid
 
 
 def _scoped_db_path_for(server_url: str, username: str, team_slug: str) -> Path:
@@ -236,115 +288,52 @@ def _patches_for_setup_plan(
 
 
 # ---------------------------------------------------------------------------
-# Test A — authenticated setup-plan cannot land queue writes on a LEGACY host
+# Test A — authenticated setup-plan journals without a swallowed capture failure
 # ---------------------------------------------------------------------------
 
 
-class TestAuthenticatedSetupPlanLandsInScoped:
-    """FR-012 evidence: authenticated setup-plan writes scoped, never legacy."""
+class TestAuthenticatedSetupPlanJournals:
+    """#3425: a fresh, un-migrated host journals its capture, never silently."""
 
-    def test_authenticated_setup_plan_lands_in_scoped(
+    def test_authenticated_setup_plan_journals_without_silent_capture_failure(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # NFR-001: redirect HOME so any queue DB lands under tmp_path.
-        home = tmp_path / "home"
-        home.mkdir()
-        monkeypatch.setenv("HOME", str(home))
+        # T030: pin SPEC_KITTY_HOME (not only HOME) so the runtime root — and the
+        # credentials / legacy queue / project store it holds — resolve inside the
+        # temp tree even on this live legacy box (get_runtime_root honours
+        # SPEC_KITTY_HOME first).
+        _scope_home_classmethod(monkeypatch, tmp_path)
 
-        # Authenticate via credentials file (the credentials path is the
-        # documented fallback for ``read_queue_scope_from_credentials``).
+        # Authenticate via credentials file (WP01 restores the TOML credential
+        # parse that resolves the canonical scope).
         _write_credentials(
-            home,
+            tmp_path,
             username="auth@example.com",
             server_url="https://test.example.com",
             team_slug="team-alpha",
         )
 
-        # Eagerly resolve the expected scoped DB path so we can assert on it
-        # after setup-plan runs.
-        from specify_cli.sync.queue import (
-            _legacy_queue_db_path,
-            build_queue_scope,
-            default_queue_db_path,
-            scope_db_path,
-        )
+        # Fresh, UN-MIGRATED root: seed only the project identity, no cutover. This
+        # is the #3425 host — one that has never run WP10 migration. The WP03 fix
+        # must still journal, by auto-publishing project_only on the first live
+        # write rather than raising the journal guard and dropping the event.
+        project_uuid = _seed_project_identity(tmp_path)
 
-        expected_scope = build_queue_scope(
-            server_url="https://test.example.com",
-            username="auth@example.com",
-            team_slug="team-alpha",
-        )
-        expected_scoped_path = scope_db_path(expected_scope)
+        from specify_cli.sync.queue import _legacy_queue_db_path
+
         legacy_path = _legacy_queue_db_path()
 
-        # Sanity check: the resolution chain picks scoped for our fake creds
-        # before we ever call setup-plan.
-        #
-        # RED today (#3425): on an un-migrated host this raises
-        # LegacyQueueMigrationRequiredError instead of returning a path —
-        # LayoutMode.LEGACY makes default_queue_db_path() fail closed.
-        assert default_queue_db_path() == expected_scoped_path
-        assert default_queue_db_path() != legacy_path
-
-        # Build minimal project root + mission directory.
         mission_slug = "test-mvp-sync-evidence"
         feature_dir = _build_minimal_repo(tmp_path, mission_slug)
 
-        # Stub out the heavy moving parts so setup-plan executes its real
-        # queue-write call site (``trigger_feature_dossier_sync_if_enabled``
-        # → ``OfflineBodyUploadQueue()`` → ``default_queue_db_path()``)
-        # without needing a real indexer/manifest/git history.
-        from specify_cli.sync.body_queue import OfflineBodyUploadQueue
         from specify_cli.cli.commands.agent.mission import setup_plan
 
-        # Surface the body queue the dossier helper instantiated so we can
-        # both verify its db_path AND drive a real enqueue against it to
-        # prove the row lands in the scoped DB.
-        created_queues: list[OfflineBodyUploadQueue] = []
-
-        original_init = OfflineBodyUploadQueue.__init__
-
-        def _record_init(self: OfflineBodyUploadQueue, *args: Any, **kwargs: Any) -> None:
-            original_init(self, *args, **kwargs)
-            created_queues.append(self)
-
-        patches = {
-            f"{MODULE}.locate_project_root": patch(
-                f"{MODULE}.locate_project_root", return_value=tmp_path
-            ),
-            f"{MODULE}._enforce_git_preflight": patch(
-                f"{MODULE}._enforce_git_preflight"
-            ),
-            f"{MODULE}._find_feature_directory": patch(
-                f"{MODULE}._find_feature_directory", return_value=feature_dir
-            ),
-            f"{MODULE}._show_branch_context": patch(
-                f"{MODULE}._show_branch_context", return_value=(tmp_path, "main")
-            ),
-            f"{MODULE}.get_current_branch": patch(
-                f"{MODULE}.get_current_branch", return_value="main"
-            ),
-            # Spec must be flagged as committed + substantive without git.
-            "specify_cli.missions._substantive.is_committed": patch(
-                "specify_cli.missions._substantive.is_committed", return_value=True
-            ),
-            "specify_cli.missions._substantive.is_substantive": patch(
-                "specify_cli.missions._substantive.is_substantive", return_value=True
-            ),
-            # Plan commit path: stub git-side _commit_to_branch.
-            f"{MODULE}._commit_to_branch": patch(
-                f"{MODULE}._commit_to_branch"
-            ),
-            # Record every body-queue creation so we can assert the path.
-            "specify_cli.sync.body_queue.OfflineBodyUploadQueue.__init__": patch(
-                "specify_cli.sync.body_queue.OfflineBodyUploadQueue.__init__",
-                autospec=True,
-                side_effect=_record_init,
-            ),
-        }
-
+        # Drive the real setup-plan command end to end; the seam only stubs
+        # git / project-root discovery, leaving the real capture path live.
+        patches = _patches_for_setup_plan(tmp_path, feature_dir)
         for p in patches.values():
             p.start()
         try:
@@ -354,53 +343,64 @@ class TestAuthenticatedSetupPlanLandsInScoped:
             for p in patches.values():
                 p.stop()
 
-        # If the dossier helper ran, it created an OfflineBodyUploadQueue
-        # without a db_path argument; that constructor must resolve to the
-        # scoped path. Some test environments will skip the dossier helper
-        # (SaaS sync disabled / no project UUID), so we additionally exercise
-        # the explicit default-path queue instantiation below.
-        for q in created_queues:
-            assert q.db_path == expected_scoped_path, (
-                f"OfflineBodyUploadQueue resolved to {q.db_path!r}, "
-                f"expected scoped {expected_scoped_path!r} — FR-012 violation."
+        # (c) LOAD-BEARING #3425 pin — warning-absence. Setup-plan drove its capture
+        # path through the command boundary WITHOUT a swallowed capture-failure
+        # warning on stderr. This is what proves the silent-success shape is gone:
+        # the #3425 P0 was `journal.py:119 ProjectLayoutRequiredError` caught and
+        # printed at `emitter.py:2115` while the command reported success.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        for banner in (
+            "event journal capture failed",
+            "live payload writes require the project_only layout",
+            "Explicit-context event capture failed",
+        ):
+            assert banner not in combined, (
+                f"#3425 regression: a swallowed capture-failure warning is present "
+                f"on the setup-plan surface:\n{combined!r}"
             )
 
-        # Drive a real enqueue through the same default-path resolution
-        # setup-plan's body queue uses, to produce a row we can count.
-        from specify_cli.sync.namespace import NamespaceRef
+        # (a) Journal conservation — a live capture on this fresh, un-migrated root
+        # lands in the project store journal EXACTLY ONCE. The store auto-publishes
+        # project_only (WP03/IC-02) instead of raising the journal guard, so the
+        # event is journaled rather than swallowed. The dossier helper is skipped
+        # when SaaS sync is disabled, so — exactly as the retired body-queue
+        # variant did — we drive the real journal path directly against the same
+        # project identity setup-plan resolves.
+        from specify_cli.event_journal.journal import EventJournal
+        from specify_cli.event_journal.models import Event
+        from specify_cli.sync.layout_generation import LayoutMode
+        from specify_cli.sync.project_store import ProjectSyncStore
 
-        body_queue = OfflineBodyUploadQueue()
-        assert body_queue.db_path == expected_scoped_path
-
-        body_queue.enqueue(
-            namespace=NamespaceRef(
-                project_uuid="550e8400-e29b-41d4-a716-446655440000",
-                mission_slug=mission_slug,
-                target_branch="main",
-                mission_type="software-dev",
-                manifest_version="1",
-            ),
-            artifact_path="spec.md",
-            content_hash="cafebabe" * 8,
-            content_body="# Test Feature\n",
-            size_bytes=15,
+        store = ProjectSyncStore(project_uuid)
+        event = Event(
+            event_id="setup-plan-capture",
+            event_type="WPStatusChanged",
+            payload=json.dumps({"project_uuid": project_uuid}).encode(),
+            occurred_at="2026-08-10T00:00:00+00:00",
+            created_at="2026-08-10T00:00:01+00:00",
+            project_uuid=project_uuid,
+            project_slug="wp04-coherent",
+            repo_slug="wp04-coherent",
         )
+        with store.unit_of_work() as unit:
+            receipt = EventJournal(unit, store.layout_generation()).append(event)
+            assert receipt.inserted is True
+            assert EventJournal(unit, store.layout_generation()).count() == 1
 
-        # Scoped DB should have rows; legacy must be untouched.
-        scoped_rows = _table_row_count(expected_scoped_path, "body_upload_queue")
+        # The fresh root cut over to project_only rather than staying LEGACY — the
+        # exact #3425 root cause (a LEGACY-default host that journalled nothing).
+        assert store.layout_generation().peek_state().mode is LayoutMode.PROJECT_ONLY
+
+        # (b) Legacy store untouched — nothing was written to the retired legacy
+        # queue db (neither the body-upload nor the event queue table).
         legacy_body_rows = _table_row_count(legacy_path, "body_upload_queue")
         legacy_event_rows = _table_row_count(legacy_path, "queue")
-
-        assert scoped_rows > 0, (
-            f"Expected scoped body_upload_queue rows > 0, got {scoped_rows}."
-        )
         assert legacy_body_rows == 0, (
-            f"FR-012 violation: legacy DB at {legacy_path} has "
-            f"{legacy_body_rows} body_upload_queue rows."
+            f"legacy DB at {legacy_path} has {legacy_body_rows} body_upload_queue rows."
         )
         assert legacy_event_rows == 0, (
-            f"FR-012 violation: legacy DB at {legacy_path} has "
-            f"{legacy_event_rows} queue rows."
+            f"legacy DB at {legacy_path} has {legacy_event_rows} queue rows."
         )
 
 
@@ -526,8 +526,13 @@ class TestSetupPlanPreflightIntegration:
             team_slug="team-alpha",
         )
 
-        # No daemon owner record on disk and no legacy queue rows means
-        # the preflight is structurally ok and the auth check passes.
+        # No daemon owner record on disk and no legacy queue rows. Post-WP01 the
+        # auth gate confirms the credentials instead of refusing; the WP04 boundary
+        # preflight then additionally requires a resolvable project identity and a
+        # migrated project_only store — seed both so the host is genuinely coherent
+        # and the preflight does NOT refuse (the pin is "did not refuse at
+        # preflight", i.e. exit code != 2).
+        _seed_coherent_project_store(tmp_path)
 
         from specify_cli.cli.commands.agent.mission import setup_plan
 

--- a/tests/sync/test_backfill_loud_failure.py
+++ b/tests/sync/test_backfill_loud_failure.py
@@ -37,7 +37,7 @@ from specify_cli.status.store import StoreError
 from specify_cli.sync.emitter import CapturedFailure
 from tests.unit.migration._backfill_fixture import build_mission
 
-pytestmark = [pytest.mark.integration]
+pytestmark = [pytest.mark.fast]
 
 runner = CliRunner()
 

--- a/tests/sync/test_backfill_loud_failure.py
+++ b/tests/sync/test_backfill_loud_failure.py
@@ -1,0 +1,234 @@
+"""WP04 loud-failure acceptance tests for ``migrate backfill-runtime-state`` (#3476).
+
+Pins the #3476 shape and its false-positive boundary at the *command* boundary via
+``typer.testing.CliRunner`` over isolated temp roots (``build_mission`` +
+``locate_project_root`` patched — never the live ``~/.spec-kitty``):
+
+* T018 — a cutover/backfill write that **cannot land** (a legacy layout refuses the
+  journal append with ``ProjectLayoutRequiredError``, ``journal.py:117-119``) must
+  surface at the boundary: exit non-zero, an actionable message naming the mission
+  and the recovery, and **no bare traceback** (``result.exception is None``). The
+  exact #3476 shape pinned: *"seed write refused on a legacy layout is swallowed and
+  the command reports success while backfilling nothing."*
+* T019 — the false-positive fence: a legitimate already-migrated no-op and a
+  ``--dry-run`` preview stay quiet and exit ``0`` with no loud-failure signal.
+* T031 — the FR-010 boundary consumer: a recorded (WP05) unrecoverable capture
+  failure is surfaced at the epilogue (report + non-zero) without crashing the
+  command; a clean run stays silent.
+
+The refusal is fault-injected at the exact verified-append seam the real legacy-layout
+guard propagates through, so the behavioural pin (exit code + surfaced detail) holds
+regardless of which WP finally wires the guard into the store append.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import Result
+from typer.testing import CliRunner
+
+from specify_cli.cli.commands.migrate_cmd import app as migrate_app
+from specify_cli.event_journal.journal import ProjectLayoutRequiredError
+from specify_cli.status.store import StoreError
+from specify_cli.sync.emitter import CapturedFailure
+from tests.unit.migration._backfill_fixture import build_mission
+
+pytestmark = [pytest.mark.integration]
+
+runner = CliRunner()
+
+_LOCATE = "specify_cli.cli.commands.migrate_cmd.locate_project_root"
+_APPEND_EVENTS = "specify_cli.migration.backfill_runtime_state.append_events_atomic_verified"
+_APPEND_ANNOTATIONS = "specify_cli.migration.backfill_runtime_state.append_annotations_atomic_verified"
+_SEED_BACKFILL = "specify_cli.migration.runtime_state_cutover.backfill_runtime_state"
+_CAPTURED_FAILURES = "specify_cli.sync.emitter.captured_failures"
+
+_REFUSAL_MESSAGE = "live payload writes require the project_only layout; legacy state is migration input only"
+
+
+def _invoke(repo_root: Path, args: list[str]) -> Result:
+    with patch(_LOCATE, return_value=repo_root):
+        return runner.invoke(migrate_app, ["backfill-runtime-state", *args])
+
+
+def _assert_no_leaked_exception(result: Result) -> None:
+    """The command surfaced its outcome — it did not crash with a bare traceback.
+
+    A clean ``typer.Exit`` rides out of ``CliRunner`` as ``SystemExit`` (only an
+    exit-0 run yields ``None``); a *leaked domain exception* (e.g. the raw
+    ``ProjectLayoutRequiredError``) is anything else. This pins "surfaced, not a
+    bare traceback" without coupling to the exit code.
+    """
+    assert result.exception is None or isinstance(result.exception, SystemExit), (
+        f"command leaked {result.exception!r} instead of surfacing it"
+    )
+
+
+def _refuse_write(*_args: object, **_kwargs: object) -> None:
+    """Stand in for the legacy-layout journal refusal at the verified-append seam."""
+    raise ProjectLayoutRequiredError(_REFUSAL_MESSAGE)
+
+
+def _refuse_write_wrapped(*_args: object, **_kwargs: object) -> None:
+    """The refusal in the store's wrapped ``StoreError`` form (cause chain preserved).
+
+    Mirrors ``append_events_atomic_verified`` re-raising the underlying refusal as a
+    ``StoreError`` subclass ``from`` the original ``ProjectLayoutRequiredError`` — the
+    layout signal survives on ``__cause__`` for the boundary to recover.
+    """
+    raise StoreError(f"append failed: {_REFUSAL_MESSAGE}") from ProjectLayoutRequiredError(
+        _REFUSAL_MESSAGE
+    )
+
+
+# --- T018: write-cannot-land surfaces as a failure ---------------------------
+
+
+def test_write_cannot_land_surfaces_actionable_failure(tmp_path: Path) -> None:
+    """#3476: a seed write refused on a legacy layout must be loud, not swallowed.
+
+    Pre-fix, the refusal either crashes with a bare traceback or is swallowed and
+    the command reports success while backfilling nothing. This asserts the
+    boundary contract: exit non-zero, no leaked exception, and an actionable
+    message naming the mission and the recovery.
+    """
+    build_mission(tmp_path, slug="legacy-refuser")
+
+    with patch(_APPEND_EVENTS, _refuse_write), patch(_APPEND_ANNOTATIONS, _refuse_write):
+        result = _invoke(tmp_path, ["--json"])
+
+    assert result.exit_code != 0, result.output
+    # Not a bare traceback: the failure is surfaced, not leaked.
+    _assert_no_leaked_exception(result)
+    payload = json.loads(result.output)
+    assert payload["summary"]["failed"] == 1
+    assert payload["summary"]["flipped"] == 0
+    row = payload["results"][0]
+    assert row["slug"] == "legacy-refuser"
+    assert row["error"] is not None
+    # Actionable: names what cannot happen and the recovery (layout cutover first).
+    assert "could not land" in row["error"].lower()
+    assert "layout" in row["error"].lower()
+    # status_phase never flipped for a mission whose seed could not land.
+    assert "status_phase" not in json.loads(
+        (tmp_path / "kitty-specs" / "legacy-refuser" / "meta.json").read_text()
+    )
+
+
+def test_write_cannot_land_surfaces_in_human_summary(tmp_path: Path) -> None:
+    """The rich (non-JSON) summary names the failing mission + the actionable reason."""
+    build_mission(tmp_path, slug="legacy-refuser")
+
+    with patch(_APPEND_EVENTS, _refuse_write), patch(_APPEND_ANNOTATIONS, _refuse_write):
+        result = _invoke(tmp_path, [])
+
+    assert result.exit_code != 0
+    _assert_no_leaked_exception(result)
+    assert "legacy-refuser" in result.output
+    assert "could not land" in result.output.lower()
+
+
+def test_write_cannot_land_wrapped_form_also_surfaces(tmp_path: Path) -> None:
+    """The refusal in its store-wrapped ``EventPersistenceError`` form is caught too."""
+    build_mission(tmp_path, slug="legacy-refuser")
+
+    with patch(_APPEND_EVENTS, _refuse_write_wrapped), patch(
+        _APPEND_ANNOTATIONS, _refuse_write_wrapped
+    ):
+        result = _invoke(tmp_path, ["--json"])
+
+    assert result.exit_code != 0
+    _assert_no_leaked_exception(result)
+    payload = json.loads(result.output)
+    assert payload["summary"]["failed"] == 1
+    assert "could not land" in payload["results"][0]["error"].lower()
+
+
+def test_seed_phase_direct_refusal_surfaces_via_cutover_mission(tmp_path: Path) -> None:
+    """A ``ProjectLayoutRequiredError`` escaping the seed phase (not the append) is
+    caught by ``cutover_mission`` itself and surfaced — the belt-and-suspenders
+    branch for a refusal raised outside the backfill append seam.
+    """
+    build_mission(tmp_path, slug="legacy-refuser")
+
+    with patch(_SEED_BACKFILL, side_effect=ProjectLayoutRequiredError(_REFUSAL_MESSAGE)):
+        result = _invoke(tmp_path, ["--json"])
+
+    assert result.exit_code != 0
+    _assert_no_leaked_exception(result)
+    payload = json.loads(result.output)
+    assert payload["summary"]["failed"] == 1
+    assert "could not land" in payload["results"][0]["error"].lower()
+
+
+# --- T019: a legitimate no-op is NOT flagged ---------------------------------
+
+
+def test_already_migrated_rerun_is_quiet(tmp_path: Path) -> None:
+    """An already-migrated re-run seeds nothing, flips nothing, exits 0, no failure."""
+    build_mission(tmp_path, slug="042-demo")
+    first = _invoke(tmp_path, [])
+    assert first.exit_code == 0
+
+    result = _invoke(tmp_path, ["--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_no_leaked_exception(result)
+    payload = json.loads(result.output)
+    assert payload["summary"]["failed"] == 0
+    assert payload["summary"]["seeded"] == 0
+    assert all(r["failed"] is False for r in payload["results"])
+    assert all(r["error"] is None for r in payload["results"])
+    assert "could not land" not in result.output.lower()
+
+
+def test_dry_run_preview_is_quiet(tmp_path: Path) -> None:
+    """A --dry-run preview over a healthy legacy corpus is not a failure (exit 0)."""
+    build_mission(tmp_path, slug="042-demo")
+
+    result = _invoke(tmp_path, ["--dry-run", "--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_no_leaked_exception(result)
+    payload = json.loads(result.output)
+    assert payload["summary"]["failed"] == 0
+    assert all(r["failed"] is False for r in payload["results"])
+    assert "could not land" not in result.output.lower()
+    assert "Failed (status_phase left untouched)" not in result.output
+
+
+# --- T031: FR-010 boundary consumer of WP05's capture-failure flag -----------
+
+
+def test_epilogue_surfaces_recorded_capture_failure(tmp_path: Path) -> None:
+    """A recorded unrecoverable capture failure is surfaced at the epilogue (non-zero).
+
+    Simulates WP05's emitter recording a swallowed capture failure during the run;
+    the cutover itself is clean. The command must surface the failure (report +
+    non-zero) WITHOUT crashing (``result.exception is None``).
+    """
+    build_mission(tmp_path, slug="042-demo")
+    failure = CapturedFailure(site="emit_status_transition", summary="OSError('disk gone')")
+
+    with patch(_CAPTURED_FAILURES, return_value=(failure,)):
+        result = _invoke(tmp_path, [])
+
+    assert result.exit_code != 0, result.output
+    _assert_no_leaked_exception(result)
+    assert "emit_status_transition" in result.output
+    assert "capture" in result.output.lower()
+
+
+def test_clean_run_stays_silent_on_capture_flag(tmp_path: Path) -> None:
+    """No recorded capture failure -> no capture report, cutover success exits 0."""
+    build_mission(tmp_path, slug="042-demo")
+
+    result = _invoke(tmp_path, ["--json"])
+
+    assert result.exit_code == 0, result.output
+    _assert_no_leaked_exception(result)
+    assert "capture failure" not in result.output.lower()

--- a/tests/sync/test_credential_scope_signal.py
+++ b/tests/sync/test_credential_scope_signal.py
@@ -1,0 +1,295 @@
+"""Credential parsing as an *auth signal* (WP01 / IC-01, FR-004 / FR-009).
+
+The #3293 consent-ledger cutover narrowed
+``specify_cli.sync.queue.read_queue_scope_from_credentials`` to a JSON-only read
+of an explicit ``queue_scope`` field. The supported on-disk credential form (a
+TOML file with ``[user]`` / ``[server]`` tables) stopped yielding a scope, so the
+FR-011 auth gate in ``mission_setup_plan._enforce_saas_sync_auth_refusal`` treated
+a genuinely-authenticated host as unauthenticated and exited 2 (regression #3425,
+research.md Decision 1 "credential half").
+
+These tests pin the fix as an **auth signal only**:
+
+* T001 — an authenticated coherent host passes the setup-plan auth gate (no
+  ``typer.Exit(2)``).
+* T002 — the restored parser yields the canonical ``server|user|team`` piped
+  scope for a TOML credentials file, still returns ``None`` for absent/garbage
+  input, and preserves the explicit-JSON ``queue_scope`` path.
+* T003 — the gate consumes the value purely as a boolean; it materialises no
+  physical queue DB.
+* T004 — **physical-store invariance (INV-6):** restoring credential parsing does
+  NOT change which physical store a live write lands in. The authoritative store
+  path (``resolve_sync_target(...).queue_db_path``) is derived from the passed
+  identity via ``_derive_queue_scope`` and is inert to the credential read — this
+  is the guard against a C-003 / FR-009 revert of #3293's ProjectSyncStore
+  selection.
+
+Isolation is mandatory: every test pins BOTH ``SPEC_KITTY_HOME`` **and** ``HOME``
+(plus ``XDG_*`` / ``APPDATA``) to a throwaway temp root. This dev box's real
+``~/.spec-kitty`` is a live legacy root (plan.md:131-133); pinning only ``HOME``
+is insufficient because scope/credential paths key off ``SPEC_KITTY_HOME``. No
+network, no ambient auth, no real credentials file.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.fast]
+
+
+@pytest.fixture
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Pin BOTH ``SPEC_KITTY_HOME`` and ``HOME`` (+ platform equivalents) to tmp.
+
+    Scope/credential resolution keys off ``SPEC_KITTY_HOME``
+    (``paths.get_runtime_root``); ``HOME`` / ``USERPROFILE`` catch any
+    ``Path.home()``-relative helper. ``SPEC_KITTY_SAAS_URL`` and the encrypted
+    session read are neutralised so the resolver stays deterministic and
+    network-free. ``monkeypatch.setenv`` restores every var (incl.
+    ``SPEC_KITTY_ENABLE_SAAS_SYNC`` set inside a test) on teardown, so gate
+    short-circuit state never leaks to sibling tests.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.delenv("SPEC_KITTY_SAAS_URL", raising=False)
+    monkeypatch.delenv("SPEC_KITTY_ENABLE_SAAS_SYNC", raising=False)
+    # Neutralise the encrypted-session scope read so the gate/resolver depend
+    # only on the on-disk credentials under test (no ambient auth).
+    monkeypatch.setattr(
+        "specify_cli.sync.queue.read_queue_scope_from_session",
+        lambda *, allow_rehydrate=True: None,
+    )
+    monkeypatch.setattr(
+        "specify_cli.sync.target_authority.read_queue_scope_from_session",
+        lambda *, allow_rehydrate=True: None,
+    )
+    return tmp_path
+
+
+def _credentials_path(root: Path) -> Path:
+    # ``SPEC_KITTY_HOME`` is used verbatim as the runtime base (not suffixed);
+    # see ``paths.windows_paths.get_runtime_root``.
+    return root / "credentials"
+
+
+def _write_toml_credentials(
+    root: Path,
+    *,
+    username: str = "tester@example.com",
+    url: str = "https://spec-kitty-dev.fly.dev",
+    team_slug: str = "t-private",
+) -> None:
+    """Write the supported on-disk credential form (TOML ``[user]``/``[server]``)."""
+    _credentials_path(root).write_text(
+        f'[user]\nusername = "{username}"\nteam_slug = "{team_slug}"\n'
+        f'[server]\nurl = "{url}"\n',
+        encoding="utf-8",
+    )
+
+
+def _write_json_credentials(root: Path, *, queue_scope: str) -> None:
+    """Write the explicit-JSON credential form (#3293's ``queue_scope`` field)."""
+    _credentials_path(root).write_text(
+        f'{{"queue_scope": "{queue_scope}"}}',
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# T002 — restored parser yields an auth signal (unit level)
+# ---------------------------------------------------------------------------
+
+
+def test_toml_credentials_yield_piped_scope_signal(isolated_home: Path) -> None:
+    """A supported TOML credentials file yields the canonical piped scope.
+
+    ``preflight._read_scope_identity_local_only`` splits this value on ``"|"``
+    expecting ``server|user|team`` (preflight.py:479-484), so the restored parse
+    must produce exactly that order.
+    """
+    from specify_cli.sync.queue import read_queue_scope_from_credentials
+
+    _write_toml_credentials(
+        isolated_home,
+        username="tester@example.com",
+        url="https://spec-kitty-dev.fly.dev",
+        team_slug="t-private",
+    )
+
+    scope = read_queue_scope_from_credentials()
+
+    assert scope == "https://spec-kitty-dev.fly.dev|tester@example.com|t-private"
+    parts = scope.split("|")
+    assert len(parts) == 3
+    assert parts[1] == "tester@example.com"
+    assert parts[2] == "t-private"
+
+
+def test_json_explicit_queue_scope_still_returned(isolated_home: Path) -> None:
+    """#3293's explicit-JSON ``queue_scope`` path is preserved (no regression)."""
+    from specify_cli.sync.queue import read_queue_scope_from_credentials
+
+    _write_json_credentials(isolated_home, queue_scope="explicit-scope-token")
+
+    assert read_queue_scope_from_credentials() == "explicit-scope-token"
+
+
+def test_absent_credentials_yield_none(isolated_home: Path) -> None:
+    from specify_cli.sync.queue import read_queue_scope_from_credentials
+
+    assert not _credentials_path(isolated_home).exists()
+    assert read_queue_scope_from_credentials() is None
+
+
+def test_garbage_credentials_yield_none_not_raise(isolated_home: Path) -> None:
+    """Corrupt/partial credentials return ``None`` defensively, never raise."""
+    from specify_cli.sync.queue import read_queue_scope_from_credentials
+
+    _credentials_path(isolated_home).write_text("{not json and [not toml", encoding="utf-8")
+    assert read_queue_scope_from_credentials() is None
+
+    # Partial TOML (missing username / url) is incomplete → no false positive.
+    _credentials_path(isolated_home).write_text('[server]\nurl = "https://x"\n', encoding="utf-8")
+    assert read_queue_scope_from_credentials() is None
+
+
+# ---------------------------------------------------------------------------
+# T001 / T003 — the FR-011 auth gate accepts an authenticated host, no DB write
+# ---------------------------------------------------------------------------
+
+
+def test_authenticated_toml_host_passes_setup_plan_gate(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FR-004 / SC-002: a coherent authenticated host is NOT refused (no exit 2)."""
+    from specify_cli.cli.commands.agent.mission_setup_plan import (
+        _enforce_saas_sync_auth_refusal,
+    )
+
+    _write_toml_credentials(isolated_home)
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+
+    # Must NOT raise typer.Exit(code=2): the authenticated host is accepted.
+    _enforce_saas_sync_auth_refusal(json_output=True)
+
+
+def test_gate_materialises_no_queue_db(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T003: the gate consumes the scope as a boolean only — no store is touched."""
+    from specify_cli.cli.commands.agent.mission_setup_plan import (
+        _enforce_saas_sync_auth_refusal,
+    )
+
+    _write_toml_credentials(isolated_home)
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+
+    _enforce_saas_sync_auth_refusal(json_output=True)
+
+    created_dbs = list(isolated_home.rglob("queue*.db"))
+    assert created_dbs == [], f"gate must not materialise a queue DB, found: {created_dbs}"
+
+
+def test_unauthenticated_host_still_refused(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard the negative: a genuinely-absent credential still exits 2 (no false accept)."""
+    import typer
+
+    from specify_cli.cli.commands.agent.mission_setup_plan import (
+        _enforce_saas_sync_auth_refusal,
+    )
+
+    assert not _credentials_path(isolated_home).exists()
+    monkeypatch.setenv("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
+
+    with pytest.raises(typer.Exit) as excinfo:
+        _enforce_saas_sync_auth_refusal(json_output=True)
+    assert excinfo.value.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# T004 — physical-store invariance (INV-6 / FR-009 / C-003 revert guard)
+# ---------------------------------------------------------------------------
+
+
+def test_authoritative_store_path_is_inert_to_credential_parse(
+    isolated_home: Path,
+) -> None:
+    """INV-6: restoring credential parsing must NOT steer the authoritative store.
+
+    ``resolve_sync_target(...).queue_db_path`` is the ProjectSyncStore-owned live
+    -write selection. It is derived from the *passed* identity via
+    ``_derive_queue_scope`` (target_authority.py:465-466), which never reads
+    credentials. So the resolved DB path must be byte-for-byte identical whether
+    the credentials file is absent, a TOML form (now parsed), or an explicit-JSON
+    form. If a future change let the credential read steer the physical store,
+    this assertion fails loudly — that is the whole point of the guard.
+    """
+    from specify_cli.sync.target_authority import resolve_sync_target
+
+    def _resolved_path() -> Path:
+        # Coerce at the typed boundary: ``specify_cli.*`` is ``Any`` to mypy
+        # under follow_imports=skip, so pin the ``Path`` return explicitly.
+        return Path(
+            resolve_sync_target(
+                user_id="tester@example.com", team_slug="t-private"
+            ).queue_db_path
+        )
+
+    creds = _credentials_path(isolated_home)
+
+    # Arm 1: no credentials on disk.
+    if creds.exists():
+        creds.unlink()
+    baseline = _resolved_path()
+
+    # Arm 2: TOML credentials (the form the restored parser now recognises).
+    _write_toml_credentials(isolated_home)
+    with_toml = _resolved_path()
+
+    # Arm 3: explicit-JSON credentials.
+    _write_json_credentials(isolated_home, queue_scope="explicit-scope-token")
+    with_json = _resolved_path()
+
+    assert with_toml == baseline, (
+        "restored credential parse changed the authoritative store path — "
+        "C-003/FR-009 revert of ProjectSyncStore selection"
+    )
+    assert with_json == baseline
+
+
+def test_readonly_preflight_store_uses_derived_scope_not_raw_credential(
+    isolated_home: Path,
+) -> None:
+    """The preflight's read-only DB path derives its scope from the resolver.
+
+    ``_resolve_queue_db_path_readonly`` routes credential *identity* through
+    ``resolve_sync_target(...).derived_queue_scope`` → ``scope_db_path`` — it never
+    feeds the raw credential string into ``scope_db_path``. So the reported DB path
+    equals the authoritative scoped path for the same identity, proving the
+    credential read is an auth/identity signal, not a physical-store selector.
+    """
+    from specify_cli.sync import preflight
+    from specify_cli.sync.queue import scope_db_path
+    from specify_cli.sync.target_authority import resolve_sync_target
+
+    _write_toml_credentials(
+        isolated_home, username="tester@example.com", team_slug="t-private"
+    )
+
+    reported = preflight._resolve_queue_db_path_readonly()
+    authoritative_scope = resolve_sync_target(
+        user_id="tester@example.com", team_slug="t-private"
+    ).derived_queue_scope
+
+    assert reported == Path(scope_db_path(authoritative_scope))

--- a/tests/sync/test_cutover_conservation.py
+++ b/tests/sync/test_cutover_conservation.py
@@ -1,0 +1,362 @@
+"""Cutover copy-identity: conservation + divergent-payload quarantine (WP02).
+
+Pins the FOUNDATION invariants WP03's cutover copy consumes (IC-00/IC-03,
+FR-005, NFR-002 / INV-2):
+
+* **Conservation (0 loss / 0 dup, incl. ownerless rows).** Every pre-existing
+  ``event_id`` — including legacy rows that predate per-project ownership and so
+  carry no ``project_uuid`` — lands in the destination journal exactly once. The
+  assertion is a before/after multiset diff (count *and* identity-set), never a
+  fixed literal.
+* **Ownerless-row attribution (IC-00).** A row with a missing/nil ``project_uuid``
+  acquires the destination store's canonical owner *before* the ``append`` owner
+  guard, so the copy no longer trips
+  ``ValueError("event-declared project UUID does not match store owner")``. A row
+  whose payload declares a *different* owner is a genuine
+  ``CONFLICTING_PROJECT_UUID`` and is refused, never force-attributed.
+* **Divergent-payload quarantine (#2846).** Same ``event_id`` + divergent canonical
+  payload parks a conflict for an operator (blocked run) rather than
+  last-write-win.
+* **Idempotence backstop.** A replayed copy is a no-op — re-running the copy adds
+  no rows, and ``journal.append`` short-circuits a replayed ``event_id``.
+
+Isolation: every test resolves its runtime from an isolated ``SPEC_KITTY_HOME`` /
+``HOME`` temp root, and the legacy sources live under a *separate* temp dir, so
+``discover_source_dbs`` only ever sees the seeded fixtures — never the real
+``~/.spec-kitty`` on this live-legacy box (plan Risk MINOR-8 / research Decision 10).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from specify_cli.event_journal.journal import EventJournal
+from specify_cli.event_journal.models import Event
+from specify_cli.sync.migrate_journal import (
+    LEGACY_DIGEST,
+    MigrationAudit,
+    discover_source_dbs,
+    migrate_queues_to_journal,
+)
+from specify_cli.sync.project_store import ProjectSyncStore
+
+pytestmark = pytest.mark.integration
+
+OWNER = "cccccccc-0000-0000-0000-000000000003"
+OTHER_OWNER = "dddddddd-0000-0000-0000-000000000004"
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the runtime store at an isolated temp root; return the legacy root."""
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir(parents=True, exist_ok=True)
+    return legacy_root
+
+
+def _seed_queue(path: Path, rows: tuple[tuple[str, dict[str, object] | None], ...]) -> None:
+    """Seed a legacy queue DB with ``(event_id, data_dict)`` rows (``None`` == empty)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE queue (id INTEGER PRIMARY KEY, event_id TEXT UNIQUE, "
+        "event_type TEXT, data TEXT, timestamp INTEGER, retry_count INTEGER)"
+    )
+    for index, (event_id, data) in enumerate(rows, start=1):
+        payload = {} if data is None else data
+        connection.execute(
+            "INSERT INTO queue VALUES (?, ?, 'MissionCreated', ?, ?, 0)",
+            (index, event_id, json.dumps(payload, sort_keys=True), index),
+        )
+    connection.commit()
+    connection.close()
+
+
+def _empty_queue(path: Path) -> None:
+    """A scoped queue DB that exists but holds zero queued rows."""
+    _seed_queue(path, ())
+
+
+def _project_only(store: ProjectSyncStore) -> None:
+    authority = store.layout_generation()
+    authority.begin_cutover("wp02-cutover-test")
+    authority.publish_project_only("wp02-cutover-test", verify_exact=lambda: True)
+
+
+def _run_migration(legacy_root: Path, store: ProjectSyncStore, audit: MigrationAudit) -> object:
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        return migrate_queues_to_journal(legacy_root, journal=journal, audit=audit)
+
+
+def _destination_event_ids(store: ProjectSyncStore) -> set[str]:
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        return {event.event_id for event in journal.read_all()}
+
+
+def _destination_count(store: ProjectSyncStore) -> int:
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        return int(journal.count())
+
+
+# --- T006: conservation (0 loss / 0 dup, incl. ownerless rows) --------------
+
+
+def test_cutover_conserves_every_event_including_ownerless(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        legacy_root / "queues" / "queue-1111111111111111.db",
+        (
+            ("evt-owned", {"payload": {"n": 1}, "project_uuid": OWNER}),
+            ("evt-ownerless", {"payload": {"n": 2}}),  # no project_uuid — the trap
+        ),
+    )
+    _seed_queue(
+        legacy_root / "queue.db",
+        (("evt-legacy-ownerless", {"payload": {"n": 3}}),),
+    )
+    # Pre-cutover event-id multiset snapshot (before/after diff, not a literal).
+    source_ids = {"evt-owned", "evt-ownerless", "evt-legacy-ownerless"}
+    # Fixture matches exactly what the engine walks (do not hand-list paths).
+    assert {source.path.name for source in discover_source_dbs(legacy_root)} == {
+        "queue-1111111111111111.db",
+        "queue.db",
+    }
+
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+    result = _run_migration(legacy_root, store, audit)
+
+    assert result.blocked is False  # type: ignore[attr-defined]
+    # INV-2: count equality AND identity-set equality; ownerless rows included.
+    assert _destination_count(store) == len(source_ids)
+    assert _destination_event_ids(store) == source_ids
+
+    # Idempotent re-run adds no rows (leans on the append event_id backstop).
+    second_audit = MigrationAudit(":memory:")
+    _run_migration(legacy_root, store, second_audit)
+    assert _destination_count(store) == len(source_ids)
+    assert _destination_event_ids(store) == source_ids
+
+
+def test_empty_legacy_store_is_a_noop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    assert result.blocked is False  # type: ignore[attr-defined]
+    assert _destination_count(store) == 0
+
+
+def test_scoped_db_with_zero_rows_is_skipped_not_errored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    _empty_queue(legacy_root / "queues" / "queue-abababababababab.db")
+    _seed_queue(
+        legacy_root / "queues" / "queue-cdcdcdcdcdcdcdcd.db",
+        (("evt-present", {"payload": {"n": 1}}),),
+    )
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    assert result.blocked is False  # type: ignore[attr-defined]
+    assert _destination_event_ids(store) == {"evt-present"}
+
+
+def test_identical_duplicate_across_sources_dedups_with_both_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    shared: dict[str, object] = {"payload": {"k": "v"}}  # ownerless + byte-identical
+    _seed_queue(legacy_root / "queues" / "queue-aaaaaaaaaaaaaaaa.db", (("dup", shared),))
+    _seed_queue(legacy_root / "queues" / "queue-bbbbbbbbbbbbbbbb.db", (("dup", shared),))
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    assert result.blocked is False  # type: ignore[attr-defined]
+    assert _destination_count(store) == 1  # collapse to ONE record …
+    # … while accumulating BOTH source provenance rows.
+    assert audit.provenance_for("dup") == ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]
+    assert audit.has_conflicts() is False  # identical payloads dedup, not quarantine
+
+
+# --- T007: divergent-payload quarantine (#2846) -----------------------------
+
+
+def test_divergent_payload_quarantines_not_last_write_win(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    # Same event_id, divergent canonical payloads (the #2846 shape).
+    _seed_queue(
+        legacy_root / "queues" / "queue-1111111111111111.db",
+        (("shared", {"payload": {"body": "A"}}),),
+    )
+    _seed_queue(
+        legacy_root / "queues" / "queue-2222222222222222.db",
+        (("shared", {"payload": {"body": "B"}}),),
+    )
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    # Blocked / non-zero exit while the conflict is unresolved.
+    assert result.blocked is True  # type: ignore[attr-defined]
+    assert result.exit_code != 0  # type: ignore[attr-defined]
+    # A quarantined conflict exists for the shared event_id.
+    assert audit.has_conflicts() is True
+    assert audit.quarantined_count() >= 1
+    assert any(conflict.event_id == "shared" for conflict in audit.conflicts())
+    # Exactly ONE authoritative record lands (not last-write-win, not two rows).
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        shared_records = [event for event in journal.read_all() if event.event_id == "shared"]
+    assert len(shared_records) == 1
+    authoritative = shared_records[0].payload
+
+    # Deterministic: a re-run does not flip the authoritative payload.
+    second_audit = MigrationAudit(":memory:")
+    _run_migration(legacy_root, store, second_audit)
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        replayed = journal.read_by_id("shared")
+    assert replayed is not None
+    assert replayed.payload == authoritative
+
+
+# --- T009: ownerless-row attribution (focused unit) -------------------------
+
+
+def test_attribute_owner_assigns_owner_and_preserves_distinct_reasons() -> None:
+    from specify_cli.sync.migrate_journal import _attribute_owner
+    from specify_cli.sync.project_store_migration import QuarantineReason
+
+    # Missing project_uuid → attributed to the destination owner (MISSING reason).
+    assert _attribute_owner(json.dumps({"payload": {}}), OWNER) == (
+        OWNER,
+        QuarantineReason.MISSING_PROJECT_UUID,
+    )
+    # Nil project_uuid → attributed to the destination owner (NIL reason).
+    assert _attribute_owner(json.dumps({"project_uuid": NIL_UUID}), OWNER) == (
+        OWNER,
+        QuarantineReason.NIL_PROJECT_UUID,
+    )
+    # Matching owner → passes through unchanged, no reason.
+    assert _attribute_owner(json.dumps({"project_uuid": OWNER}), OWNER) == (OWNER, None)
+    # Divergent declared owner → refused (never force-attributed), CONFLICTING.
+    assert _attribute_owner(json.dumps({"project_uuid": OTHER_OWNER}), OWNER) == (
+        None,
+        QuarantineReason.CONFLICTING_PROJECT_UUID,
+    )
+    # Malformed declared owner → refused, distinct MALFORMED reason.
+    assert _attribute_owner(json.dumps({"project_uuid": "not-a-uuid"}), OWNER) == (
+        None,
+        QuarantineReason.MALFORMED_PROJECT_UUID,
+    )
+
+
+def test_ownerless_row_satisfies_owner_guard_after_attribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        legacy_root / "queue.db",
+        (("evt-ownerless", {"payload": {"n": 1}}),),
+    )
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    # Attributed (not dropped, not quarantined) and stored under the owner.
+    assert result.blocked is False  # type: ignore[attr-defined]
+    assert audit.has_conflicts() is False
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        stored = journal.read_by_id("evt-ownerless")
+    assert stored is not None
+    assert stored.project_uuid == OWNER  # passes the owner guard on copy
+    assert audit.provenance_for("evt-ownerless") == [LEGACY_DIGEST]
+
+
+def test_divergent_declared_owner_is_refused_not_misattributed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    legacy_root = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        legacy_root / "queue.db",
+        (("evt-foreign", {"payload": {"n": 1}, "project_uuid": OTHER_OWNER}),),
+    )
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    audit = MigrationAudit(":memory:")
+
+    result = _run_migration(legacy_root, store, audit)
+
+    # A foreign-owned row is refused: blocked, and it never lands in this store.
+    assert result.blocked is True  # type: ignore[attr-defined]
+    assert _destination_count(store) == 0
+    assert audit.has_conflicts() is True
+
+
+# --- T010: journal.append event_id idempotence backstop ---------------------
+
+
+def test_journal_append_is_idempotent_on_replayed_event_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    store = ProjectSyncStore(OWNER)
+    _project_only(store)
+    event = Event(
+        event_id="evt-replay",
+        event_type="MissionCreated",
+        payload=json.dumps({"payload": {"n": 1}}).encode(),
+        occurred_at="2026-08-10T00:00:00+00:00",
+        created_at="2026-08-10T00:00:01+00:00",
+        project_uuid=OWNER,
+    )
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        first = journal.append(event)
+        second = journal.append(event)  # replay — must be a no-op
+
+    assert first.inserted is True
+    assert second.inserted is False
+    assert first.capture_sequence == second.capture_sequence  # no duplicate row
+    assert _destination_count(store) == 1

--- a/tests/sync/test_cutover_conservation.py
+++ b/tests/sync/test_cutover_conservation.py
@@ -44,7 +44,7 @@ from specify_cli.sync.migrate_journal import (
 )
 from specify_cli.sync.project_store import ProjectSyncStore
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.fast
 
 OWNER = "cccccccc-0000-0000-0000-000000000003"
 OTHER_OWNER = "dddddddd-0000-0000-0000-000000000004"

--- a/tests/sync/test_emitter_observability.py
+++ b/tests/sync/test_emitter_observability.py
@@ -47,7 +47,7 @@ from specify_cli.sync.emitter import EventEmitter
 from specify_cli.sync.layout_generation import LayoutMode
 from specify_cli.sync.project_store import ProjectSyncStore
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.fast
 
 OWNER = "eeeeeeee-0000-0000-0000-000000000005"
 

--- a/tests/sync/test_emitter_observability.py
+++ b/tests/sync/test_emitter_observability.py
@@ -1,0 +1,350 @@
+"""Observable emitter capture failure + resolve-before-UoW cutover seam (WP05).
+
+IC-05 (plan.md:179-185) / FR-001 + FR-010, folding #3391. Two orthogonal
+guarantees the emitter must uphold at once when a capture cannot land:
+
+* **Non-fatal** — no exception escapes any public ``emit_*`` call (or the two
+  helper capture sites) when the inner write raises. ``_emit`` is contractually
+  "never raises" (``emitter.py`` docstring) and is the sole body behind ~30
+  ``emit_*`` methods; raising would crash the whole status/build/mission surface.
+* **Observable** — a *process-level* captured-failure surface (``captured_failures``
+  / ``reset_captured_failures``) is incremented, readable without a filesystem
+  rescan (mirrors ``AgentProfileRepository.skipped_profiles``). This is the
+  machine-observable half; the human warning is the complementary, throttled half.
+
+Both swallow sites are covered: ``_capture_to_journal`` (site 1) and
+``_emit_for_project_context`` (site 2, the live-reproduced site — ``mission
+create`` printed it five times authoring this mission). The loud warning is
+rate-limited so a residual systemic fault is loud-once-and-counted-fully, never a
+per-event storm.
+
+**Part B (resolve-before-UoW).** WP03 proved the layout lock is not re-entrant:
+``resolve_layout_for_write`` invoked *inside* an open write unit-of-work cannot
+complete the cutover copy (the store lock is held), so a legacy-with-data root
+surfaced ``LayoutCutoverIncompleteError`` on the live emit path. ``_queue_event_locally``
+now resolves/drives the layout *before* opening its own UoW, so the common
+legacy-with-data case COMPLETES and the event lands in the project store.
+
+**Isolation is safety-critical (plan Risk MINOR-8).** This dev box is itself a
+live legacy root; every store/emit test pins BOTH ``SPEC_KITTY_HOME`` and
+``HOME`` to ``tmp_path`` so a stray cutover can never touch the real
+machine-global ``~/.spec-kitty``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from specify_cli.event_journal.journal import EventJournal
+from specify_cli.sync import emitter as emitter_mod
+from specify_cli.sync.emitter import EventEmitter
+from specify_cli.sync.layout_generation import LayoutMode
+from specify_cli.sync.project_store import ProjectSyncStore
+
+pytestmark = pytest.mark.integration
+
+OWNER = "eeeeeeee-0000-0000-0000-000000000005"
+
+
+class _RecordingConsole:
+    """A stand-in for the module stderr console that counts warnings."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(self, message: str = "", *args: object, **kwargs: object) -> None:
+        self.messages.append(str(message))
+
+
+@pytest.fixture(autouse=True)
+def _clean_surface() -> Iterator[None]:
+    """Guarantee a clean process-level surface around every test (reset pin)."""
+    emitter_mod.reset_captured_failures()
+    yield
+    emitter_mod.reset_captured_failures()
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin the runtime + home to temp; return the runtime root (== spec_kitty_dir)."""
+    runtime = tmp_path / "runtime"
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(runtime))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("SPEC_KITTY_SYNC_DISABLE", "1")
+    monkeypatch.delenv("SPEC_KITTY_NO_AUTO_CUTOVER", raising=False)
+    return runtime
+
+
+def _seed_queue(path: Path, rows: tuple[tuple[str, dict[str, object]], ...]) -> None:
+    """Seed a legacy queue DB with ``(event_id, data_dict)`` rows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE queue (id INTEGER PRIMARY KEY, event_id TEXT UNIQUE, "
+        "event_type TEXT, data TEXT, timestamp INTEGER, retry_count INTEGER)"
+    )
+    for index, (event_id, data) in enumerate(rows, start=1):
+        connection.execute(
+            "INSERT INTO queue VALUES (?, ?, 'MissionCreated', ?, ?, 0)",
+            (index, event_id, json.dumps(data, sort_keys=True), index),
+        )
+    connection.commit()
+    connection.close()
+
+
+def _journal_ids(store: ProjectSyncStore) -> set[str]:
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        return {event.event_id for event in journal.read_all()}
+
+
+def _live_event(event_id: str) -> dict[str, object]:
+    return {
+        "event_id": event_id,
+        "event_type": "MissionCreated",
+        "aggregate_id": "M-1",
+        "aggregate_type": "Mission",
+        "project_uuid": OWNER,
+        "payload": {"n": 1},
+        "created_at": "2026-08-15T00:00:00+00:00",
+        "occurred_at": "2026-08-15T00:00:00+00:00",
+    }
+
+
+# --- T022 / T025: non-fatal + observable, both sites --------------------------
+
+
+def test_public_emit_never_raises_when_capture_fails_and_is_observed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-fatal + observable pin driven through a public ``emit_*`` method."""
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setattr(emitter_mod, "_console", _RecordingConsole())
+
+    emitter = EventEmitter()
+
+    def _boom(_event: dict[str, object]) -> bool:
+        raise RuntimeError("forced queue append failure")
+
+    monkeypatch.setattr(emitter, "_queue_event_locally", _boom)
+
+    # Non-fatal: the public call returns normally, no exception escapes.
+    result = emitter.emit_history_added("WP01", "note", "hello")
+    assert result is None or isinstance(result, dict)
+
+    # Observable: the process-level surface saw the capture failure, no rescan.
+    failures = emitter_mod.captured_failures()
+    assert failures, "unrecoverable capture failure must be boundary-observable"
+    assert any("journal" in f.site.lower() for f in failures)
+
+
+def test_capture_to_journal_site_records_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site 1 (``_capture_to_journal``) records into the surface and stays non-fatal."""
+    monkeypatch.setattr(emitter_mod, "_console", _RecordingConsole())
+    emitter = EventEmitter()
+
+    def _boom(_event: dict[str, object]) -> bool:
+        raise RuntimeError("forced journal append failure")
+
+    monkeypatch.setattr(emitter, "_queue_event_locally", _boom)
+
+    # No exception escapes the helper (its ``-> None`` non-raising contract).
+    emitter._capture_to_journal(
+        event_id="E1",
+        event_type="MissionCreated",
+        event={"event_id": "E1"},
+        occurred_at="2026-08-15T00:00:00+00:00",
+        team_slug=None,
+    )
+
+    failures = emitter_mod.captured_failures()
+    assert len(failures) == 1
+    assert "journal" in failures[0].site.lower()
+    # The record carries a site label + exception summary, never the envelope.
+    assert "forced journal append failure" in failures[0].summary
+
+
+def test_explicit_context_site_records_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Site 2 (``_emit_for_project_context``) records and still returns ``None``."""
+    monkeypatch.setattr(emitter_mod, "_console", _RecordingConsole())
+    # Bypass the authority validation so the mismatched-identity guard raises
+    # inside the try body, exercising the live-reproduced except handler.
+    monkeypatch.setattr(
+        "specify_cli.sync.project_context.validate_project_sync_context_authority",
+        lambda _ctx: None,
+    )
+    emitter = EventEmitter()
+
+    context = SimpleNamespace(
+        store_identity=object(),
+        project_uuid=SimpleNamespace(storage_token=OWNER),
+    )
+    unit = SimpleNamespace(store_identity=object())  # deliberately different identity
+
+    result = emitter._emit_for_project_context(
+        event_type="MissionCreated",
+        aggregate_id="M-1",
+        aggregate_type="Mission",
+        payload={"n": 1},
+        causation_id=None,
+        envelope_fields=None,
+        occurred_at=None,
+        project_context=context,
+        project_unit=unit,
+        project_layout=object(),
+    )
+
+    # Explicit-context contract: a refused capture yields ``None`` (non-fatal).
+    assert result is None
+    failures = emitter_mod.captured_failures()
+    assert len(failures) == 1
+    assert "explicit" in failures[0].site.lower()
+
+
+def test_reset_clears_surface_between_cases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reset_captured_failures`` leaves a clean slate (per-invocation isolation)."""
+    monkeypatch.setattr(emitter_mod, "_console", _RecordingConsole())
+    emitter = EventEmitter()
+
+    def _boom(_event: dict[str, object]) -> bool:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(emitter, "_queue_event_locally", _boom)
+    emitter._capture_to_journal(
+        event_id="E1",
+        event_type="MissionCreated",
+        event={"event_id": "E1"},
+        occurred_at="2026-08-15T00:00:00+00:00",
+        team_slug=None,
+    )
+    assert emitter_mod.captured_failures()
+
+    emitter_mod.reset_captured_failures()
+    assert emitter_mod.captured_failures() == ()
+
+
+# --- T026: rate-limit the loud path, exact count ------------------------------
+
+
+def test_warning_is_rate_limited_but_count_is_exact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A burst of identical failures warns at most once but counts every one."""
+    console = _RecordingConsole()
+    monkeypatch.setattr(emitter_mod, "_console", console)
+    emitter = EventEmitter()
+
+    def _boom(_event: dict[str, object]) -> bool:
+        raise RuntimeError("systemic capture fault")
+
+    monkeypatch.setattr(emitter, "_queue_event_locally", _boom)
+
+    for _ in range(50):
+        emitter._capture_to_journal(
+            event_id="E",
+            event_type="MissionCreated",
+            event={"event_id": "E"},
+            occurred_at="2026-08-15T00:00:00+00:00",
+            team_slug=None,
+        )
+
+    # Counter is exact (INV-1 sees the true count) ...
+    assert len(emitter_mod.captured_failures()) == 50
+    # ... but the human warning fired at most once for this distinct failure.
+    assert len(console.messages) == 1
+
+
+def test_mixed_burst_across_sites_is_bounded_not_doubled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mixed burst across both sites is bounded (one warning per site), not per-event."""
+    console = _RecordingConsole()
+    monkeypatch.setattr(emitter_mod, "_console", console)
+    monkeypatch.setattr(
+        "specify_cli.sync.project_context.validate_project_sync_context_authority",
+        lambda _ctx: None,
+    )
+    emitter = EventEmitter()
+
+    def _boom(_event: dict[str, object]) -> bool:
+        raise RuntimeError("systemic capture fault")
+
+    monkeypatch.setattr(emitter, "_queue_event_locally", _boom)
+
+    context = SimpleNamespace(
+        store_identity=object(),
+        project_uuid=SimpleNamespace(storage_token=OWNER),
+    )
+    unit = SimpleNamespace(store_identity=object())
+
+    for _ in range(50):
+        emitter._capture_to_journal(
+            event_id="E",
+            event_type="MissionCreated",
+            event={"event_id": "E"},
+            occurred_at="2026-08-15T00:00:00+00:00",
+            team_slug=None,
+        )
+        emitter._emit_for_project_context(
+            event_type="MissionCreated",
+            aggregate_id="M-1",
+            aggregate_type="Mission",
+            payload={"n": 1},
+            causation_id=None,
+            envelope_fields=None,
+            occurred_at=None,
+            project_context=context,
+            project_unit=unit,
+            project_layout=object(),
+        )
+
+    # Every failure counted (100), warnings bounded to one-per-distinct-site (2).
+    assert len(emitter_mod.captured_failures()) == 100
+    assert len(console.messages) == 2
+
+
+# --- Part B: resolve-before-UoW completes a legacy-with-data cutover ----------
+
+
+def test_emit_completes_legacy_with_data_cutover_on_live_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live emit on a legacy-with-data root COMPLETES the cutover and lands.
+
+    RED before the resolve-before-UoW seam: ``queue_event`` drives
+    ``resolve_layout_for_write`` inside its own open unit-of-work, the cutover
+    copy contends on the held store lock and cannot complete, and the write
+    surfaces ``LayoutCutoverIncompleteError``. GREEN after: the emitter resolves
+    the layout before opening the UoW, so the cutover completes where the lock is
+    free and the event lands in the project store, legacy events conserved.
+    """
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        spec_dir / "queue.db",
+        (("evt-legacy-a", {"payload": {"n": 1}}), ("evt-legacy-b", {"payload": {"n": 2}})),
+    )
+    emitter = EventEmitter()
+
+    # This is the live path (transient store; ``queue is None``): it must not raise.
+    landed = emitter._queue_event_locally(_live_event("evt-live-new"))
+    assert landed is True
+
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+    # The cutover COMPLETED — the machine layout is project-only, not stuck pending.
+    assert authority.peek_state().mode is LayoutMode.PROJECT_ONLY
+    # The new event landed AND the pre-existing legacy events were conserved.
+    assert _journal_ids(store) == {"evt-legacy-a", "evt-legacy-b", "evt-live-new"}

--- a/tests/sync/test_layout_cutover.py
+++ b/tests/sync/test_layout_cutover.py
@@ -1,0 +1,402 @@
+"""Layout resolution + canonical crash-safe auto-cutover (WP03, IC-02).
+
+Closes the silent zero-capture defect (#3425) at its origin — the layout-resolution
+state machine in ``sync/layout_generation.py``. The three hazards proven here:
+
+* **T011 (greenfield)** — a fresh repository-root checkout with no ``.layout-generation``
+  record and no legacy queue data resolves ``PROJECT_ONLY`` *before* any ``LEGACY`` state
+  is persisted (Hazard (b): ``_read_locked`` self-destructs the greenfield signal), so its
+  first event actually lands in the journal (FR-002 / SC-001).
+* **T012 (idempotence under interruption)** — a crash between ``begin_cutover`` and
+  ``publish_project_only`` re-enters the *same* deterministic ``migration_id`` and
+  converges, never bricking the root, copying each legacy event exactly once
+  (FR-003 / NFR-005 / INV-3).
+* **T013 (emit during CUTOVER_PENDING)** — a live write arriving while a migration is in
+  flight blocks-and-retries within a bounded, hook-driven wait and, on timeout, surfaces
+  a distinguishable loud condition — it is **never** silently routed to LEGACY-and-swallowed
+  (Hazard (a) / INV-5).
+* **T014 (escape hatch)** — ``SPEC_KITTY_NO_AUTO_CUTOVER`` on a legacy-with-data root
+  yields a loud, actionable, non-mutating refusal pointing at ``sync project-store-migrate``
+  (Cutover Transition 5).
+
+**Isolation is safety-critical (plan Risk MINOR-8).** This dev box is itself a live legacy
+root; every test pins BOTH ``SPEC_KITTY_HOME`` and ``HOME`` to ``tmp_path`` so a stray
+cutover can never touch the real machine-global ``~/.spec-kitty``. Legacy source DBs are
+seeded *inside* the isolated runtime root (that is where ``discover_source_dbs`` reads).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from specify_cli.event_journal.journal import EventJournal
+from specify_cli.event_journal.models import Event
+from specify_cli.sync.layout_generation import (
+    LayoutAutoCutoverRefusedError,
+    LayoutCutoverIncompleteError,
+    LayoutDestination,
+    LayoutMode,
+    LayoutTestHooks,
+    LayoutVerificationError,
+)
+from specify_cli.sync.project_store import ProjectSyncStore
+
+pytestmark = pytest.mark.integration
+
+OWNER = "cccccccc-0000-0000-0000-000000000003"
+OTHER_OWNER = "dddddddd-0000-0000-0000-000000000004"
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin the runtime + home to temp; return the runtime root (== spec_kitty_dir)."""
+    runtime = tmp_path / "runtime"
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(runtime))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("SPEC_KITTY_SYNC_DISABLE", "1")
+    monkeypatch.delenv("SPEC_KITTY_NO_AUTO_CUTOVER", raising=False)
+    return runtime
+
+
+def _seed_queue(path: Path, rows: tuple[tuple[str, dict[str, object] | None], ...]) -> None:
+    """Seed a legacy queue DB with ``(event_id, data_dict)`` rows (``None`` == empty)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE queue (id INTEGER PRIMARY KEY, event_id TEXT UNIQUE, "
+        "event_type TEXT, data TEXT, timestamp INTEGER, retry_count INTEGER)"
+    )
+    for index, (event_id, data) in enumerate(rows, start=1):
+        payload = {} if data is None else data
+        connection.execute(
+            "INSERT INTO queue VALUES (?, ?, 'MissionCreated', ?, ?, 0)",
+            (index, event_id, json.dumps(payload, sort_keys=True), index),
+        )
+    connection.commit()
+    connection.close()
+
+
+def _event(event_id: str, owner: str = OWNER) -> Event:
+    return Event(
+        event_id=event_id,
+        event_type="MissionCreated",
+        payload=json.dumps({"payload": {"n": 1}}).encode(),
+        occurred_at="2026-08-10T00:00:00+00:00",
+        created_at="2026-08-10T00:00:01+00:00",
+        project_uuid=owner,
+    )
+
+
+def _journal_ids(store: ProjectSyncStore) -> set[str]:
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        return {event.event_id for event in journal.read_all()}
+
+
+def _record_on_disk(path: Path) -> dict[str, object] | None:
+    if not path.exists():
+        return None
+    raw: dict[str, object] = json.loads(path.read_text(encoding="utf-8"))
+    return raw
+
+
+# --- T011: greenfield -> PROJECT_ONLY, never persists LEGACY, captures --------
+
+
+def test_greenfield_resolves_project_only_before_any_legacy_persist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    # A snapshot read on a greenfield root must NOT persist anything (Hazard (b)).
+    assert authority.peek_state().mode is LayoutMode.LEGACY  # in-memory default only
+    assert not authority.record_path.exists()
+
+    # The write-path resolution flips a fresh root to PROJECT_ONLY without ever
+    # persisting a LEGACY record (the RED behavior today: _read_locked writes LEGACY).
+    permit = authority.issue_write_permit()
+    assert permit.destination is LayoutDestination.PROJECT_STORE
+
+    on_disk = _record_on_disk(authority.record_path)
+    assert on_disk is not None
+    assert on_disk["mode"] == LayoutMode.PROJECT_ONLY.value
+    assert on_disk["migration_id"] is None
+    assert on_disk["generation"] == 1
+
+    # SC-001: the first live event actually lands (journal 0 -> 1).
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        assert journal.count() == 0
+        journal.append(_event("evt-first"))
+        assert journal.count() == 1
+
+
+def test_greenfield_regression_guard_leaves_migrated_root_untouched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    authority.issue_write_permit()  # resolve greenfield -> PROJECT_ONLY
+    before_bytes = authority.record_path.read_bytes()
+    before_gen = json.loads(before_bytes)["generation"]
+
+    # An already-migrated root is a no-op on every subsequent resolution (NFR-003).
+    for _ in range(3):
+        authority.issue_write_permit()
+    after_bytes = authority.record_path.read_bytes()
+    assert after_bytes == before_bytes
+    assert json.loads(after_bytes)["generation"] == before_gen
+
+
+# --- T012: idempotence under interruption (crash between begin/publish) --------
+
+
+def test_crash_between_begin_and_publish_reenters_same_id_and_converges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        spec_dir / "queue.db",
+        (("evt-a", {"payload": {"n": 1}}), ("evt-b", {"payload": {"n": 2}})),
+    )
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+    migration_id = authority.auto_migration_id()
+
+    # Simulate a crash: begin_cutover advanced to CUTOVER_PENDING; publish never ran.
+    authority.begin_cutover(migration_id)
+    assert authority.peek_state().mode is LayoutMode.CUTOVER_PENDING
+
+    # Re-enter the resolution path: it must reuse the SAME migration_id (no "another
+    # migration owns cutover"), converge to PROJECT_ONLY, and copy each event once.
+    state = authority.resolve_layout_for_write()
+    assert state.mode is LayoutMode.PROJECT_ONLY
+    assert _journal_ids(store) == {"evt-a", "evt-b"}
+
+    # Convergence is a pure no-op once PROJECT_ONLY: a second pass writes nothing.
+    # Prove it on the persisted record — the authority uses __slots__, so a
+    # byte-identical record + unchanged generation is the observable "zero writes".
+    before_bytes = authority.record_path.read_bytes()
+    second = authority.resolve_layout_for_write()
+    assert second.mode is LayoutMode.PROJECT_ONLY
+    assert authority.record_path.read_bytes() == before_bytes  # zero additional writes (INV-3)
+    assert _journal_ids(store) == {"evt-a", "evt-b"}  # no drop, no dup
+
+
+def test_deterministic_migration_id_is_stable_per_root_and_distinct_across_roots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    first = store.layout_generation().auto_migration_id()
+    second = store.layout_generation().auto_migration_id()
+    assert first == second  # stable across constructions (crash-and-retry re-enters same)
+
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "other-runtime"))
+    other = ProjectSyncStore(OWNER).layout_generation().auto_migration_id()
+    assert other != first  # distinct across roots
+
+
+def test_incomplete_copy_does_not_publish_project_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(spec_dir / "queue.db", (("evt-present", {"payload": {"n": 1}}),))
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    # A copy driver that reports success but leaves the journal empty must NOT publish:
+    # verify_exact (conservation) refuses cutover, so the root stays CUTOVER_PENDING.
+    with pytest.raises(LayoutVerificationError):
+        authority.resolve_layout_for_write(cutover_copy=lambda _mig: False)
+    assert authority.peek_state().mode is LayoutMode.CUTOVER_PENDING
+
+
+# --- T013: emit during CUTOVER_PENDING -> zero loss ---------------------------
+
+
+def test_live_write_during_cutover_pending_is_never_a_silent_legacy_swallow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    # Hold the machine in CUTOVER_PENDING under a *foreign* migration id (an operator
+    # migration in flight), so resolution will not auto-complete it.
+    authority.begin_cutover("held-by-operator-migration")
+
+    permit = authority.issue_write_permit()
+    assert permit.destination is LayoutDestination.LEGACY  # unresolved, still pending
+
+    waited: list[int] = []
+    wrote: list[object] = []
+
+    # No publish during the wait -> the write surfaces LOUDLY, never silently written.
+    with pytest.raises(LayoutCutoverIncompleteError):
+        authority.execute_write(
+            permit,
+            lambda p: wrote.append(p.destination),
+            test_hooks=LayoutTestHooks(before_revalidate=lambda _p: waited.append(1)),
+        )
+    assert waited  # it blocked-and-retried (bounded), not an instant silent LEGACY write
+    assert wrote == []  # the writer never ran against a LEGACY permit
+
+
+def test_live_write_lands_in_project_store_when_publish_races_the_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+    authority.begin_cutover("held-by-operator-migration")
+
+    published: list[bool] = []
+
+    def _publish_mid_wait(_permit: object) -> None:
+        if not published:
+            published.append(True)
+            authority.publish_project_only("held-by-operator-migration", verify_exact=lambda: True)
+
+    wrote: list[LayoutDestination] = []
+    permit = authority.issue_write_permit()
+    authority.execute_write(
+        permit,
+        lambda p: wrote.append(p.destination),
+        test_hooks=LayoutTestHooks(before_revalidate=_publish_mid_wait),
+    )
+    # Redirected to the project store exactly once (not dropped, not double-written).
+    assert wrote == [LayoutDestination.PROJECT_STORE]
+
+
+# --- T014: SPEC_KITTY_NO_AUTO_CUTOVER -> loud actionable refusal, no mutation --
+
+
+def test_escape_hatch_on_legacy_data_root_refuses_loudly_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(spec_dir / "queue.db", (("evt-x", {"payload": {"n": 1}}),))
+    monkeypatch.setenv("SPEC_KITTY_NO_AUTO_CUTOVER", "1")
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    assert not authority.record_path.exists()
+    with pytest.raises(LayoutAutoCutoverRefusedError) as excinfo:
+        authority.resolve_layout_for_write()
+    assert "sync project-store-migrate" in str(excinfo.value)
+
+    # No mutation: no begin_cutover, no record persisted, nothing captured.
+    assert not authority.record_path.exists()
+    assert _journal_ids(store) == set()
+
+
+def test_escape_hatch_still_allows_greenfield_journaling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setenv("SPEC_KITTY_NO_AUTO_CUTOVER", "1")
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    # The hatch suppresses auto-cutover of legacy data, NOT greenfield journaling.
+    state = authority.resolve_layout_for_write()
+    assert state.mode is LayoutMode.PROJECT_ONLY
+    with store.unit_of_work() as unit:
+        journal = EventJournal(unit, store.layout_generation())
+        journal.append(_event("evt-green"))
+    assert _journal_ids(store) == {"evt-green"}
+
+
+def test_escape_hatch_still_completes_an_already_begun_cutover(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(spec_dir / "queue.db", (("evt-inflight", {"payload": {"n": 1}}),))
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+    migration_id = authority.auto_migration_id()
+    authority.begin_cutover(migration_id)  # migration already authorized
+
+    # The hatch gates *initiating* auto-cutover, not *finishing* one already begun.
+    monkeypatch.setenv("SPEC_KITTY_NO_AUTO_CUTOVER", "1")
+    state = authority.resolve_layout_for_write()
+    assert state.mode is LayoutMode.PROJECT_ONLY
+    assert _journal_ids(store) == {"evt-inflight"}
+
+
+# --- T015: detection-before-persist via the real reader -----------------------
+
+
+def test_detects_greenfield_for_absent_empty_and_malformed_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    authority = ProjectSyncStore(OWNER).layout_generation()
+
+    # (a) absent queue dir -> greenfield
+    assert authority.has_legacy_data() is False
+
+    # (b) present-but-empty scoped DB -> not legacy data awaiting migration
+    _seed_queue(spec_dir / "queues" / "queue-abababababababab.db", ())
+    assert authority.has_legacy_data() is False
+
+    # (c) malformed filename -> skipped, still greenfield
+    _seed_queue(spec_dir / "queues" / "queue-notahex.db", (("ghost", {"payload": {}}),))
+    assert authority.has_legacy_data() is False
+
+    # (d) a real scoped DB with a queued row -> legacy data present
+    _seed_queue(spec_dir / "queues" / "queue-cdcdcdcdcdcdcdcd.db", (("evt", {"payload": {}}),))
+    assert authority.has_legacy_data() is True
+
+
+def test_detects_legacy_data_in_the_legacy_queue_db(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    authority = ProjectSyncStore(OWNER).layout_generation()
+    _seed_queue(spec_dir / "queue.db", (("evt-legacy", {"payload": {}}),))
+    assert authority.has_legacy_data() is True
+
+
+# --- T016: lazy auto-cutover invoking the canonical engine --------------------
+
+
+def test_auto_cutover_copies_via_canonical_engine_and_publishes_project_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec_dir = _isolate(tmp_path, monkeypatch)
+    _seed_queue(
+        spec_dir / "queues" / "queue-1111111111111111.db",
+        (("evt-owned", {"payload": {"n": 1}, "project_uuid": OWNER}),),
+    )
+    _seed_queue(spec_dir / "queue.db", (("evt-ownerless", {"payload": {"n": 2}}),))
+    store = ProjectSyncStore(OWNER)
+    authority = store.layout_generation()
+
+    state = authority.resolve_layout_for_write()
+
+    assert state.mode is LayoutMode.PROJECT_ONLY
+    assert state.migration_id is None
+    # Conservation via the canonical engine: every legacy event, incl. ownerless.
+    assert _journal_ids(store) == {"evt-owned", "evt-ownerless"}

--- a/tests/sync/test_layout_cutover.py
+++ b/tests/sync/test_layout_cutover.py
@@ -45,7 +45,7 @@ from specify_cli.sync.layout_generation import (
 )
 from specify_cli.sync.project_store import ProjectSyncStore
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.fast
 
 OWNER = "cccccccc-0000-0000-0000-000000000003"
 OTHER_OWNER = "dddddddd-0000-0000-0000-000000000004"

--- a/tests/sync/test_layout_generation.py
+++ b/tests/sync/test_layout_generation.py
@@ -17,6 +17,7 @@ from specify_cli.sync.layout_generation import (
     LayoutMode,
     LayoutTestHooks,
     LayoutVerificationError,
+    LayoutWritePermit,
     StaleLayoutWritePermitError,
 )
 from specify_cli.sync.project_store import ProjectSyncStore
@@ -30,6 +31,30 @@ PROJECT_UUID = "aaaaaaaa-0000-0000-0000-000000000001"
 def _store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ProjectSyncStore:
     monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
     return ProjectSyncStore(PROJECT_UUID)
+
+
+def _legacy_generation_permit(
+    store: ProjectSyncStore,
+    authority: LayoutGenerationAuthority,
+) -> LayoutWritePermit:
+    """Bind a permit to the machine's initial legacy generation.
+
+    Post cutover-flip (WP03/IC-02) ``issue_write_permit`` is the write-path
+    resolution seam: on a greenfield root it publishes ``project_only`` *before*
+    any legacy persist, and on a legacy-data root it auto-migrates — so it no
+    longer hands back a raw ``LEGACY`` permit. These barrier tests exercise how
+    ``execute_write`` treats a permit a writer obtained *under the legacy
+    generation, before cutover advanced*. ``read_state`` establishes that
+    generation on disk (mode ``legacy``, generation 1) and we bind a permit to it
+    directly, modelling exactly that pre-cutover writer.
+    """
+    state = authority.read_state()
+    assert state.mode is LayoutMode.LEGACY
+    return LayoutWritePermit(
+        project_uuid=store.project_uuid,
+        generation=state.generation,
+        destination=LayoutDestination.LEGACY,
+    )
 
 
 def test_layout_authority_can_only_be_constructed_by_project_store(
@@ -88,7 +113,7 @@ def test_cutover_requires_exact_verification_and_project_only_has_no_legacy_path
 ) -> None:
     store = _store(tmp_path, monkeypatch)
     authority = store.layout_generation()
-    legacy = authority.issue_write_permit()
+    legacy = _legacy_generation_permit(store, authority)
     assert legacy.destination is LayoutDestination.LEGACY
     assert legacy.project_uuid == store.project_uuid
     assert legacy.redirect_count == 0
@@ -121,14 +146,14 @@ def test_stale_permit_never_reaches_insert_and_redirects_exactly_once(
 ) -> None:
     store = _store(tmp_path, monkeypatch)
     authority = store.layout_generation()
-    stale = authority.issue_write_permit()
+    stale = _legacy_generation_permit(store, authority)
     authority.begin_cutover("migration-1")
     authority.publish_project_only("migration-1", verify_exact=lambda: True)
 
     with pytest.raises(StaleLayoutWritePermitError):
         authority.revalidate(stale)
 
-    inserts = []
+    inserts: list[LayoutWritePermit] = []
     refreshed = authority.execute_write(stale, inserts.append)
     assert inserts == [refreshed]
     assert refreshed.destination is LayoutDestination.PROJECT_STORE
@@ -136,7 +161,7 @@ def test_stale_permit_never_reaches_insert_and_redirects_exactly_once(
     assert refreshed.generation == authority.read_state().generation
 
     already_redirected = replace(stale, redirect_count=1)
-    unexpected_inserts = []
+    unexpected_inserts: list[LayoutWritePermit] = []
     with pytest.raises(StaleLayoutWritePermitError):
         authority.execute_write(already_redirected, unexpected_inserts.append)
     assert unexpected_inserts == []
@@ -148,10 +173,10 @@ def test_writer_racing_generation_advance_is_redirected_without_loss_or_double_w
 ) -> None:
     store = _store(tmp_path, monkeypatch)
     authority = store.layout_generation()
-    writer_a_permit = authority.issue_write_permit()
+    writer_a_permit = _legacy_generation_permit(store, authority)
     permit_acquired = threading.Event()
     allow_revalidation = threading.Event()
-    inserted = []
+    inserted: list[LayoutWritePermit] = []
     failures: list[BaseException] = []
 
     def pause_after_permit(_permit: object) -> None:
@@ -192,12 +217,12 @@ def test_writer_first_holds_layout_lock_until_legacy_insert_finishes(
 ) -> None:
     store = _store(tmp_path, monkeypatch)
     authority = store.layout_generation()
-    permit = authority.issue_write_permit()
+    permit = _legacy_generation_permit(store, authority)
     writer_entered = threading.Event()
     release_writer = threading.Event()
     cutover_attempting = threading.Event()
     cutover_done = threading.Event()
-    inserts = []
+    inserts: list[LayoutWritePermit] = []
     failures: list[BaseException] = []
 
     def writer_callback(candidate: object) -> None:
@@ -250,9 +275,11 @@ def test_published_record_loss_fails_closed_without_legacy_reset(
 ) -> None:
     store = _store(tmp_path, monkeypatch)
     authority = store.layout_generation()
-    authority.issue_write_permit()
-    authority.begin_cutover("migration-1")
-    authority.publish_project_only("migration-1", verify_exact=lambda: True)
+    # Post-flip, the first write on a greenfield root resolves straight to
+    # project_only (auto-published before any legacy persist), which writes both
+    # the authority record and its durable initialization marker.
+    permit = authority.issue_write_permit()
+    assert permit.destination is LayoutDestination.PROJECT_STORE
     assert authority.marker_path.is_file()
     authority.record_path.unlink()
 

--- a/tests/sync/test_migration_writer_barrier.py
+++ b/tests/sync/test_migration_writer_barrier.py
@@ -7,13 +7,17 @@ import os
 import sqlite3
 import subprocess
 import sys
-import threading
 from pathlib import Path
 from typing import cast
 
 import pytest
 
-from specify_cli.sync.layout_generation import LayoutDestination, LayoutMode
+from specify_cli.sync.layout_generation import (
+    LayoutDestination,
+    LayoutMode,
+    LayoutTestHooks,
+    LayoutWritePermit,
+)
 from specify_cli.sync.daemon_protocol import (
     DaemonCutoverProtocol,
     QuiesceAcknowledgement,
@@ -211,7 +215,17 @@ def test_writer_redirects_once_when_cutover_wins(
     monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
     store = ProjectSyncStore(PROJECT)
     authority = store.layout_generation()
-    permit = authority.issue_write_permit()
+    # Post cutover-flip (WP03/IC-02) ``issue_write_permit`` no longer hands back a
+    # raw LEGACY permit — it resolves greenfield roots straight to project_only.
+    # Bind a permit to the legacy generation directly to model a writer that
+    # obtained it before cutover advanced, which is what this barrier exercises.
+    state = authority.read_state()
+    assert state.mode is LayoutMode.LEGACY
+    permit = LayoutWritePermit(
+        project_uuid=store.project_uuid,
+        generation=state.generation,
+        destination=LayoutDestination.LEGACY,
+    )
     assert permit.destination is LayoutDestination.LEGACY
     authority.begin_cutover("migration-writer")
     authority.publish_project_only("migration-writer", verify_exact=lambda: True)
@@ -241,7 +255,7 @@ def test_commit_immediately_before_cutover_is_in_winning_snapshot(
         )
         connection.commit()
         connection.close()
-        return original(cast("object", manifest), hooks=hooks)  # type: ignore[arg-type]
+        return original(manifest, hooks=hooks)
 
     monkeypatch.setattr(migration, "_cutover", commit_then_cutover)
     completed = migration.migrate("migration-late-before-cutover")
@@ -258,68 +272,62 @@ def test_writer_waiting_post_verify_redirects_once_after_publication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
-    source = tmp_path / "legacy.db"
-    _source(source)
+    """A live capture that waits out a cutover window redirects exactly once to the
+    project store after publication — it is never silently dropped to legacy (INV-5).
+
+    WP03/IC-02 replaced the old lock-blocking writer barrier with a *bounded*
+    block-and-retry whose deterministic sync point is the ``before_revalidate`` hook
+    (the migration publishes mid-wait). This reconciles the pin to that model: hold
+    the machine CUTOVER_PENDING under a foreign (operator-owned) migration id so the
+    capture resolves to a LEGACY (pending) permit, publish project_only during the
+    wait, and assert the event lands in the project store — a capture only succeeds
+    against a project_store permit — with no legacy db left behind.
+    """
+    from specify_cli.event_journal.journal import EventJournal
+    from specify_cli.event_journal.models import Event
+
+    runtime = tmp_path / "runtime"
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(runtime))
     store = ProjectSyncStore(PROJECT)
     authority = store.layout_generation()
-    permit = authority.issue_write_permit()
-    entered = threading.Event()
-    finished = threading.Event()
+    authority.begin_cutover("held-by-operator-migration")
+
     observed: list[LayoutDestination] = []
 
-    def writer(current: object) -> None:
-        destination = cast("object", current).destination  # type: ignore[attr-defined]
-        observed.append(destination)
-        if destination is not LayoutDestination.PROJECT_STORE:
-            raise AssertionError("post-verify writer was not redirected")
-        connection = sqlite3.connect(store.database_path)
-        epoch_id = int(connection.execute("SELECT MAX(epoch_id) FROM consent_epochs").fetchone()[0])
-        sequence = int(connection.execute("SELECT COALESCE(MAX(capture_sequence), 0) + 1 FROM journal_entries").fetchone()[0])
-        connection.execute(
-            "INSERT INTO journal_entries "
-            "(entry_id, project_uuid, epoch_id, capture_sequence, payload_json, created_at) "
-            "VALUES ('event-redirected', ?, ?, ?, ?, '2026-08-01T00:00:02Z')",
-            (PROJECT, epoch_id, sequence, json.dumps({"event_id": "event-redirected", "project_uuid": PROJECT})),
-        )
-        connection.execute(
-            "INSERT INTO capture_sequences (project_uuid, next_sequence) VALUES (?, ?) "
-            "ON CONFLICT(project_uuid) DO UPDATE SET next_sequence = excluded.next_sequence",
-            (PROJECT, sequence),
-        )
-        connection.commit()
-        connection.close()
+    def publish_mid_wait(permit: LayoutWritePermit) -> None:
+        if observed:
+            return
+        observed.append(permit.destination)
+        authority.publish_project_only("held-by-operator-migration", verify_exact=lambda: True)
 
-    def run_writer() -> None:
-        entered.set()
-        authority.execute_write(permit, writer)
-        finished.set()
-
-    thread: threading.Thread | None = None
-
-    def start_waiting_writer() -> None:
-        nonlocal thread
-        thread = threading.Thread(target=run_writer)
-        thread.start()
-        assert entered.wait(timeout=2)
-        assert not finished.is_set(), "writer crossed the machine lock before publication"
-
-    LegacyProjectStoreMigration(tmp_path / "runtime", (source,)).migrate(
-        "migration-continuous-lock",
-        hooks=MigrationTestHooks(before_project_only_publish=start_waiting_writer),
+    event = Event(
+        event_id="event-redirected",
+        event_type="WPStatusChanged",
+        payload=json.dumps({"event_id": "event-redirected", "project_uuid": PROJECT}).encode(),
+        occurred_at="2026-08-01T00:00:02+00:00",
+        created_at="2026-08-01T00:00:02+00:00",
+        project_uuid=PROJECT,
+        project_slug="continuous-lock",
+        repo_slug="continuous-lock",
     )
-    assert thread is not None
-    thread.join(timeout=5)
-    assert finished.is_set()
-    assert observed == [LayoutDestination.PROJECT_STORE]
+
+    with store.unit_of_work() as unit:
+        receipt = EventJournal(unit, authority).append(
+            event,
+            test_hooks=LayoutTestHooks(before_revalidate=publish_mid_wait),
+        )
+        assert EventJournal(unit, authority).count() == 1
+
+    # The permit the capture waited on was LEGACY (pending); after publication the
+    # write redirected once and landed against a project_store permit.
+    assert observed == [LayoutDestination.LEGACY]
+    assert receipt.inserted is True
     with ProjectSyncStore(PROJECT).unit_of_work() as unit:
-        assert unit.execute("SELECT entry_id FROM journal_entries ORDER BY entry_id").fetchall() == [
-            ("event-1",),
-            ("event-redirected",),
-        ]
-    connection = sqlite3.connect(source)
-    assert connection.execute("SELECT event_id FROM event_journal ORDER BY event_id").fetchall() == [("event-1",)]
-    connection.close()
+        assert unit.execute(
+            "SELECT entry_id FROM journal_entries ORDER BY entry_id"
+        ).fetchall() == [("event-redirected",)]
+    # Only the project store db exists — nothing was dropped to a legacy queue.
+    assert list(runtime.rglob("*.db")) == [store.database_path]
 
 
 def test_new_migration_identity_cannot_rematerialize_post_cutover_residue(

--- a/tests/sync/test_target_authority.py
+++ b/tests/sync/test_target_authority.py
@@ -345,14 +345,22 @@ url = "{CONFIG_URL}"
 """.strip(),
         encoding="utf-8",
     )
-    # The resolver derives the same opaque scope from the URL + identity, while
-    # retired credentials metadata is no longer consulted as live authority.
+    # The resolver derives the same opaque scope from the URL + identity. With
+    # credential parsing restored (#3425 revert-guard, queue.py
+    # ``read_queue_scope_from_credentials``), the credentials file now yields a
+    # visible piped "server|user|team" auth signal — a different string shape
+    # than the sha256 ``derived_queue_scope`` — so the diagnostic status is
+    # STALE_NON_AUTHORITATIVE (visible-but-non-matching), not ABSENT. That still
+    # satisfies "not a live target authority": the cached value is a diagnostic
+    # only and never drives ``queue_db_path``, which stays derived purely from
+    # the resolved URL + identity (proven by the T004 physical-store invariance
+    # test in tests/sync/test_credential_scope_signal.py).
     expected = build_queue_scope(
         server_url=CONFIG_URL, username="alice@example.com", team_slug="team-red"
     )
     target = resolve_sync_target(user_id="alice@example.com", team_slug="team-red")
     assert target.derived_queue_scope == expected
-    assert target.active_queue_scope_status is QueueScopeStatus.ABSENT
+    assert target.active_queue_scope_status is QueueScopeStatus.STALE_NON_AUTHORITATIVE
 
 
 def test_session_scope_read_returning_value_is_consulted(


### PR DESCRIPTION
## Un-migrated machines stop silently capturing nothing

If you run Spec Kitty on a machine that never ran the layout migration, the event
journal **silently captured zero events while reporting success** (#3425): the root
defaulted to a legacy capture layout, every live write was refused deep in the stack,
and the refusal was swallowed to a stderr-only warning. A separate #3293 regression
also refused genuinely-authenticated hosts at the setup-plan gate.

This lands the fix end-to-end, plus three folded siblings on the same surface.

### What changed

- **Credentials (auth signal, no revert):** `read_queue_scope_from_credentials` is
  restored to parse the supported credential form as a **boolean auth signal only** — it
  does **not** re-introduce credential→store-path derivation, so #3293's ProjectSyncStore
  selection is preserved (`queue.py`, `mission_setup_plan.py`).
- **Layout resolution + crash-safe cutover:** fresh roots resolve to `project_only`
  **before** any LEGACY state is persisted; legacy-with-data roots **auto-migrate** by
  reusing the canonical `migrate_journal` / `project_store_migration` engines with a
  **deterministic, root-derived `migration_id`** and crash-safe re-entry (a crash between
  begin and publish converges on the next run — **never bricks** a root). The
  `CUTOVER_PENDING` drop window is closed: live writes block-and-retry within a bounded
  wait, else surface loudly (`LayoutCutoverIncompleteError`) — **never a silent LEGACY
  swallow** (`layout_generation.py`).
- **Emitter observability + live-path completion (folds #3391):** both swallow sites are
  made observable via a process-level captured-failure flag + read API (the `_emit`
  never-raises contract and the ~30 `emit_*` signatures are untouched; the loud path is
  rate-limited). A **resolve-before-UoW** seam completes legacy-with-data cutover on the
  live emit path (the layout `FileLock` is not re-entrant inside an open write
  unit-of-work) (`emitter.py`).
- **Single authoritative record (folds #2846):** cutover copy deduplicates by
  `(event_id, source_digest)`, attributes a `project_uuid` to ownerless legacy rows, and
  **quarantines** divergent payloads rather than last-write-win (`migrate_journal.py`).
- **Loud cutover/backfill (folds #3476):** `backfill-runtime-state` surfaces a
  write-that-cannot-land as an actionable non-zero failure with an honest
  `CutoverResult.error`, while a legitimate already-migrated no-op / dry-run stays quiet
  (`migrate_cmd.py`, `migration/*`).
- **Reproductions + reconcile:** the mis-built #3425 red-first tests are rewritten to the
  real ProjectSyncStore contract (attribution corrected to `journal.py`'s
  `ProjectLayoutRequiredError`) **keeping the conservation + warning-absence pins**, and
  the LEGACY-default test set is reconciled to the new project-only default.

### Testing

All work was **red-first** and **temp-root isolated** (`SPEC_KITTY_HOME`/`HOME` fixtures;
the machine-global store is never touched). The mission's 75-test surface (the 3 #3425
reproductions, the blocking regression selection, and the reconciled `tests/sync` +
`tests/event_journal` set) passes on this base:

```
tests/regression/test_issue_3425_* + tests/sync/* + tests/event_journal/test_project_store_journal.py
75 passed
```

Built with the Spec Kitty mission workflow (spec → plan → tasks → implement → review →
merge) with two adversarial-squad passes; the mission record (spec/plan/tasks/research/
data-model/WP prompts) is included under `kitty-specs/legacy-journal-capture-cutover-01M03BSX/`.

### Scope / deferrals

Honest `sync now` convergence (#3278) is **deferred** — the code proves it requires
*deleting* migrated legacy rows, which reopens the legacy-`queue.db` retirement (#2750,
out of scope); auto-migration hardening (#2688) is likewise deferred. Each is tracked as a
follow-up in the issue-matrix.

Closes #3425
Closes #2846
Closes #3391
Closes #3476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789465971&installation_model_id=427282&pr_number=3497&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3497&signature=66456d866cf221cdb7527bf4ab023888eaf55a86fca4e13563796cb5ed8bbcbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->