### PR TITLE
feat(doctrine): internal org-tier doctrine pack + pack-ownership ADRs

### DIFF
--- a/.kittify/config.yaml
+++ b/.kittify/config.yaml
@@ -25,3 +25,11 @@ mission_type_activations:
 - documentation
 - research
 - plan
+# Internal (maintainer-only) org-tier doctrine pack — catfooding the pack approach.
+# Repo-local; loaded as an overlay on built-in. NOT shipped to consumers (the wheel
+# force-include is scoped to packs/built-in — see pyproject.toml).
+doctrine:
+  org:
+    packs:
+    - name: internal
+      local_path: packs/internal

--- a/docs/adr/3.x/2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md
+++ b/docs/adr/3.x/2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md
@@ -1,0 +1,144 @@
+---
+title: 'ADR: Open-packs Is the Source of Truth for Built-in Doctrine; CI Re-vendors It Into the Core Release'
+description: 'Inverts built-in doctrine ownership: content is authored in spec-kitty-open-packs, and CI re-vendors it into the core wheel at release so consumers see no change.'
+status: Accepted
+date: '2026-08-16'
+related:
+- docs/adr/3.x/2026-04-25-1-shared-package-boundary.md
+- docs/adr/3.x/2026-05-16-1-doctrine-layer-merge-semantics.md
+- docs/adr/3.x/2026-08-16-1-pack-metadata-manifest-unification.md
+- docs/adr/3.x/2026-05-24-3-shipped-to-built-in-cutover.md
+---
+
+# Open-packs Is the Source of Truth for Built-in Doctrine; CI Re-vendors It Into the Core Release
+
+**Filename:** `2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md`
+
+**Status:** Accepted
+
+**Date:** 2026-08-16
+
+**Deciders:** Maintainer
+
+**Technical Story:** Internal doctrine-pack initiative; grounds on core #2196 (catfooding) and the open-packs catalog. Depends on the open-packs distribution umbrella (#2466) and the pack manifest schema / validator / checksum work (#2467, #2471, #2539/#2543). Supersedes the "built-in is authored in core" assumption carried by mission `relocate-builtin-doctrine-packs-01KYT87F`.
+
+---
+
+## Context and Problem Statement
+
+Built-in doctrine content today is authored **inside** the core repository at
+`packs/built-in/` and shipped to consumers by force-inclusion in the PyPI wheel
+(mission `relocate-builtin-doctrine-packs-01KYT87F` relocated it there from
+`src/doctrine/**` and drew the shared `resolve_pack_root(tier)` seam). The
+`spec-kitty-open-packs` repository was created to be the **canonical, curated,
+community-friendly publishing home** for doctrine packs — its own vision statement
+frames the monolithic built-in bundle as *the problem* open-packs answers, yet its
+"division of responsibility" table still keeps built-in authored in core while
+open-packs only carves *additive* slices from it.
+
+That leaves the ownership of built-in content ambiguous and split: the place that
+is meant to be the curation home (open-packs) is not the source, and the place that
+is not meant to own content (core) is. We want a single, unambiguous source of truth
+for doctrine **content**, without changing anything a consumer experiences (built-in
+must still arrive, transparently, with a normal `pip install`).
+
+The mechanics of doctrine — the resolver, DRG merge, charter activation, and the
+validator — are deliberately **out of scope**: they stay in core (per the open-packs
+vision and the doctrine-layer-merge-semantics ADR). This decision is only about where
+the built-in **content** is authored and how it reaches the shipped artifact.
+
+## Decision Drivers
+
+* One unambiguous source of truth for doctrine content — the curation home, not core.
+* Consumer experience unchanged: built-in still ships in the core wheel, transparently.
+* Reuse the already-built resolution seam (`resolve_pack_root("built-in")` is a
+  filesystem ancestor-walk); do not force a runtime resolver rewrite.
+* Keep doctrine *mechanics* in core; move only *content*.
+* Honour the graduated-trust direction (checksum-verifiable packs) rather than an
+  opaque copy.
+
+## Considered Options
+
+* **A — Status quo:** built-in authored in core; open-packs adds only additive org slices.
+* **B — Invert with CI re-vendor (chosen):** built-in content authored in open-packs;
+  a release-time CI step vendors it into `packs/built-in/` before `hatch build`, so the
+  wheel still force-includes it. Resolution is unchanged because it is filesystem-based.
+* **C — Published data dependency:** built-in ships as a separate PyPI data package
+  (e.g. `spec-kitty-doctrine`) that core depends on and resolves at runtime from the
+  installed dependency.
+
+## Decision Outcome
+
+**Chosen option: "B — Invert with CI re-vendor",** because it makes open-packs the
+single source of truth for content while leaving the consumer install, the runtime
+resolver, and the core mechanics untouched. Built-in remains present on disk at build
+time (satisfying the parity and corpus gates) and in the wheel (satisfying consumers),
+but its **canonical origin** becomes the open-packs catalog. Option C is the eventual
+"north star" but requires the dormant nested-doctrine-wheel groundwork
+(`src/doctrine/hatch_build.py`, guarded dormant by `test_doctrine_wheel_closure.py`) to
+become a real published package plus a resolver that finds packs inside an installed
+dependency — a larger lift deferred until the manifest/checksum work (#2467/#2539) lands.
+Option A is rejected because it permanently contradicts the open-packs vision and leaves
+content ownership split.
+
+### Consequences
+
+#### Positive
+
+* Single curation home; contributors and SK Inc. maintain built-in where the catalog,
+  docsite, and validator already live.
+* Consumers see no change — same `pip install`, same force-included `packs/built-in/`.
+* The runtime resolver, DRG merge, and charter activation are untouched.
+
+#### Negative
+
+* Core's release now has a **build-time dependency** on open-packs (a checkout/copy step
+  before `hatch build`); a broken or unpinned open-packs breaks the core release.
+* Release reproducibility now depends on a **pinned open-packs ref** (tag or SHA), which
+  must be recorded and verified (ideally by checksum) at build time.
+* Parity/corpus gates (`test_packaging_parity.py`, the `packs`-triggered CI jobs) assume
+  `packs/built-in/` is present in-tree; the vendor step must complete before they run,
+  and contributor checkouts need a documented way to materialize built-in locally.
+* Runs against the direction of the shared-package-boundary ADR (which retired vendored
+  *code* in favour of a published dependency). Packs are **data, not code**, so that ADR
+  does not bind — but the tension is real and Option C remains the longer-term resolution.
+
+#### Neutral
+
+* `packs/built-in/` continues to exist in the core tree; only its provenance changes.
+
+### Confirmation
+
+Success = (1) built-in content has exactly one authoritative copy (open-packs), pinned by
+ref/checksum in the core release; (2) a released wheel's `packs/built-in/` is byte-identical
+to the pinned open-packs content; (3) `test_packaging_parity.py` and the corpus jobs stay
+green against the vendored tree; (4) consumers observe no behavioural change. **Not yet
+built** — this ADR ratifies direction; the implementation is a separate epic gated on
+open-packs CI scaffolding (none exists today) and the manifest/checksum dependencies above.
+
+## Pros and Cons of the Options
+
+### A — Status quo (built-in in core)
+
+**Pros:** No build-time coupling; simplest release; reproducible from one repo.
+**Cons:** Content ownership stays split; contradicts the open-packs vision; two curation
+surfaces for the same corpus.
+
+### B — Invert with CI re-vendor
+
+**Pros:** Single source of truth; unchanged consumer + runtime; reuses the filesystem seam.
+**Cons:** Build-time dependency on open-packs; release must pin + verify a ref; local
+checkouts need a materialize step.
+
+### C — Published data dependency
+
+**Pros:** Cleanest boundary; aligns with the shared-package-boundary philosophy; no vendoring.
+**Cons:** Largest lift — needs the dormant doctrine wheel productionized and a resolver that
+reads packs from an installed dependency; blocked on manifest/checksum work.
+
+## More Information
+
+* Open-packs vision: `spec-kitty-open-packs/docs/architecture/vision.md` (division-of-responsibility
+  table is amended by this ADR: built-in *content* now originates in open-packs).
+* Blockers: `spec-kitty-open-packs/docs/research/blockers-and-core-dependencies.md` (#2466/#2467/#2471/#2539).
+* Companion decision: `2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md`.

--- a/docs/adr/3.x/2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md
+++ b/docs/adr/3.x/2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md
@@ -1,0 +1,138 @@
+---
+title: 'ADR: spec-kitty-internal Is One Public Org Pack, Consumed via the Org Tier, Never Force-Shipped'
+description: 'The internal maintainer pack is one public artifact (open-packs catalog #16), consumed as an org-tier pack and kept out of the core wheel — not secret, just not shipped.'
+status: Accepted
+date: '2026-08-16'
+related:
+- docs/adr/3.x/2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md
+- docs/adr/3.x/2026-05-16-1-doctrine-layer-merge-semantics.md
+- docs/adr/3.x/2026-05-24-2-pack-augmentation-vocabulary.md
+---
+
+# spec-kitty-internal Is One Public Org Pack, Consumed via the Org Tier, Never Force-Shipped
+
+**Filename:** `2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md`
+
+**Status:** Accepted
+
+**Date:** 2026-08-16
+
+**Deciders:** Maintainer
+
+**Technical Story:** Internal doctrine-pack initiative. The open-packs catalog proposal already scopes `spec-kitty-internal` as base pack #16 (public, "so contributors and downstream teams can adopt or study it"), grounded in core #2196. A repo-local `packs/internal/` first step was built on branch `feat/internal-pack`.
+
+---
+
+## Context and Problem Statement
+
+Spec Kitty wants an **internal** doctrine pack + org charter that governs how the
+core team works on the project itself (PR-landing, tracker processing, keeping main
+honest, the internal glossary), stated as "**not shipped to our consumers**" — yet
+also "**built in the open**" as "an example for our user-base." Read literally these
+pull in opposite directions: private vs. public.
+
+Separately, the open-packs catalog already scopes a pack for exactly this slot —
+`spec-kitty-internal` (base pack #16), framed as **public and studyable**. Building a
+second, private pack would **duplicate** #16 and its `org-charter.yaml`, and force a
+policy for what is secret vs. public.
+
+We must decide whether `spk-internal` is a distinct private artifact or the same
+public pack #16, and what "not shipped to consumers" actually constrains.
+
+## Decision Drivers
+
+* Avoid duplicating catalog pack #16 and its charter.
+* Reconcile "build in the open" with "not shipped to consumers".
+* Keep the public built-in product context clean — maintainer doctrine must not flood
+  every consumer's LLM session.
+* Reuse the already-built org-tier consumption path (no new plumbing).
+
+## Considered Options
+
+* **A — Distinct private pack:** a maintainer-only pack that never appears in the public
+  catalog.
+* **B — One public org pack, not force-shipped (chosen):** `spk-internal` **is** catalog
+  pack #16 — authored in the open in open-packs (studyable), consumed by SK-Inc projects
+  as an **org-tier** pack via `.kittify/config.yaml`, and **never force-included** in the
+  core consumer wheel. "Not shipped" == not in the wheel; **not** == secret.
+* **C — Ship it like built-in:** force-include the internal pack in the wheel alongside
+  `packs/built-in/`.
+
+## Decision Outcome
+
+**Chosen option: "B — One public org pack, not force-shipped."** There is one artifact,
+not two: the open-packs catalog pack #16 `spec-kitty-internal`. It is developed publicly
+(anyone may study or adopt it), and SK-Inc projects consume it as an **org-tier** pack —
+the merged org-pack loader, `subdir:` support, and `${ENV}`/`~` indirection already make
+this a config entry, not new code. It is deliberately **excluded from the core wheel**:
+`pyproject.toml`'s `force-include` and sdist globs are scoped to `packs/built-in/` so a
+consumer's default install never inherits maintainer doctrine, keeping their context clean.
+This precisely reconciles "built in the open" (public source) with "not shipped to
+consumers" (absent from the distributed artifact).
+
+The repo-local `packs/internal/` created as the first step is a **transitional staging
+location** inside the core repo; its permanent home is the open-packs catalog (per the
+companion ADR `2026-08-16-2`, which makes open-packs the source of truth for pack content).
+
+Option A is rejected (duplicates #16, needs a secrecy policy for no real benefit — the
+content is not sensitive, only context-noisy). Option C is rejected (pollutes every
+consumer's default context with maintainer-only doctrine — the exact problem the pack
+system exists to solve).
+
+### Consequences
+
+#### Positive
+
+* One artifact, one `org-charter.yaml`; no duplication.
+* Consumers keep a clean default context; SK-Inc projects opt in explicitly.
+* Reuses the org tier — a config entry, not new plumbing.
+* The pack is public and studyable, serving as the worked example for the user base.
+
+#### Negative
+
+* "Not shipped" is enforced only by the packaging-scope guard; a future whole-tree
+  `force-include` regression would re-leak it. Mitigated by
+  `tests/cross_cutting/packaging/test_packaging_safety.py` (tightened to `packs/built-in/`
+  with an explicit "internal must not ship" assertion).
+* SK-Inc projects must each register the org pack (via `.kittify/config.yaml`, or a seeded
+  `spec-kitty init` default) — there is no auto-broadcast to "all projects" today.
+
+#### Neutral
+
+* The internal pack's content overlaps maintainer doctrine already in built-in; the pack
+  **references** those via DRG edges rather than re-authoring them.
+
+### Confirmation
+
+Success = (1) exactly one `spec-kitty-internal` pack exists (open-packs #16); (2) it never
+appears in a released wheel (guard test green; a real wheel build shows 0 `packs/internal/`
+files while `packs/built-in/` ships fully — verified for the first-step scaffold); (3)
+SK-Inc projects load it as a healthy org layer (`doctor doctrine` reports it with resolved
+edges, no dangling/collisions — verified for the first-step scaffold).
+
+## Pros and Cons of the Options
+
+### A — Distinct private pack
+
+**Pros:** Clean secrecy story.
+**Cons:** Duplicates #16 + its charter; needs a private-vs-public policy; no real benefit
+since the content is not sensitive.
+
+### B — One public org pack, not force-shipped
+
+**Pros:** No duplication; clean consumer context; reuses org tier; public/studyable.
+**Cons:** Non-shipment relies on a packaging guard; no auto-broadcast to all SK-Inc projects.
+
+### C — Ship it like built-in
+
+**Pros:** Auto-present everywhere.
+**Cons:** Floods every consumer's context with maintainer-only doctrine — defeats the pack
+system's purpose.
+
+## More Information
+
+* First step: `packs/internal/` scaffold on branch `feat/internal-pack` (glossary_pack +
+  `landing-contributor-prs` procedure + `drg/fragment.yaml` + `org-charter.yaml`), packaging
+  scoped to `packs/built-in`, guard test tightened.
+* Companion decision (source of truth + re-vendor): `2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md`.
+* Catalog: `spec-kitty-open-packs/docs/packs/catalog-proposal.md` (pack #16).

--- a/docs/adr/3.x/index.md
+++ b/docs/adr/3.x/index.md
@@ -183,3 +183,5 @@ Use the shared template at [`docs/architecture/adr-template.md`](../../architect
 | 2026-08-13 | [Mission-Type Roster Layering Is the Availability Slice, Not the Kind-Promotion Slice](2026-08-13-1-mission-type-roster-layering-seam.md) |
 | 2026-08-15 | [Own a Tool-Agnostic, Versioned, Optional Handoff-Packet Intake Contract](2026-08-15-1-handoff-packet-intake-contract.md) |
 | 2026-08-16 | [Unify Pack Metadata on a Single Manifest — Enumerated Constituents + Delegated Lineage](2026-08-16-1-pack-metadata-manifest-unification.md) |
+| 2026-08-16 | [Open-packs Is the Source of Truth for Built-in Doctrine; CI Re-vendors It Into the Core Release](2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md) |
+| 2026-08-16 | [spec-kitty-internal Is One Public Org Pack, Consumed via the Org Tier, Never Force-Shipped](2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md) |

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -2876,6 +2876,38 @@ pages:
     - {slug: "3-lineage-delegates-never-re-walks", text: "3. Lineage delegates, never re-walks", level: 3}
     - {slug: "bridge-is-a-migration-tactic-not-a-destination", text: "Bridge is a migration tactic, not a destination", level: 3}
     - {slug: "consequences", text: "Consequences", level: 2}
+  - path: "docs/adr/3.x/2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md"
+    title: "ADR: Open-packs Is the Source of Truth for Built-in Doctrine; CI Re-vendors It Into the Core Release"
+    divio_type: "none"
+    abstract: "Inverts built-in doctrine ownership: content is authored in spec-kitty-open-packs, and CI re-vendors it into the core wheel at release so consumers see no change."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "confirmation", text: "Confirmation", level: 3}
+    - {slug: "pros-and-cons-of-the-options", text: "Pros and Cons of the Options", level: 2}
+    - {slug: "a-status-quo-built-in-in-core", text: "A — Status quo (built-in in core)", level: 3}
+    - {slug: "b-invert-with-ci-re-vendor", text: "B — Invert with CI re-vendor", level: 3}
+    - {slug: "c-published-data-dependency", text: "C — Published data dependency", level: 3}
+    - {slug: "more-information", text: "More Information", level: 2}
+  - path: "docs/adr/3.x/2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md"
+    title: "ADR: spec-kitty-internal Is One Public Org Pack, Consumed via the Org Tier, Never Force-Shipped"
+    divio_type: "none"
+    abstract: "The internal maintainer pack is one public artifact (open-packs catalog #16), consumed as an org-tier pack and kept out of the core wheel — not secret, just not shipped."
+    anchors:
+    - {slug: "context-and-problem-statement", text: "Context and Problem Statement", level: 2}
+    - {slug: "decision-drivers", text: "Decision Drivers", level: 2}
+    - {slug: "considered-options", text: "Considered Options", level: 2}
+    - {slug: "decision-outcome", text: "Decision Outcome", level: 2}
+    - {slug: "consequences", text: "Consequences", level: 3}
+    - {slug: "confirmation", text: "Confirmation", level: 3}
+    - {slug: "pros-and-cons-of-the-options", text: "Pros and Cons of the Options", level: 2}
+    - {slug: "a-distinct-private-pack", text: "A — Distinct private pack", level: 3}
+    - {slug: "b-one-public-org-pack-not-force-shipped", text: "B — One public org pack, not force-shipped", level: 3}
+    - {slug: "c-ship-it-like-built-in", text: "C — Ship it like built-in", level: 3}
+    - {slug: "more-information", text: "More Information", level: 2}
   - path: "docs/adr/3.x/README.md"
     title: "3.x ADRs"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -992,6 +992,18 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/adr/3.x/2026-08-16-2-open-packs-is-source-of-truth-for-built-in-doctrine.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/adr/3.x/2026-08-16-3-spec-kitty-internal-is-a-public-org-pack-not-force-shipped.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/adr/3.x/README.md
   tag: current
   divio_type: none

--- a/packs/internal/README.md
+++ b/packs/internal/README.md
@@ -1,0 +1,42 @@
+# `spec-kitty-internal` — org-tier doctrine pack (NOT shipped to consumers)
+
+This is Spec Kitty's own **internal** doctrine pack: the doctrine that governs
+*contributors, maintainers, and the core team* of the Spec Kitty project itself.
+It is loaded as an **org-tier** pack (registered in `.kittify/config.yaml` under
+`doctrine.org.packs`), overlaying the public `packs/built-in/` product doctrine.
+
+## Why this is a separate pack — and why it is NOT built-in
+
+- The `built-in` tier (`packs/built-in/`) is the **public product doctrine** that
+  ships to every consumer via the PyPI wheel. It is single-rooted and resolved by
+  a kernel ancestor-walk (`kernel.sibling_paths.resolve_installed_sibling`), so it
+  **cannot** host a second pack.
+- Maintainer-only doctrine (how *we* land PRs, process the tracker, keep main
+  honest, run our internal glossary) must **not** be force-shipped to consumers.
+  It is therefore an **org pack**, and `pyproject.toml` narrows the wheel/sdist
+  `packs` include to `packs/built-in/` specifically so this tree never ships.
+  `tests/cross_cutting/packaging/test_packaging_safety.py` guards that boundary.
+
+## Layout (org-tier shape — differs from `built-in`)
+
+```
+packs/internal/
+├── org-charter.yaml                          # pack name/description + required_* activation lists
+├── drg/fragment.yaml                         # SINGLE DRG fragment (org tier), not sharded *.graph.yaml
+├── glossary_packs/
+│   └── spk-internal.glossary-pack.yaml       # maintainer/engineering glossary (net-new internal terms)
+└── procedures/
+    └── landing-contributor-prs.procedure.yaml
+```
+
+## Reference, don't duplicate
+
+A lot of maintainer-flavoured doctrine already ships in `packs/built-in/`
+(`red-main-release-discipline`, `tracker-organisation-workflow`,
+`pr-agent-worktree-isolation`, `mission-tracer-files`, …). This pack **references**
+those via DRG `refines` edges rather than re-authoring them. Only genuinely
+repo-only residue (PR-landing specifics, the internal glossary) is authored here.
+
+> First-step scaffold. See the initiative synthesis for the deferred decisions
+> (built-in ownership inversion, open-packs as the permanent home, private-vs-public
+> reconciliation with catalog pack #16 `spec-kitty-internal`).

--- a/packs/internal/drg/fragment.yaml
+++ b/packs/internal/drg/fragment.yaml
@@ -1,0 +1,25 @@
+pack_name: spec-kitty-internal
+source_kind: local_path
+source_ref: packs/internal
+layer_index: 1
+provenance_marker: org
+nodes:
+  - id: spk-internal-glossary
+    kind: glossary_packs
+    title: "Spec Kitty Internal Glossary (maintainer/engineering terms)"
+    body_path: glossary_packs/spk-internal.glossary-pack.yaml
+  - id: landing-contributor-prs
+    kind: procedures
+    title: "Landing Contributor PRs (maintainer runbook)"
+    body_path: procedures/landing-contributor-prs.procedure.yaml
+edges:
+  # Reference-not-duplicate: the landing runbook refines built-in doctrine that
+  # already ships publicly, rather than re-authoring it. Targets are
+  # fully-qualified <kind>:<id> DRG URNs (singular kind), verified present in
+  # packs/built-in/.
+  - source: landing-contributor-prs
+    target: "procedure:red-main-release-discipline"
+    relation: refines
+  - source: landing-contributor-prs
+    target: "tactic:pr-agent-worktree-isolation"
+    relation: refines

--- a/packs/internal/glossary_packs/spk-internal.glossary-pack.yaml
+++ b/packs/internal/glossary_packs/spk-internal.glossary-pack.yaml
@@ -1,0 +1,121 @@
+# spk-internal.glossary-pack.yaml
+# Spec Kitty INTERNAL glossary — maintainer/engineering domain terms that govern
+# how the core team works on the project itself. These are deliberately NOT part
+# of the public product glossary (packs/built-in/glossary_packs/spec-kitty-core)
+# and must not ship to consumers. Net-new internal terms only; product terms live
+# in the built-in pack.
+id: spk-internal-glossary
+description: Spec Kitty maintainer/engineering terminology (internal, not shipped).
+provenance: org
+terms:
+  - surface: red main
+    definition: >
+      The policy that main is allowed to carry known-failing tests when they are
+      honestly documented (an ADR-tracked P0), rather than papered over. CI, not a
+      green local run, is the release authority. See built-in procedure
+      red-main-release-discipline.
+    confidence: 0.9
+    status: active
+    see_also:
+      - baseline-red gotcha
+      - release readiness
+
+  - surface: baseline-red gotcha
+    definition: >
+      The trap where a broad local test run shows red that is NOT caused by your
+      change (pre-existing known-P0 reds, CI-environment-only failures, or
+      stale-install false reds). A failure is only yours if it is red on your branch
+      AND green on the merge-base.
+    confidence: 0.9
+    status: active
+    see_also:
+      - red main
+      - stale-install false red
+
+  - surface: stale-install false red
+    definition: >
+      A false failure produced when code that shells out to the installed
+      `spec-kitty` executable runs against an out-of-date editable install; the
+      test only reflects reality after `pip install -e .`.
+    confidence: 0.85
+    status: active
+
+  - surface: landing pass
+    definition: >
+      A maintainer work session that takes one or more contributor PRs from
+      "open with red CI" to "merge-ready": claim, isolate, rebase, classify reds,
+      fold fixes, verify, post evidence, and hand off. The maintainer never merges.
+    confidence: 0.9
+    status: active
+    see_also:
+      - fold
+      - campsite cleaning
+
+  - surface: fold
+    definition: >
+      A maintainer remediation commit applied directly onto a contributor's PR
+      branch during a landing pass (rebase, test fix, campsite cleanup), keeping the
+      contributor's authorship while making the branch merge-ready.
+    confidence: 0.85
+    status: active
+    see_also:
+      - landing pass
+
+  - surface: campsite cleaning
+    definition: >
+      The boy-scout practice of leaving touched code cleaner than found — bounded,
+      in-scope cleanups folded alongside the primary change, never an open-ended
+      refactor. One of the eight Quality & Tech-Debt Standing Orders.
+    confidence: 0.85
+    status: active
+
+  - surface: mission tracer file
+    definition: >
+      A durable per-mission record capturing the decision trail and evidence for a
+      unit of work, so later agents can reconstruct why choices were made without
+      re-deriving them. See built-in procedure mission-tracer-files.
+    confidence: 0.8
+    status: active
+
+  - surface: adversarial squad
+    definition: >
+      A bounded, profile-loaded review squad deployed at an SDD point-cut so
+      independent doctrine lenses converge on findings a single reviewer would miss.
+      An optional enrichment, never a gate.
+    confidence: 0.85
+    status: active
+
+  - surface: red-first verification
+    definition: >
+      For a bugfix, the discipline of first confirming the new/failing test is RED
+      against the unpatched code (proving it captures the defect) before applying the
+      fix and watching it go green. Guards against tests that pass vacuously.
+    confidence: 0.9
+    status: active
+    see_also:
+      - red main
+
+  - surface: safe commit
+    definition: >
+      The commit pattern Spec Kitty's git layer uses to record work without
+      clobbering concurrent changes or crossing worktree boundaries — targeted
+      staging over a blanket `git add -A`.
+    confidence: 0.8
+    status: active
+
+  - surface: cutover-guard
+    definition: >
+      A repo-specific CI gate that fails when a migration/cutover is incompletely
+      applied (e.g. old and new surfaces both present). Reads the primary checkout,
+      which is a footgun in shared worktrees.
+    confidence: 0.75
+    status: active
+
+  - surface: coord/primary partition
+    definition: >
+      The execution-workspace split routing lifecycle surfaces (status, notes, trace,
+      issue-matrix, move-task) to the coord branch and stable planning (spec/plan/WP
+      outlines) to the primary branch. Missions with no coordination topology route
+      everything to primary.
+    confidence: 0.8
+    status: active

--- a/packs/internal/org-charter.yaml
+++ b/packs/internal/org-charter.yaml
@@ -1,12 +1,4 @@
 org_name: spec-kitty-internal
-description: |
-  Spec Kitty's own internal doctrine — governance for contributors, maintainers,
-  and the core team of the Spec Kitty project itself. Loaded as an org-tier pack
-  overlaying the public built-in product doctrine; NOT shipped to consumers.
-
-  First-step scaffold (catfooding the pack approach): one internal glossary_pack
-  and one maintainer procedure distilled from docs/development/. Reference edges
-  point at built-in doctrine rather than duplicating it.
 required_procedures:
   - landing-contributor-prs
 required_glossary_packs:

--- a/packs/internal/org-charter.yaml
+++ b/packs/internal/org-charter.yaml
@@ -1,0 +1,13 @@
+org_name: spec-kitty-internal
+description: |
+  Spec Kitty's own internal doctrine — governance for contributors, maintainers,
+  and the core team of the Spec Kitty project itself. Loaded as an org-tier pack
+  overlaying the public built-in product doctrine; NOT shipped to consumers.
+
+  First-step scaffold (catfooding the pack approach): one internal glossary_pack
+  and one maintainer procedure distilled from docs/development/. Reference edges
+  point at built-in doctrine rather than duplicating it.
+required_procedures:
+  - landing-contributor-prs
+required_glossary_packs:
+  - spk-internal-glossary

--- a/packs/internal/procedures/landing-contributor-prs.procedure.yaml
+++ b/packs/internal/procedures/landing-contributor-prs.procedure.yaml
@@ -100,12 +100,3 @@ steps:
       Close claim comments, note follow-up issues for any deferred debt, and leave the
       landing queue in a state the next maintainer can read.
     actor: agent
-references:
-  - type: procedure
-    id: red-main-release-discipline
-    reason: >
-      Red-classification and green-on-base rules for adjudicating CI failures during
-      a landing pass. Source prose: docs/development/how-to/pr-landing.md.
-  - type: tactic
-    id: pr-agent-worktree-isolation
-    reason: One isolated worktree per PR; never mix a landing pass with hand-edits.

--- a/packs/internal/procedures/landing-contributor-prs.procedure.yaml
+++ b/packs/internal/procedures/landing-contributor-prs.procedure.yaml
@@ -1,0 +1,111 @@
+schema_version: "1.0"
+id: landing-contributor-prs
+name: Landing Contributor PRs
+purpose: >
+  The maintainer workflow for taking a contributor PR from "open with red CI" to
+  "merge-ready": claimed, rebased onto current upstream/main, every red check
+  adjudicated, fixes folded onto the contributor branch, evidence posted, and
+  landing-order constraints stated — so the operator can merge without
+  re-deriving the adjudication. Distilled from docs/development/how-to/pr-landing.md.
+entry_condition: >
+  A contributor (or older maintainer) PR is open, typically with red or stale CI,
+  and has been assigned to a maintainer for a landing pass. The maintainer is NOT
+  the operator; the deliverable of this procedure is a merge-ready PR, never a merge.
+exit_condition: >
+  The PR is rebased onto current upstream/main, green (or its remaining reds are
+  documented as pre-existing known-P0 with proof of green-on-base), un-drafted,
+  carries a full evidence trail in its comment thread, and names any landing-order
+  constraints. Hand-off is posted; the operator merges.
+steps:
+  - title: Claim before touching
+    description: >
+      Post a claim comment on the PR before any rebase or review work: what you are
+      picking up, in which landing queue, and what you plan to do. Prevents duplicated
+      maintainer effort and surprise commits on the contributor's branch.
+    actor: agent
+
+  - title: One isolated worktree per PR
+    description: >
+      Check the PR branch out into its own dedicated worktree. Never share a worktree
+      across PRs or mix a landing pass with hand-edits — concurrent work in one
+      worktree silently reverts changes. See built-in tactic pr-agent-worktree-isolation.
+    actor: agent
+    on_failure: >
+      If a worktree is stale or points at a missing gitdir, create a fresh standalone
+      checkout rather than reusing the broken one.
+
+  - title: Rebase onto current upstream/main first
+    description: >
+      Fetch and rebase the PR branch onto the latest upstream/main before classifying
+      any failure, so you never adjudicate reds that main already fixed or introduced.
+    actor: agent
+
+  - title: Classify every red check
+    description: >
+      For each failing check decide: (a) pre-existing known-P0 red honestly on main —
+      leave red, prove green-on-base; (b) CI-environment-only failure (auth, sync
+      toggles) — not the PR's fault; (c) stale-install false red — reinstall and
+      re-run; or (d) genuinely caused by this PR — must be fixed. Only red-on-branch
+      AND green-on-base failures are the PR's to fold.
+    actor: agent
+    on_failure: >
+      If you cannot attribute a failure, reproduce it on the merge-base before
+      treating it as the PR's; never green-wash a category-1 known-P0 red.
+
+  - title: Fold remediation commits onto the contributor branch
+    description: >
+      Apply fixes (rebase resolution, test corrections, bounded campsite cleanup) as
+      commits on the contributor's branch, preserving their authorship. Keep folds
+      in-scope; do not open-ended refactor.
+    actor: agent
+
+  - title: Red-first verification for bugfix PRs
+    description: >
+      For a bugfix, confirm the test is RED against the unpatched code before the fix,
+      then green after — proving the test captures the defect rather than passing
+      vacuously.
+    actor: agent
+
+  - title: Review beyond CI and run an adversarial squad where warranted
+    description: >
+      Review intent, risk, and API-surface impact beyond what CI covers. For
+      architectural or API-surface PRs, deploy an adversarial squad so independent
+      doctrine lenses converge on findings one reviewer would miss.
+    actor: agent
+
+  - title: Push with discipline
+    description: >
+      Push folds to the contributor's fork remote (over SSH where HTTPS auth fails).
+      Never force-push to origin/main; never push directly to a protected branch.
+    actor: agent
+    on_failure: >
+      If a force-push is required and blocked by the classifier, hand it to the
+      operator rather than working around protection.
+
+  - title: Post the remediation summary
+    description: >
+      Post a full evidence trail in the PR thread: what was rebased, each red's
+      classification, folds applied, verification performed, and any landing-order
+      constraints. This is what lets the operator merge without re-deriving.
+    actor: agent
+
+  - title: Hand off — the operator merges
+    description: >
+      Un-draft the PR and hand off. The maintainer never merges; the operator merges
+      once the evidence trail and constraints are posted.
+    actor: human
+
+  - title: Follow-up hygiene
+    description: >
+      Close claim comments, note follow-up issues for any deferred debt, and leave the
+      landing queue in a state the next maintainer can read.
+    actor: agent
+references:
+  - type: procedure
+    id: red-main-release-discipline
+    reason: >
+      Red-classification and green-on-base rules for adjudicating CI failures during
+      a landing pass. Source prose: docs/development/how-to/pr-landing.md.
+  - type: tactic
+    id: pr-agent-worktree-isolation
+    reason: One isolated worktree per PR; never mix a landing pass with hand-edits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,15 +189,21 @@ artifacts = [
 # ancestor walk (`kernel.sibling_paths.resolve_installed_sibling`, which
 # `resolve_pack_root("built-in")` now delegates to since #3091/#3204) expects:
 # it walks up from an installed module to the ancestor holding `packs/built-in`.
-force-include = { "packs" = "packs" }
+#
+# SCOPED TO `packs/built-in` ON PURPOSE: only the public product doctrine ships to
+# consumers. Other repo-local packs (e.g. `packs/internal/`, the maintainer-only
+# org-tier pack) must NOT be force-included into the wheel. Guarded by
+# tests/cross_cutting/packaging/test_packaging_safety.py.
+force-include = { "packs/built-in" = "packs/built-in" }
 
 [tool.hatch.build.targets.sdist]
 include = [
     "src/**/*",
     # Relocated built-in doctrine packs — a top-level tree that `src/**/*` excludes.
     # Without this the sdist ships ZERO built-in doctrine content (mission
-    # relocate-builtin-doctrine-packs-01KYT87F, WP05 / NFR-002).
-    "packs/**",
+    # relocate-builtin-doctrine-packs-01KYT87F, WP05 / NFR-002). Scoped to
+    # `packs/built-in/**` so the maintainer-only `packs/internal/` pack never ships.
+    "packs/built-in/**",
     "src/doctrine/curation/imports/**/*",
     "README.md",
     "LICENSE",

--- a/tests/cross_cutting/packaging/test_packaging_safety.py
+++ b/tests/cross_cutting/packaging/test_packaging_safety.py
@@ -73,8 +73,10 @@ def test_wheel_contains_only_known_packages(build_artifacts: dict[str, Path]) ->
         "runtime/",
         # Built-in doctrine data relocated to a top-level packs/built-in pack root,
         # force-included in the wheel as a site-packages sibling of ``doctrine``
-        # (mission relocate-builtin-doctrine-packs).
-        "packs/",
+        # (mission relocate-builtin-doctrine-packs). Scoped to ``packs/built-in/``:
+        # only the PUBLIC product doctrine ships. Maintainer-only org packs such as
+        # ``packs/internal/`` must never appear in the wheel.
+        "packs/built-in/",
     )
 
     with zipfile.ZipFile(wheel_path) as zf:
@@ -84,6 +86,13 @@ def test_wheel_contains_only_known_packages(build_artifacts: dict[str, Path]) ->
         assert any(file_path.startswith(p) for p in known_prefixes), (
             f"File outside known package directories: {file_path}"
         )
+
+    # Explicit boundary: the internal (maintainer-only) org pack must not ship.
+    leaked_internal = [f for f in all_files if f.startswith("packs/internal/")]
+    assert not leaked_internal, (
+        "Maintainer-only packs/internal/ leaked into the consumer wheel: "
+        f"{leaked_internal}"
+    )
 
 
 @pytest.mark.slow

--- a/tests/doctrine/test_packaging_parity.py
+++ b/tests/doctrine/test_packaging_parity.py
@@ -55,8 +55,9 @@ def _expected_pack_paths() -> set[str]:
     tree** — specifically the VCS inventory that hatchling's ``force-include``
     ships.
 
-    ``pyproject.toml`` uses ``force-include = { "packs" = "packs" }``, so the
-    wheel/sdist auto-ship the ENTIRE tracked ``packs/`` tree; hatchling's
+    ``pyproject.toml`` uses ``force-include = { "packs/built-in" = "packs/built-in" }``
+    (scoped so maintainer-only org packs such as ``packs/internal/`` never ship),
+    so the wheel/sdist auto-ship the tracked ``packs/built-in/`` tree; hatchling's
     VCS-respecting selection rule ships exactly the git-tracked, non-ignored
     files (e.g. the ``__pycache__/*.pyc`` under ``packs/built-in`` is
     ``.gitignore``-d and never shipped). ``git ls-files`` reproduces that same

--- a/tests/kernel/test_sibling_paths.py
+++ b/tests/kernel/test_sibling_paths.py
@@ -126,9 +126,10 @@ def build_post_relocation_wheel_shaped_site_packages(tmp_path: Path) -> tuple[Pa
       generic ``"*/missions"`` wildcard sibling pattern would still match,
       one ancestor level up from ``repository.py``'s own file, before ever
       considering the real data;
-    * the real data at ``site-packages/packs/built-in/missions`` (``packs/``
+    * the real data at ``site-packages/packs/built-in/missions`` (``packs/built-in``
       ships as a site-packages-level sibling of every top-level package, per
-      the root ``pyproject.toml``'s ``force-include = {"packs" = "packs"}``).
+      the root ``pyproject.toml``'s
+      ``force-include = {"packs/built-in" = "packs/built-in"}``).
 
     A caller-level test using this fixture only passes if the resolver finds
     the SECOND location -- proving both that the real (relocated) data

--- a/tests/release/test_coverage_topology_ownership.py
+++ b/tests/release/test_coverage_topology_ownership.py
@@ -26,11 +26,15 @@ model in ``tests.architectural._gate_coverage`` (its public ``cov_targets``
 relation): every emitter this guard detects is a model-recognised coverage job.
 The step-level artifact detail the model deliberately does not carry (upload
 artifact names, ``--cov-report=xml:`` filenames, the aggregator's download
-``pattern`` and ``find`` glob) is read through a structured ``yaml.safe_load`` of
-the same workflow file — the identical structured parse the model itself uses,
-not a regex hand-parse of raw YAML text. The consumer globs are discovered live
-from the aggregator's own steps, so the guard tracks the real aggregator instead
-of a hand-maintained mirror.
+``pattern`` and ``find`` glob) is read through the model's own
+``load_spliced_workflow`` reader of the same workflow file — the identical
+structured parse the model itself uses, with reusable ``uses:`` delegation
+inlined (mission #3447) so a caller job such as ``kernel-tests`` (which
+delegates to ``module-kernel.yml``) is seen with its delegate's
+``--cov-report=xml:`` and upload steps. A raw ``yaml.safe_load`` would miss that
+delegated emitter entirely; a regex hand-parse of raw YAML text is likewise
+avoided. The consumer globs are discovered live from the aggregator's own steps,
+so the guard tracks the real aggregator instead of a hand-maintained mirror.
 """
 
 from __future__ import annotations
@@ -42,7 +46,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
 from tests.architectural import _gate_coverage as gc
 
@@ -171,8 +174,16 @@ def _discover_report_file_globs(jobs: dict[str, Any]) -> tuple[str, ...]:
 
 
 def load_coverage_topology(path: Path = _CI_QUALITY_PATH) -> CoverageTopology:
-    """Parse the emit/consume coverage topology out of a workflow file."""
-    data: dict[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8"))
+    """Parse the emit/consume coverage topology out of a workflow file.
+
+    Loads through :func:`gc.load_spliced_workflow` (NOT a raw ``yaml.safe_load``)
+    so a reusable-workflow caller job (``uses: ./.github/workflows/<file>``,
+    mission #3447) is seen with its delegate's ``--cov-report=xml:`` and upload
+    steps inlined — otherwise a delegated emitter like ``kernel-tests`` (which
+    delegates to ``module-kernel.yml``) would be invisible and silently dropped
+    from the coverage-ownership guard.
+    """
+    data: dict[str, Any] = gc.load_spliced_workflow(path)
     jobs: dict[str, Any] = data["jobs"]
     emitters = [
         CoverageEmitter(
@@ -251,6 +262,31 @@ def test_coverage_emitters_are_present(topology: CoverageTopology) -> None:
     parsed_jobs = {emitter.job for emitter in topology.emitters}
     missing = sorted(_REQUIRED_EMITTER_JOBS - parsed_jobs)
     assert not missing, f"expected coverage emitters not parsed: {missing}"
+
+
+def test_reusable_delegated_emitter_is_spliced_and_detected(
+    topology: CoverageTopology,
+) -> None:
+    """A ``uses:`` caller job's delegated emitter is detected (mission #3447).
+
+    ``kernel-tests`` in ``ci-quality.yml`` carries no inline ``run:`` steps — it
+    delegates to ``module-kernel.yml`` via ``uses:``. Its ``coverage-kernel.xml``
+    emitter and ``kernel-test-reports`` upload live in the reusable workflow.
+    This pins that :func:`load_coverage_topology` loads through
+    ``load_spliced_workflow`` so the delegate is inlined; a regression to a raw
+    ``yaml.safe_load`` would drop ``kernel-tests`` from the emitter set and red
+    :func:`test_coverage_emitters_are_present` for the wrong (obscure) reason.
+    """
+    kernel = next(
+        (e for e in topology.emitters if e.job == "kernel-tests"),
+        None,
+    )
+    assert kernel is not None, (
+        "kernel-tests emitter not parsed — reusable-workflow delegation to "
+        "module-kernel.yml was not spliced (load_spliced_workflow bypassed?)"
+    )
+    assert "coverage-kernel.xml" in kernel.report_filenames
+    assert "kernel-test-reports" in kernel.upload_names
 
 
 def test_detected_emitters_are_model_recognised_coverage_jobs(


### PR DESCRIPTION
## What & why

**Spec Kitty now dogfoods its own pack system: a maintainer-only `packs/internal/`
org-tier doctrine pack, plus two ratified ADRs recording how built-in vs internal
vs open packs relate.** Nothing changes for a consumer — the internal pack is
governance for *this project's* contributors and maintainers, and it is provably
kept out of the shipped wheel. This is the **first step** of a larger open-packs
initiative; the migration + CI re-vendor pipeline is deliberately deferred to a
follow-up epic (see the ADRs).

## What's in this PR

**An org-tier `packs/internal/` pack** (the correct tier — *not* a second built-in,
which is single-rooted):
- `spk-internal` glossary_pack — 12 net-new maintainer/engineering terms (red main,
  baseline-red gotcha, landing pass, fold, campsite cleaning, …).
- `landing-contributor-prs` procedure — distilled from `docs/development/how-to/pr-landing.md`.
- `drg/fragment.yaml` + `org-charter.yaml`. Reference-not-duplicate: `refines` edges
  point at built-in doctrine rather than re-authoring it.
- Registered as an org pack in `.kittify/config.yaml` (`doctrine.org.packs`).

**Kept out of the consumer wheel (the one real blocker):**
- `pyproject.toml` `force-include` + sdist globs scoped from the whole `packs/` tree to
  **`packs/built-in`** specifically, so the maintainer pack never lands in the wheel.
  Consumer wheel content is unchanged (built-in ships exactly as before; internal never
  existed for them).
- `test_packaging_safety.py` tightened to `packs/built-in/` + an explicit
  "`packs/internal` must not ship" assertion, verified against a **real built wheel**.

**ADRs (Accepted as *direction*; implementation is a future epic):**
- `2026-08-16-2` — open-packs is the source of truth for built-in doctrine; CI re-vendors
  `packs/built-in` into the core release (consumer experience unchanged).
- `2026-08-16-3` — `spec-kitty-internal` is one **public** org pack (= open-packs catalog
  #16), consumed via the org tier, **never force-shipped** ("not shipped" == absent from
  the wheel, not secret). It names and resolves the tension with the shared-package-boundary
  ADR (`2026-04-25-1`): packs are *data*, not vendored *code*.

## Verification

- Internal pack validates clean (`validate_pack` → ok), DRG merge resolves both `refines`
  edges against real built-in nodes with **no dangling endpoints / no collisions**; glossary
  merged (120 terms, zero collisions with built-in).
- **Real wheel build ships all of `packs/built-in/` and zero `packs/internal/` files.**
- `ruff` clean; terminology guard green (10/10).

## Landing note (maintainer folds)

Rebased onto current `upstream/main`. The stale-base CI red (`arch_shard_3`) was the
pre-existing census #3509, unrelated to this PR and already fixed on main by #3510 — it
clears on rebase. A profile-loaded adversarial squad (architect + doctrine lenses) then
surfaced two pack-correctness defects, both folded:

1. **`fix(landing):`** `org-charter.yaml` carried a `description:` key that `OrgCharterPolicy`
   (`extra="forbid"`) rejects, so `validate_pack` failed — and the consuming path *swallows*
   that error, meaning the pack's `required_procedures`/`required_glossary_packs` **silently
   never activated**. Removed the stray key (the prose lives in the README + node titles);
   the pack now validates and its requirements parse.
2. **`refactor(landing):`** the procedure carried an inline `references:` block duplicating the
   two DRG `refines` edges (the forbidden inline form). Dropped it — the edges are the single
   source of truth.

The architect lens confirmed the "must-not-ship" contract is complete (real wheel-build gate,
no other broad `packs/` glob), the ADRs are coherent with the shared-package-boundary decision,
and the coverage-topology CI change *tightens* the emitter-detection gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
