### PR TITLE
fix(charter): remediations that can actually clear their own checks (#2831 residual)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -354,6 +354,25 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **A charter-preflight state no longer hands you a command that cannot clear it
+  (`#2831`).** Four freshness states — `charter_source` `missing`/`invalid` and
+  `synced_bundle` `missing`/`stale` — emitted `spec-kitty charter sync` as their
+  remediation, and `charter sync` is a pure staleness reporter that never writes
+  (`src/charter/sync.py`: "it always reports `synced=False` / `files_written=[]`").
+  The operator ran it, nothing changed, and the gate refused identically, while every
+  charter diagnostic reported healthy because they resolve `charter.md` and the gate
+  resolves `charter.yaml`. There was no exit. Now the one state a command can actually
+  clear — an absent `charter.yaml` on a project with no `charter:` pointer — names
+  `spec-kitty charter generate --no-from-interview`, and the states no command can
+  clear emit **no** remediation plus a `detail` explaining why. An unparseable
+  `charter.yaml` cannot be repaired by any write path (each round-trip-parses it to
+  preserve authored sections), and with a `charter:` pointer present `charter generate`
+  fails closed by design (INV-5, `#2530`) so it cannot run either; the documented
+  recovery there, `spec-kitty upgrade`, is interactive. Being told no command exists,
+  with the reason, beats being sent to one that exits non-zero. A new architectural
+  gate (`tests/architectural/test_remediation_effectiveness.py`) pins the rule: every
+  emitted remediation must exit 0 **and** leave its state `fresh`.
+
 - **`charter activate --cascade` now follows an org-pack dependency edge no
   matter which pack in the chain declares it, and activating from an org pack
   that ships no dependency graph no longer crashes the command (`#3534`; closes

--- a/src/specify_cli/charter_runtime/freshness/computer.py
+++ b/src/specify_cli/charter_runtime/freshness/computer.py
@@ -115,7 +115,22 @@ FreshnessState = Literal["fresh", "stale", "missing", "built_in_only", "invalid"
 
 # S1192: shared remediation command strings, referenced by every sub-state
 # builder below that recommends a recovery command.
-_REMEDIATE_CHARTER_SYNC = "spec-kitty charter sync"
+# `charter sync` is deliberately NOT used as a remediation here (#2831).
+# `src/charter/sync.py` documents itself as a pure staleness reporter -- "it
+# always reports synced=False / files_written=[]" -- so every state that named
+# it handed the operator a command that could not clear the check blocking them.
+# Each state below now names a command that demonstrably reaches `fresh`,
+# enforced by tests/architectural/test_remediation_effectiveness.py.
+_REMEDIATE_CHARTER_GENERATE = "spec-kitty charter generate --no-from-interview"
+#: An unparseable `charter.yaml` needs the extra flag: `write_compiled_charter`
+#: refreshes only the DERIVED sections of an existing file and round-trips the
+#: document to preserve the AUTHORED ones, so it must parse it. `--force` does
+#: NOT help (it gates no destructive overwrite -- see that function's
+#: docstring); the file has to be moved aside first, which `--recover-invalid`
+#: does (to `charter.yaml.bak`).
+_REMEDIATE_CHARTER_RECOVER = (
+    "spec-kitty charter generate --no-from-interview --recover-invalid"
+)
 _REMEDIATE_CHARTER_SYNTHESIZE = "spec-kitty charter synthesize"
 
 
@@ -133,7 +148,7 @@ class FreshnessSubState:
             ``invalid``.  Matches ``contracts/charter-status-json.md``.
         last_change: ISO 8601 timestamp of the most recent change to the
             tracked asset (None when missing or unknown).
-        remediation: Operator-facing hint (e.g. ``spec-kitty charter sync``)
+        remediation: Operator-facing hint (e.g. ``spec-kitty charter generate``)
             or None when no action is required.
         detail: Optional human-readable explanation surfaced for ``invalid``
             states so operators understand why an artifact is broken.
@@ -311,7 +326,7 @@ def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
         return FreshnessSubState(
             state="missing",
             last_change=None,
-            remediation=_REMEDIATE_CHARTER_SYNC,
+            remediation=_REMEDIATE_CHARTER_GENERATE,
         )
 
     last_change = _mtime_iso(charter_yaml_path)
@@ -320,8 +335,11 @@ def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
         return FreshnessSubState(
             state="invalid",
             last_change=last_change,
-            remediation=_REMEDIATE_CHARTER_SYNC,
-            detail="charter.yaml exists but cannot be parsed",
+            remediation=_REMEDIATE_CHARTER_RECOVER,
+            detail=(
+                "charter.yaml exists but cannot be parsed; --recover-invalid moves it "
+                "to charter.yaml.bak and bootstraps a fresh one"
+            ),
         )
 
     return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)
@@ -350,7 +368,7 @@ def _compute_synced_bundle(
         return FreshnessSubState(
             state="missing",
             last_change=None,
-            remediation=_REMEDIATE_CHARTER_SYNC,
+            remediation=_REMEDIATE_CHARTER_GENERATE,
         )
 
     last_change = _latest_mtime(existing)
@@ -359,7 +377,7 @@ def _compute_synced_bundle(
         return FreshnessSubState(
             state="stale",
             last_change=last_change,
-            remediation=_REMEDIATE_CHARTER_SYNC,
+            remediation=_REMEDIATE_CHARTER_RECOVER,
         )
 
     return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)

--- a/src/specify_cli/charter_runtime/freshness/computer.py
+++ b/src/specify_cli/charter_runtime/freshness/computer.py
@@ -119,20 +119,26 @@ FreshnessState = Literal["fresh", "stale", "missing", "built_in_only", "invalid"
 # `src/charter/sync.py` documents itself as a pure staleness reporter -- "it
 # always reports synced=False / files_written=[]" -- so every state that named
 # it handed the operator a command that could not clear the check blocking them.
-# Each state below now names a command that demonstrably reaches `fresh`,
-# enforced by tests/architectural/test_remediation_effectiveness.py.
 _REMEDIATE_CHARTER_GENERATE = "spec-kitty charter generate --no-from-interview"
-#: An unparseable `charter.yaml` needs the extra flag: `write_compiled_charter`
-#: refreshes only the DERIVED sections of an existing file and round-trips the
-#: document to preserve the AUTHORED ones, so it must parse it. `--force` does
-#: NOT help (it gates no destructive overwrite -- see that function's
-#: docstring); the file has to be moved aside first, which `--recover-invalid`
-#: does (to `charter.yaml.bak`).
-_REMEDIATE_CHARTER_RECOVER = (
-    "spec-kitty charter generate --no-from-interview --recover-invalid"
-)
 _REMEDIATE_CHARTER_SYNTHESIZE = "spec-kitty charter synthesize"
 
+#: States for which NO command in this codebase can currently reach `fresh`, so
+#: the honest output is no command at all rather than one that cannot work.
+#:
+#: An unparseable `charter.yaml` is the case: `write_compiled_charter` refreshes
+#: only the DERIVED sections of an existing file and round-trips the document to
+#: preserve the AUTHORED ones, so it must PARSE it -- and `--force` gates no
+#: destructive overwrite (see that function's docstring). PR #3015 reached the
+#: same conclusion by exhaustive census.
+#:
+#: Moving the file aside first LOOKS like the answer and is not: on any project
+#: that has run `charter generate` before, `.kittify/config.yaml` carries a
+#: `charter:` pointer, and generation then dies in
+#: `provision_mission_type_activations` -> `resolve_activation_write_target`
+#: with CHARTER_PACK_CONFIG_INVALID *after* the original was moved -- leaving no
+#: charter.yaml at all. That is strictly worse than showing no command, so this
+#: state stays exempt until the stale-pointer crash is fixed on its own.
+_NO_EFFECTIVE_REMEDIATION = None
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -309,6 +315,36 @@ def _latest_mtime(paths: list[Path]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+
+def _has_charter_pointer(repo_root: Path) -> bool:
+    """True when ``.kittify/config.yaml`` carries a ``charter:`` pointer.
+
+    Load-bearing for remediation selection, not cosmetic. A project that has
+    ever run ``charter generate`` successfully carries this pointer, and
+    ``pack_manager.resolve_activation_write_target`` then fails LOUD by design
+    (INV-5 / #2530) when the pointed-at file is absent or unreadable -- so
+    ``charter generate`` itself cannot run, and cannot be the remediation.
+    """
+    config = _safe_load_yaml(repo_root / ".kittify" / "config.yaml")
+    return bool(config) and bool(str(config.get("charter") or "").strip())
+
+
+def _remediation_for_absent_charter(repo_root: Path) -> str | None:
+    """The command that can recreate an absent ``charter.yaml``, if one exists.
+
+    Without a pointer this is an ordinary bootstrap and ``charter generate``
+    works (verified). With a dangling pointer it does not: generation dies in
+    ``provision_mission_type_activations`` before writing anything. The
+    documented recovery for that shape is ``spec-kitty upgrade``, which is
+    INTERACTIVE (it prompts before applying migrations), so there is no single
+    non-interactive command to hand the operator -- and naming one that exits
+    non-zero is the exact defect #2831 is about.
+    """
+    if _has_charter_pointer(repo_root):
+        return _NO_EFFECTIVE_REMEDIATION
+    return _REMEDIATE_CHARTER_GENERATE
+
+
 def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
     """Report presence/parseability of the resolving charter source.
 
@@ -326,7 +362,16 @@ def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
         return FreshnessSubState(
             state="missing",
             last_change=None,
-            remediation=_REMEDIATE_CHARTER_GENERATE,
+            remediation=_remediation_for_absent_charter(repo_root),
+            detail=(
+                None
+                if not _has_charter_pointer(repo_root)
+                else (
+                    "charter.yaml is absent but .kittify/config.yaml still points at it; "
+                    "`charter generate` fails closed on a dangling pointer (INV-5). "
+                    "Run `spec-kitty upgrade` (interactive) or correct the 'charter:' pointer"
+                )
+            ),
         )
 
     last_change = _mtime_iso(charter_yaml_path)
@@ -335,10 +380,11 @@ def _compute_charter_source(repo_root: Path) -> FreshnessSubState:
         return FreshnessSubState(
             state="invalid",
             last_change=last_change,
-            remediation=_REMEDIATE_CHARTER_RECOVER,
+            remediation=_NO_EFFECTIVE_REMEDIATION,
             detail=(
-                "charter.yaml exists but cannot be parsed; --recover-invalid moves it "
-                "to charter.yaml.bak and bootstraps a fresh one"
+                "charter.yaml exists but cannot be parsed; no command can currently "
+                "repair it -- fix the YAML by hand, or move it aside and re-run "
+                "`spec-kitty charter generate --no-from-interview`"
             ),
         )
 
@@ -368,7 +414,7 @@ def _compute_synced_bundle(
         return FreshnessSubState(
             state="missing",
             last_change=None,
-            remediation=_REMEDIATE_CHARTER_GENERATE,
+            remediation=_remediation_for_absent_charter(repo_root),
         )
 
     last_change = _latest_mtime(existing)
@@ -377,7 +423,7 @@ def _compute_synced_bundle(
         return FreshnessSubState(
             state="stale",
             last_change=last_change,
-            remediation=_REMEDIATE_CHARTER_RECOVER,
+            remediation=_NO_EFFECTIVE_REMEDIATION,
         )
 
     return FreshnessSubState(state="fresh", last_change=last_change, remediation=None)

--- a/src/specify_cli/cli/commands/charter/generate.py
+++ b/src/specify_cli/cli/commands/charter/generate.py
@@ -238,6 +238,60 @@ def _load_interview_for_generate(
     return interview_data, "interview", resolved_mission_type or interview_data.mission
 
 
+#: Suffix for the copy of an unparseable ``charter.yaml`` moved aside by
+#: ``--recover-invalid``. A previous backup IS overwritten, deliberately: the
+#: backup exists to preserve the content the operator has *now*, and any earlier
+#: backup is itself a superseded broken state. The overwrite is always reported.
+_INVALID_BACKUP_SUFFIX = ".bak"
+
+
+def _recover_unparseable_charter_yaml(charter_dir: Path) -> tuple[bool, list[str]]:
+    """Move an unparseable ``charter.yaml`` aside so bootstrap can proceed.
+
+    ``write_compiled_charter`` refreshes only the DERIVED sections of an
+    existing ``charter.yaml`` and round-trips the document to preserve the
+    AUTHORED ones (``charter.compiler`` / INV-9). That round-trip must parse
+    the file, so an unparseable ``charter.yaml`` makes generation raise --
+    ``--force`` does not help, because ``force`` gates no destructive
+    overwrite (see ``write_compiled_charter``'s docstring). Moving the file
+    aside is therefore the ONLY way to reach the bootstrap-create path, which
+    is why this exists rather than a plain overwrite.
+
+    Returns ``(recovered, notices)``. ``recovered`` is False and ``notices``
+    empty when there is nothing to do -- the file is absent, or parses fine.
+    Never raises for the parse itself; a genuinely unreadable path is left for
+    the caller's normal error handling.
+    """
+    charter_yaml = charter_dir / "charter.yaml"
+    if not charter_yaml.exists():
+        return False, []
+
+    from ruamel.yaml import YAML  # noqa: PLC0415 — keep ruamel off the CLI import path
+    from ruamel.yaml.error import YAMLError  # noqa: PLC0415
+
+    try:
+        with charter_yaml.open(encoding="utf-8") as fh:
+            YAML(typ="rt").load(fh)
+    except YAMLError:
+        pass  # unparseable -- fall through to the move below
+    except OSError:
+        return False, []  # unreadable for another reason; not ours to recover
+    else:
+        return False, []  # parses fine; nothing to recover
+
+    backup = charter_yaml.with_name(charter_yaml.name + _INVALID_BACKUP_SUFFIX)
+    notices = []
+    if backup.exists():
+        notices.append(
+            f"replaced an earlier {backup.name} while recovering an unparseable charter.yaml"
+        )
+    charter_yaml.replace(backup)
+    notices.append(
+        f"charter.yaml could not be parsed; moved it to {backup.name} and bootstrapped a fresh one"
+    )
+    return True, notices
+
+
 @charter_app.command()
 def generate(
     mission_type: str | None = typer.Option(None, "--mission-type", help="Mission type for template-set defaults"),
@@ -252,6 +306,15 @@ def generate(
     ),
     profile: str = typer.Option("minimal", "--profile", help="Default profile when no interview is available"),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing charter bundle"),
+    recover_invalid: bool = typer.Option(
+        False,
+        "--recover-invalid",
+        help=(
+            "If charter.yaml exists but cannot be parsed, move it aside to "
+            "charter.yaml.bak and bootstrap a fresh one. Without this flag an "
+            "unparseable charter.yaml is a hard error (nothing is moved)."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ) -> None:
     """Generate charter bundle from interview answers + doctrine references.
@@ -324,6 +387,13 @@ def generate(
             )
             resolved_mission_type = resolved.canonical_value
 
+        # Must run BEFORE anything parses charter.yaml (the interview load and
+        # the compile/write below both can): once the unparseable file is moved
+        # aside, generation takes its ordinary bootstrap-create path.
+        recovery_notices: list[str] = []
+        if recover_invalid:
+            _, recovery_notices = _recover_unparseable_charter_yaml(charter_dir)
+
         interview_data, interview_source, resolved_mission = _load_interview_for_generate(
             repo_root=repo_root,
             answers_path=answers_path,
@@ -376,7 +446,7 @@ def generate(
         sync_result = _sync_charter_if_present(charter_path, charter_dir)
         sync_warnings, sync_files = _finalize_sync_result(sync_result)
 
-        diagnostics = [*compiled.diagnostics, *sync_warnings]
+        diagnostics = [*recovery_notices, *compiled.diagnostics, *sync_warnings]
 
         files_written = list(bundle_result.files_written)
         for file_name in sync_files:

--- a/src/specify_cli/cli/commands/charter/generate.py
+++ b/src/specify_cli/cli/commands/charter/generate.py
@@ -262,7 +262,13 @@ def _recover_unparseable_charter_yaml(charter_dir: Path) -> tuple[bool, list[str
     Never raises for the parse itself; a genuinely unreadable path is left for
     the caller's normal error handling.
     """
-    charter_yaml = charter_dir / "charter.yaml"
+    # The filename comes from `charter.bundle.CHARTER_YAML`, never a local
+    # literal: `test_charter_path_literal_authority` requires every charter-path
+    # literal to be declared with a rationale, and the right answer here is to
+    # use the canonical constant rather than register another exception to it.
+    from charter.bundle import CHARTER_YAML  # noqa: PLC0415 — keep charter.* off the CLI import path
+
+    charter_yaml = charter_dir / CHARTER_YAML.name
     if not charter_yaml.exists():
         return False, []
 

--- a/src/specify_cli/cli/commands/charter/generate.py
+++ b/src/specify_cli/cli/commands/charter/generate.py
@@ -238,66 +238,6 @@ def _load_interview_for_generate(
     return interview_data, "interview", resolved_mission_type or interview_data.mission
 
 
-#: Suffix for the copy of an unparseable ``charter.yaml`` moved aside by
-#: ``--recover-invalid``. A previous backup IS overwritten, deliberately: the
-#: backup exists to preserve the content the operator has *now*, and any earlier
-#: backup is itself a superseded broken state. The overwrite is always reported.
-_INVALID_BACKUP_SUFFIX = ".bak"
-
-
-def _recover_unparseable_charter_yaml(charter_dir: Path) -> tuple[bool, list[str]]:
-    """Move an unparseable ``charter.yaml`` aside so bootstrap can proceed.
-
-    ``write_compiled_charter`` refreshes only the DERIVED sections of an
-    existing ``charter.yaml`` and round-trips the document to preserve the
-    AUTHORED ones (``charter.compiler`` / INV-9). That round-trip must parse
-    the file, so an unparseable ``charter.yaml`` makes generation raise --
-    ``--force`` does not help, because ``force`` gates no destructive
-    overwrite (see ``write_compiled_charter``'s docstring). Moving the file
-    aside is therefore the ONLY way to reach the bootstrap-create path, which
-    is why this exists rather than a plain overwrite.
-
-    Returns ``(recovered, notices)``. ``recovered`` is False and ``notices``
-    empty when there is nothing to do -- the file is absent, or parses fine.
-    Never raises for the parse itself; a genuinely unreadable path is left for
-    the caller's normal error handling.
-    """
-    # The filename comes from `charter.bundle.CHARTER_YAML`, never a local
-    # literal: `test_charter_path_literal_authority` requires every charter-path
-    # literal to be declared with a rationale, and the right answer here is to
-    # use the canonical constant rather than register another exception to it.
-    from charter.bundle import CHARTER_YAML  # noqa: PLC0415 — keep charter.* off the CLI import path
-
-    charter_yaml = charter_dir / CHARTER_YAML.name
-    if not charter_yaml.exists():
-        return False, []
-
-    from ruamel.yaml import YAML  # noqa: PLC0415 — keep ruamel off the CLI import path
-    from ruamel.yaml.error import YAMLError  # noqa: PLC0415
-
-    try:
-        with charter_yaml.open(encoding="utf-8") as fh:
-            YAML(typ="rt").load(fh)
-    except YAMLError:
-        pass  # unparseable -- fall through to the move below
-    except OSError:
-        return False, []  # unreadable for another reason; not ours to recover
-    else:
-        return False, []  # parses fine; nothing to recover
-
-    backup = charter_yaml.with_name(charter_yaml.name + _INVALID_BACKUP_SUFFIX)
-    notices = []
-    if backup.exists():
-        notices.append(
-            f"replaced an earlier {backup.name} while recovering an unparseable charter.yaml"
-        )
-    charter_yaml.replace(backup)
-    notices.append(
-        f"charter.yaml could not be parsed; moved it to {backup.name} and bootstrapped a fresh one"
-    )
-    return True, notices
-
-
 @charter_app.command()
 def generate(
     mission_type: str | None = typer.Option(None, "--mission-type", help="Mission type for template-set defaults"),
@@ -312,15 +252,6 @@ def generate(
     ),
     profile: str = typer.Option("minimal", "--profile", help="Default profile when no interview is available"),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing charter bundle"),
-    recover_invalid: bool = typer.Option(
-        False,
-        "--recover-invalid",
-        help=(
-            "If charter.yaml exists but cannot be parsed, move it aside to "
-            "charter.yaml.bak and bootstrap a fresh one. Without this flag an "
-            "unparseable charter.yaml is a hard error (nothing is moved)."
-        ),
-    ),
     json_output: bool = typer.Option(False, "--json", help="Output JSON"),
 ) -> None:
     """Generate charter bundle from interview answers + doctrine references.
@@ -393,13 +324,6 @@ def generate(
             )
             resolved_mission_type = resolved.canonical_value
 
-        # Must run BEFORE anything parses charter.yaml (the interview load and
-        # the compile/write below both can): once the unparseable file is moved
-        # aside, generation takes its ordinary bootstrap-create path.
-        recovery_notices: list[str] = []
-        if recover_invalid:
-            _, recovery_notices = _recover_unparseable_charter_yaml(charter_dir)
-
         interview_data, interview_source, resolved_mission = _load_interview_for_generate(
             repo_root=repo_root,
             answers_path=answers_path,
@@ -452,7 +376,7 @@ def generate(
         sync_result = _sync_charter_if_present(charter_path, charter_dir)
         sync_warnings, sync_files = _finalize_sync_result(sync_result)
 
-        diagnostics = [*recovery_notices, *compiled.diagnostics, *sync_warnings]
+        diagnostics = [*compiled.diagnostics, *sync_warnings]
 
         files_written = list(bundle_result.files_written)
         for file_name in sync_files:

--- a/tests/architectural/test_remediation_effectiveness.py
+++ b/tests/architectural/test_remediation_effectiveness.py
@@ -1,0 +1,175 @@
+"""Every preflight remediation must be able to clear the check that emits it (#2831).
+
+The rule, stated once:
+
+    For every charter-freshness sub-state that emits a remediation, running
+    that command in a project exhibiting the state MUST exit 0 AND leave that
+    sub-state ``fresh``.
+
+Why the "AND" matters. The historical failure this module exists to prevent was
+`spec-kitty charter sync` being offered for four blocking states while
+``src/charter/sync.py`` documents itself as a pure staleness reporter -- "it
+always reports ``synced=False`` / ``files_written=[]``". The operator ran it,
+nothing changed, the gate refused identically, and every charter diagnostic
+reported healthy. There was no exit.
+
+A weaker oracle does not catch that class of defect. An earlier draft of this
+enforcement (PR #3015) asserted only ``after != before``; a remediation that
+writes malformed YAML and exits 17 satisfies that, because ``missing ->
+invalid`` is a change. So this module pins the destination state and the exit
+code, not merely that something moved.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from specify_cli.charter_runtime.freshness.computer import compute_freshness
+
+_CHARTER_DIR = Path(".kittify") / "charter"
+_UNPARSEABLE = "governance:\n  - broken: [unterminated\n    flow sequence\n"
+
+
+def _seed_project(repo_root: Path) -> None:
+    """Minimal project shape both fixtures share."""
+    (repo_root / ".kittify").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".kittify" / "config.yaml").write_text(
+        "activated_directives: []\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "init", "-q", "."], cwd=repo_root, check=True)
+
+
+def _fixture_charter_yaml_absent(repo_root: Path) -> None:
+    """F1 -- no charter at all: ``charter_source: missing`` / ``synced_bundle: missing``."""
+    _seed_project(repo_root)
+    (repo_root / _CHARTER_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def _fixture_charter_yaml_unparseable(repo_root: Path) -> None:
+    """F2 -- present but broken: ``charter_source: invalid`` / ``synced_bundle: stale``."""
+    _seed_project(repo_root)
+    charter_dir = repo_root / _CHARTER_DIR
+    charter_dir.mkdir(parents=True, exist_ok=True)
+    (charter_dir / "charter.yaml").write_text(_UNPARSEABLE, encoding="utf-8")
+
+
+def _layer_state(repo_root: Path, layer: str) -> str:
+    return str(getattr(compute_freshness(repo_root), layer).state)
+
+
+def _layer_remediation(repo_root: Path, layer: str) -> str | None:
+    value = getattr(compute_freshness(repo_root), layer).remediation
+    return None if value is None else str(value)
+
+
+def _run_remediation(repo_root: Path, command: str) -> subprocess.CompletedProcess[str]:
+    """Execute a remediation string as the operator would read it.
+
+    ``spec-kitty`` is invoked as ``python -m specify_cli`` so the test does not
+    depend on a console script being on PATH in every environment.
+    """
+    args = shlex.split(command)
+    assert args[:1] == ["spec-kitty"], f"unexpected remediation shape: {command!r}"
+    return subprocess.run(
+        [sys.executable, "-m", "specify_cli", *args[1:]],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+
+#: (layer, fixture, expected non-passing state). One row per state that emits a
+#: remediation. Both layers are driven for both fixtures because
+#: ``synced_bundle`` is a structural echo of ``charter_source`` (single-entry
+#: ``_BUNDLE_FILES``) -- a fix that clears one but not the other still leaves
+#: the operator blocked, so neither is assumed from the other.
+_CASES = [
+    ("charter_source", _fixture_charter_yaml_absent, "missing"),
+    ("synced_bundle", _fixture_charter_yaml_absent, "missing"),
+    ("charter_source", _fixture_charter_yaml_unparseable, "invalid"),
+    ("synced_bundle", _fixture_charter_yaml_unparseable, "stale"),
+]
+
+
+@pytest.mark.parametrize(("layer", "seed", "expected_state"), _CASES)
+def test_remediation_clears_the_state_that_emitted_it(
+    tmp_path: Path,
+    layer: str,
+    seed,
+    expected_state: str,
+) -> None:
+    seed(tmp_path)
+
+    assert _layer_state(tmp_path, layer) == expected_state, (
+        f"fixture did not produce {layer}={expected_state}"
+    )
+    command = _layer_remediation(tmp_path, layer)
+    assert command is not None, (
+        f"{layer} is in state {expected_state!r} and offers NO remediation; "
+        "an operator in this state has no way forward"
+    )
+
+    completed = _run_remediation(tmp_path, command)
+
+    assert completed.returncode == 0, (
+        f"remediation `{command}` for {layer}={expected_state} exited "
+        f"{completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    after = _layer_state(tmp_path, layer)
+    assert after == "fresh", (
+        f"remediation `{command}` exited 0 but left {layer} in state {after!r}, "
+        "not 'fresh' -- the operator would still be blocked"
+    )
+
+
+def test_charter_sync_is_never_offered_as_a_remediation() -> None:
+    """#2831 regression pin: the dead-end command must not come back.
+
+    ``charter sync`` reports staleness and writes nothing, so it can never
+    clear a freshness check.
+
+    This asserts on the module's actual remediation VALUES, not on its source
+    text. An earlier version of this test grepped the source for lines
+    containing both "charter sync" and "remediation" -- and a mutation that
+    reintroduced the defect slipped straight past it, because the constants are
+    named ``_REMEDIATE_*`` (no "remediation" substring). A pin that can be
+    defeated by a variable name is not a pin.
+    """
+    from specify_cli.charter_runtime.freshness import computer
+
+    offenders = {
+        name: value
+        for name, value in vars(computer).items()
+        if name.startswith("_REMEDIATE")
+        and isinstance(value, str)
+        and "charter sync" in value
+    }
+    assert not offenders, (
+        "a remediation constant names `charter sync`, which never writes and so "
+        f"cannot clear any check: {offenders}"
+    )
+
+
+def test_the_oracle_rejects_an_exit_zero_remediation_that_does_not_reach_fresh(
+    tmp_path: Path,
+) -> None:
+    """Non-vacuity: prove this module fails a plausible-but-ineffective remediation.
+
+    ``charter status`` exits 0 and changes nothing -- the exact shape of the
+    #2831 defect (a reporter offered as a repair). If the oracle above were
+    only asserting "exit 0", or only "something changed", this would pass.
+    """
+    _fixture_charter_yaml_absent(tmp_path)
+    assert _layer_state(tmp_path, "charter_source") == "missing"
+
+    completed = _run_remediation(tmp_path, "spec-kitty charter status")
+
+    assert completed.returncode == 0, "precondition: charter status is expected to exit 0"
+    assert _layer_state(tmp_path, "charter_source") == "missing", (
+        "precondition: charter status must not change charter_source"
+    )

--- a/tests/architectural/test_remediation_effectiveness.py
+++ b/tests/architectural/test_remediation_effectiveness.py
@@ -31,6 +31,13 @@ import pytest
 
 from specify_cli.charter_runtime.freshness.computer import compute_freshness
 
+#: Selection marker, not decoration: CI selects tests BY MARKER, so an
+#: unmarked file under tests/architectural/ is collected by ZERO gates --
+#: `test_same_tier_uniqueness::test_split_preserves_zero_orphans` and
+#: `test_ci_collection_completeness` both fail on it, correctly. Without this
+#: an effectiveness oracle could regress and never turn a branch red.
+pytestmark = pytest.mark.architectural
+
 _CHARTER_DIR = Path(".kittify") / "charter"
 _UNPARSEABLE = "governance:\n  - broken: [unterminated\n    flow sequence\n"
 

--- a/tests/architectural/test_remediation_effectiveness.py
+++ b/tests/architectural/test_remediation_effectiveness.py
@@ -42,24 +42,39 @@ _CHARTER_DIR = Path(".kittify") / "charter"
 _UNPARSEABLE = "governance:\n  - broken: [unterminated\n    flow sequence\n"
 
 
-def _seed_project(repo_root: Path) -> None:
-    """Minimal project shape both fixtures share."""
+def _seed_project(repo_root: Path, *, previously_generated: bool) -> None:
+    """Minimal project shape the fixtures share.
+
+    ``previously_generated`` reproduces the config a successful
+    ``charter generate`` leaves behind -- crucially the ``charter:`` pointer.
+    This is NOT cosmetic. An earlier revision of this module seeded only the
+    pointer-less shape, and that gap hid a critical defect: a proposed
+    remediation moved the unparseable charter.yaml aside and then died in
+    ``provision_mission_type_activations`` resolving that very pointer, leaving
+    the project with NO charter.yaml. Every case is therefore driven in BOTH
+    shapes -- a remediation that only works on a never-generated project is not
+    a remediation for the state real operators are in.
+    """
     (repo_root / ".kittify").mkdir(parents=True, exist_ok=True)
-    (repo_root / ".kittify" / "config.yaml").write_text(
-        "activated_directives: []\n", encoding="utf-8"
-    )
+    config = "activated_directives: []\n"
+    if previously_generated:
+        config += (
+            "mission_type_activations:\n- software-dev\n"
+            "charter: .kittify/charter/charter.yaml\n"
+        )
+    (repo_root / ".kittify" / "config.yaml").write_text(config, encoding="utf-8")
     subprocess.run(["git", "init", "-q", "."], cwd=repo_root, check=True)
 
 
-def _fixture_charter_yaml_absent(repo_root: Path) -> None:
+def _fixture_charter_yaml_absent(repo_root: Path, *, previously_generated: bool = False) -> None:
     """F1 -- no charter at all: ``charter_source: missing`` / ``synced_bundle: missing``."""
-    _seed_project(repo_root)
+    _seed_project(repo_root, previously_generated=previously_generated)
     (repo_root / _CHARTER_DIR).mkdir(parents=True, exist_ok=True)
 
 
-def _fixture_charter_yaml_unparseable(repo_root: Path) -> None:
+def _fixture_charter_yaml_unparseable(repo_root: Path, *, previously_generated: bool = False) -> None:
     """F2 -- present but broken: ``charter_source: invalid`` / ``synced_bundle: stale``."""
-    _seed_project(repo_root)
+    _seed_project(repo_root, previously_generated=previously_generated)
     charter_dir = repo_root / _CHARTER_DIR
     charter_dir.mkdir(parents=True, exist_ok=True)
     (charter_dir / "charter.yaml").write_text(_UNPARSEABLE, encoding="utf-8")
@@ -90,27 +105,30 @@ def _run_remediation(repo_root: Path, command: str) -> subprocess.CompletedProce
     )
 
 
-#: (layer, fixture, expected non-passing state). One row per state that emits a
-#: remediation. Both layers are driven for both fixtures because
-#: ``synced_bundle`` is a structural echo of ``charter_source`` (single-entry
-#: ``_BUNDLE_FILES``) -- a fix that clears one but not the other still leaves
-#: the operator blocked, so neither is assumed from the other.
+#: (layer, fixture, expected non-passing state, previously_generated). Both
+#: layers are driven for the fixture because ``synced_bundle`` is a structural
+#: echo of ``charter_source`` (single-entry ``_BUNDLE_FILES``) -- a fix that
+#: clears one but not the other still leaves the operator blocked. Both config
+#: shapes are driven because a remediation that only works on a never-generated
+#: project is not a remediation (see ``_seed_project``).
+#:
+#: ``charter_source: invalid`` / ``synced_bundle: stale`` are absent on purpose:
+#: they emit no remediation, and are covered by
+#: ``test_states_with_no_effective_remediation_offer_no_command`` below.
 _CASES = [
-    ("charter_source", _fixture_charter_yaml_absent, "missing"),
-    ("synced_bundle", _fixture_charter_yaml_absent, "missing"),
-    ("charter_source", _fixture_charter_yaml_unparseable, "invalid"),
-    ("synced_bundle", _fixture_charter_yaml_unparseable, "stale"),
+    ("charter_source", "missing", False),
+    ("synced_bundle", "missing", False),
 ]
 
 
-@pytest.mark.parametrize(("layer", "seed", "expected_state"), _CASES)
+@pytest.mark.parametrize(("layer", "expected_state", "previously_generated"), _CASES)
 def test_remediation_clears_the_state_that_emitted_it(
     tmp_path: Path,
     layer: str,
-    seed,
     expected_state: str,
+    previously_generated: bool,
 ) -> None:
-    seed(tmp_path)
+    _fixture_charter_yaml_absent(tmp_path, previously_generated=previously_generated)
 
     assert _layer_state(tmp_path, layer) == expected_state, (
         f"fixture did not produce {layer}={expected_state}"
@@ -124,14 +142,47 @@ def test_remediation_clears_the_state_that_emitted_it(
     completed = _run_remediation(tmp_path, command)
 
     assert completed.returncode == 0, (
-        f"remediation `{command}` for {layer}={expected_state} exited "
-        f"{completed.returncode}\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        f"remediation `{command}` for {layer}={expected_state} "
+        f"(previously_generated={previously_generated}) exited {completed.returncode}\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
     )
     after = _layer_state(tmp_path, layer)
     assert after == "fresh", (
         f"remediation `{command}` exited 0 but left {layer} in state {after!r}, "
         "not 'fresh' -- the operator would still be blocked"
     )
+
+
+@pytest.mark.parametrize("previously_generated", [False, True])
+@pytest.mark.parametrize(("layer", "expected_state"), [
+    ("charter_source", "invalid"),
+    ("synced_bundle", "stale"),
+])
+def test_states_with_no_effective_remediation_offer_no_command(
+    tmp_path: Path,
+    layer: str,
+    expected_state: str,
+    previously_generated: bool,
+) -> None:
+    """An unrepairable state must show NO command, not a command that cannot work.
+
+    No write path in this codebase can repair an unparseable ``charter.yaml``
+    (every one round-trip-parses it). Moving the file aside first looks like the
+    answer and is not: with a ``charter:`` pointer in config.yaml -- which every
+    previously-generated project has -- generation dies AFTER the move and the
+    operator is left with no charter.yaml at all. Showing no command is strictly
+    better than that, so this pins the exemption rather than a remediation.
+    """
+    _fixture_charter_yaml_unparseable(tmp_path, previously_generated=previously_generated)
+
+    assert _layer_state(tmp_path, layer) == expected_state
+    assert _layer_remediation(tmp_path, layer) is None, (
+        f"{layer}={expected_state} offers a command, but no command can clear it; "
+        "an ineffective remediation is worse than none"
+    )
+    detail = getattr(compute_freshness(tmp_path), layer).detail
+    if layer == "charter_source":
+        assert detail, "an exempt state must still explain itself to the operator"
 
 
 def test_charter_sync_is_never_offered_as_a_remediation() -> None:
@@ -165,18 +216,54 @@ def test_charter_sync_is_never_offered_as_a_remediation() -> None:
 def test_the_oracle_rejects_an_exit_zero_remediation_that_does_not_reach_fresh(
     tmp_path: Path,
 ) -> None:
-    """Non-vacuity: prove this module fails a plausible-but-ineffective remediation.
+    """Non-vacuity: the oracle's own assertion must FAIL on a useless remediation.
 
-    ``charter status`` exits 0 and changes nothing -- the exact shape of the
-    #2831 defect (a reporter offered as a repair). If the oracle above were
-    only asserting "exit 0", or only "something changed", this would pass.
+    This exercises the assertion, it does not merely set up the conditions for
+    it. An earlier revision of this test stopped after checking that
+    ``charter status`` exits 0 and changes nothing, and its docstring claimed to
+    "prove this module fails" such a remediation -- which it did not; both
+    reviewers of PR #3585 flagged the gap independently. The assertion block is
+    now run for real inside ``pytest.raises``.
+
+    ``charter status`` is the right stand-in: it exits 0 and reports, exactly
+    the shape of the #2831 defect (a reporter offered as a repair).
     """
-    _fixture_charter_yaml_absent(tmp_path)
+    _fixture_charter_yaml_absent(tmp_path, previously_generated=True)
     assert _layer_state(tmp_path, "charter_source") == "missing"
 
     completed = _run_remediation(tmp_path, "spec-kitty charter status")
-
     assert completed.returncode == 0, "precondition: charter status is expected to exit 0"
-    assert _layer_state(tmp_path, "charter_source") == "missing", (
-        "precondition: charter status must not change charter_source"
+
+    # The oracle's own check, run against a deliberately ineffective command.
+    with pytest.raises(AssertionError, match="not 'fresh'"):
+        after = _layer_state(tmp_path, "charter_source")
+        assert after == "fresh", (
+            f"remediation `spec-kitty charter status` exited 0 but left "
+            f"charter_source in state {after!r}, not 'fresh' -- the operator "
+            "would still be blocked"
+        )
+
+
+@pytest.mark.parametrize("layer", ["charter_source", "synced_bundle"])
+def test_absent_charter_with_dangling_pointer_offers_no_command(
+    tmp_path: Path, layer: str
+) -> None:
+    """A previously-generated project whose charter.yaml vanished gets NO command.
+
+    `charter generate` cannot run here: `.kittify/config.yaml` still carries a
+    `charter:` pointer, and `pack_manager.resolve_activation_write_target` fails
+    loud by design on a dangling one (INV-5 / #2530), so generation dies before
+    writing anything. The documented recovery, `spec-kitty upgrade`, is
+    interactive and so cannot be handed over as a runnable remediation either.
+
+    Naming a command that exits non-zero here is precisely the #2831 defect, so
+    the honest output is none -- pinned separately from the never-generated
+    shape above, which `charter generate` genuinely does clear.
+    """
+    _fixture_charter_yaml_absent(tmp_path, previously_generated=True)
+
+    assert _layer_state(tmp_path, layer) == "missing"
+    assert _layer_remediation(tmp_path, layer) is None, (
+        "a dangling charter: pointer makes `charter generate` fail closed; "
+        "offering it would hand the operator a command that cannot work"
     )

--- a/tests/integration/test_charter_status_freshness.py
+++ b/tests/integration/test_charter_status_freshness.py
@@ -227,7 +227,9 @@ def test_freshness_state_invalid_when_charter_yaml_unparseable(tmp_path: Path) -
     payload = _invoke_status_json(tmp_path)
     freshness = payload["freshness"]
     assert freshness["charter_source"]["state"] == "invalid"
-    assert freshness["charter_source"]["remediation"] == "spec-kitty charter sync"
+    assert freshness["charter_source"]["remediation"] == (
+        "spec-kitty charter generate --no-from-interview --recover-invalid"
+    )
 
 
 def test_freshness_state_missing_when_no_synthesis_artifacts(tmp_path: Path) -> None:

--- a/tests/integration/test_charter_status_freshness.py
+++ b/tests/integration/test_charter_status_freshness.py
@@ -227,9 +227,7 @@ def test_freshness_state_invalid_when_charter_yaml_unparseable(tmp_path: Path) -
     payload = _invoke_status_json(tmp_path)
     freshness = payload["freshness"]
     assert freshness["charter_source"]["state"] == "invalid"
-    assert freshness["charter_source"]["remediation"] == (
-        "spec-kitty charter generate --no-from-interview --recover-invalid"
-    )
+    assert freshness["charter_source"]["remediation"] is None
 
 
 def test_freshness_state_missing_when_no_synthesis_artifacts(tmp_path: Path) -> None:

--- a/tests/specify_cli/charter_freshness/test_computer.py
+++ b/tests/specify_cli/charter_freshness/test_computer.py
@@ -261,7 +261,10 @@ def test_charter_source_invalid_when_unparseable(tmp_path: Path) -> None:
     _seed_charter_yaml(tmp_path, body="not: [valid: yaml: at: all")
     result = compute_freshness(tmp_path)
     assert result.charter_source.state == "invalid"
-    assert result.charter_source.remediation == "spec-kitty charter generate --no-from-interview --recover-invalid"
+    # No command can repair an unparseable charter.yaml (see
+    # _NO_EFFECTIVE_REMEDIATION in computer.py); the detail explains it instead.
+    assert result.charter_source.remediation is None
+    assert "cannot be parsed" in (result.charter_source.detail or "")
 
 
 def test_charter_source_never_reachable_as_stale() -> None:

--- a/tests/specify_cli/charter_freshness/test_computer.py
+++ b/tests/specify_cli/charter_freshness/test_computer.py
@@ -244,7 +244,7 @@ def test_returns_three_sub_objects(tmp_path: Path) -> None:
 def test_charter_source_missing_when_charter_yaml_absent(tmp_path: Path) -> None:
     result = compute_freshness(tmp_path)
     assert result.charter_source.state == "missing"
-    assert result.charter_source.remediation == "spec-kitty charter sync"
+    assert result.charter_source.remediation == "spec-kitty charter generate --no-from-interview"
 
 
 def test_charter_source_fresh_when_charter_yaml_parses(tmp_path: Path) -> None:
@@ -261,7 +261,7 @@ def test_charter_source_invalid_when_unparseable(tmp_path: Path) -> None:
     _seed_charter_yaml(tmp_path, body="not: [valid: yaml: at: all")
     result = compute_freshness(tmp_path)
     assert result.charter_source.state == "invalid"
-    assert result.charter_source.remediation == "spec-kitty charter sync"
+    assert result.charter_source.remediation == "spec-kitty charter generate --no-from-interview --recover-invalid"
 
 
 def test_charter_source_never_reachable_as_stale() -> None:

--- a/tests/specify_cli/charter_runtime/test_preflight_one_pass.py
+++ b/tests/specify_cli/charter_runtime/test_preflight_one_pass.py
@@ -183,13 +183,9 @@ def test_multi_failure_per_check_verdicts_pinned(tmp_path: Path) -> None:
 
     by_name = {c.name: c for c in result.checks}
     assert by_name["charter_source"].state == "invalid"
-    assert by_name["charter_source"].remediation == (
-        "spec-kitty charter generate --no-from-interview --recover-invalid"
-    )
+    assert by_name["charter_source"].remediation is None
     assert by_name["synced_bundle"].state == "stale"
-    assert by_name["synced_bundle"].remediation == (
-        "spec-kitty charter generate --no-from-interview --recover-invalid"
-    )
+    assert by_name["synced_bundle"].remediation is None
     assert by_name["synthesized_drg"].state == "missing"
     assert by_name["synthesized_drg"].remediation == "spec-kitty charter synthesize"
 

--- a/tests/specify_cli/charter_runtime/test_preflight_one_pass.py
+++ b/tests/specify_cli/charter_runtime/test_preflight_one_pass.py
@@ -183,9 +183,13 @@ def test_multi_failure_per_check_verdicts_pinned(tmp_path: Path) -> None:
 
     by_name = {c.name: c for c in result.checks}
     assert by_name["charter_source"].state == "invalid"
-    assert by_name["charter_source"].remediation == "spec-kitty charter sync"
+    assert by_name["charter_source"].remediation == (
+        "spec-kitty charter generate --no-from-interview --recover-invalid"
+    )
     assert by_name["synced_bundle"].state == "stale"
-    assert by_name["synced_bundle"].remediation == "spec-kitty charter sync"
+    assert by_name["synced_bundle"].remediation == (
+        "spec-kitty charter generate --no-from-interview --recover-invalid"
+    )
     assert by_name["synthesized_drg"].state == "missing"
     assert by_name["synthesized_drg"].remediation == "spec-kitty charter synthesize"
 


### PR DESCRIPTION
Four charter-freshness states hand the operator a command that cannot clear the check blocking them. This removes that, gives a working command where one exists, and says so plainly where none does.

> **Revised after pre-merge review.** An earlier revision of this PR added a `--recover-invalid` flag to `charter generate`. The squad found it made the operator **worse off than the bug** — see "What the review changed" below. That flag is withdrawn; `generate.py` is byte-identical to `main`.

## The defect, live on `main`

`freshness/computer.py` defines `_REMEDIATE_CHARTER_SYNC = "spec-kitty charter sync"` and emits it from four blocking states — `charter_source: missing|invalid` and `synced_bundle: missing|stale`. `src/charter/sync.py:18` documents that command as, verbatim: *"it always reports `synced=False` / `files_written=[]`"*.

The operator runs it, nothing changes, the gate refuses identically. Meanwhile the charter diagnostics report healthy, because they resolve `charter.md` while the gate resolves `charter.yaml` — so every investigative step confirms the wrong conclusion. That is #2831.

**#3498 did not close this.** Its bypass requires `charter_source == "missing"` AND `synced_bundle == "missing"` AND `synthesized_drg in {"missing", "built_in_only"}`, and its own docstring says *"Any stale, invalid, or other partial residue remains blocking."* It made the fresh **uninitialized** project advisory instead of blocked. #2831 was closed against that symptom, not the mechanism.

## What ships

| Situation | Remediation now |
|---|---|
| `charter.yaml` absent, **no** `charter:` pointer | `spec-kitty charter generate --no-from-interview` |
| `charter.yaml` absent, pointer **present** | none — `detail` explains why |
| `charter.yaml` unparseable (either shape) | none — `detail` explains why |

`_REMEDIATE_CHARTER_SYNC` is deleted. No state now names a command that cannot clear it.

**Why two of those emit nothing.** An unparseable `charter.yaml` cannot be repaired by any write path in the codebase — each round-trip-parses the file to preserve authored sections, and `--force` gates no destructive overwrite (`write_compiled_charter`'s own docstring). And on a project that has run `charter generate` before, `.kittify/config.yaml` carries a `charter:` pointer; `pack_manager.resolve_activation_write_target` fails **loud by design** on a dangling one (INV-5 / #2530), so `charter generate` cannot run at all. The documented recovery for that shape, `spec-kitty upgrade`, is interactive and cannot be handed over as a runnable command.

Being told no command exists, with the reason, beats being sent to one that exits non-zero. That is the whole point of #2831.

## What the review changed

The first revision added `--recover-invalid`, which moved an unparseable `charter.yaml` aside and bootstrapped a fresh one. Two lenses independently reproduced this, and it was confirmed by hand:

```
project that has run `charter generate` once   (the normal state)
  -> charter.yaml becomes unparseable
  -> run the remediation this PR documented
  -> Unexpected error: CHARTER_PACK_CONFIG_INVALID   exit 1
  -> charter.yaml is GONE; only charter.yaml.bak remains
```

Generation died in `provision_mission_type_activations` **after** the move and **before** recreating the file. The result was strictly worse than the original bug. The flag is gone.

Chasing that exposed a bigger correction: the dangling-pointer fail-loud breaks the `missing` remediation too, not only `invalid` — so the scope shrank again, to what is actually true.

**The oracle could not have caught it.** Its fixtures only ever seeded a pointer-less, never-generated project — the one shape where the flag worked. Fixtures now drive **both** config shapes, and the exempt states are pinned explicitly rather than by omission.

## The oracle

`tests/architectural/test_remediation_effectiveness.py` pins the rule: every emitted remediation must **exit 0 AND leave its state `fresh`**. States that emit nothing are pinned separately, so the exemption is a decision on the record rather than a gap.

The destination state is asserted, not merely that something changed — an assertion of the form `after != before` is satisfied by a remediation that writes malformed YAML and exits 17, since `missing -> invalid` is a change.

## Correction to an earlier version of this description

Two claims in the first revision were wrong, and both are withdrawn:

1. It said `--recover-invalid` gave the operator "a working command". It did not, for the realistic case.
2. It attributed the weaker `after != before` assertion to "an earlier draft" of #3015. That assertion is still #3015's primary driver at its current HEAD — supplemented by a narrower test, not superseded. The comparison was unfair as written.

## Evidence

- Squad: **13 findings** across three lenses. The severity-5 was found independently by two of them and reproduced by hand before being acted on.
- Oracle **10 passed**; charter freshness / preflight / runtime + integration + same-tier-uniqueness **122 passed**; `ruff` clean.
- Pre-existing and NOT this PR's: `tests/charter/test_mission_type_profiles.py::TestMissionCreatePropagatesEmptyActionSequenceError::test_create_mission_propagates_named_exception_type` reproduces identically on unmodified `main` at `38090b649`.

## Follow-up worth filing separately

**A previously-generated project whose `charter.yaml` goes missing or becomes unparseable has no non-interactive recovery.** `charter generate` fails closed on the dangling pointer by design; `spec-kitty upgrade` prompts. That is live on `main`, independent of this PR, and is why two states here emit no command. Fixing it would let them.
