### PR TITLE
fix(review): print a rejection feedback path move-task will accept

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -304,6 +304,20 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **Rejecting a work package no longer costs a wasted cycle: the feedback-file
+  path `agent action review` prints in its rejection command is now one
+  `move-task` will actually accept (`#3554`; closes `#3430`).** Before, the
+  review prompt told the reviewer to write feedback to
+  `tasks/<wp>/review-cycle-N.md` and then pass that same file to `move-task
+  --review-feedback-file` — but inside the WP's own directory that exact
+  filename is the tool-authored verdict artifact, which the provenance guard
+  refuses as a feedback source. So the rejection command printed verbatim always
+  failed, and the reviewer only discovered it after burning a cycle. The
+  advertised path is now `tasks/<wp>/review-feedback-N.md` — still committed in
+  the WP's own in-repo directory — and the name is owned in `review/cycle.py`
+  beside the guard that decides what is acceptable, so the printed path and the
+  accepted path cannot drift apart again.
+
 - **The two `kitty-specs/` lane guards no longer disagree about a bulk-edit
   mission's own occurrence map, so it can be kept current from the implementing
   lane without a manual unwind (`#2980`).** The pre-commit ownership guard warned

--- a/src/doctrine/skills/spk-run-verdict-capture/SKILL.md
+++ b/src/doctrine/skills/spk-run-verdict-capture/SKILL.md
@@ -26,7 +26,7 @@ append-only, deterministic, and identical across every agent.
 - **Reject** a WP (send it back with structured feedback):
   ```bash
   spec-kitty agent tasks move-task <WP> --to planned \
-    --review-feedback-file <path/to/review-cycle-N.md> --mission <slug>
+    --review-feedback-file <path/to/review-feedback-N.md> --mission <slug>
   ```
 - **Terminal (done) with an explicit review triple** (reviewer / verdict / reference):
   ```bash

--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -30,10 +30,13 @@ Sites in this module that **mention** ``review-cycle-*`` artifacts but do
 * ``_has_prior_rejection``, which performs a read-only ``glob`` check.
 * fix-mode prompt rendering, which reads the latest artifact via
   ``ReviewCycleArtifact.from_file`` / ``.latest``; no write.
-* review-prompt rendering, which computes a *placeholder* path
-  ``review-cycle-{next_cycle}.md`` for inclusion in instructional output to
-  the human reviewer. Nothing is written; the file only materialises when
-  the reviewer subsequently runs ``move-task --to planned``.
+* review-prompt rendering, which reads the counter to compute a *placeholder*
+  path ``review-feedback-{next_cycle}.md``
+  (:func:`specify_cli.review.cycle.review_feedback_source_path`) for
+  inclusion in instructional output to the human reviewer. Nothing is
+  written; the reviewer authors that file and the ``review-cycle-N.md``
+  artifact only materialises when they subsequently run ``move-task --to
+  planned``.
 
 Re-running ``spec-kitty agent action implement WPNN`` is therefore a
 counter-no-op by construction: this module never calls
@@ -91,7 +94,11 @@ from specify_cli.review.prompt_metadata import (
     write_review_prompt_with_metadata,
 )
 from specify_cli.review.antipattern_checklist import render_wp_review_antipattern_checklist
-from specify_cli.review.cycle import REVIEW_FEEDBACK_SENTINELS, resolve_review_cycle_pointer
+from specify_cli.review.cycle import (
+    REVIEW_FEEDBACK_SENTINELS,
+    resolve_review_cycle_pointer,
+    review_feedback_source_path,
+)
 from specify_cli.status import feature_status_lock
 from specify_cli.status import AgentAssignment, Lane
 from specify_cli.status import (
@@ -1771,7 +1778,7 @@ def review(
         sub_artifact_dir.mkdir(parents=True, exist_ok=True)
         existing_cycles = sorted(sub_artifact_dir.glob("review-cycle-*.md"))
         next_cycle = len(existing_cycles) + 1
-        review_feedback_path = sub_artifact_dir / f"review-cycle-{next_cycle}.md"
+        review_feedback_path = review_feedback_source_path(sub_artifact_dir, next_cycle)
 
         prompt_lines = _executor.build_review_prompt_lines(
             normalized_wp_id=normalized_wp_id,

--- a/src/specify_cli/review/cycle.py
+++ b/src/specify_cli/review/cycle.py
@@ -53,6 +53,21 @@ _COMMIT_CONTENTION_RETRY_SLEEP_SECONDS = 0.15
 _REVIEW_CYCLE_FILE_RE = re.compile(r"^review-cycle-(?P<cycle>[1-9][0-9]*)\.md$")
 
 
+def review_feedback_source_path(sub_artifact_dir: Path, cycle_number: int) -> Path:
+    """Return the in-repo path a reviewer should write cycle *cycle_number*'s
+    rejection feedback to.
+
+    Deliberately NOT ``review-cycle-N.md``: inside *sub_artifact_dir* that
+    filename is the TOOL-authored verdict artifact, which
+    :func:`_guard_feedback_source_provenance` refuses as a ``feedback_source``.
+    The review prompt used to advertise exactly that path, so the rejection
+    command it printed could never be run as printed (#3430). Owning the name
+    here, beside the guard, is what stops the advertised path and the accepted
+    path drifting apart again.
+    """
+    return sub_artifact_dir / f"review-feedback-{cycle_number}.md"
+
+
 def _review_cycle_wp_dir(
     repo_root: Path,
     mission_slug: str,

--- a/tests/review/test_cycle.py
+++ b/tests/review/test_cycle.py
@@ -23,6 +23,7 @@ from specify_cli.review.cycle import (
     build_review_cycle_pointer,
     create_rejected_review_cycle,
     resolve_review_cycle_pointer,
+    review_feedback_source_path,
     validate_review_artifact_file,
     validate_review_cycle_pointer,
 )
@@ -266,6 +267,59 @@ def test_self_referential_feedback_source_is_rejected(tmp_path: Path) -> None:
     latest = ReviewCycleArtifact.latest(wp_dir)
     assert latest is not None
     assert latest.reviewer_agent == "reviewer-renata"
+
+
+def test_review_prompt_feedback_path_is_accepted_as_a_feedback_source(
+    tmp_path: Path,
+) -> None:
+    """Guard for #3430: the rejection command ``agent action review`` prints
+    must be runnable verbatim.
+
+    The prompt names ``review_feedback_path`` twice -- once as the file the
+    reviewer writes, once as the ``--review-feedback-file`` argument -- so
+    whatever :func:`review_feedback_source_path` returns has to survive
+    ``_guard_feedback_source_provenance``. It did not: the prompt advertised
+    the WP's own ``review-cycle-N.md``, which is precisely what the guard
+    refuses, so every rejection cost a cycle to discover the printed command
+    could not be followed.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    tasks_dir = repo / "kitty-specs" / MISSION_SLUG / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / f"{WP_SLUG}.md").write_text("# WP03\n", encoding="utf-8")
+    wp_dir = tasks_dir / WP_SLUG
+    wp_dir.mkdir()
+
+    # The path the review prompt tells the reviewer to write feedback to, for
+    # the first cycle (``len(glob("review-cycle-*.md")) + 1`` in workflow.py).
+    feedback = review_feedback_source_path(wp_dir, 1)
+    assert feedback.parent == wp_dir, "the prompt promises an in-repo path"
+    feedback.write_text(
+        "**Issue 1**: Ledger grammar drops the census delimiter.\n",
+        encoding="utf-8",
+    )
+
+    created = create_rejected_review_cycle(
+        main_repo_root=repo,
+        mission_slug=MISSION_SLUG,
+        wp_id=WP_ID,
+        wp_slug=WP_SLUG,
+        feedback_source=feedback,
+        reviewer_agent="reviewer-renata",
+    )
+
+    # The tool authors the verdict artifact itself, so the reviewer's feedback
+    # file and the generated cycle must be two distinct files.
+    assert created.artifact_path == wp_dir / "review-cycle-1.md"
+    assert created.artifact_path != feedback
+
+    # The next cycle's advertised path does not collide with the artifact just
+    # written either.
+    assert review_feedback_source_path(wp_dir, 2).name not in {
+        path.name for path in wp_dir.glob("review-cycle-*.md")
+    }
 
 
 def test_guard_feedback_source_provenance_refuses_by_parse_alone_no_verdict_read(


### PR DESCRIPTION
Fixes #3430.

## What changes for you

When a reviewer rejects a work package, `spec-kitty agent action review` prints
a ready-to-run rejection command. **That command used to fail every time.** It
told you to write your feedback to `tasks/<wp>/review-cycle-N.md` and then pass
that same file to `move-task --review-feedback-file` — but inside the WP's own
directory that exact filename is the *tool-authored verdict artifact*, which the
feedback-provenance guard refuses as a feedback source. So the command printed
right in front of you could never be run as printed, and you only found that out
after burning a review cycle to hit the error.

Now the prompt advertises `tasks/<wp>/review-feedback-N.md` — a path
`move-task` accepts. Copy-paste the printed command and it works.

## The fix

- The advertised feedback path moves to `review-feedback-N.md`, still committed
  in the WP's own in-repo directory so the "feedback lives with the project"
  promise holds. It no longer matches `_REVIEW_CYCLE_FILE_RE`, so the provenance
  guard admits it.
- The name is owned by a single helper, `review_feedback_source_path()`, in
  `src/specify_cli/review/cycle.py` — **beside the guard that decides what's
  acceptable.** That co-location is what stops the advertised path and the
  accepted path drifting apart again; `agent/workflow.py` now calls the helper
  instead of hard-coding the string.
- The same wrong path in the `spk-run-verdict-capture` skill (which repeats the
  reject command to agents) is corrected too.

## Tests

`tests/review/test_cycle.py::test_review_prompt_feedback_path_is_accepted_as_a_feedback_source`
drives the advertised path through `create_rejected_review_cycle` and asserts it
survives the provenance guard. **Red-first verified during landing:** against
`upstream/main`'s code the old advertised `review-cycle-1.md` raises the exact
#3430 error (`feedback_source is this WP's own review-cycle artifact …`); the
fix's `review-feedback-N.md` passes.

## Landing notes

- Rebased clean onto current `upstream/main`; three-dot diff is the 4 intended
  files only.
- Gates green on the rebased tip: `ruff`, `mypy`, `tests/review/test_cycle.py`
  (27 passed), terminology guard, docs-freshness (`errors=0`), markdownlint on
  the changelog.
- Changelog entry added under `[Unreleased] › Fixed` as a separate
  `docs(landing)` fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
