### PR TITLE
feat(doctrine): add compact visual communication skill

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -19,6 +19,21 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### ✨ Added
 
+- **Spec Kitty now ships a `spk-doctrine-show-me` skill that guides any agent to
+  explain work with compact, checkable visuals — the smallest diagram,
+  pseudocode, or tree that answers the question — recommended from the specify
+  and plan surfaces (`#3528`).** Before, agents had no shared doctrine for _when_
+  a visual earns its place or _which_ shape fits the point (call tree, sequence,
+  state diagram, C4, or a `diff` over the matching tree), so visual explanations
+  were ad-hoc and often missing. The skill routes to Spec Kitty's canonical
+  Mermaid, PlantUML, C4, and diagram-review sources — bundling byte-pinned
+  portable copies of the guides and themes so it keeps working once installed in
+  a consumer project — and documents faithful `/spec-kitty.status` TUI rendering
+  from `--json` (lifecycle lanes vs the five-group display, and done-progress vs
+  weighted-readiness, so a custom board never mislabels weighted readiness as
+  completed work). Adapted from HumanLayer's MIT-licensed `show-me` skill with
+  full attribution and license notice preserved.
+
 - **An organisation doctrine pack can now ship templates and mission-FSM
   content, and `spec-kitty` actually resolves them at runtime — before, an org
   pack could declare a template or mission that no resolution path would ever

--- a/packs/built-in/missions/mission-steps/plan/plan/prompt.md
+++ b/packs/built-in/missions/mission-steps/plan/plan/prompt.md
@@ -73,6 +73,14 @@ structure and a set of decisions, not a build.
    for example, spinning off one software-dev mission per Must sub-problem,
    or routing a specific decision back to a stakeholder for final sign-off.
 
+## Visual Communication (recommended)
+
+Apply the visual doctrine when decomposition, dependencies, sequencing,
+decision paths, or handoffs are clearer visually. Load `spk-doctrine-show-me`
+and add the smallest useful diagram. Prefer Mermaid inline; use PlantUML only
+when its richer layout or DSL materially helps. Keep tables and decisions
+authoritative, and skip diagrams that merely decorate the plan.
+
 ## Deliverable
 
 Fill in the plan template (`artifact_key: plan`) with: Problem

--- a/packs/built-in/missions/mission-steps/plan/specify/prompt.md
+++ b/packs/built-in/missions/mission-steps/plan/specify/prompt.md
@@ -33,6 +33,13 @@ Produce a plan specification that a stakeholder could read cold and
 understand: what problem is being planned for, why it matters now, who has
 to agree, and what boundaries constrain an acceptable plan.
 
+## Visual Communication (recommended)
+
+Apply the visual doctrine when stakeholder relationships, decision boundaries,
+dependencies, or a non-trivial sequence is clearer visually. Load
+`spk-doctrine-show-me` and add the smallest useful diagram. Keep it focused on
+the planning problem; do not introduce implementation architecture.
+
 ## What to Do
 
 1. **State the problem.** In 1-3 sentences, name the decision-shaped problem

--- a/packs/built-in/missions/mission-steps/software-dev/plan/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/plan/prompt.md
@@ -115,8 +115,9 @@ spec-kitty charter context --action plan --json
 
 ## Visual Communication (recommended)
 
-For non-trivial architecture, data/control flow, boundaries, migrations, or
-risky interactions, load `spk-doctrine-show-me` and use the smallest diagram
+Apply the visual doctrine for non-trivial architecture, data/control flow,
+boundaries, migrations, or risky interactions. Load `spk-doctrine-show-me` and
+use the smallest diagram
 that materially reduces prose. Prefer Mermaid in Markdown; use PlantUML when
 richer layout, mature C4 support, or its DSL earns the added rendering cost.
 Apply C4 progressive zoom for architecture and stop at the first level that

--- a/packs/built-in/missions/mission-steps/software-dev/plan/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/plan/prompt.md
@@ -113,6 +113,16 @@ spec-kitty charter context --action plan --json
 - If JSON `mode` is `bootstrap`, apply JSON `text` as first-run governance context and follow referenced docs as needed.
 - If JSON `mode` is `compact`, continue with condensed governance context.
 
+## Visual Communication (recommended)
+
+For non-trivial architecture, data/control flow, boundaries, migrations, or
+risky interactions, load `spk-doctrine-show-me` and use the smallest diagram
+that materially reduces prose. Prefer Mermaid in Markdown; use PlantUML when
+richer layout, mature C4 support, or its DSL earns the added rendering cost.
+Apply C4 progressive zoom for architecture and stop at the first level that
+answers the planning question. Text contracts and plan decisions remain
+authoritative; do not generate speculative diagrams.
+
 ## Location Check (0.11.0+)
 
 This command runs in the **repository root checkout**, not in a worktree.

--- a/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
@@ -185,8 +185,9 @@ spec-kitty charter context --action specify --json
 
 ## Visual Communication (recommended)
 
-When a non-trivial actor flow, domain lifecycle, rule, or concept boundary is
-clearer visually, load `spk-doctrine-show-me` and add the smallest useful
+Apply the visual doctrine when a non-trivial actor flow, domain lifecycle,
+rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
+add the smallest useful
 diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
 layout or DSL materially helps. Keep the visual focused on product intent—do
 not introduce implementation architecture into the specification. Requirements

--- a/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
@@ -183,6 +183,16 @@ spec-kitty charter context --action specify --json
 - If no charter exists yet, note that and continue. Missing charter is not a
   blocker for `/spec-kitty.specify`.
 
+## Visual Communication (recommended)
+
+When a non-trivial actor flow, domain lifecycle, rule, or concept boundary is
+clearer visually, load `spk-doctrine-show-me` and add the smallest useful
+diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
+layout or DSL materially helps. Keep the visual focused on product intent—do
+not introduce implementation architecture into the specification. Requirements
+and acceptance scenarios remain authoritative, and trivial content needs no
+diagram.
+
 ## Brief Context Detection (check before discovery)
 
 Before starting discovery, check for a pre-existing mission brief:

--- a/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
+++ b/packs/built-in/missions/mission-steps/software-dev/specify/prompt.md
@@ -187,12 +187,11 @@ spec-kitty charter context --action specify --json
 
 Apply the visual doctrine when a non-trivial actor flow, domain lifecycle,
 rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
-add the smallest useful
-diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
-layout or DSL materially helps. Keep the visual focused on product intent—do
-not introduce implementation architecture into the specification. Requirements
-and acceptance scenarios remain authoritative, and trivial content needs no
-diagram.
+add the smallest useful diagram. Prefer an inline Mermaid diagram; use PlantUML
+only when its richer layout or DSL materially helps. Keep the visual focused on
+product intent—do not introduce implementation architecture into the
+specification. Requirements and acceptance scenarios remain authoritative, and
+trivial content needs no diagram.
 
 ## Brief Context Detection (check before discovery)
 

--- a/src/doctrine/skills/README.md
+++ b/src/doctrine/skills/README.md
@@ -53,6 +53,7 @@ Families:
 - `spk-admin-*`: setup, agent config, upgrade, dashboard/status.
 - `spk-team-*`: auth, sync, tracker, connectors.
 - `spk-doctrine-*`: charter, glossary, SPDD, profile load, bulk-edit policy.
+- `spk-doctrine-show-me`: compact visual communication grounded in diagram doctrine.
 - `spk-doctrine-semantic-compression`: behavior-preserving code reduction.
 - `spk-integrate-*`: orchestrator API, CI, external automation.
 - `spk-meta-*`: skill discovery and future skill authoring.
@@ -98,6 +99,7 @@ the public user-facing hierarchy moves to `spk-*`.
 | `spk-doctrine-glossary` | Terminology |
 | `spk-doctrine-spdd-reasons` | REASONS Canvas |
 | `spk-doctrine-profile-load` | Agent profiles |
+| `spk-doctrine-show-me` | Compact visuals, diagrams, and TUI status rendering |
 | `spk-doctrine-semantic-compression` | Semantic compression |
 | `spk-doctrine-bulk-edit` | Bulk-edit classification |
 | `spk-integrate-orchestrator-api` | External orchestrator API |

--- a/src/doctrine/skills/spec-kitty/SKILL.md
+++ b/src/doctrine/skills/spec-kitty/SKILL.md
@@ -42,6 +42,11 @@ spec-kitty dispatch "<request verbatim>" --profile <profile-id> --json
 Do not answer directly before dispatching. The point is to load governance and
 record the Op before doing the work.
 
+When the user asks to show, explain, compare, map, or visualize the governed
+work—or when dense prose hides its structure—also load `spk-doctrine-show-me`.
+Use its smallest-useful-visual rule while keeping the dispatch lifecycle here
+authoritative.
+
 ## The open->work->close contract
 
 Every standalone invocation follows the same three-step lifecycle:

