### PR TITLE
fix(coordination): base lane kitty-specs guard on the planning branch + reconcile the two kitty-specs guards (#3271, #2274, #2980)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -304,6 +304,24 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **The lane "no kitty-specs on lane branches" `move-task` guard no longer
+  false-positives on inherited planning artifacts in `coord` topology, so lane
+  transitions stop demanding `--force` on every step (`#3271`; closes `#2274`).**
+  The guard is a two-pass content delta (the shipped `#2274`/FR-007 fix), but
+  both passes keyed off the lane's coordination/mission base ref, whose
+  merge-base predates the `kitty-specs/**` a lane legitimately holds — prior
+  missions' committed artifacts inherited from the base, plus this mission's own
+  planning artifacts merged in via the recorded planning commit (ADR
+  `2026-07-29-1` / `#2993`). Both are ancestors of the planning branch but not of
+  the coord base, so they surfaced as lane-introduced contamination and the
+  guard's own "clean the branch" remedy would have deleted other missions'
+  artifacts — leaving `--force`, documented as "not recommended", as the only
+  safe path. The delta is now measured against the planning branch
+  (`planning_base_branch`, else the mission's `target_branch`), falling back to
+  the lane base ref only for legacy/flat missions without `meta.json`. The
+  sibling branch-currency and implementation-commit gates keep the coordination
+  ref, which is correct for them.
+
 - **A spec that writes some requirements as plain prose sentences no longer
   passes the coverage gate as if they were covered — `spec-kitty next` and
   `finalize-tasks` now block and name the uncounted ids (mission

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -304,6 +304,18 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **The two `kitty-specs/` lane guards no longer disagree about a bulk-edit
+  mission's own occurrence map, so it can be kept current from the implementing
+  lane without a manual unwind (`#2980`).** The pre-commit ownership guard warned
+  (and let the commit through) while `move-task` blocked the later transition,
+  so `kitty-specs/<mission>/occurrence_map.yaml` — which DIRECTIVE_035 requires
+  the lane to update as the sweep proceeds — tripped the gate after the work was
+  committed. The exception is now expressed once (`is_occurrence_map_path` in
+  `core.constants`) and honored by both guards: the map is permitted on the lane
+  at both, while every other `kitty-specs/` path stays governed (a sibling
+  `spec.md` on the lane is still blocked). The commit-guard `mode` semantics for
+  non-exception paths are unchanged.
+
 - **The lane "no kitty-specs on lane branches" `move-task` guard no longer
   false-positives on inherited planning artifacts in `coord` topology, so lane
   transitions stop demanding `--force` on every step (`#3271`; closes `#2274`).**

--- a/src/specify_cli/bulk_edit/occurrence_map.py
+++ b/src/specify_cli/bulk_edit/occurrence_map.py
@@ -24,6 +24,7 @@ import jsonschema
 from ruamel.yaml import YAML
 
 from kernel.schema_utils import SchemaUtilities
+from specify_cli.core.constants import OCCURRENCE_MAP_FILENAME
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +210,7 @@ def load_occurrence_map(feature_dir: Path) -> OccurrenceMap | None:
 
     Returns ``None`` when the file does not exist.
     """
-    yaml_path = feature_dir / "occurrence_map.yaml"
+    yaml_path = feature_dir / OCCURRENCE_MAP_FILENAME
     if not yaml_path.exists():
         return None
 

--- a/src/specify_cli/cli/commands/agent/tasks_parsing_validation.py
+++ b/src/specify_cli/cli/commands/agent/tasks_parsing_validation.py
@@ -736,6 +736,50 @@ def _check_implementation_commit_present(
     return guidance
 
 
+def _resolve_planning_branch_for_lane_guard(feature_dir: Path) -> str | None:
+    """Resolve the planning branch the lane kitty-specs guard measures against.
+
+    FR-009 / FR-010: reads the planning branch from meta.json — ``planning_base_
+    branch`` with precedence, else the meta ``target_branch`` (routed through the
+    single ``read_target_branch_from_meta`` authority per FR-008 / #2139). Returns
+    ``None`` for legacy missions without meta.json so callers fall back to the
+    lane base ref.
+
+    #3271: this ref is now the guard's DELTA base, not just the error-message
+    hint. In coord topology a lane legitimately inherits prior missions' committed
+    ``kitty-specs/**`` from the base and — via the recorded planning-commit merge
+    (ADR 2026-07-29-1 / #2993) — this mission's own planning artifacts. Both are
+    ancestors of the planning branch, so diffing the lane against it yields an
+    empty delta for that inherited content while still flagging genuine lane-
+    authored ``kitty-specs`` edits. The lane's coordination/mission base ref
+    (``check_branch``), by contrast, predates the inherited content and produced a
+    false positive on every transition.
+    """
+    try:
+        # FR-007 route: this site was INVISIBLE to the WP07 census, whose raw
+        # ``grep "load_meta("`` cannot see an aliased import. Routed onto the
+        # one fail-closed reader like every other divergent wrapper. The broad
+        # catch below is retained deliberately: it guards the two imports and
+        # BOTH readers (pre-existing best-effort contract -- the lane guard must
+        # still report contamination when the optional planning-branch metadata
+        # is unavailable).
+        from specify_cli.core.paths import load_meta_fail_closed as _load_meta_lggrd
+        from specify_cli.core.paths import read_target_branch_from_meta as _read_target_branch_lggrd
+
+        _meta = _load_meta_lggrd(feature_dir)
+        if _meta:
+            _planning = _meta.get("planning_base_branch")
+            if isinstance(_planning, str) and _planning:
+                return _planning
+            _target: str | None = _read_target_branch_lggrd(feature_dir)
+            return _target
+    except Exception as _lane_meta_exc:  # noqa: BLE001 - lane guard still reports contamination without optional metadata
+        logger.debug(
+            "Could not resolve planning_base_branch for lane guard: %s", _lane_meta_exc
+        )
+    return None
+
+
 def _check_kitty_specs_contamination(
     *,
     worktree_path: Path,
@@ -746,39 +790,20 @@ def _check_kitty_specs_contamination(
     list_wp_branch_specs_changes_for_guard: Callable[..., list[str]],
 ) -> list[str] | None:
     """Block when kitty-specs/ files were committed on the lane branch."""
+    # #3271: measure the lane-hygiene delta against the PLANNING branch, not the
+    # lane's coordination/mission base ref (``check_branch``). See
+    # ``_resolve_planning_branch_for_lane_guard`` for why — inherited base content
+    # and the #2993-merged planning artifacts are ancestors of the planning
+    # branch, so they no longer false-positive. Legacy missions without meta.json
+    # fall back to ``check_branch`` (unchanged behaviour for the flat/legacy case).
+    _planning_branch = _resolve_planning_branch_for_lane_guard(feature_dir)
+    _guard_base = _planning_branch or check_branch
     contamination_files = list_wp_branch_specs_changes_for_guard(
         worktree_path=worktree_path,
-        base_branch=check_branch,
+        base_branch=_guard_base,
     )
     if not contamination_files:
         return None
-
-    # FR-009 / FR-010: resolve the planning branch from meta.json so
-    # the error message names the branch and gives a `git show` example.
-    # Falls back gracefully for legacy missions without meta.json.
-    # FR-008 / #2139: the target_branch half of this lookup routes through the
-    # single read_target_branch_from_meta authority rather than a raw
-    # `_meta.get("target_branch")` extraction; planning_base_branch keeps
-    # precedence exactly as before.
-    _planning_branch: str | None = None
-    try:
-        # FR-007 route: this site was INVISIBLE to the WP07 census, whose raw
-        # ``grep "load_meta("`` cannot see an aliased import. Routed onto the
-        # one fail-closed reader like every other divergent wrapper. The broad
-        # catch below is retained deliberately: it guards the two imports and
-        # BOTH readers, not just this one call (pre-existing best-effort
-        # contract -- the lane guard must still report contamination when the
-        # optional planning-branch metadata is unavailable).
-        from specify_cli.core.paths import load_meta_fail_closed as _load_meta_lggrd
-        from specify_cli.core.paths import read_target_branch_from_meta as _read_target_branch_lggrd
-
-        _meta = _load_meta_lggrd(feature_dir)
-        if _meta:
-            _planning_branch = _meta.get("planning_base_branch") or _read_target_branch_lggrd(feature_dir)
-    except Exception as _lane_meta_exc:  # noqa: BLE001 - lane guard still reports contamination without optional metadata
-        logger.debug(
-            "Could not resolve planning_base_branch for lane guard: %s", _lane_meta_exc
-        )
 
     guidance: list[str] = []
     guidance.append("Committed kitty-specs files on this lane branch:")
@@ -805,7 +830,7 @@ def _check_kitty_specs_contamination(
     guidance.append("")
     guidance.append(f"Clean the branch before moving to {target_lane}:")
     guidance.append(f"  cd {worktree_path}")
-    guidance.append(f"  git restore --source {check_branch} --staged --worktree -- {KITTY_SPECS_DIR}/")
+    guidance.append(f"  git restore --source {_guard_base} --staged --worktree -- {KITTY_SPECS_DIR}/")
     guidance.append('  git commit -m "chore: remove planning artifacts from lane branch"')
     guidance.append("")
     guidance.append(f"Then retry: spec-kitty agent tasks move-task {wp_id} --to {target_lane}")

--- a/src/specify_cli/cli/commands/agent/tasks_shared.py
+++ b/src/specify_cli/cli/commands/agent/tasks_shared.py
@@ -42,7 +42,7 @@ from specify_cli.cli.commands.agent.tasks_parsing_validation import (
 )
 from specify_cli.cli.selector_resolution import resolve_mission_handle
 from specify_cli.core.constants import KITTY_SPECS_DIR
-from specify_cli.core.vcs.git import merge_base_changed_files
+from specify_cli.core.vcs.git import git_diff_names_checked, merge_base_changed_files
 from specify_cli.mission_metadata import resolve_mission_identity
 from specify_cli.status import is_dossier_snapshot as _is_dossier_snapshot
 
@@ -567,42 +567,24 @@ def _filter_by_planning_tip_content(
 ) -> list[str]:
     """Drop candidates byte-identical to the planning-branch tip (FR-007 / #2274).
 
-    Runs ``git diff <planning_tip> HEAD -- <path>`` for each candidate.  An
-    empty diff means the file is byte-identical to the planning tip (e.g. after
-    a planning-branch rebase that brought no content change) and must not be
-    flagged as a lane-hygiene violation.  On any git failure the candidate is
-    kept conservatively so the guard never silently loses signal.
+    Compares the candidates against the planning tip through the canonical
+    ``vcs.git`` seam — the same seam pass 1 uses (``merge_base_changed_files``)
+    rather than a hand-rolled ``git diff`` subprocess. A candidate that does not
+    appear in ``git diff <base_branch> HEAD -- kitty-specs/`` is byte-identical
+    to the planning tip (e.g. after a planning-branch rebase that brought no
+    content change) and must not be flagged as a lane-hygiene violation. On any
+    git failure — including an unresolvable ``base_branch`` —
+    ``git_diff_names_checked`` returns ``None`` and every candidate is kept
+    conservatively so the guard never silently loses signal.
     """
-    from specify_cli.cli.commands.agent import tasks as _tasks
-
-    planning_tip_result = _tasks.subprocess.run(
-        ["git", "rev-parse", base_branch],
-        cwd=worktree_path,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
+    diverged = git_diff_names_checked(
+        worktree_path, base_branch, "HEAD", pathspec=f"{KITTY_SPECS_DIR}/"
     )
-    if planning_tip_result.returncode != 0 or not planning_tip_result.stdout.strip():
+    if diverged is None:
+        # git failure or unresolvable base ref → keep conservatively.
         return candidates
-
-    planning_tip = planning_tip_result.stdout.strip()
-    files: list[str] = []
-    for path in candidates:
-        content_diff = _tasks.subprocess.run(
-            ["git", "diff", planning_tip, "HEAD", "--", path],
-            cwd=worktree_path,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-        )
-        # Non-empty diff or git error → genuinely diverges from planning tip; keep.
-        if content_diff.returncode != 0 or content_diff.stdout.strip():
-            files.append(path)
-    return files
+    diverged_set = set(diverged)
+    return [path for path in candidates if path in diverged_set]
 
 
 def _list_wp_branch_mission_specs_changes(worktree_path: Path, base_branch: str) -> list[str]:

--- a/src/specify_cli/cli/commands/agent/tasks_shared.py
+++ b/src/specify_cli/cli/commands/agent/tasks_shared.py
@@ -41,7 +41,7 @@ from specify_cli.cli.commands.agent.tasks_parsing_validation import (
     _validate_ready_for_review as _seam_validate_ready_for_review,
 )
 from specify_cli.cli.selector_resolution import resolve_mission_handle
-from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.constants import KITTY_SPECS_DIR, is_occurrence_map_path
 from specify_cli.core.vcs.git import git_diff_names_checked, merge_base_changed_files
 from specify_cli.mission_metadata import resolve_mission_identity
 from specify_cli.status import is_dossier_snapshot as _is_dossier_snapshot
@@ -613,6 +613,12 @@ def _list_wp_branch_mission_specs_changes(worktree_path: Path, base_branch: str)
         if not path or not path.startswith(f"{KITTY_SPECS_DIR}/"):
             continue
         if path in seen:
+            continue
+        # #2980: a bulk-edit mission's own occurrence map is the single permitted
+        # kitty-specs/ lane write (DIRECTIVE_035). Honor the same exception the
+        # pre-commit guard applies, expressed once in is_occurrence_map_path, so
+        # the two kitty-specs guards agree instead of warn-here / block-there.
+        if is_occurrence_map_path(path):
             continue
         seen.add(path)
         candidates.append(path)

--- a/src/specify_cli/core/constants.py
+++ b/src/specify_cli/core/constants.py
@@ -18,6 +18,36 @@ RETROSPECTIVE_FILENAME = "retrospective.yaml"
 # forbidden (#2628 SSOT fold).
 LINT_REPORT_FILENAME = "lint-report.json"
 
+# Canonical filename for a bulk-edit mission's occurrence map, written to
+# ``kitty-specs/<mission>/occurrence_map.yaml`` (DIRECTIVE_035).  The semantic
+# owner is ``specify_cli.bulk_edit.occurrence_map``; this is the shared path
+# literal (Sonar S1192) so the two kitty-specs lane guards below express the
+# occurrence-map exception once instead of duplicating the string.
+OCCURRENCE_MAP_FILENAME = "occurrence_map.yaml"
+
+
+def is_occurrence_map_path(path: str) -> bool:
+    """Return True when *path* is a mission occurrence map (the #2980 exception SSOT).
+
+    The single authority both ``kitty-specs/`` lane guards consult — the
+    pre-commit ownership guard (``policy.commit_guard``) and the ``move-task``
+    lane-hygiene guard (``cli.commands.agent.tasks_shared``) — to permit a
+    bulk-edit mission's own ``kitty-specs/<mission>/occurrence_map.yaml`` on an
+    implementation lane. DIRECTIVE_035 requires the map be kept current *as the
+    sweep proceeds*, which means the implementing lane writes it; without this
+    single exception the commit guard warned while ``move-task`` blocked, so the
+    map could not be kept current without a manual unwind (#2980).
+
+    Matches exactly ``kitty-specs/<mission>/occurrence_map.yaml`` — the map lives
+    directly under the mission directory (three path segments). Every other
+    ``kitty-specs/`` path stays governed.
+    """
+    if not path.startswith(f"{KITTY_SPECS_DIR}/"):
+        return False
+    if not path.endswith(f"/{OCCURRENCE_MAP_FILENAME}"):
+        return False
+    return path.count("/") == 2
+
 # Named scalar aliases for individual built-in mission-type identifiers, used at
 # the CLI comparison sites.  The canonical *roster* (the full built-in set) is
 # ``doctrine.missions.mission_type_repository.builtin_mission_type_ids`` (#2669) —
@@ -32,8 +62,10 @@ __all__ = [
     "KITTIFY_DIR",
     "RETROSPECTIVE_FILENAME",
     "LINT_REPORT_FILENAME",
+    "OCCURRENCE_MAP_FILENAME",
     "WORKTREES_DIR",
     "MISSION_TYPE_SOFTWARE_DEV",
     "MISSION_TYPE_DOCUMENTATION",
     "MISSION_TYPE_RESEARCH",
+    "is_occurrence_map_path",
 ]

--- a/src/specify_cli/policy/commit_guard.py
+++ b/src/specify_cli/policy/commit_guard.py
@@ -6,7 +6,7 @@ scope and blocks modifications to kitty-specs/ from implementation branches.
 
 from __future__ import annotations
 
-from specify_cli.core.constants import KITTY_SPECS_DIR
+from specify_cli.core.constants import KITTY_SPECS_DIR, is_occurrence_map_path
 import fnmatch
 import re
 from dataclasses import dataclass, field
@@ -81,9 +81,13 @@ def validate_staged_files(
         )
 
     # Check kitty-specs/ protection.
+    # #2980: a bulk-edit mission's own occurrence map is the single permitted
+    # kitty-specs/ lane write (DIRECTIVE_035). The exception is expressed once in
+    # ``is_occurrence_map_path`` and honored identically by the move-task
+    # lane-hygiene guard, so the two guards no longer disagree on it.
     if policy.block_mission_specs:
         for f in staged_files:
-            if f.startswith(f"{KITTY_SPECS_DIR}/"):
+            if f.startswith(f"{KITTY_SPECS_DIR}/") and not is_occurrence_map_path(f):
                 violations.append(
                     f"Protected path: {f} — implementation branches must not modify kitty-specs/"
                 )

--- a/tests/policy/test_commit_guard.py
+++ b/tests/policy/test_commit_guard.py
@@ -58,6 +58,35 @@ class TestKittySpecsProtection:
         assert result.allowed is True
         assert len(result.violations) == 0
 
+    def test_allows_own_occurrence_map_on_lane_branch(self):
+        """#2980: a bulk-edit mission's own occurrence map is the single permitted
+        kitty-specs/ lane write — even in block mode, and not even a warning."""
+        result = validate_staged_files(
+            staged_files=["kitty-specs/057-feat/occurrence_map.yaml", "src/app.py"],
+            owned_files=["src/**"],
+            branch_name="kitty/mission-057-feat-lane-a",
+            policy=CommitGuardConfig(mode="block"),
+        )
+        assert result.allowed is True
+        assert not any("kitty-specs" in v for v in result.violations)
+        assert not any("kitty-specs" in w for w in result.warnings)
+
+    def test_still_blocks_other_kitty_specs_alongside_occurrence_map(self):
+        """The exception is scoped to occurrence_map.yaml; a sibling spec.md on
+        the lane is still a protected-path violation."""
+        result = validate_staged_files(
+            staged_files=[
+                "kitty-specs/057-feat/occurrence_map.yaml",
+                "kitty-specs/057-feat/spec.md",
+            ],
+            owned_files=["src/**"],
+            branch_name="kitty/mission-057-feat-lane-a",
+            policy=CommitGuardConfig(mode="block"),
+        )
+        assert result.allowed is False
+        assert any("spec.md" in v for v in result.violations)
+        assert not any("occurrence_map.yaml" in v for v in result.violations)
+
 
 class TestOwnershipEnforcement:
     def test_in_scope_files_allowed(self):

--- a/tests/specify_cli/cli/commands/agent/test_lane_hygiene_content_diff.py
+++ b/tests/specify_cli/cli/commands/agent/test_lane_hygiene_content_diff.py
@@ -274,3 +274,91 @@ class TestGenuinelyDivergentStillFlagged:
         assert "spec.md" not in flagged_names, (
             f"Identical file 'spec.md' should NOT be flagged, got {flagged!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# T027 / T028: coord-topology inheritance (#3271)
+# ---------------------------------------------------------------------------
+
+
+def _build_coord_inheritance_scenario(tmp_path: Path) -> tuple[Path, str, str]:
+    """Simulate the #3271 coord-topology inheritance layout.
+
+    Layout::
+
+        A (main) ── README
+          └── coord:  A → C   (adds kitty-specs/prior-mission/spec.md)
+                └── target: C → T   (adds kitty-specs/this-mission/spec.md)
+        lane: forked from coord (C), then MERGES the recorded planning commit T
+              (ADR 2026-07-29-1 / #2993) → lane kitty-specs is byte-identical to
+              target, with zero lane-authored delta.
+
+    The coordination branch is minted at mission-create *before* the planning
+    commit exists, so ``merge-base(lane, coord)`` predates ``this-mission``'s
+    planning artifacts even though the lane holds them byte-identically to the
+    planning tip. Diffing against ``coord`` therefore false-positives; diffing
+    against ``target`` (the planning branch) is clean.
+
+    Returns ``(repo, coord_branch, target_branch)``.
+    """
+    repo = _init_repo(tmp_path)
+
+    (repo / "README.md").write_text("anchor\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "anchor")
+
+    # Coordination branch: prior mission's committed kitty-specs, no planning yet.
+    _git(repo, "checkout", "-q", "-b", "coord")
+    prior = repo / "kitty-specs" / "prior-mission"
+    prior.mkdir(parents=True)
+    (prior / "spec.md").write_text("prior mission spec\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "coord: inherit prior-mission kitty-specs")
+
+    # Target/planning branch: adds THIS mission's planning artifacts on top.
+    _git(repo, "checkout", "-q", "-b", "target")
+    this_mission = repo / "kitty-specs" / "this-mission"
+    this_mission.mkdir(parents=True)
+    (this_mission / "spec.md").write_text("this mission spec\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "target: record this-mission planning commit")
+    planning_sha = subprocess.run(
+        ["git", "rev-parse", "target"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Lane: forked from coord, then merges the recorded planning commit (#2993).
+    _git(repo, "checkout", "-q", "coord")
+    _git(repo, "checkout", "-q", "-b", "lane")
+    _git(repo, "merge", "-q", "--no-edit", planning_sha)
+
+    return repo, "coord", "target"
+
+
+class TestCoordInheritanceNotFlagged:
+    """#3271: a lane whose kitty-specs are byte-identical to the planning branch
+    must not be flagged, even when the coordination base ref predates them."""
+
+    def test_t027_coord_base_reproduces_the_false_positive(self, tmp_path: Path) -> None:
+        """Characterisation: basing the delta on the coordination branch flags
+        inherited/merged content — the pre-fix behaviour #3271 reports."""
+        repo, coord, _target = _build_coord_inheritance_scenario(tmp_path)
+
+        flagged = _list_wp_branch_mission_specs_changes(repo, coord)
+
+        assert flagged, (
+            "Scenario invariant: diffing against the coordination base ref must "
+            "surface the inherited/merged kitty-specs (the #3271 false positive)."
+        )
+
+    def test_t028_planning_base_is_clean(self, tmp_path: Path) -> None:
+        """The fix: basing the delta on the planning/target branch yields an empty
+        result — inherited and #2993-merged artifacts are ancestors of it."""
+        repo, _coord, target = _build_coord_inheritance_scenario(tmp_path)
+
+        flagged = _list_wp_branch_mission_specs_changes(repo, target)
+
+        assert flagged == [], (
+            f"False positive: lane kitty-specs byte-identical to the planning "
+            f"branch were flagged. Flagged paths: {flagged!r}"
+        )

--- a/tests/specify_cli/cli/commands/agent/test_lane_hygiene_content_diff.py
+++ b/tests/specify_cli/cli/commands/agent/test_lane_hygiene_content_diff.py
@@ -362,3 +362,77 @@ class TestCoordInheritanceNotFlagged:
             f"False positive: lane kitty-specs byte-identical to the planning "
             f"branch were flagged. Flagged paths: {flagged!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Occurrence-map exception (#2980): a bulk-edit mission's own occurrence map is
+# a permitted lane write and must not be flagged by the lane-hygiene guard.
+# ---------------------------------------------------------------------------
+
+
+class TestOccurrenceMapException:
+    """#2980: the move-task lane-hygiene guard honours the same occurrence-map
+    exception the pre-commit guard does — the lane may carry its own mission's
+    ``kitty-specs/<mission>/occurrence_map.yaml`` without being flagged, while a
+    sibling planning artifact on the lane is still flagged."""
+
+    def test_own_occurrence_map_is_not_flagged(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+
+        (repo / "README.md").write_text("anchor\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "anchor")
+
+        # Planning branch has no occurrence map yet.
+        _git(repo, "checkout", "-q", "-b", "planning")
+        (repo / "kitty-specs" / "mission-x").mkdir(parents=True)
+        (repo / "kitty-specs" / "mission-x" / "spec.md").write_text("spec\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "planning: spec")
+
+        # Lane writes ONLY its own occurrence map (DIRECTIVE_035 sweep upkeep).
+        _git(repo, "checkout", "-q", "-b", "lane")
+        (repo / "kitty-specs" / "mission-x" / "occurrence_map.yaml").write_text(
+            "target: {}\n", encoding="utf-8"
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "lane: keep occurrence map current")
+
+        flagged = _list_wp_branch_mission_specs_changes(repo, "planning")
+
+        assert flagged == [], (
+            f"Occurrence map wrongly flagged as lane contamination: {flagged!r}"
+        )
+
+    def test_sibling_planning_artifact_still_flagged(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+
+        (repo / "README.md").write_text("anchor\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "anchor")
+
+        _git(repo, "checkout", "-q", "-b", "planning")
+        (repo / "kitty-specs" / "mission-x").mkdir(parents=True)
+        (repo / "kitty-specs" / "mission-x" / "spec.md").write_text("spec\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "planning: spec")
+
+        # Lane writes its occurrence map AND edits spec.md (a real violation).
+        _git(repo, "checkout", "-q", "-b", "lane")
+        (repo / "kitty-specs" / "mission-x" / "occurrence_map.yaml").write_text(
+            "target: {}\n", encoding="utf-8"
+        )
+        (repo / "kitty-specs" / "mission-x" / "spec.md").write_text(
+            "spec EDITED on lane\n", encoding="utf-8"
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-q", "-m", "lane: map + spec edit")
+
+        flagged = _list_wp_branch_mission_specs_changes(repo, "planning")
+
+        assert any("spec.md" in p for p in flagged), (
+            f"Genuine spec.md edit on the lane must still be flagged, got {flagged!r}"
+        )
+        assert not any("occurrence_map.yaml" in p for p in flagged), (
+            f"Occurrence map must be excepted even alongside a real violation, got {flagged!r}"
+        )

--- a/tests/specify_cli/cli/commands/agent/test_tasks_parsing_validation.py
+++ b/tests/specify_cli/cli/commands/agent/test_tasks_parsing_validation.py
@@ -27,6 +27,7 @@ from specify_cli.cli.commands.agent.tasks_parsing_validation import (
     _check_uncommitted_worktree_changes,
     _check_worktree_health,
     _issue_matrix_approval_blocker,
+    _resolve_planning_branch_for_lane_guard,
     _self_review_fallback_option_error,
     _validate_research_artifacts,
     _validate_worktree_state,
@@ -816,6 +817,100 @@ def test_check_kitty_specs_contamination_clean_returns_none(tmp_path: Path) -> N
         list_wp_branch_specs_changes_for_guard=lambda **_k: [],
     )
     assert result is None
+
+
+def test_check_kitty_specs_contamination_diffs_against_planning_branch(tmp_path: Path) -> None:
+    """#3271 red-first: the lane-hygiene delta must be measured against the
+    PLANNING branch, not the lane's coordination/mission base ref.
+
+    Pre-fix the guard passed ``check_branch`` (the coord/mission branch) to the
+    lister, so a lane that legitimately inherited kitty-specs from the base — or
+    got this mission's planning artifacts via the #2993 recorded-planning-commit
+    merge — false-positived on every transition. The captured ``base_branch``
+    must now be the planning branch resolved from meta.json.
+    """
+    captured: dict[str, object] = {}
+
+    def _spy(**kwargs: object) -> list[str]:
+        captured["base_branch"] = kwargs["base_branch"]
+        return []  # clean delta against the planning branch → guard passes
+
+    with patch(
+        "specify_cli.mission_metadata.load_meta",
+        return_value={"planning_base_branch": "kitty/plan"},
+    ):
+        result = _check_kitty_specs_contamination(
+            worktree_path=tmp_path,
+            check_branch="kitty/mission-coord-01ABC",
+            feature_dir=tmp_path,
+            wp_id="WP01",
+            target_lane="for_review",
+            list_wp_branch_specs_changes_for_guard=_spy,
+        )
+
+    assert result is None
+    # RED pre-fix: was "kitty/mission-coord-01ABC" (the coordination base ref).
+    assert captured["base_branch"] == "kitty/plan"
+
+
+def test_check_kitty_specs_contamination_falls_back_to_check_branch_without_meta(
+    tmp_path: Path,
+) -> None:
+    """Legacy/flat missions without meta.json keep the lane base ref (#3271).
+
+    When no planning branch can be resolved the delta base must fall back to
+    ``check_branch`` exactly as before — the flat/legacy topology forks from the
+    mission branch, which is the correct base there.
+    """
+    captured: dict[str, object] = {}
+
+    def _spy(**kwargs: object) -> list[str]:
+        captured["base_branch"] = kwargs["base_branch"]
+        return []
+
+    with patch("specify_cli.mission_metadata.load_meta", return_value=None):
+        _check_kitty_specs_contamination(
+            worktree_path=tmp_path,
+            check_branch="kitty/mission-legacy",
+            feature_dir=tmp_path,
+            wp_id="WP01",
+            target_lane="for_review",
+            list_wp_branch_specs_changes_for_guard=_spy,
+        )
+
+    assert captured["base_branch"] == "kitty/mission-legacy"
+
+
+# ---------------------------------------------------------------------------
+# Sub-split helper: _resolve_planning_branch_for_lane_guard (#3271)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_planning_branch_prefers_planning_base_branch(tmp_path: Path) -> None:
+    with patch(
+        "specify_cli.mission_metadata.load_meta",
+        return_value={"planning_base_branch": "kitty/plan", "target_branch": "docs/x"},
+    ):
+        assert _resolve_planning_branch_for_lane_guard(tmp_path) == "kitty/plan"
+
+
+def test_resolve_planning_branch_falls_back_to_target_branch(tmp_path: Path) -> None:
+    with (
+        patch(
+            "specify_cli.mission_metadata.load_meta",
+            return_value={"target_branch": "docs/3253-docs-gaps"},
+        ),
+        patch(
+            "specify_cli.core.paths.read_target_branch_from_meta",
+            return_value="docs/3253-docs-gaps",
+        ),
+    ):
+        assert _resolve_planning_branch_for_lane_guard(tmp_path) == "docs/3253-docs-gaps"
+
+
+def test_resolve_planning_branch_returns_none_without_meta(tmp_path: Path) -> None:
+    with patch("specify_cli.mission_metadata.load_meta", return_value=None):
+        assert _resolve_planning_branch_for_lane_guard(tmp_path) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/specify_cli/core/test_constants.py
+++ b/tests/specify_cli/core/test_constants.py
@@ -1,0 +1,45 @@
+"""Unit tests for shared path constants and the occurrence-map exception SSOT.
+
+``is_occurrence_map_path`` is the single authority both ``kitty-specs/`` lane
+guards consult for the DIRECTIVE_035 bulk-edit exception (#2980), so it is pinned
+directly here rather than only through its two consumers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.core.constants import (
+    OCCURRENCE_MAP_FILENAME,
+    is_occurrence_map_path,
+)
+
+pytestmark = [pytest.mark.fast]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"kitty-specs/057-feat/{OCCURRENCE_MAP_FILENAME}",
+        "kitty-specs/my-mission-01ABCDEF/occurrence_map.yaml",
+    ],
+)
+def test_permits_mission_occurrence_map(path: str) -> None:
+    assert is_occurrence_map_path(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "kitty-specs/057-feat/spec.md",
+        "kitty-specs/057-feat/plan.md",
+        "kitty-specs/occurrence_map.yaml",  # not under a mission dir (2 segments)
+        "kitty-specs/057-feat/nested/occurrence_map.yaml",  # too deep (4 segments)
+        "src/occurrence_map.yaml",  # outside kitty-specs/
+        "docs/kitty-specs/057/occurrence_map.yaml",  # kitty-specs not at root
+        "occurrence_map.yaml",
+        "",
+    ],
+)
+def test_rejects_non_exception_paths(path: str) -> None:
+    assert is_occurrence_map_path(path) is False


### PR DESCRIPTION
## Summary

Fixes a P0 that recurs on **every** `coord`-topology mission run in a dogfooding repo: the lane "no kitty-specs on lane branches" `move-task` guard false-positives on inherited planning artifacts and forces `--force` on every WP transition. Also reconciles a companion split-brain between the two `kitty-specs/` guards.

Closes #3271 · Closes #2274 · Closes #2980

## Root cause (#3271)

The guard is **already** a two-pass content delta (merge-base diff + planning-tip content re-check — the shipped #2274 / FR-007 fix). But both passes keyed off `check_branch`, which under `coord` topology is the lane's **coordination/mission** base ref. That ref's merge-base with the lane predates the `kitty-specs/**` the lane legitimately holds:

- prior missions' committed artifacts inherited from the base, **plus**
- this mission's own planning artifacts merged in via the recorded planning commit (ADR `2026-07-29-1` / #2993).

Both are ancestors of the **planning** branch but not of the coord base, so they surfaced as lane-introduced contamination and survived the content re-check (which diffed against the same wrong ref). The guard's own "clean the branch" remedy would have deleted *other* missions' planning artifacts, leaving `--force` — documented as "not recommended" — as the only safe path.

The issue's "presence check" framing is refuted: it's a delta check, just against the wrong ref.

## What changed

**Fix #3271** — measure the lane-hygiene delta against the **planning branch** (`planning_base_branch`, else the mission's `target_branch`), falling back to `check_branch` only for legacy/flat missions without `meta.json`. Local to `_check_kitty_specs_contamination`; the sibling branch-currency and implementation-commit gates keep the coord ref (correct for them). Extracted `_resolve_planning_branch_for_lane_guard` (previously inline, used only for the error hint) as the single resolver.

**Fix #2980** — the pre-commit ownership guard *warned* on a `kitty-specs/` lane write while `move-task` *blocked* the later transition, so a bulk-edit mission's own `kitty-specs/<mission>/occurrence_map.yaml` (which DIRECTIVE_035 requires the lane to keep current) tripped the gate after commit. The exception is now expressed **once** — `is_occurrence_map_path` + `OCCURRENCE_MAP_FILENAME` in `core.constants` (beside `RETROSPECTIVE_FILENAME`/`LINT_REPORT_FILENAME`, same S1192 SSOT rationale) — and honored by **both** guards. Every other `kitty-specs/` path stays governed; the commit-guard `mode` semantics are unchanged (reporter's option B).

**Campsite (first commit)** — pass-2 (`_filter_by_planning_tip_content`) hand-rolled `git rev-parse` + per-candidate `git diff` via raw `subprocess`; routed it through the canonical `git_diff_names_checked` seam pass-1 already uses (N calls → 1, typed, conservative-on-failure preserved). Behaviour-preserving.

## Testing

- **Red-first** for both fixes: the #3271 wiring test fails pre-fix (guard passed the coord ref, not the planning branch); neutering the #2980 SSOT predicate reddens all three consuming surfaces.
- New coverage: `_resolve_planning_branch_for_lane_guard` unit tests; a real-git coord-inheritance scenario (coord base reproduces the FP, planning base is clean); `is_occurrence_map_path` matrix; commit-guard + move-task occurrence-map exception tests (map permitted, sibling `spec.md` still blocked).
- Targeted suites green (434 + 86); `ruff` + `mypy --strict` clean on changed files; terminology guard green.

## Scope boundary

Self-contained base-ref/exception fixes. The broader "write target derived from ambient location" class (#3129 *scoped shadow workspaces*) is **not** touched — this does not need it and does not substitute for it. Unclaimed siblings deferred there: #2334, #2367, #2570, #2613, #2745, #3049, #3051, #3124, #3540.

## Sonar

No new hotspots expected. `tasks_shared.py` retains two pre-existing `no-any-return` notes (`:467`, `:623`) that resolve under the whole-package `mypy` run and route through a required monkeypatch seam — left as-is, out of this change's domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789648603&installation_model_id=427282&pr_number=3556&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3556&signature=03b90c6e7282948e218cda6b6820ee52bbfced2333b18beee961d85b48989f60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->