### PR TITLE
fix(retrospect): report the generator diagnosis, not the wrong schema's errors

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -244,8 +244,9 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
   errors describing the nested reader's schema — twice leading readers to
   believe the tool contradicted itself when one enum value was wrong. It now
   reports the generator reader's accurate one-line diagnosis (e.g.
-  `not_helpful[0].category is invalid`) and appends the allowed finding
-  categories, so the fix is obvious instead of a guess.
+  `not_helpful[0].category is invalid`) and appends the categories that field
+  actually allows — findings and proposals draw from different sets — so the
+  fix is obvious instead of a guess.
 
 - **Writing an honest cardinality assertion in a test no longer costs you an
   annotation toll: the golden-count architectural gate

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -236,6 +236,17 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **`retrospect synthesize` now tells you the one thing that is actually
+  wrong with a retrospective instead of burying it under ~100 errors about a
+  schema the file was never meant to satisfy (`#3537`; closes `#3533`).** When
+  a hand-edited retrospective had a single invalid finding category, the
+  command printed a wall of Pydantic `extra_forbidden` / `Field required`
+  errors describing the nested reader's schema — twice leading readers to
+  believe the tool contradicted itself when one enum value was wrong. It now
+  reports the generator reader's accurate one-line diagnosis (e.g.
+  `not_helpful[0].category is invalid`) and appends the allowed finding
+  categories, so the fix is obvious instead of a guess.
+
 - **Writing an honest cardinality assertion in a test no longer costs you an
   annotation toll: the golden-count architectural gate
   (`tests/architectural/test_golden_count_ban.py`) stopped flagging

--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -36,7 +36,13 @@ from specify_cli.retrospective import (
     RetrospectiveActor,
 )
 from specify_cli.retrospective.lifecycle_events import Actor as LifecycleActor