--- a/src/doctrine/skills/spk-admin-dashboard/SKILL.md
+++ b/src/doctrine/skills/spk-admin-dashboard/SKILL.md
@@ -16,6 +16,8 @@ dashboard as a generic status abstraction.
    not show the URL until validation succeeds.
 3. Use `spec-kitty dashboard --json` only for machine-readable mission rows.
 4. Use `spec-kitty dashboard --kill` only when the user asks to stop it.
+5. When presenting `/spec-kitty.status` in a text TUI, load
+   `spk-doctrine-show-me` and follow its status rendering contract.
 
 ## Reference
 

--- a/src/doctrine/skills/spk-doctrine-show-me/SKILL.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: spk-doctrine-show-me
+description: "Explain Spec Kitty work with compact, checkable visuals. Use for specs, plans, architecture, control flow, diffs, status boards, or whenever prose obscures structure."
+---
+
+# spk-doctrine-show-me
+
+Make the current point visible. Skip the preamble, keep prose brief, and pick
+the smallest representation that answers the question. Do not add a diagram
+when a sentence or short list is clearer.
+
+## Choose the Shape
+
+- Logic or an algorithm: compact pseudocode.
+- Runtime behavior: call tree or sequence diagram.
+- UI composition: component tree with only relevant state and boundaries.
+- Ownership or refactor scope: shallow file tree with one responsibility per entry.
+- Existing-to-proposed change: `diff` over the matching tree, flow, or pseudocode.
+- Domain lifecycle: state diagram.
+- Data or concept relationships: entity-relationship or class diagram.
+- Architecture: C4 Context first, then Container or Component only when useful.
+- Dense visual UI/layout comparison: one focused HTML artifact when the host can
+  open it; keep durable project documentation diagram-as-code.
+
+Place each visual beside the text it supports. Include only the calls, files,
+states, relationships, and boundaries needed for the current decision. Label
+relationships and preserve source paths or identifiers that make the visual
+checkable against code and artifacts.
+
+## Use Spec Kitty's Diagram Sources
+
+Prefer Mermaid for inline Markdown. Use PlantUML for richer layout control,
+standalone sources, mature C4 support, or the workshop/stickies DSL. Read only
+the guide needed for the selected notation:
+
+- `packs/built-in/toolguides/MERMAID_DIAGRAMMING.md`
+- `packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md`
+- `src/doctrine/templates/diagrams/` for project-owned themes and examples
+
+For architecture, apply `USE_C4_MODEL_TECHNIQUES`; zoom progressively and stop
+when the question is answered. Before sharing an architecture diagram, apply
+the `architecture-diagram-review-checklist` tactic: title, audience, legend
+when needed, typed/described elements, and labelled unidirectional relationships.
+
+In specification, visualize actor flows, concepts, rules, and lifecycle states;
+do not smuggle implementation choices into product requirements. In planning,
+visualize architecture, data/control flow, boundaries, migrations, and risky
+interactions. Prose requirements and contracts remain authoritative.
+
+## Render `/spec-kitty.status` in a TUI
+
+Use the command's Rich human output in a capable terminal. For a custom TUI,
+consume structured data instead of scraping ANSI output:
+
+```bash
+spec-kitty agent tasks status --json --mission <handle>
+```
+
+Render the canonical flow in this order:
+
+```text
+Planned → Doing → For Review → Approved → Done
+```
+
+Fold `claimed`, `in_progress`, and `in_review` into **Doing**; mark claimed and
+in-review entries rather than inventing extra columns. Surface blocked,
+canceled, stale, stalled-review, and stale-verdict items in a warning section.
+On narrow screens, stack the same five groups vertically instead of squeezing a
+wide table.
+
+Show **Done progress** (`done_count / total_wps`) separately from **Weighted readiness**
+(`progress_percentage`). Never label weighted readiness as completed
+work. End with the exact next action from status output, normally
+`spec-kitty next --agent <name> --mission <handle>`.
+
+## Origin and Attribution
+
+Adapted from HumanLayer's MIT-licensed `show-me` skill by Dexter Horthy:
+<https://github.com/humanlayer/skills/tree/main/plugins/show-me/skills/show-me>.
+The source article also credits Dillon Mulroy for the call-tree shape and Matt
+Pocock for HTML-explainer inspiration. Preserve the notice and provenance in
+`references/humanlayer-origin-and-license.md` when redistributing this skill.

--- a/src/doctrine/skills/spk-doctrine-show-me/SKILL.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/SKILL.md
@@ -27,20 +27,13 @@ states, relationships, and boundaries needed for the current decision. Label
 relationships and preserve source paths or identifiers that make the visual
 checkable against code and artifacts.
 
-## Use Spec Kitty's Diagram Sources
+## Load Spec Kitty's Diagram Doctrine
 
-Prefer Mermaid for inline Markdown. Use PlantUML for richer layout control,
-standalone sources, mature C4 support, or the workshop/stickies DSL. Read only
-the guide needed for the selected notation:
-
-- `packs/built-in/toolguides/MERMAID_DIAGRAMMING.md`
-- `packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md`
-- `src/doctrine/templates/diagrams/` for project-owned themes and examples
-
-For architecture, apply `USE_C4_MODEL_TECHNIQUES`; zoom progressively and stop
-when the question is answered. Before sharing an architecture diagram, apply
-the `architecture-diagram-review-checklist` tactic: title, audience, legend
-when needed, typed/described elements, and labelled unidirectional relationships.
+Prefer Mermaid inline; use PlantUML when richer layout, C4 support, or its DSL
+earns the rendering cost. Read `references/spec-kitty-diagram-sources.md`, then
+load only the needed toolguide, directive, or tactic through `spec-kitty charter
+context --include ...`. It maps portable commands to the canonical Mermaid and
+PlantUML guides, C4 directive, diagram-review tactic, and bundled theme assets.
 
 In specification, visualize actor flows, concepts, rules, and lifecycle states;
 do not smuggle implementation choices into product requirements. In planning,
@@ -56,22 +49,24 @@ consume structured data instead of scraping ANSI output:
 spec-kitty agent tasks status --json --mission <handle>
 ```
 
-Render the canonical flow in this order:
+Keep lifecycle truth distinct from the current status display projection:
 
 ```text
