### PR TITLE
docs(charter): re-point stale #3091 deferral to live follow-up #3575

### DIFF
--- a/src/charter/mission_type_profile_repository.py
+++ b/src/charter/mission_type_profile_repository.py
@@ -61,10 +61,12 @@ def builtin_missions_root() -> Path:
     is layer-rule-clean (charter → doctrine, no ``specify_cli``) and
     byte-identical in the return value: :meth:`default_missions_root` is
     itself ``importlib.resources``-based (wheel-safe), which the previous
-    ``Path(__file__)``-relative literal here was not. Full convergence onto
-    ``doctrine.pack_paths.built_in_dir`` remains deferred to #3091 —
-    ``pack_paths`` has no ``missions/`` content directory today — and is
-    explicitly NOT claimed by this delegation.
+    ``Path(__file__)``-relative literal here was not. Full convergence onto the
+    promoted ``pack_paths`` missions authority
+    (``doctrine.pack_paths.built_in_missions_root``) is a tracked follow-up
+    (#3575), now unblocked — #3091 relocated the missions tree into
+    ``packs/built-in`` and ``pack_paths`` exposes ``built_in_missions_root()`` —
+    and is explicitly NOT claimed by this delegation.
 
     Public module-level accessor (#2668) so cross-module consumers (e.g.
     ``charter.action_grain``, ``charter.mission_type_profiles``) no longer


### PR DESCRIPTION
## What changes

A code comment in `charter/mission_type_profile_repository.py::builtin_missions_root` deferred "full convergence onto `pack_paths`" to **#3091**, on the premise that "`pack_paths` has no `missions/` content directory today." Both halves are now stale:

- **#3091 is COMPLETED** — the `missions/` doctrine tree was relocated into `packs/built-in/missions`.
- **`pack_paths` now exposes the missions leaf** — `doctrine/pack_paths.py::built_in_missions_root()` exists.

The convergence itself is **unblocked but not done** (the accessor still delegates to `MissionTemplateRepository`), so the comment now points at its live tracked follow-up **#3575** and states the corrected status, instead of presenting completed prerequisite work as pending.

Surfaced by a charter-cascade / org-pack-DRG research sweep. Comment-only; no behavior change; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789711218&installation_model_id=427282&pr_number=3576&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3576&signature=dd26bb1be59a151ed960021d46e96e08b9c983d03278bf44ec742c0861a91586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->