-from specify_cli.retrospective.reader import SchemaError, YAMLParseError, read_gen_record, read_record
+from specify_cli.retrospective.reader import (
+    FINDING_CATEGORIES,
+    SchemaError,
+    YAMLParseError,
+    read_gen_record,
+    read_record,
+)
 from specify_cli.retrospective.schema import (
     ActorRef,
     GenActor,
@@ -528,11 +534,13 @@ def synthesize_cmd(
             _err_console.print(f"[red]Error:[/red] {msg}")
             raise typer.Exit(3) from missing_record_exc
     except (YAMLParseError, SchemaError) as exc:
+        gen_exc: Exception | None = None
         try:
             generator_record = read_gen_record(retro_file)
             record = None
-        except (FileNotFoundError, YAMLParseError, SchemaError):
+        except (FileNotFoundError, YAMLParseError, SchemaError) as gen_error:
             generator_record = None
+            gen_exc = gen_error
         else:
             outcome = "retrospective_synthesized"
             if generator_record.proposals:
@@ -542,12 +550,24 @@ def synthesize_cmd(
                     "so synthesize will run as an empty dry-run batch."
                 )
         if generator_record is None:
-            msg = f"Retrospective record malformed: {exc}"
+            # #3533: report the GENERATOR reader's diagnosis, not the Pydantic one.
+            # A record written by `retrospect create` is generator-shaped, so the
+            # nested-schema reader ALWAYS fails on it and its ~100 field errors
+            # describe a schema the file was never meant to satisfy. The generator
+            # reader's message is one line and names the offending field, e.g.
+            # "not_helpful[0].category is invalid" — the only actionable half.
+            # Surfacing the wrong one has twice led readers to conclude the tool
+            # contradicts itself when a single enum value was wrong.
+            detail = str(gen_exc) if gen_exc is not None else str(exc)
+            if gen_exc is not None and "category is invalid" in detail:
+                allowed = ", ".join(sorted(FINDING_CATEGORIES))
+                detail = f"{detail}\nAllowed finding categories: {allowed}"
+            msg = f"Retrospective record malformed: {detail}"
             if json_only:
-                _err_console.print_json(json.dumps({"error": "record_malformed", "detail": str(exc)}))
+                _err_console.print_json(json.dumps({"error": "record_malformed", "detail": detail}))
             else:
                 _err_console.print(f"[red]Error:[/red] {msg}")
-            raise typer.Exit(3) from exc
+            raise typer.Exit(3) from (gen_exc if gen_exc is not None else exc)
     except OSError as exc:
         msg = f"I/O error reading retrospective: {exc}"
         if json_only:

--- a/src/specify_cli/cli/commands/agent_retrospect.py
+++ b/src/specify_cli/cli/commands/agent_retrospect.py
@@ -38,6 +38,7 @@ from specify_cli.retrospective import (
 from specify_cli.retrospective.lifecycle_events import Actor as LifecycleActor
 from specify_cli.retrospective.reader import (
     FINDING_CATEGORIES,
+    PROPOSAL_CATEGORIES,
     SchemaError,
     YAMLParseError,
     read_gen_record,
@@ -560,8 +561,15 @@ def synthesize_cmd(
             # contradicts itself when a single enum value was wrong.
             detail = str(gen_exc) if gen_exc is not None else str(exc)
             if gen_exc is not None and "category is invalid" in detail:
-                allowed = ", ".join(sorted(FINDING_CATEGORIES))
-                detail = f"{detail}\nAllowed finding categories: {allowed}"
+                # Findings and proposals both raise "<label>.category is invalid"
+                # but draw from DIFFERENT allow-lists (#3537 landing). Pick by the
+                # label so a bad proposal category is not handed the finding set.
+                if "proposals[" in detail:
+                    allowed = ", ".join(sorted(PROPOSAL_CATEGORIES))
+                    detail = f"{detail}\nAllowed proposal categories: {allowed}"
+                else:
+                    allowed = ", ".join(sorted(FINDING_CATEGORIES))
+                    detail = f"{detail}\nAllowed finding categories: {allowed}"
             msg = f"Retrospective record malformed: {detail}"
             if json_only:
                 _err_console.print_json(json.dumps({"error": "record_malformed", "detail": detail}))

--- a/src/specify_cli/retrospective/reader.py
+++ b/src/specify_cli/retrospective/reader.py
@@ -97,7 +97,7 @@ _PROVENANCE_KINDS = frozenset({
     "backfill",
     "synthesize_fabricate",
 })
-_FINDING_CATEGORIES = frozenset({
+FINDING_CATEGORIES = frozenset({
     "process",
     "tooling",
     "spec_quality",
@@ -194,7 +194,7 @@ def _validate_gen_evidence_ref(raw: object, *, label: str) -> None:
 def _validate_gen_finding(raw: object, *, label: str) -> None:
     finding = _validate_mapping(raw, label=label)
     _validate_keys(finding, _FINDING_KEYS, label=label)
-    if finding.get("category") not in _FINDING_CATEGORIES:
+    if finding.get("category") not in FINDING_CATEGORIES:
         raise ValueError(f"{label}.category is invalid")
     _validate_string_list(finding.get("evidence_refs", []), label=f"{label}.evidence_refs")
 

--- a/src/specify_cli/retrospective/reader.py
+++ b/src/specify_cli/retrospective/reader.py
@@ -107,7 +107,7 @@ FINDING_CATEGORIES = frozenset({
     "doc",
     "other",
 })
-_PROPOSAL_CATEGORIES = frozenset({"glossary", "drg", "doctrine", "tooling", "process", "other"})
+PROPOSAL_CATEGORIES = frozenset({"glossary", "drg", "doctrine", "tooling", "process", "other"})
 _EVIDENCE_KINDS = frozenset({"file", "event_range", "external"})
 _FINDINGS_STATUSES = frozenset({"has_findings", "ran_no_findings"})
 
@@ -202,7 +202,7 @@ def _validate_gen_finding(raw: object, *, label: str) -> None:
 def _validate_gen_proposal(raw: object, *, label: str) -> None:
     proposal = _validate_mapping(raw, label=label)
     _validate_keys(proposal, _PROPOSAL_KEYS, label=label)
-    if proposal.get("category") not in _PROPOSAL_CATEGORIES:
+    if proposal.get("category") not in PROPOSAL_CATEGORIES:
         raise ValueError(f"{label}.category is invalid")
     if proposal.get("risk_class") not in {"low", "structural"}:
         raise ValueError(f"{label}.risk_class is invalid")

--- a/tests/cli/test_agent_retrospect_synthesize.py
+++ b/tests/cli/test_agent_retrospect_synthesize.py
@@ -786,3 +786,86 @@ def test_invalid_category_reports_generator_diagnosis_not_pydantic_wall(tmp_path
     # The Pydantic wall for the schema this file never targeted must NOT appear.
     assert "extra_forbidden" not in result.output, result.output
     assert "Field required" not in result.output, result.output
+
+
+def test_invalid_proposal_category_reports_proposal_allow_list(tmp_path: Path) -> None:
+    """#3537 landing: findings and proposals both raise "<label>.category is invalid"
+    but draw from DIFFERENT allow-lists. A bad *proposal* category must be handed the
+    proposal vocabulary, not the finding one — otherwise the "accurate diagnosis" the
+    fix promises steers the author toward values that are invalid for a proposal.
+    """
+    root = tmp_path
+    retro_path = _write_generator_retrospective(root)
+    # Findings stay valid; add a proposal whose category is out of the proposal set.
+    retro_path.write_text(
+        retro_path.read_text(encoding="utf-8").replace(
+            "proposals: []",
+            "proposals:\n  - id: p-001\n    category: implementation\n",
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.locate_project_root",
+            return_value=root,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.resolve_mission_handle",
+            return_value=_make_resolved_mission(tmp_path=root),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["retrospect", "synthesize", "--mission", FAKE_SLUG],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 3, result.output
+    # `implementation` is a valid FINDING category but NOT a proposal one, so the
+    # generator reader flags the proposal and we must show the proposal allow-list.
+    assert "proposals[0].category is invalid" in result.output, result.output
+    assert "Allowed proposal categories:" in result.output, result.output
+    assert "glossary" in result.output, result.output  # proposal-only value
+    # The finding allow-list (and its finding-only values) must NOT be offered here.
+    assert "Allowed finding categories:" not in result.output, result.output
+    assert "review_loop" not in result.output, result.output
+    assert "spec_quality" not in result.output, result.output
+
+
+def test_invalid_category_json_surface_carries_diagnosis_and_allow_list(tmp_path: Path) -> None:
+    """#3537: the ``--json`` envelope's ``detail`` carries the same corrected
+    generator diagnosis and allow-list as the Rich surface, not the Pydantic wall.
+    """
+    root = tmp_path
+    retro_path = _write_generator_retrospective(root)
+    retro_path.write_text(
+        retro_path.read_text(encoding="utf-8").replace(
+            "category: process", "category: terminus"
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.locate_project_root",
+            return_value=root,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.resolve_mission_handle",
+            return_value=_make_resolved_mission(tmp_path=root),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["retrospect", "synthesize", "--mission", FAKE_SLUG, "--json"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 3, result.output
+    envelope = json.loads(result.output)
+    assert envelope["error"] == "record_malformed", envelope
+    detail = envelope["detail"]
+    assert "not_helpful[0].category is invalid" in detail, detail
+    assert "Allowed finding categories:" in detail, detail
+    assert "extra_forbidden" not in detail, detail

--- a/tests/cli/test_agent_retrospect_synthesize.py
+++ b/tests/cli/test_agent_retrospect_synthesize.py
@@ -740,3 +740,49 @@ def test_json_out_writes_file(tmp_path: Path) -> None:
     envelope = json.loads(out_file.read_text())
     assert envelope["schema_version"] == "1"
     assert envelope["command"] == "agent.retrospect.synthesize"
+
+
+def test_invalid_category_reports_generator_diagnosis_not_pydantic_wall(tmp_path: Path) -> None:
+    """#3533: one bad enum value must not surface ~100 errors for the other schema.
+
+    A record written by ``retrospect create`` is generator-shaped, so the nested
+    Pydantic reader always rejects it. When the generator reader ALSO rejects it,
+    the actionable message is the generator's one-liner naming the field -- not
+    the Pydantic error list, which describes a schema the file never targeted.
+    Reporting the wrong one twice led readers to conclude the tool contradicts
+    itself when a single category value was wrong.
+    """
+    root = tmp_path
+    retro_path = _write_generator_retrospective(root)
+    retro_path.write_text(
+        retro_path.read_text(encoding="utf-8").replace(
+            "category: process", "category: terminus"
+        ),
+        encoding="utf-8",
+    )
+
+    with (
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.locate_project_root",
+            return_value=root,
+        ),
+        patch(
+            "specify_cli.cli.commands.agent_retrospect.resolve_mission_handle",
+            return_value=_make_resolved_mission(tmp_path=root),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["retrospect", "synthesize", "--mission", FAKE_SLUG],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 3, result.output
+    # The generator reader's precise diagnosis is what reaches the operator.
+    assert "not_helpful[0].category is invalid" in result.output, result.output
+    # And the allow-list, because it is otherwise only a frozenset in reader.py.
+    assert "Allowed finding categories:" in result.output, result.output
+    assert "review_loop" in result.output, result.output
+    # The Pydantic wall for the schema this file never targeted must NOT appear.
+    assert "extra_forbidden" not in result.output, result.output
+    assert "Field required" not in result.output, result.output


### PR DESCRIPTION
Closes #3533.

## The bug

A retrospective written by `retrospect create` is generator-shaped, so the nested Pydantic reader always rejects it. `synthesize` already handles that — it falls back to `read_gen_record`, warns, and runs an empty dry-run batch. That part works.

But when the generator reader **also** rejects the file, the command reported the *Pydantic* exception instead of the generator one. So a single invalid enum value surfaced as roughly a hundred field errors about a schema the file was never meant to satisfy, while the accurate message was computed and thrown away:

```
Generator schema validation failed for .../retrospective.yaml:
not_helpful[0].category is invalid
```

One line, names the field and the index.

## Why it is worth fixing

It has now produced a wrong diagnosis twice in one day. An agent reported that `retrospect create` "generated a record its own synthesize command rejects with 115 schema errors," and I filed #3533 repeating that framing. Neither was true. `create` writes a valid record, `synthesize` consumes it, and the actual fault was six hand-authored finding categories outside the eight-value allow-list.

An error that points at the wrong subsystem costs more than one that says nothing.

## Changes

- Capture the generator reader's exception and prefer it over the Pydantic one, on both the Rich and JSON surfaces.
- When the failure is a category, append the allowed set. It was otherwise only discoverable as a frozenset in `reader.py`, so anyone hand-editing a retrospective had to guess — which is exactly what happened.
- Export `FINDING_CATEGORIES` (was `_FINDING_CATEGORIES`) so the message can name the allow-list without duplicating it. Grepped for stale references; none.

## Verification

Neuter-checked rather than assumed: reverting the one-line detail selection turns the new test red with exactly the old Pydantic wall.

```
tests/cli/test_agent_retrospect_synthesize.py    23 passed
tests/retrospective/                            476 passed
tests/cli/test_agent_retrospect_missing_record.py  9 passed
ruff                                              clean
```

The new test asserts the generator diagnosis and the allow-list are present **and** that `extra_forbidden` / `Field required` are absent, so it fails if the wrong schema's errors come back.

## Noted, not fixed here

The test fixture writes to `.kittify/missions/<id>/retrospective.yaml` — the legacy gitignored path that `retrospective_terminus.py:77` says was re-homed to `kitty-specs/<slug>/` by #2119. The mission-review skill still documents the legacy path as well, which had me conclude a retrospective was missing earlier today when it may have existed at the canonical path. That split is the other half of #3533 and deserves its own change rather than being smuggled in here.

## Landing notes (maintainer pass)

Rebased onto current `upstream/main` (was 20 commits behind; clean, no conflicts). CI was already green pre-rebase; the fix and the `_FINDING_CATEGORIES` → `FINDING_CATEGORIES` de-privatization are intact with **zero stale references** anywhere in `src`/`tests`. Red-first neuter-check reproduced: reverting the detail-selection line reds the new test with exactly the old Pydantic wall.

**Maintainer folds on top of the contributor commit:**
- **`docs(landing)` — changelog.** This user-facing fix shipped without a changelog entry; added a BLUF Fixed entry under the open 3.2.6rc2 cycle.
- **`fix(retrospect)` — allow-list by field kind (adversarial-review MAJOR).** A lightweight review squad found a fresh defect *in the diagnosis this PR adds*: the `"category is invalid"` substring is raised by **both** `_validate_gen_finding` (allow-list `FINDING_CATEGORIES`) and `_validate_gen_proposal` (allow-list `PROPOSAL_CATEGORIES` = `{glossary, drg, doctrine, tooling, process, other}`), so a bad **proposal** category got the **finding** allow-list appended — steering the author toward values like `design`/`implementation` that are invalid for a proposal. Fixed: select the allow-list by the `proposals[` label prefix on both surfaces; de-privatize `PROPOSAL_CATEGORIES` (symmetric with the `FINDING_CATEGORIES` export). Added a proposal-category regression test (red-first verified) and a `--json`-surface test that closes the previously-untested JSON branch.

**Review outcome:** 1 MAJOR folded (above); scope + docs/plans checks clean. MINOR/NOTE follow-ups (typed error boundary instead of substring matching; document the category enums in `docs/api/retrospective-schema.md`; reconcile the roadmap's stale #1239 framing) collected in #3551.

The deferred second half of #3533 (the legacy `.kittify/missions/<id>/` retrospective path still documented by the mission-review skill) is **already tracked by #2961** — deferring it here loses nothing.

Verification on the rebased tip: 505 retrospect/CLI tests pass · `ruff` clean · `mypy --strict` clean on changed files · terminology green · `docs-freshness --ci` errors=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595732&installation_model_id=427282&pr_number=3537&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3537&signature=ca004f3ab9dd2f61523dc7b74053f8603f744f574c6ab123466bb391c7257e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