-Planned → Doing → For Review → Approved → Done
+planned → claimed → in_progress → for_review → in_review → approved → done
+Display: Planned → Doing → For Review → Approved → Done
 ```
 
-Fold `claimed`, `in_progress`, and `in_review` into **Doing**; mark claimed and
-in-review entries rather than inventing extra columns. Surface blocked,
-canceled, stale, stalled-review, and stale-verdict items in a warning section.
-On narrow screens, stack the same five groups vertically instead of squeezing a
-wide table.
+For the five-group display only, fold `claimed`, `in_progress`, and `in_review`
+into **Doing** and mark claimed/review entries. Read blocked/canceled from
+`work_packages[].lane`, stale from `work_packages[].is_stale`, and review
+warnings from `stalled_wps` and `stale_verdicts`; show them off-board. On narrow
+screens, stack the same groups vertically.
 
 Show **Done progress** (`done_count / total_wps`) separately from **Weighted readiness**
 (`progress_percentage`). Never label weighted readiness as completed
-work. End with the exact next action from status output, normally
-`spec-kitty next --agent <name> --mission <handle>`.
+work. JSON has no `next_action`: reproduce the human hint from `mission_slug` as
+`spec-kitty next --agent <your-name> --mission <mission_slug>`, with the caller
+supplying the agent. That command—not status—selects the exact workflow action.
 
 ## Origin and Attribution
 

--- a/src/doctrine/skills/spk-doctrine-show-me/assets/MERMAID_DIAGRAMMING.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/assets/MERMAID_DIAGRAMMING.md
@@ -1,0 +1,302 @@
+# Mermaid Diagramming
+
+Diagram-as-code reference for Mermaid usage in Spec Kitty projects.
+
+## Purpose and When to Use
+
+Mermaid renders diagrams from plain-text definitions embedded directly in
+Markdown. It requires no external tooling in most rendering environments
+(GitHub, GitLab, VS Code, Hugo, Docusaurus). Use Mermaid when:
+
+- Diagrams must render natively in Markdown previews and pull requests.
+- No Java/Graphviz dependency is acceptable.
+- The diagram type is well-supported: flowchart, sequence, class, state,
+  entity-relationship, Gantt, pie, git graph, C4 (experimental).
+- Inline rendering in `.md` files is preferred over separate source files.
+
+Avoid Mermaid when:
+
+- Fine-grained layout control is needed (Mermaid auto-layout is less
+  configurable than PlantUML).
+- Workshop-style sticky note macros or causal mapping DSLs are required
+  (use PlantUML stickies theme instead).
+- The diagram type is not yet well-supported in Mermaid (deployment,
+  component packages, mind maps with deep nesting).
+
+## Getting Started
+
+### Quickest (no install)
+
+Use the Mermaid Live Editor: <https://mermaid.live>
+
+### VS Code
+
+Install the **Markdown Preview Mermaid Support** extension. Mermaid blocks in
+`.md` files render automatically in the preview pane.
+
+### Command Line (Mermaid CLI)
+
+```bash
+# Install globally
+npm install -g @mermaid-js/mermaid-cli
+
+# Or use npx without install
+npx @mermaid-js/mermaid-cli -h
+
+# Render a .mmd file to SVG
+mmdc -i diagram.mmd -o diagram.svg
+
+# Render to PNG
+mmdc -i diagram.mmd -o diagram.png
+```
+
+## Core Diagram Types
+
+### Flowchart
+
+General-purpose directed graphs. Use for architecture, process flows, and
+dependency maps.
+
+```mermaid
+flowchart LR
+    A[Input] --> B{Decision}
+    B -- Yes --> C[Action A]
+    B -- No --> D[Action B]
+    C --> E[Output]
+    D --> E
+```
+
+### Sequence Diagram
+
+Model request flows, handoffs, and async interactions.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant API
+    participant DB as Database
+
+    User->>API: GET /tasks
+    API->>DB: SELECT * FROM tasks
+    DB-->>API: Task list
+    API-->>User: JSON response
+```
+
+### Class Diagram
+
+Model domain entities, value objects, and relationships.
+
+```mermaid
+classDiagram
+    class Task {
+        -UUID id
+        -String name
+        -Status status
+        +complete() void
+        +isPending() boolean
+    }
+
+    class Status {
+        <<enumeration>>
+        PENDING
+        IN_PROGRESS
+        COMPLETED
+    }
+
+    Task --> Status
+```
+
+### State Diagram
+
+Model lifecycle transitions.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Planned
+    Planned --> Doing : start
+    Doing --> ForReview : submit
+    ForReview --> Doing : reject
+    ForReview --> Done : approve
+    Done --> [*]
+```
+
+### Entity-Relationship Diagram
+
+Model data relationships.
+
+```mermaid
+erDiagram
+    MISSION ||--o{ WORK_PACKAGE : contains
+    WORK_PACKAGE ||--|| TASK : "is assigned"
+    MISSION {
+        string id
+        string title
+        string status
+    }
+    WORK_PACKAGE {
+        string id
+        string lane
+        string title
+    }
+```
+
+## Theming
+
+Mermaid does not support `!include` files. Theming is done via `%%{init}%%`
+directives embedded at the top of each diagram block.
+
+### Common (Neutral) Theme
+
+```mermaid
+%%{init: {'theme':'base','themeVariables': {
+  'fontFamily': 'Trebuchet MS, Verdana, Arial, sans-serif',
+  'fontSize': '16px',
+  'primaryColor': '#f5f5f5',
+  'primaryTextColor': '#103a82',
+  'primaryBorderColor': '#1c75cc',
+  'lineColor': '#0a0721',
+  'secondaryColor': '#eef3f7',
+  'tertiaryColor': '#ffffff'
+}}}%%
+flowchart LR
+    a[Context A] -->|relationship| b[Context B]
+```
+
+### Bluegray Conversation Theme
+
+```mermaid
+%%{init: {'theme':'base','themeVariables': {
+  'fontFamily': 'Verdana, Arial, sans-serif',
+  'fontSize': '14px',
+  'primaryColor': '#1c75cc',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#1168bd',
+  'secondaryColor': '#f2f2f2',
+  'secondaryTextColor': '#5a5a5a',
+  'lineColor': '#5a5a5a',
+  'tertiaryColor': '#ffffff'
+}}}%%
+sequenceDiagram
+    actor User
+    participant Service
+    User->>Service: Request
+    Service-->>User: Response
+```
+
+### Custom Node Classes
+
+Use `classDef` and `class` to apply consistent styling per node role:
+
+```mermaid
+flowchart LR
+    a[Core System]
+    b[External System]
+
+    classDef core fill:#dceafd,stroke:#1168bd,color:#103a82,stroke-width:2px;
+    classDef external fill:#f7f7f7,stroke:#8c9cab,color:#384b5f,stroke-width:1.5px;
+
+    class a core;
+    class b external;
+```
+
+Theme snippets are available as copy-paste templates in
+`src/doctrine/templates/diagrams/mermaid/themes/`.
+
+## Rendering
+
+### Inline in Markdown
+
+Wrap Mermaid source in a fenced code block with the `mermaid` language tag:
+
+````markdown
+```mermaid
+flowchart LR
+    A --> B
+```
+````
+
+This renders natively on GitHub, GitLab, VS Code preview, and most static
+site generators with Mermaid support.
+
+### Command Line
+
+```bash
+# SVG (preferred)
+mmdc -i diagram.mmd -o diagram.svg
+
+# PNG
+mmdc -i diagram.mmd -o diagram.png -b transparent
+
+# With custom theme config
+mmdc -i diagram.mmd -o diagram.svg -c mermaid-config.json
+```
+
+### CI Integration (GitHub Actions)
+
+```yaml
+- name: Render Mermaid diagrams
+  uses: neenjaw/compile-mermaid-markdown-action@v1
+  with:
+    files: "docs/**/*.md"
+    output: "docs/rendered"
+```
+
+## Project Conventions
+
+1. Prefer Mermaid for diagrams embedded in Markdown documentation.
+2. Prefer PlantUML for standalone diagram files, workshop visuals, and
+   diagrams needing the stickies/causal DSL.
+3. Use the `%%{init}%%` directive to apply project theme variables
+   consistently.
+4. Use `classDef` for role-based node styling (core, external, storage,
+   boundary).
+5. Use `{{placeholder}}` double-brace convention for template fill-in values.
+6. Keep diagrams semantically focused: structure over decoration.
+7. Store diagram source inline in `.md` files or as `.mmd` files alongside
+   the documentation they support.
+
+## Accessibility
+
+- Provide alt text when embedding rendered images: `![Description](diagram.svg)`.
+- Use descriptive node labels; avoid abbreviations.
+- Ensure sufficient color contrast between node fill and text.
+- Test diagrams in both light and dark mode rendering contexts.
+
+## Common Pitfalls
+
+- **Init directive syntax**: The `%%{init}%%` block must be the first line of
+  the Mermaid block. Whitespace before it causes parsing failures.
+- **No include support**: Unlike PlantUML, Mermaid cannot `!include` shared
+  files. Theme snippets must be copy-pasted.
+- **Subgraph nesting**: Deeply nested subgraphs can produce unexpected
+  layouts. Keep nesting to two levels maximum.
+- **Long labels**: Wrap long text in quotes and keep labels concise to avoid
+  layout overflow.
+- **Renderer differences**: GitHub, VS Code, and `mmdc` may render the same
+  diagram slightly differently. Test in your primary rendering target.
+
+## Template Library
+
+Spec Kitty ships ready-to-copy Mermaid templates in
+`src/doctrine/templates/diagrams/mermaid/examples/`:
+
+- `causal-map-mermaid-template.md`
+- `content-map-mermaid-template.md`
+- `frontend-architecture-mermaid-template.md`
+- `repo-content-graph-mermaid-template.md`
+- `request-lifecycle-sequence-mermaid-template.md`
+- `structure-meta-model-mermaid-template.md`
+- `system-map-mermaid-template.md`
+
+Theme snippets are in `src/doctrine/templates/diagrams/themes/`:
+
+- `mermaid-theme-common-template.md`
+- `mermaid-theme-bluegray-conversation-template.md`
+
+## References
+
+- [Mermaid Official Documentation](https://mermaid.js.org/)
+- [Mermaid Live Editor](https://mermaid.live)
+- [Mermaid CLI (mmdc)](https://github.com/mermaid-js/mermaid-cli)
+- [GitHub Mermaid Support](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams)

--- a/src/doctrine/skills/spk-doctrine-show-me/assets/PLANTUML_DIAGRAMMING.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/assets/PLANTUML_DIAGRAMMING.md
@@ -1,0 +1,305 @@
+# PlantUML Diagramming
+
+Diagram-as-code reference for PlantUML usage in Spec Kitty projects.
+
+## Purpose and When to Use
+
+PlantUML renders diagrams from plain-text source files that version-control
+cleanly and produce consistent, auto-laid-out visuals. Use PlantUML when:
+
+- Diagrams must be diffable and reviewable in pull requests.
+- Consistent auto-layout matters more than pixel-perfect positioning.
+- The diagram type is well-supported: sequence, component, class, deployment,
+  C4, activity, state, mind map, or the custom stickies DSL.
+
+Avoid PlantUML when:
+
+- Pixel-perfect mockups or presentation-quality visuals are required.
+- The target rendering environment has no Java/Graphviz support.
+- Mermaid is already the project standard for the diagram category in question.
+
+## Getting Started
+
+### Quickest (no install)
+
+Use the PlantUML Online Server: <https://www.plantuml.com/plantuml/uml>
+
+### VS Code
+
+Install the **PlantUML** extension. Press `Alt+D` to preview.
+
+### Command Line
+
+Prerequisites: JRE (Java 8+), PlantUML JAR, Graphviz.
+
+```bash
+# macOS
+brew install plantuml graphviz
+
+# Ubuntu/Debian
+sudo apt install plantuml graphviz
+
+# Verify
+plantuml -version
+```
+
+## Core Diagram Types
+
+### Sequence Diagram
+
+Model request flows, handoffs, and async interactions.
+
+```plantuml
+@startuml
+autonumber
+actor User as U
+participant "API" as API
+database "DB" as DB
+
+U -> API: GET /tasks
+API -> DB: SELECT * FROM tasks
+DB --> API: Task list
+API --> U: JSON response
+@enduml
+```
+
+### Component Diagram
+
+Show packages, components, and their wiring.
+
+```plantuml
+@startuml
+package "Presentation" {
+  [Web UI]
+  [REST API]
+}
+package "Business Logic" {
+  [Task Service]
+}
+database "PostgreSQL" {
+  [Tasks Table]
+}
+
+[Web UI] --> [REST API]
+[REST API] --> [Task Service]
+[Task Service] --> [Tasks Table]
+@enduml
+```
+
+### Class Diagram
+
+Model domain entities, value objects, and relationships.
+
+```plantuml
+@startuml
+class Task {
+  - id: UUID
+  - name: String
+  - status: Status
+  + complete(): void
+  + isPending(): boolean
+}
+
+enum Status {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+}
+
+Task --> Status
+@enduml
+```
+
+### Deployment Diagram
+
+Show infrastructure nodes and their connections.
+
+```plantuml
+@startuml
+node "Web Server" {
+  [Nginx]
+}
+node "Application Server" {
+  [Spring Boot App]
+}
+node "Database Server" {
+  database "PostgreSQL"
+}
+
+[Nginx] --> [Spring Boot App]: reverse proxy
+[Spring Boot App] --> [PostgreSQL]: JDBC
+@enduml
+```
+
+### C4 Context Diagram
+
+Uses the C4-PlantUML stdlib for standardized architecture views.
+
+```plantuml
+@startuml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Context.puml
+
+Person(user, "User", "Task manager user")
+System(taskSystem, "Task Management System", "Manages user tasks")
+System_Ext(emailSystem, "Email System", "Sends notifications")
+
+Rel(user, taskSystem, "Uses")
+Rel(taskSystem, emailSystem, "Sends emails via")
+@enduml
+```
+
+## Theming
+
+Spec Kitty provides three PlantUML themes in
+`src/doctrine/templates/diagrams/plantuml/themes/`:
+
+| Theme | Use Case |
+|---|---|
+| **common** | Neutral baseline. ADRs, technical designs. |
+| **bluegray_conversation** | Sequence/interaction diagrams. Full element styling. |
+| **stickies** | Workshop visuals. Sticky note macros, causal relationships. |
+
+### Including a Theme
+
+```plantuml
+@startuml
+!include <relative-path>/puml-theme-bluegray_conversation.puml
+
+' Your diagram content here
+@enduml
+```
+
+### When to Skip Theming
+
+- Teaching or exploring PlantUML basics.
+- Neutral baselines for documentation or ADRs.
+- Maximum portability across rendering contexts.
+
+## Styling Patterns
+
+### Basic Skinparam
+
+```plantuml
+skinparam shadowing false
+skinparam linetype ortho
+skinparam rectangle {
+    BackgroundColor LightBlue
+    BorderColor DarkBlue
+}
+```
+
+### Shared Definitions
+
+```plantuml
+!define PROJECT_COLOR #1c75cc
+!include common-styles.iuml
+```
+
+### Notes
+
+```plantuml
+note right of Task
+  Tasks transition from PENDING
+  to COMPLETED via complete().
+  Status changes are immutable.
+end note
+```
+
+## Rendering
+
+### Command Line
+
+```bash
+# PNG (default)
+plantuml diagram.puml
+
+# SVG (preferred for documentation)
+plantuml -tsvg diagram.puml
+
+# Render all .puml files in a directory
+plantuml -tsvg "src/doctrine/templates/diagrams/plantuml/examples/*.puml"
+
+# Watch mode
+plantuml -gui diagram.puml
+```
+
+### GitHub/GitLab Embedding
+
+Use the PlantUML proxy to render in Markdown without local tooling:
+
+```markdown
+![Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/org/repo/main/docs/diagram.puml)
+```
+
+### CI Integration (GitHub Actions)
+
+```yaml
+- name: Render PlantUML diagrams
+  uses: grassedge/generate-plantuml-action@v1
+  with:
+    path: docs/diagrams
+    message: "Render PlantUML diagrams"
+```
+
+### Makefile
+
+```makefile
+PUML_SRC := $(wildcard docs/diagrams/*.puml)
+PUML_SVG := $(PUML_SRC:.puml=.svg)
+
+diagrams: $(PUML_SVG)
+
+%.svg: %.puml
+ plantuml -tsvg $<
+```
+
+## Project Conventions
+
+1. Prefer SVG output for scalability and accessibility.
+2. Store `.puml` source files alongside the documentation they support.
+3. Commit diagram source; generate rendered output in CI or locally before review.
+4. Use `{{placeholder}}` double-brace convention for template fill-in values.
+5. Keep diagrams semantically focused: structure over decoration.
+6. Prefer diagram-as-code over screenshots to keep artifacts diffable.
+7. Use `skinparam monochrome true` for high-contrast accessibility mode.
+
+## Accessibility
+
+- Provide alt text in Markdown: `![Description](diagram.svg)`.
+- Prefer SVG over PNG for screen reader compatibility.
+- Use descriptive labels; avoid abbreviations.
+- Add `'` comments in PlantUML source to explain design intent.
+
+## Common Pitfalls
+
+- **Graphviz dependency**: Component and class diagrams require Graphviz.
+  Sequence diagrams do not.
+- **Large diagrams**: Break into multiple focused diagrams rather than one
+  monolithic view.
+- **Layout quirks**: Use `left to right direction`, hidden arrows, and
+  `together {}` blocks to influence layout.
+- **Color accessibility**: Avoid red-green-only distinctions.
+- **Over-detailing**: Show the level of detail appropriate for the audience.
+
+## Template Library
+
+Spec Kitty ships ready-to-copy PlantUML templates in
+`src/doctrine/templates/diagrams/plantuml/examples/`:
+
+- `causal-map-plantuml-template.md`
+- `content-map-plantuml-template.md`
+- `frontend-architecture-plantuml-template.md`
+- `repo-content-graph-plantuml-template.md`
+- `request-lifecycle-plantuml-template.md`
+- `structure-meta-model-plantuml-template.md`
+- `system-map-plantuml-template.md`
+- `event-storming-plantuml-template.md`
+
+## References
+
+- [PlantUML Language Reference Guide](https://plantuml.com/guide)
+- [PlantUML Official Site](https://plantuml.com)
+- [Real World PlantUML](https://real-world-plantuml.com)
+- [C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML)
+- [PlantUML Cheat Sheet](https://ogom.github.io/draw_uml/plantuml/)

--- a/src/doctrine/skills/spk-doctrine-show-me/assets/mermaid-theme-bluegray-conversation-template.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/assets/mermaid-theme-bluegray-conversation-template.md
@@ -1,0 +1,38 @@
+# Mermaid Theme: Bluegray Conversation
+
+Use for interaction-heavy sequence diagrams where dialogue and handoff clarity
+are primary.
+
+## Snippet
+
+```mermaid
+%%{init: {'theme':'base','themeVariables': {
+  'fontFamily': 'Verdana, Arial, sans-serif',
+  'fontSize': '14px',
+  'primaryColor': '#1c75cc',
+  'primaryTextColor': '#ffffff',
+  'primaryBorderColor': '#1168bd',
+  'secondaryColor': '#f2f2f2',
+  'secondaryTextColor': '#5a5a5a',
+  'lineColor': '#5a5a5a',
+  'tertiaryColor': '#ffffff'
+}}}%%
+sequenceDiagram
+    autonumber
+    actor User
+    participant Runtime as Runtime Resolver
+    participant State as Status/Event Layer
+    participant Tracker as Tracker Connector
+
+    User->>Runtime: Request next action
+    Runtime-->>User: Recommended step
+    User->>State: Execute lifecycle mutation
+    State-->>User: Transition result + evidence
+    State->>Tracker: Optional projection
+```
+
+## Recommended Use
+
+1. Runtime handoff narratives.
+2. Request lifecycle documentation.
+3. Integration sequence sketches.

--- a/src/doctrine/skills/spk-doctrine-show-me/assets/mermaid-theme-common-template.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/assets/mermaid-theme-common-template.md
@@ -1,0 +1,36 @@
+# Mermaid Theme: Common (Neutral)
+
+Use this as the default visual baseline for architecture and ADR diagrams.
+
+## Snippet
+
+```mermaid
+%%{init: {'theme':'base','themeVariables': {
+  'fontFamily': 'Trebuchet MS, Verdana, Arial, sans-serif',
+  'fontSize': '16px',
+  'primaryColor': '#f5f5f5',
+  'primaryTextColor': '#103a82',
+  'primaryBorderColor': '#1c75cc',
+  'lineColor': '#0a0721',
+  'secondaryColor': '#eef3f7',
+  'tertiaryColor': '#ffffff'
+}}}%%
+flowchart LR
+    a[Context A]
+    b[Context B]
+    a -->|relationship| b
+
+    classDef boundary fill:#f8fbff,stroke:#1c75cc,color:#103a82,stroke-width:2px;
+    classDef core fill:#dceafd,stroke:#1168bd,color:#103a82,stroke-width:2px;
+    classDef external fill:#f7f7f7,stroke:#8c9cab,color:#384b5f,stroke-width:1.5px;
+    classDef storage fill:#fff6e7,stroke:#ea7400,color:#6e3d00,stroke-width:1.5px;
+
+    class a core;
+    class b external;
+```
+
+## Recommended Use
+
+1. C4 context/container/component views.
+2. Domain maps and authority boundary diagrams.
+3. Neutral ADR support diagrams.

--- a/src/doctrine/skills/spk-doctrine-show-me/references/humanlayer-origin-and-license.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/references/humanlayer-origin-and-license.md
@@ -1,0 +1,35 @@
+# HumanLayer `show-me` provenance and license
+
+This Spec Kitty skill is adapted from HumanLayer's `show-me` skill.
+
+- Original author: Dexter Horthy
+- Original publisher and copyright holder: HumanLayer
+- Article: <https://www.linkedin.com/pulse/show-me-coding-agent-skill-compact-visual-dexter-horthy-w5yac/>
+- Source: <https://github.com/humanlayer/skills/tree/main/plugins/show-me/skills/show-me>
+- Source revision reviewed: `3c2629142c5d437428269b1b722b08c0b87f574d`
+- `show-me` history reviewed through: `6ab9013a10c28f5046f7f999549cd5328a0b30d7`
+
+The article credits Dillon Mulroy for the call-tree shape and Matt Pocock for
+HTML-explainer inspiration.
+
+## MIT License
+
+Copyright (c) 2026 HumanLayer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/doctrine/skills/spk-doctrine-show-me/references/spec-kitty-diagram-sources.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/references/spec-kitty-diagram-sources.md
@@ -1,6 +1,7 @@
 # Spec Kitty diagram sources
 
-Load only the artifact needed for the visual. Run one include per command:
+Load only the on-demand artifact summary needed for the visual. Run one include
+per command:
 
 ```bash
 spec-kitty charter context --include toolguide:mermaid-diagramming
@@ -9,16 +10,30 @@ spec-kitty charter context --include directive:USE_C4_MODEL_TECHNIQUES
 spec-kitty charter context --include tactic:architecture-diagram-review-checklist
 ```
 
-The returned artifact is governing context. Toolguide context also reports its
-canonical `guide_path`; read that path when it exists in the current checkout.
-In the Spec Kitty source repository, the core guides and templates are:
+An included artifact is canonical guidance, but inclusion alone does not
+activate it as binding governance. First load the current action context:
+
+```bash
+spec-kitty charter context --action <action> --mission-type <type> --json
+```
+
+Treat guidance as binding only when that action context or the project charter
+activates it. Otherwise use it as optional advice.
+
+The toolguide summaries report canonical `guide_path` values. Project-installed
+skills cannot assume those checkout-relative paths exist, so full byte-pinned
+copies ship with this skill:
+
+- `assets/MERMAID_DIAGRAMMING.md`
+- `assets/PLANTUML_DIAGRAMMING.md`
+
+In the Spec Kitty source repository, their authorities and templates are:
 
 - `packs/built-in/toolguides/MERMAID_DIAGRAMMING.md`
 - `packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md`
 - `src/doctrine/templates/diagrams/`
 
-Project-installed skills cannot assume those checkout-relative paths exist.
 Use this skill's portable `assets/mermaid-theme-common-template.md` or
 `assets/mermaid-theme-bluegray-conversation-template.md` as optional visual
-baselines. They are bundled snapshots of Spec Kitty's canonical theme examples;
-the loaded directive, tactic, and toolguide remain authoritative.
+baselines. The bundled guides and themes mirror canonical Spec Kitty sources;
+repository parity tests prevent silent drift.

--- a/src/doctrine/skills/spk-doctrine-show-me/references/spec-kitty-diagram-sources.md
+++ b/src/doctrine/skills/spk-doctrine-show-me/references/spec-kitty-diagram-sources.md
@@ -1,0 +1,24 @@
+# Spec Kitty diagram sources
+
+Load only the artifact needed for the visual. Run one include per command:
+
+```bash
+spec-kitty charter context --include toolguide:mermaid-diagramming
+spec-kitty charter context --include toolguide:plantuml-diagramming
+spec-kitty charter context --include directive:USE_C4_MODEL_TECHNIQUES
+spec-kitty charter context --include tactic:architecture-diagram-review-checklist
+```
+
+The returned artifact is governing context. Toolguide context also reports its
+canonical `guide_path`; read that path when it exists in the current checkout.
+In the Spec Kitty source repository, the core guides and templates are:
+
+- `packs/built-in/toolguides/MERMAID_DIAGRAMMING.md`
+- `packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md`
+- `src/doctrine/templates/diagrams/`
+
+Project-installed skills cannot assume those checkout-relative paths exist.
+Use this skill's portable `assets/mermaid-theme-common-template.md` or
+`assets/mermaid-theme-bluegray-conversation-template.md` as optional visual
+baselines. They are bundled snapshots of Spec Kitty's canonical theme examples;
+the loaded directive, tactic, and toolguide remain authoritative.

--- a/src/doctrine/skills/spk-meta-skill-map/SKILL.md
+++ b/src/doctrine/skills/spk-meta-skill-map/SKILL.md
@@ -24,7 +24,8 @@ Families:
 - `spk-gate-*`: accept, merge, mission review, and retrospectives.
 - `spk-admin-*`: setup, configuration, upgrades, dashboard/status.
 - `spk-team-*`: auth, sync, tracker, connectors.
-- `spk-doctrine-*`: charter, glossary, SPDD, profiles, bulk-edit policy.
+- `spk-doctrine-*`: charter, glossary, SPDD, profiles, visual communication,
+  and bulk-edit policy.
 - `spk-integrate-*`: APIs, CI, external automation.
 - `spk-meta-*`: skill discovery and authoring.
 

--- a/src/doctrine/skills/spk-meta-skill-map/references/spk-skill-map.md
+++ b/src/doctrine/skills/spk-meta-skill-map/references/spk-skill-map.md
@@ -56,6 +56,7 @@ detailed workflows or aliases while new public operating skills use `spk-*`.
 - `spk-doctrine-glossary`: terminology.
 - `spk-doctrine-spdd-reasons`: REASONS Canvas.
 - `spk-doctrine-profile-load`: agent profiles.
+- `spk-doctrine-show-me`: compact visuals, diagram selection, and TUI status rendering.
 - `spk-doctrine-semantic-compression`: behavior-preserving code reduction.
 - `spk-doctrine-bulk-edit`: bulk edit classification.
 

--- a/src/doctrine/skills/spk-mission-plan/SKILL.md
+++ b/src/doctrine/skills/spk-mission-plan/SKILL.md
@@ -15,6 +15,9 @@ Use this skill when a mission has a spec and needs an implementation plan.
    rollout, and risks.
 4. Route research gaps to `spk-mission-research`.
 5. Route unclear mission type or workflow questions to `spk-mission-types`.
+6. For non-trivial architecture, data/control flow, boundaries, migrations, or
+   risky interactions, load `spk-doctrine-show-me` and use diagrams where they
+   materially reduce prose.
 
 ## Guardrail
 

--- a/src/doctrine/skills/spk-mission-specify/SKILL.md
+++ b/src/doctrine/skills/spk-mission-specify/SKILL.md
@@ -16,6 +16,9 @@ Use this skill when creating or revising a mission specification.
    details.
 4. If terminology matters, route to `spk-doctrine-glossary`.
 5. If governance affects scope, route to `spk-doctrine-charter`.
+6. When a non-trivial user flow, domain lifecycle, rule, or concept boundary is
+   clearer visually, load `spk-doctrine-show-me` and add the smallest useful
+   diagram. Keep implementation choices out of the specification.
 
 ## Output Standard
 

--- a/src/doctrine/skills/spk-start-here/SKILL.md
+++ b/src/doctrine/skills/spk-start-here/SKILL.md
@@ -43,6 +43,7 @@ the smallest useful workflow.
 - Review or approval work: use `spk-run-review-wp`, then `spk-gate-accept`.
 - Team, SaaS, tracker, or sync concern: use `spk-team-sync` or `spk-team-tracker`.
 - Doctrine or governance concern: use the `spk-doctrine-*` family.
+- Visual explanation or diagram request: use `spk-doctrine-show-me`.
 - Unsure which skill applies: use `spk-meta-skill-map`.
 
 ## Agent Behavior

--- a/tests/architectural/test_no_dead_doctrine_paths.py
+++ b/tests/architectural/test_no_dead_doctrine_paths.py
@@ -251,10 +251,20 @@ def test_code_example_links_would_false_red_without_their_discriminator() -> Non
     # Relocated (mission relocate-builtin-doctrine-packs-01KYT87F): the toolguide
     # markdown moved to the flattened ``packs/built-in/toolguides/`` home; the
     # SKILL.md stays under ``src/doctrine/skills/`` (skills did not move).
+    # ``spk-doctrine-show-me`` carries byte-pinned portable copies of both
+    # guides, so their fenced link examples intentionally appear twice.
     assert excluded == [
         ("packs/built-in/toolguides/MERMAID_DIAGRAMMING.md", "diagram.svg"),
         ("packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md", "diagram.svg"),
         ("src/doctrine/skills/spec-kitty-spdd-reasons/SKILL.md", "../spec.md#x"),
+        (
+            "src/doctrine/skills/spk-doctrine-show-me/assets/MERMAID_DIAGRAMMING.md",
+            "diagram.svg",
+        ),
+        (
+            "src/doctrine/skills/spk-doctrine-show-me/assets/PLANTUML_DIAGRAMMING.md",
+            "diagram.svg",
+        ),
     ], f"C1's effect set moved: {excluded}"
 
 

--- a/tests/doctrine/test_spk_show_me_skill.py
+++ b/tests/doctrine/test_spk_show_me_skill.py
@@ -47,6 +47,8 @@ def test_skill_builds_on_canonical_diagram_doctrine(skill_text: str) -> None:
     assert "toolguide:plantuml-diagramming" in sources
     assert "directive:USE_C4_MODEL_TECHNIQUES" in sources
     assert "tactic:architecture-diagram-review-checklist" in sources
+    assert "--action <action> --mission-type <type> --json" in sources
+    assert "inclusion alone does not" in sources
     assert "packs/built-in/toolguides/MERMAID_DIAGRAMMING.md" in sources
     assert "packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md" in sources
 
@@ -99,6 +101,8 @@ def test_installed_skill_carries_portable_sources_and_themes(
 
     installed = project / ".agents" / "skills" / "spk-doctrine-show-me"
     assert (installed / "references" / "spec-kitty-diagram-sources.md").is_file()
+    assert (installed / "assets" / "MERMAID_DIAGRAMMING.md").is_file()
+    assert (installed / "assets" / "PLANTUML_DIAGRAMMING.md").is_file()
     assert (installed / "assets" / "mermaid-theme-common-template.md").is_file()
     assert (
         installed / "assets" / "mermaid-theme-bluegray-conversation-template.md"
@@ -115,6 +119,16 @@ def test_installed_skill_carries_portable_sources_and_themes(
 def test_bundled_theme_matches_canonical_template(filename: str) -> None:
     bundled = SKILL.parent / "assets" / filename
     canonical = REPO_ROOT / "src" / "doctrine" / "templates" / "diagrams" / "themes" / filename
+    assert bundled.read_bytes() == canonical.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["MERMAID_DIAGRAMMING.md", "PLANTUML_DIAGRAMMING.md"],
+)
+def test_bundled_guide_matches_canonical_toolguide(filename: str) -> None:
+    bundled = SKILL.parent / "assets" / filename
+    canonical = REPO_ROOT / "packs" / "built-in" / "toolguides" / filename
     assert bundled.read_bytes() == canonical.read_bytes()
 
 

--- a/tests/doctrine/test_spk_show_me_skill.py
+++ b/tests/doctrine/test_spk_show_me_skill.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 import pytest
 
+from specify_cli.skills.installer import install_skills_for_agent
+from specify_cli.skills.registry import SkillRegistry
+from specify_cli.status.models import Lane
+
 
 pytestmark = [pytest.mark.doctrine, pytest.mark.fast]
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -27,23 +31,91 @@ def test_skill_attributes_humanlayer_source_and_carries_mit_notice(
     assert "HumanLayer" in skill_text
     assert "https://github.com/humanlayer/skills" in skill_text
     assert notice.is_file()
-    assert "MIT License" in notice.read_text(encoding="utf-8")
+    notice_text = notice.read_text(encoding="utf-8")
+    assert "MIT License" in notice_text
+    assert "Copyright (c) 2026 HumanLayer" in notice_text
+    assert "The above copyright notice and this permission notice" in notice_text
 
 
 def test_skill_builds_on_canonical_diagram_doctrine(skill_text: str) -> None:
-    assert "MERMAID_DIAGRAMMING.md" in skill_text
-    assert "PLANTUML_DIAGRAMMING.md" in skill_text
-    assert "USE_C4_MODEL_TECHNIQUES" in skill_text
-    assert "architecture-diagram-review-checklist" in skill_text
-    assert "src/doctrine/templates/diagrams/" in skill_text
+    sources = (SKILL.parent / "references" / "spec-kitty-diagram-sources.md").read_text(
+        encoding="utf-8"
+    )
+    assert "spec-kitty charter" in skill_text
+    assert "context --include" in skill_text
+    assert "toolguide:mermaid-diagramming" in sources
+    assert "toolguide:plantuml-diagramming" in sources
+    assert "directive:USE_C4_MODEL_TECHNIQUES" in sources
+    assert "tactic:architecture-diagram-review-checklist" in sources
+    assert "packs/built-in/toolguides/MERMAID_DIAGRAMMING.md" in sources
+    assert "packs/built-in/toolguides/PLANTUML_DIAGRAMMING.md" in sources
 
 
 def test_skill_pins_status_tui_rendering_contract(skill_text: str) -> None:
+    lifecycle = " → ".join(
+        lane.value
+        for lane in (
+            Lane.PLANNED,
+            Lane.CLAIMED,
+            Lane.IN_PROGRESS,
+            Lane.FOR_REVIEW,
+            Lane.IN_REVIEW,
+            Lane.APPROVED,
+            Lane.DONE,
+        )
+    )
+    renderer = (
+        REPO_ROOT / "src/specify_cli/cli/commands/agent/tasks_status_cmd.py"
+    ).read_text(encoding="utf-8")
+
     assert "spec-kitty agent tasks status --json" in skill_text
-    assert "Planned → Doing → For Review → Approved → Done" in skill_text
+    assert lifecycle in skill_text
+    for heading in (
+        "📋 Planned",
+        "🔄 Doing",
+        "👀 For Review",
+        "👍 Approved",
+        "✅ Done",
+    ):
+        assert f'table.add_column("{heading}"' in renderer
+        assert heading.split(maxsplit=1)[1] in skill_text
+    assert "Lane.CLAIMED" in renderer and "Lane.IN_REVIEW" in renderer
+    assert "work_packages[].lane" in skill_text
+    assert "JSON has no `next_action`" in skill_text
     assert "Done progress" in skill_text
     assert "Weighted readiness" in skill_text
-    assert "in_review" in skill_text
+
+
+def test_installed_skill_carries_portable_sources_and_themes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    project = tmp_path / "project"
+    project.mkdir()
+    skill = SkillRegistry.from_local_repo(REPO_ROOT).get_skill("spk-doctrine-show-me")
+    assert skill is not None
+
+    install_skills_for_agent(project, "codex", [skill])
+
+    installed = project / ".agents" / "skills" / "spk-doctrine-show-me"
+    assert (installed / "references" / "spec-kitty-diagram-sources.md").is_file()
+    assert (installed / "assets" / "mermaid-theme-common-template.md").is_file()
+    assert (
+        installed / "assets" / "mermaid-theme-bluegray-conversation-template.md"
+    ).is_file()
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "mermaid-theme-common-template.md",
+        "mermaid-theme-bluegray-conversation-template.md",
+    ],
+)
+def test_bundled_theme_matches_canonical_template(filename: str) -> None:
+    bundled = SKILL.parent / "assets" / filename
+    canonical = REPO_ROOT / "src" / "doctrine" / "templates" / "diagrams" / "themes" / filename
+    assert bundled.read_bytes() == canonical.read_bytes()
 
 
 @pytest.mark.parametrize(
@@ -55,8 +127,22 @@ def test_skill_pins_status_tui_rendering_contract(skill_text: str) -> None:
         "src/doctrine/skills/spk-admin-dashboard/SKILL.md",
         "packs/built-in/missions/mission-steps/software-dev/specify/prompt.md",
         "packs/built-in/missions/mission-steps/software-dev/plan/prompt.md",
+        "packs/built-in/missions/mission-steps/plan/specify/prompt.md",
+        "packs/built-in/missions/mission-steps/plan/plan/prompt.md",
     ],
 )
 def test_primary_surfaces_recommend_the_skill(relative_path: str) -> None:
     text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
     assert "spk-doctrine-show-me" in text
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md",
+        "tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml",
+    ],
+)
+def test_rendered_specify_command_preserves_exact_skill_name(relative_path: str) -> None:
+    text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert "`spk-doctrine-show-me`" in text

--- a/tests/doctrine/test_spk_show_me_skill.py
+++ b/tests/doctrine/test_spk_show_me_skill.py
@@ -52,6 +52,7 @@ def test_skill_pins_status_tui_rendering_contract(skill_text: str) -> None:
         "src/doctrine/skills/spec-kitty/SKILL.md",
         "src/doctrine/skills/spk-mission-specify/SKILL.md",
         "src/doctrine/skills/spk-mission-plan/SKILL.md",
+        "src/doctrine/skills/spk-admin-dashboard/SKILL.md",
         "packs/built-in/missions/mission-steps/software-dev/specify/prompt.md",
         "packs/built-in/missions/mission-steps/software-dev/plan/prompt.md",
     ],

--- a/tests/doctrine/test_spk_show_me_skill.py
+++ b/tests/doctrine/test_spk_show_me_skill.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import json
+import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from typer.testing import CliRunner
 
+from specify_cli.cli.commands.agent.tasks import app as status_app
 from specify_cli.skills.installer import install_skills_for_agent
 from specify_cli.skills.registry import SkillRegistry
-from specify_cli.status.models import Lane
+from specify_cli.status.models import Lane, StatusEvent
+from specify_cli.status.store import append_event
+from tests.mocked_env import setup_mocked_env
 
 
 pytestmark = [pytest.mark.doctrine, pytest.mark.fast]
@@ -86,6 +93,113 @@ def test_skill_pins_status_tui_rendering_contract(skill_text: str) -> None:
     assert "JSON has no `next_action`" in skill_text
     assert "Done progress" in skill_text
     assert "Weighted readiness" in skill_text
+
+
+def test_skill_documented_status_json_keys_match_live_emitter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, skill_text: str
+) -> None:
+    """Live-invoke ``spec-kitty agent tasks status --json`` and pin the
+    documented JSON keys to what ``_st_emit_json`` actually constructs.
+
+    The skill (lines ~61-68) tells a TUI consumer to read top-level
+    ``done_count``, ``total_wps``, ``progress_percentage``, ``stalled_wps``,
+    ``stale_verdicts``, ``mission_slug``, and per-WP ``work_packages[].lane``
+    / ``work_packages[].is_stale``. Nothing previously coupled those literal
+    names to the emitter's real output, so a future key rename there would
+    let the skill silently document a JSON shape that no longer exists. This
+    builds a small fixture mission (same shape as
+    ``tests/specify_cli/cli/commands/agent/test_tasks_status_progress.py``),
+    runs the real CLI ``--json`` path, and asserts the documented keys are
+    present in the actual payload -- not merely re-grepped from the prose.
+    """
+    mission_slug = "show-me-json-contract"
+    (tmp_path / ".kittify").mkdir()
+    feature_dir = tmp_path / "kitty-specs" / mission_slug
+    tasks_dir = feature_dir / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (feature_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "mission_slug": mission_slug,
+                "mission_number": "042",
+                "mission_type": "software-dev",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    lanes = {"WP01": "approved", "WP02": "in_progress"}
+    for wp_id, lane in lanes.items():
+        (tasks_dir / f"{wp_id}-test.md").write_text(
+            textwrap.dedent(
+                f"""\
+                ---
+                work_package_id: {wp_id}
+                title: Test {wp_id}
+                execution_mode: code_change
+                ---
+                # {wp_id}
+                """
+            ),
+            encoding="utf-8",
+        )
+        append_event(
+            feature_dir,
+            StatusEvent(
+                event_id=f"test-{wp_id}-{lane}",
+                mission_slug=mission_slug,
+                wp_id=wp_id,
+                from_lane=Lane.PLANNED,
+                to_lane=Lane(lane),
+                at="2026-01-01T00:00:00+00:00",
+                actor="test",
+                force=True,
+                execution_mode="worktree",
+            ),
+        )
+
+    workspace = SimpleNamespace(execution_mode="code_change", resolution_kind="lane_workspace")
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    with setup_mocked_env(tmp_path, workspace_resolution=workspace):
+        result = runner.invoke(status_app, ["status", "--mission", mission_slug, "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    documented_top_level_keys = (
+        "done_count",
+        "total_wps",
+        "progress_percentage",
+        "stalled_wps",
+        "stale_verdicts",
+        "mission_slug",
+    )
+    for documented_key in documented_top_level_keys:
+        assert documented_key in skill_text, (
+            f"expected SKILL.md to still document {documented_key!r}"
+        )
+        assert documented_key in payload, (
+            f"SKILL.md documents top-level status-JSON key {documented_key!r}, "
+            "but the live `_st_emit_json` payload does not contain it -- the "
+            "skill's documented contract has drifted from the real emitter"
+        )
+
+    work_packages = payload["work_packages"]
+    assert work_packages, "fixture must produce at least one WP row"
+    assert "work_packages[].lane" in skill_text
+    for wp in work_packages:
+        assert "lane" in wp, (
+            "SKILL.md documents `work_packages[].lane`, but a live WP row "
+            "is missing the `lane` key"
+        )
+
+    in_progress_wp = next(wp for wp in work_packages if wp["id"] == "WP02")
+    assert "work_packages[].is_stale" in skill_text
+    assert "is_stale" in in_progress_wp, (
+        "SKILL.md documents `work_packages[].is_stale`, but the live "
+        "in-progress WP row is missing the `is_stale` key"
+    )
 
 
 def test_installed_skill_carries_portable_sources_and_themes(

--- a/tests/doctrine/test_spk_show_me_skill.py
+++ b/tests/doctrine/test_spk_show_me_skill.py
@@ -1,0 +1,61 @@
+"""Contract pins for the compact visual-communication skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = [pytest.mark.doctrine, pytest.mark.fast]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPO_ROOT / "src" / "doctrine" / "skills"
+SKILL = SKILLS_ROOT / "spk-doctrine-show-me" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def test_skill_attributes_humanlayer_source_and_carries_mit_notice(
+    skill_text: str,
+) -> None:
+    notice = SKILL.parent / "references" / "humanlayer-origin-and-license.md"
+
+    assert "Dexter Horthy" in skill_text
+    assert "HumanLayer" in skill_text
+    assert "https://github.com/humanlayer/skills" in skill_text
+    assert notice.is_file()
+    assert "MIT License" in notice.read_text(encoding="utf-8")
+
+
+def test_skill_builds_on_canonical_diagram_doctrine(skill_text: str) -> None:
+    assert "MERMAID_DIAGRAMMING.md" in skill_text
+    assert "PLANTUML_DIAGRAMMING.md" in skill_text
+    assert "USE_C4_MODEL_TECHNIQUES" in skill_text
+    assert "architecture-diagram-review-checklist" in skill_text
+    assert "src/doctrine/templates/diagrams/" in skill_text
+
+
+def test_skill_pins_status_tui_rendering_contract(skill_text: str) -> None:
+    assert "spec-kitty agent tasks status --json" in skill_text
+    assert "Planned → Doing → For Review → Approved → Done" in skill_text
+    assert "Done progress" in skill_text
+    assert "Weighted readiness" in skill_text
+    assert "in_review" in skill_text
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "src/doctrine/skills/spec-kitty/SKILL.md",
+        "src/doctrine/skills/spk-mission-specify/SKILL.md",
+        "src/doctrine/skills/spk-mission-plan/SKILL.md",
+        "packs/built-in/missions/mission-steps/software-dev/specify/prompt.md",
+        "packs/built-in/missions/mission-steps/software-dev/plan/prompt.md",
+    ],
+)
+def test_primary_surfaces_recommend_the_skill(relative_path: str) -> None:
+    text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert "spk-doctrine-show-me" in text

--- a/tests/doctrine/test_spk_skill_pack.py
+++ b/tests/doctrine/test_spk_skill_pack.py
@@ -21,6 +21,7 @@ SPK_SKILLS = {
     "spk-doctrine-charter",
     "spk-doctrine-glossary",
     "spk-doctrine-profile-load",
+    "spk-doctrine-show-me",
     "spk-doctrine-semantic-compression",
     "spk-doctrine-spdd-reasons",
     "spk-gate-accept",

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -206,12 +206,11 @@ spec-kitty charter context --action specify --json
 
 Apply the visual doctrine<!-- glossary:glossary:doctrine --> when a non-trivial actor flow, domain lifecycle,
 rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
-add the smallest useful
-diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
-layout or DSL materially helps. Keep the visual focused on product intent—do
-not introduce implementation architecture into the specification. Requirements
-and acceptance scenarios remain authoritative, and trivial content needs no
-diagram.
+add the smallest useful diagram. Prefer an inline Mermaid diagram; use PlantUML
+only when its richer layout or DSL materially helps. Keep the visual focused on
+product intent—do not introduce implementation architecture into the
+specification. Requirements and acceptance scenarios remain authoritative, and
+trivial content needs no diagram.
 
 ## Brief Context Detection (check before discovery)
 

--- a/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/claude/specify.md
@@ -202,6 +202,17 @@ spec-kitty charter context --action specify --json
 - If no charter exists yet, note that and continue. Missing charter is not a
   blocker for `/spec-kitty.specify`.
 
+## Visual Communication (recommended)
+
+Apply the visual doctrine<!-- glossary:glossary:doctrine --> when a non-trivial actor flow, domain lifecycle,
+rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
+add the smallest useful
+diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
+layout or DSL materially helps. Keep the visual focused on product intent—do
+not introduce implementation architecture into the specification. Requirements
+and acceptance scenarios remain authoritative, and trivial content needs no
+diagram.
+
 ## Brief Context Detection (check before discovery)
 
 Before starting discovery, check for a pre-existing mission brief:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -201,6 +201,17 @@ spec-kitty charter context --action specify --json
 - If no charter exists yet, note that and continue. Missing charter is not a
   blocker for `/spec-kitty.specify`.
 
+## Visual Communication (recommended)
+
+Apply the visual doctrine<!-- glossary:glossary:doctrine --> when a non-trivial actor flow, domain lifecycle,
+rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
+add the smallest useful
+diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
+layout or DSL materially helps. Keep the visual focused on product intent—do
+not introduce implementation architecture into the specification. Requirements
+and acceptance scenarios remain authoritative, and trivial content needs no
+diagram.
+
 ## Brief Context Detection (check before discovery)
 
 Before starting discovery, check for a pre-existing mission brief:

--- a/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
+++ b/tests/specify_cli/regression/_twelve_agent_baseline/gemini/specify.toml
@@ -205,12 +205,11 @@ spec-kitty charter context --action specify --json
 
 Apply the visual doctrine<!-- glossary:glossary:doctrine --> when a non-trivial actor flow, domain lifecycle,
 rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
-add the smallest useful
-diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
-layout or DSL materially helps. Keep the visual focused on product intent—do
-not introduce implementation architecture into the specification. Requirements
-and acceptance scenarios remain authoritative, and trivial content needs no
-diagram.
+add the smallest useful diagram. Prefer an inline Mermaid diagram; use PlantUML
+only when its richer layout or DSL materially helps. Keep the visual focused on
+product intent—do not introduce implementation architecture into the
+specification. Requirements and acceptance scenarios remain authoritative, and
+trivial content needs no diagram.
 
 ## Brief Context Detection (check before discovery)
 

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -200,6 +200,16 @@ spec-kitty charter context --action specify --json
 - If no charter exists yet, note that and continue. Missing charter is not a
   blocker for `/spec-kitty.specify`.
 
+## Visual Communication (recommended)
+
+When a non-trivial actor flow, domain lifecycle, rule, or concept boundary is
+clearer visually, load `spk-doctrine-show-me` and add the smallest useful
+diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
+layout or DSL materially helps. Keep the visual focused on product intent—do
+not introduce implementation architecture into the specification. Requirements
+and acceptance scenarios remain authoritative, and trivial content needs no
+diagram.
+
 ## Brief Context Detection (check before discovery)
 
 Before starting discovery, check for a pre-existing mission brief:

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -202,8 +202,9 @@ spec-kitty charter context --action specify --json
 
 ## Visual Communication (recommended)
 
-When a non-trivial actor flow, domain lifecycle, rule, or concept boundary is
-clearer visually, load `spk-doctrine-show-me` and add the smallest useful
+Apply the visual doctrine when a non-trivial actor flow, domain lifecycle,
+rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
+add the smallest useful
 diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
 layout or DSL materially helps. Keep the visual focused on product intent—do
 not introduce implementation architecture into the specification. Requirements

--- a/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
+++ b/tests/specify_cli/skills/__snapshots__/codex/specify.SKILL.md
@@ -204,12 +204,11 @@ spec-kitty charter context --action specify --json
 
 Apply the visual doctrine when a non-trivial actor flow, domain lifecycle,
 rule, or concept boundary is clearer visually. Load `spk-doctrine-show-me` and
-add the smallest useful
-diagram. Prefer an inline Mermaid diagram; use PlantUML only when its richer
-layout or DSL materially helps. Keep the visual focused on product intent—do
-not introduce implementation architecture into the specification. Requirements
-and acceptance scenarios remain authoritative, and trivial content needs no
-diagram.
+add the smallest useful diagram. Prefer an inline Mermaid diagram; use PlantUML
+only when its richer layout or DSL materially helps. Keep the visual focused on
+product intent—do not introduce implementation architecture into the
+specification. Requirements and acceptance scenarios remain authoritative, and
+trivial content needs no diagram.
 
 ## Brief Context Detection (check before discovery)
 


### PR DESCRIPTION
## What changes for you

Spec Kitty now ships **`spk-doctrine-show-me`** — a doctrine skill that guides any
agent to explain its work with **compact, checkable visuals** instead of walls of
prose. When a spec, plan, architecture, control-flow, or status point is clearer as
a picture, the skill tells the agent _when_ a visual earns its place and _which_
shape fits (call tree, sequence diagram, state diagram, C4, or a `diff` over the
matching tree), then routes it to Spec Kitty's canonical Mermaid / PlantUML / C4 /
diagram-review doctrine.

Before this, agents had no shared doctrine for visual explanation, so diagrams were
ad-hoc and usually absent; and anyone building a custom `/spec-kitty.status` view had
no authoritative mapping of the status JSON. This skill closes both gaps.

## What's in it

- **The skill** (`src/doctrine/skills/spk-doctrine-show-me/`): shape-selection
  guidance, plus byte-pinned portable copies of the Mermaid/PlantUML guides and theme
  templates so it keeps working once installed in a consumer project — a byte-parity
  test reds if a copy drifts from its canonical source.
- **Faithful `/spec-kitty.status` TUI guidance**: lifecycle lanes vs the five-group
  display projection, the exact JSON field mapping, done-progress vs weighted-readiness
  (so a custom board never labels weighted readiness as completed work), and how to
  construct the follow-up `spec-kitty next` command.
- **Recommended from the entry surfaces**: Spec Kitty start-here, the skill map, the
  dashboard, and the software-dev + plan-mission specify/plan prompts.

## Attribution and license

Adapted from HumanLayer's MIT-licensed `show-me` skill by Dexter Horthy. The full MIT
notice, reviewed source revision, and article credits (Dillon Mulroy for the call-tree
shape, Matt Pocock for the HTML-explainer inspiration) are preserved in
`references/humanlayer-origin-and-license.md`.

## Tests & landing notes

- **New tests** (`tests/doctrine/test_spk_show_me_skill.py`): skill presence, byte-parity
  of the bundled guides/themes against canonical sources, MIT attribution, entry-surface
  recommendations, and the documented status-JSON key contract. Gate C's cross-link
  effect-set pin was extended for the two bundled guides.
- **Landing pass** (maintainer): rebased onto current `upstream/main` (was 89 commits
  behind); the stale-base architectural-test red cleared on rebase. An adversarial review
  squad (doctrine-daphne, diagram-daisy, reviewer-renata) found **no MAJOR issues**; the
  MINORs were folded — see the remediation-summary comment.
- **Pre-existing, out of scope**: the repo-wide `mypy --strict` findings the lint bot
  reports are in `sync/`/`tracker/`/`charter/` modules this PR never touches — advisory
  (non-blocking) baseline debt, not this change's defect. The `-m timing` NFR-003 budget
  test is a known wall-clock perf flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
