### PR TITLE
fix: triage quick-wins — unrunnable command strings, swallowed guard warning, missions-root convergence, sync env retirement (#3577, #3580, #3575, #3569)

### DIFF
--- a/docs/api/terminology.md
+++ b/docs/api/terminology.md
@@ -68,7 +68,7 @@ See the [mission identity migration runbook](../migrations/mission-id-canonical-
 | **current branch** | The branch checked out when planning starts | The mission's intended landing branch if it was explicitly overridden |
 | **primary branch** | The repository's default integration branch, usually resolved from `origin/HEAD` | The mission's intended landing branch after `target_branch` is persisted |
 | **feature branch** | A dedicated branch for pr-bound mission planning and implementation work | The protected/default branch or every lane worktree branch |
-| **start branch** | The branch `mission create --start-branch` creates or switches to before writing mission scaffolding | A later merge override or a separate branch from `--target-branch` |
+| **start branch** | The branch `agent mission create --start-branch` creates or switches to before writing mission scaffolding | A later merge override or a separate branch from `--target-branch` |
 | **target branch** | The branch the mission records planning and merge intent against | "Whatever branch happens to be checked out later" |
 | **base_branch** | At mission level, alias for `target_branch`; at WP level, the immediate parent branch for a lane worktree | A universal synonym for `main` |
 | **planning_base_branch** | Canonical helper alias for the intended planning branch | A second repository or a worktree |

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -354,6 +354,23 @@ _The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land her
 
 ### 🐛 Fixed
 
+- **`safe-commit`/`spec-commit` and work-package prompts now print commands you
+  can actually run — before, they named invocations that error out when
+  copy-pasted (`#3577`).** The protected-branch commit refusals told operators to
+  run `spec-kitty mission create --start-branch …` and the WP task-prompt
+  templates showed `spec-kitty agent status`, but neither is real: `--start-branch`
+  lives only on `agent mission create`, and the status board is `agent tasks
+  status` (`agent status` is a command group with no board). Both are corrected
+  at the source, so a printed command runs as-is.
+
+- **A warn-mode commit-guard warning is no longer swallowed on a successful
+  `safe-commit`/`spec-commit` — operators now see the guard's warning instead of
+  it vanishing (`#3580`).** Before, a successful commit discarded the guard's
+  warn-mode output, so a warning the guard emitted never reached the operator.
+  Now the guard's stderr is surfaced on the success path, while git's routine
+  stdout summary is routed to debug so an ordinary commit no longer emits a
+  spurious warning on the same channel.
+
 - **A procedure named in an agent profile's `operating-procedures` field now
   becomes a real, cascade-reachable dependency of that profile — and a fictional
   or wrong-kind entry fails the doctrine build loudly instead of drifting in

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -9049,7 +9049,7 @@ pages:
   - path: "docs/operations/start-branch-coord-divergence.md"
     title: "Recovery: --start-branch Coordination Divergence"
     divio_type: "none"
-    abstract: "Recovery when mission create --start-branch plus coord topology diverges the coordination branch from the primary planning commit, blocking every lane claim."
+    abstract: "Recovery when agent mission create --start-branch plus coord topology diverges the coordination branch from the primary planning commit, blocking every lane claim."
     anchors:
     - {slug: "why-this-happens", text: "Why this happens", level: 2}
     - {slug: "no-shipped-fix-for-this-case", text: "No shipped `--fix` for this case", level: 2}

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -9422,9 +9422,9 @@ pages:
   - path: "docs/plans/code-quality/sync-env-census.md"
     title: "SPEC_KITTY_* env census — sync surface"
     divio_type: "none"
-    abstract: "Env census of the sync surface: a live or retire-candidate verdict for every SPEC_KITTY_* reference, proving the Wave-4 de-god deleted no environment name."
+    abstract: "Env census of the sync surface: a live or retired verdict for every SPEC_KITTY_* reference, proving the Wave-4 de-god deleted no environment name."
     anchors:
-    - {slug: "census-8-references-7-live-1-retire-candidate", text: "Census (8 references, 7 `live` / 1 `retire-candidate`)", level: 2}
+    - {slug: "census-7-references-all-live-1-historical-retired", text: "Census (7 references, all `live`; 1 historical `retired`)", level: 2}
     - {slug: "verdict-rationale", text: "Verdict rationale", level: 3}
     - {slug: "anti-deletion-invariant-fr-007", text: "Anti-deletion invariant (FR-007)", level: 2}
   - path: "docs/plans/code-quality/targeted-cleanup-scoping.md"

--- a/docs/development/testing/testing-parallel.md
+++ b/docs/development/testing/testing-parallel.md
@@ -61,7 +61,7 @@ isolated home directory. The isolation is set up in `tests/conftest.py`:
 - `pytest_configure` points `HOME` / `USERPROFILE` and the XDG dirs
   (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`) at a per-worker base
   **before collection**, so modules that bind a home-derived path at import time
-  (for example `specify_cli.sync.daemon.SPEC_KITTY_DIR`) resolve into the
+  (for example paths derived from `get_runtime_root()`) resolve into the
   isolated home.
 - An autouse, function-scoped fixture re-asserts the `HOME` / `USERPROFILE` / XDG
   env vars for every test, keyed by worker id, so call-time `Path.home()` reads

--- a/docs/operations/start-branch-coord-divergence.md
+++ b/docs/operations/start-branch-coord-divergence.md
@@ -1,6 +1,6 @@
 ---
 title: 'Recovery: --start-branch Coordination Divergence'
-description: 'Recovery when mission create --start-branch plus coord topology diverges the coordination branch from the primary planning commit, blocking every lane claim.'
+description: 'Recovery when agent mission create --start-branch plus coord topology diverges the coordination branch from the primary planning commit, blocking every lane claim.'
 doc_status: active
 updated: '2026-08-15'
 related:
@@ -16,7 +16,7 @@ conflict on `lanes.json`, even after re-finalizing tasks.
 
 ## Why this happens
 
-`spec-kitty mission create --start-branch <start-branch>` (pr-bound) plus
+`spec-kitty agent mission create --start-branch <start-branch>` (pr-bound) plus
 coord topology produces a coordination branch (`kitty/mission-<slug>`) that
 does **not** contain the primary planning commit: coord branches from the
 old base and gets its own planning snapshot, while spec/plan/tasks and

--- a/docs/plans/code-quality/sync-env-census.md
+++ b/docs/plans/code-quality/sync-env-census.md
@@ -1,8 +1,8 @@
 ---
 title: SPEC_KITTY_* env census — sync surface
-description: 'Env census of the sync surface: a live or retire-candidate verdict for every SPEC_KITTY_* reference, proving the Wave-4 de-god deleted no environment name.'
+description: 'Env census of the sync surface: a live or retired verdict for every SPEC_KITTY_* reference, proving the Wave-4 de-god deleted no environment name.'
 doc_status: active
-updated: '2026-08-19'
+updated: '2026-08-20'
 related:
 - docs/plans/code-quality/index.md
 - docs/plans/code-quality/targeted-cleanup-scoping.md
@@ -17,9 +17,15 @@ god-module into the `specify_cli.sync.sync_*` seam modules, and this census esta
 the relocation **deleted no environment reference** — a relocation moves a reference from the
 husk to a seam module, but the *set* of referenced names is invariant.
 
-**Retirement is out of scope (WS6 / INV-6).** Verdicts are an inventory only. No variable is
-deleted, renamed, or rewired by this mission. Every `retire-candidate` is handed to the WS6
-follow-on issue (FR-008); it is *documented*, never *actioned*, here.
+**Retirement was out of scope for the Wave-4 mission itself (WS6 / INV-6).** Verdicts were an
+inventory only there; no variable was deleted, renamed, or rewired by that mission. Every
+`retire-candidate` was handed to the WS6 follow-on issue (FR-008) for deliberate, later action.
+
+**Update (#3569, 2026-08-20).** The sole `retire-candidate`, `SPEC_KITTY_DIR`, has been retired:
+its remaining test importers were migrated off the name (they patched it defensively alongside
+the real `DAEMON_*_FILE` lazy attributes but nothing in production ever read it — the patches
+were removed outright) and the shim was deleted from `daemon.py`. The census below reflects the
+post-retirement state (7 references, all `live`).
 
 **Surface scanned.** `src/specify_cli/cli/commands/sync.py` (the husk) plus every `*.py` under
 `src/specify_cli/sync/` (recursively). The frozen expected set and the executable guard live in
@@ -32,7 +38,7 @@ token on the surface is the wildcard `SPEC_KITTY_SYNC_*` written in a `restart.p
 (`# ... the #2573b disable-env skip (SPEC_KITTY_SYNC_*)`), which is a family reference, not a
 distinct name.
 
-## Census (8 references, 7 `live` / 1 `retire-candidate`)
+## Census (7 references, all `live`; 1 historical `retired`)
 
 | # | Reference | Kind | Verdict | Where / role |
 |---|-----------|------|---------|--------------|
@@ -43,17 +49,18 @@ distinct name.
 | 5 | `SPEC_KITTY_SYNC_READONLY_IDENTITY` | env var | **live** | Read-only-identity flag (`events.py`, `READ_ONLY_IDENTITY_ENV`) gating identity mutation on event emission. |
 | 6 | `SPEC_KITTY_NO_AUTO_CUTOVER` | env var | **live** | Refuses legacy-root auto-cutover (`layout_generation.py`, `NO_AUTO_CUTOVER_ENV`). Active operator escape hatch. |
 | 7 | `SPEC_KITTY_CLI_VERSION` | env var | **live** | Pins the CLI version across daemon respawn (`daemon.py`): read on start, re-exported onto the respawned child's env. |
-| 8 | `SPEC_KITTY_DIR` | module-attribute shim | **retire-candidate** | *Not* an `os.environ` variable — a legacy lazily-resolved module attribute on `daemon.py` (`_LAZY_PATH_RESOLVERS`, served via `__getattr__`), the import-time path constant **superseded by `SPEC_KITTY_HOME` + `get_runtime_root()`**. Kept only for external importers/tests that still reference the name. Candidate for removal once those callers migrate — deferred to WS6. |
+| ~~8~~ | `SPEC_KITTY_DIR` | module-attribute shim | **retired (#3569)** | *Was not* an `os.environ` variable — a legacy lazily-resolved module attribute on `daemon.py` (`_LAZY_PATH_RESOLVERS`, served via `__getattr__`), superseded at runtime by `SPEC_KITTY_HOME` + `get_runtime_root()`. Had no production readers; the only remaining bindings were defensive `monkeypatch`/`patch` calls in daemon tests (alongside the still-live `DAEMON_*_FILE` lazy attributes) that had no effect on behaviour. Those bindings were deleted and the shim removed from `daemon.py` and `_LAZY_PATH_RESOLVERS`. |
 
 ### Verdict rationale
 
-- **`live` (7)** — every entry except #8 is a genuine, actively-consumed environment variable
-  whose deletion would change `sync` behaviour. None is a de-god artefact; all pre-date the
-  mission and survive the relocation unchanged.
-- **`retire-candidate` (1)** — `SPEC_KITTY_DIR` is a backward-compatibility module shim, not an
-  env var. Its runtime authority already moved to `SPEC_KITTY_HOME` / `get_runtime_root()`. It
-  is retained (not deleted) because external importers still bind the name; retiring it requires
-  migrating those callers, which is WS6 follow-on work, not this mission (WS6 / INV-6).
+- **`live` (7)** — every entry except the retired #8 is a genuine, actively-consumed environment
+  variable whose deletion would change `sync` behaviour. None is a de-god artefact; all pre-date
+  the mission and survive the relocation unchanged.
+- **`retired` (1, was `retire-candidate`)** — `SPEC_KITTY_DIR` was a backward-compatibility module
+  shim, not an env var. Its runtime authority had already moved to `SPEC_KITTY_HOME` /
+  `get_runtime_root()`; the only remaining callers were test monkeypatches that did nothing (they
+  set an attribute production code never read). #3569 (the WS6 follow-on, FR-008) confirmed that
+  and deleted the shim.
 
 ## Anti-deletion invariant (FR-007)
 
@@ -62,7 +69,6 @@ it from the live tree on every run; any shrinkage (a deleted reference) fails th
 
 ```
 SPEC_KITTY_CLI_VERSION
-SPEC_KITTY_DIR
 SPEC_KITTY_ENABLE_SAAS_SYNC
 SPEC_KITTY_HOME
 SPEC_KITTY_NO_AUTO_CUTOVER
@@ -70,3 +76,6 @@ SPEC_KITTY_SAAS_URL
 SPEC_KITTY_SYNC_MINIMAL_IMPORT
 SPEC_KITTY_SYNC_READONLY_IDENTITY
 ```
+
+(`SPEC_KITTY_DIR` was removed from this frozen set by #3569's deliberate retirement — see the
+census row above.)

--- a/packs/built-in/missions/documentation/templates/task-prompt-template.md
+++ b/packs/built-in/missions/documentation/templates/task-prompt-template.md
@@ -20,7 +20,7 @@ history:
 
 **Read this first if you are implementing this task!**
 
-- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent status` or the Activity Log below).
+- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent tasks status` or the Activity Log below).
 - **You must address all feedback** before your work is complete. Feedback items are your implementation TODO list.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.
 

--- a/packs/built-in/missions/research/templates/task-prompt-template.md
+++ b/packs/built-in/missions/research/templates/task-prompt-template.md
@@ -20,7 +20,7 @@ history:
 
 **Read this first if you are working on this research task!**
 
-- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent status` or the Activity Log below).
+- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent tasks status` or the Activity Log below).
 - **You must address all feedback** before your work is complete. Feedback items are your research TODO list.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.
 

--- a/packs/built-in/missions/software-dev/templates/task-prompt-template.md
+++ b/packs/built-in/missions/software-dev/templates/task-prompt-template.md
@@ -42,7 +42,7 @@ If no profile is specified, run `spec-kitty agent profile list` and select the b
 
 **Read this first if you are implementing this task!**
 
-- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent status` or the Activity Log below).
+- **Has review feedback?**: Check the `review_ref` field in the event log (via `spec-kitty agent tasks status` or the Activity Log below).
 - **You must address all feedback** before your work is complete. Feedback items are your implementation TODO list.
 - **Report progress**: As you address each feedback item, update the Activity Log explaining what you changed.
 

--- a/src/charter/mission_type_profile_repository.py
+++ b/src/charter/mission_type_profile_repository.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 from charter.mission_type_profiles import MissionTypeProfile
 from doctrine.base import BaseDoctrineRepository
-from doctrine.missions.repository import MissionTemplateRepository
+from doctrine.pack_paths import built_in_missions_root as _pack_paths_built_in_missions_root
 
 __all__ = ["MissionTypeProfileRepository", "builtin_missions_root"]
 
@@ -53,27 +53,33 @@ _PROJECT_OVERRIDE_PARTS: tuple[str, ...] = (".kittify", "doctrine", "mission_typ
 
 
 def builtin_missions_root() -> Path:
-    """Shipped profiles root: ``src/doctrine/missions``.
+    """Shipped profiles root: ``packs/built-in/missions``.
 
-    Thin delegate (FR-004) onto the ONE promoted missions-root authority,
-    :meth:`~doctrine.missions.repository.MissionTemplateRepository.default_missions_root`
+    Thin delegate (FR-004, #3575) directly onto the ONE canonical
+    missions-root authority, :func:`~doctrine.pack_paths.built_in_missions_root`
     — this accessor is not a second, co-equal path-hardcode. The delegation
     is layer-rule-clean (charter → doctrine, no ``specify_cli``) and
-    byte-identical in the return value: :meth:`default_missions_root` is
-    itself ``importlib.resources``-based (wheel-safe), which the previous
-    ``Path(__file__)``-relative literal here was not. Full convergence onto the
-    promoted ``pack_paths`` missions authority
-    (``doctrine.pack_paths.built_in_missions_root``) is a tracked follow-up
-    (#3575), now unblocked — #3091 relocated the missions tree into
-    ``packs/built-in`` and ``pack_paths`` exposes ``built_in_missions_root()`` —
-    and is explicitly NOT claimed by this delegation.
+    byte-identical in the return value to the previous hop through
+    :meth:`~doctrine.missions.repository.MissionTemplateRepository.default_missions_root`
+    (itself a thin wrapper over the same ``pack_paths`` call plus an
+    existence check — see behaviour note below).
+
+    Behaviour note: unlike ``default_missions_root()``, this accessor does
+    **not** fail closed with ``MissionsRootNotFound`` when the missions
+    directory is missing from disk — it returns the joined path
+    unconditionally, per :func:`~doctrine.pack_paths.built_in_missions_root`'s
+    own contract. No current caller of this accessor catches
+    ``MissionsRootNotFound``, so this is not a behaviour change for any
+    known call site in a healthy install; a caller that needs the fail-closed
+    guarantee should call ``MissionTemplateRepository.default_missions_root()``
+    directly instead.
 
     Public module-level accessor (#2668) so cross-module consumers (e.g.
     ``charter.action_grain``, ``charter.mission_type_profiles``) no longer
     need to reach into :class:`MissionTypeProfileRepository`'s private
     ``_default_built_in_dir`` classmethod.
     """
-    return MissionTemplateRepository.default_missions_root()
+    return _pack_paths_built_in_missions_root()
 
 
 class MissionTypeProfileRepository(BaseDoctrineRepository[MissionTypeProfile]):
@@ -118,7 +124,7 @@ class MissionTypeProfileRepository(BaseDoctrineRepository[MissionTypeProfile]):
 
     @staticmethod
     def _default_built_in_dir() -> Path:
-        """Shipped profiles root: ``src/doctrine/missions``.
+        """Shipped profiles root: ``packs/built-in/missions``.
 
         Delegates to the public module-level :func:`builtin_missions_root`
         (#2668) — kept as a thin classmethod wrapper so the existing

--- a/src/specify_cli/coordination/commit_router.py
+++ b/src/specify_cli/coordination/commit_router.py
@@ -264,7 +264,7 @@ def _commit_partition_group(
             diagnostic=(
                 f"Refusing to commit planning artifacts to the protected branch "
                 f"'{placement.ref}'. Start a non-protected feature branch and "
-                f"commit there: 'spec-kitty mission create --start-branch "
+                f"commit there: 'spec-kitty agent mission create --start-branch "
                 f"<feature-branch>' (or check out an existing feature branch). "
                 f"Planning artifacts must land on a feature branch."
             ),

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -289,7 +289,7 @@ class ProtectedBranchRefused(SafeCommitError):
             f"safe_commit: refusing to commit to protected branch "
             f"{destination_ref!r} in {worktree_root}. "
             f"Start a non-protected feature branch and commit there "
-            f"('spec-kitty mission create --start-branch <feature-branch>', or "
+            f"('spec-kitty agent mission create --start-branch <feature-branch>', or "
             f"check out an existing feature branch). Planning artifacts must land "
             f"on a feature branch, or land via the mission lane worktree."
         )

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -867,13 +867,31 @@ def _staged_tree_is_empty(repo_path: Path) -> bool:
     return result.returncode == 0
 
 
-def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> tuple[str | None, str]:
+def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> tuple[str | None, str, str]:
     """Run ``git commit``.
 
-    Returns ``(new SHA, "")`` on success, or ``(None, combined_output)`` on
-    failure — where ``combined_output`` carries git's stdout+stderr so the
-    caller can tell an empty changeset apart from a genuine commit failure
-    (e.g. a failing pre-commit hook) instead of collapsing both to ``None``.
+    Returns ``(new_sha, stdout, stderr)``. ``new_sha`` is ``None`` on failure.
+    ``stdout`` and ``stderr`` are kept SEPARATE rather than merged, because the
+    two streams mean different things on the success path:
+
+    - ``stdout`` carries git's own routine commit summary (``[branch sha]
+      message``, ``N files changed``, ``create mode ...``) — printed on
+      *every* successful commit, not a signal worth an operator's attention.
+    - ``stderr`` is where the spec-kitty commit guard's warn-mode warning
+      lands (``commit_guard_hook.py`` writes via
+      ``print(..., file=sys.stderr)`` and exits 0, #3580).
+
+    Merging both into ``combined`` and surfacing it on every successful commit
+    (the #3580 fix as first landed) made the routine stdout summary look like
+    a guard warning on every single commit — noise that defeats the fix's
+    purpose. Keeping the streams separate lets the caller log stdout at DEBUG
+    and reserve WARNING for non-empty stderr.
+
+    The FAILURE path is unaffected by this split: callers still combine both
+    streams for ``RuntimeError`` detail text, and ``_staged_tree_is_empty`` —
+    not this output — remains the sole authority for the
+    empty-changeset-vs-genuine-failure classification (audit BLOCK_MATERIAL,
+    PR #3269).
     """
     commit_result = subprocess.run(
         ["git", "-c", "commit.gpgsign=false", "commit", "-m", commit_message],
@@ -885,10 +903,9 @@ def _run_commit_capture_sha(repo_path: Path, commit_message: str) -> tuple[str |
         check=False,
     )
     if commit_result.returncode != 0:
-        combined = f"{commit_result.stdout}\n{commit_result.stderr}".strip()
-        return None, combined
+        return None, commit_result.stdout, commit_result.stderr
     sha = _run_git_text(repo_path, ["rev-parse", "HEAD"])
-    return sha, ""
+    return sha, commit_result.stdout, commit_result.stderr
 
 
 def _derive_mission_id(paths: list[str]) -> str:
@@ -1152,8 +1169,33 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
         except SafeCommitBackstopError as exc:
             backstop_error = exc
         else:
-            new_sha, commit_output = _run_commit_capture_sha(worktree_root, message)
+            new_sha, commit_stdout, commit_stderr = _run_commit_capture_sha(worktree_root, message)
             commit_created = new_sha is not None
+            if commit_created:
+                # SUCCESS path: stdout is git's own routine commit summary
+                # (`[branch sha] message`, `N files changed`, ...), printed on
+                # every successful commit -- not operator-actionable, so it
+                # goes to DEBUG rather than crowding the WARNING channel.
+                if commit_stdout.strip():
+                    logger.debug(
+                        "git commit in %s: %s",
+                        worktree_root,
+                        commit_stdout.strip(),
+                    )
+                # stderr is where a pre-commit hook writes (e.g. the
+                # spec-kitty commit guard in warn mode, #3580, which prints
+                # via `print(..., file=sys.stderr)` and exits 0). Non-empty
+                # stderr on an otherwise-successful commit is the genuine
+                # signal `capture_output=True` would otherwise swallow --
+                # warn-mode still commits; only the discarded signal was the
+                # defect. Gating on stderr (not "any output") keeps the
+                # channel meaningful: it no longer fires on every commit.
+                if commit_stderr.strip():
+                    logger.warning(
+                        "git commit in %s produced warnings on a successful commit: %s",
+                        worktree_root,
+                        commit_stderr.strip(),
+                    )
             if not commit_created:
                 # AUTHORITY: staged state, not git's output text (audit
                 # BLOCK_MATERIAL, PR #3269). A rejecting pre-commit hook can
@@ -1163,6 +1205,7 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
                 # that as a benign no-op. `_staged_tree_is_empty` cannot be
                 # fooled by hook output: it is only True when the index
                 # genuinely matches HEAD.
+                commit_output = f"{commit_stdout}\n{commit_stderr}".strip()
                 if _staged_tree_is_empty(worktree_root):
                     # Benign no-op: staged content already matches HEAD. The
                     # commit router maps this distinct message to "unchanged".
@@ -1171,7 +1214,8 @@ def safe_commit(  # noqa: C901 -- sequential validation gates; splitting harms r
                         f"destination_ref={destination_ref!r} (empty changeset)"
                     )
                 # Genuine failure (rejecting pre-commit hook, lock, etc.) — carry
-                # git's own output so it is NOT mistaken for an empty changeset.
+                # git's own combined output so it is NOT mistaken for an empty
+                # changeset (failure-path behavior unchanged: both streams).
                 detail = f": {commit_output}" if commit_output else ""
                 raise RuntimeError(
                     f"safe_commit: git commit failed in {worktree_root} for "

--- a/src/specify_cli/sync/daemon.py
+++ b/src/specify_cli/sync/daemon.py
@@ -65,20 +65,6 @@ from specify_cli.sync.diagnostics import SyncDiagnosticCode, emit_sync_diagnosti
 logger = logging.getLogger(__name__)
 
 
-def _spec_kitty_dir() -> Path:
-    """Return the runtime state root, honouring ``SPEC_KITTY_HOME`` (WP01).
-
-    Resolved lazily on every call so environment overrides and test ``HOME``
-    monkeypatching are honoured (research.md D5). On POSIX this is
-    ``~/.spec-kitty`` when ``SPEC_KITTY_HOME`` is unset — byte-identical to the
-    retired import-time ``SPEC_KITTY_DIR`` constant it replaces.
-    """
-    # ``get_runtime_root`` is seen as ``Any`` here because mypy skips imports
-    # for ``specify_cli.*`` (follow_imports=skip); coerce at the typed boundary.
-    base: Path = get_runtime_root().base
-    return base
-
-
 def _sync_root() -> Path:
     """Return the sync state directory for the current platform.
 
@@ -112,7 +98,9 @@ def _daemon_root() -> Path:
 # ``_daemon_root()`` helper. Resolving them on every access (rather than freezing
 # them at import time) is what lets ``SPEC_KITTY_HOME`` — and test ``HOME``
 # monkeypatching — take effect even when it is set or changed after this module
-# was first imported (#2171, mirrors the ``SPEC_KITTY_DIR`` shim below).
+# was first imported (#2171). A legacy module-attribute shim that used to mirror
+# this pattern for the runtime root itself was retired (#3569): it had no
+# production readers, only ``get_runtime_root()`` does.
 #
 # A test (or caller) may still pin an explicit value with
 # ``monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", path)``; that binds the name
@@ -126,7 +114,7 @@ def _resolve_lazy_path(name: str, resolver: Callable[[], Path]) -> Path:
     """Return an explicitly-pinned module override for ``name`` if present, else
     the lazily-resolved default.
 
-    The four lazy path names are never defined as real module globals (they are
+    The three lazy path names are never defined as real module globals (they are
     served by ``__getattr__``), so ``globals().get(name)`` is ``None`` unless a
     caller — typically a test via ``monkeypatch.setattr`` — pinned a value. Any
     such override (a real ``Path`` or a duck-typed test double exposing the
@@ -157,7 +145,6 @@ def _daemon_lock_file() -> Path:
 
 
 _LAZY_PATH_RESOLVERS = {
-    "SPEC_KITTY_DIR": _spec_kitty_dir,
     "DAEMON_STATE_FILE": _daemon_state_file,
     "DAEMON_LOG_FILE": _daemon_log_file,
     "DAEMON_LOCK_FILE": _daemon_lock_file,
@@ -167,14 +154,18 @@ _LAZY_PATH_RESOLVERS = {
 def __getattr__(name: str) -> Path:
     """Lazily resolve path-valued module constants on every access.
 
-    ``SPEC_KITTY_DIR`` and the ``DAEMON_*_FILE`` paths used to be evaluated at
-    import time, which froze them to the home directory present when the module
-    first loaded and defeated ``SPEC_KITTY_HOME`` / test ``HOME`` monkeypatching
-    (research.md D5, #2171). They are now resolved on every access. Kept as
-    module-level shims because external importers (and several daemon tests)
-    reference the names. NOTE: importers must read them as module attributes
+    The ``DAEMON_*_FILE`` paths used to be evaluated at import time, which
+    froze them to the home directory present when the module first loaded and
+    defeated ``SPEC_KITTY_HOME`` / test ``HOME`` monkeypatching (research.md
+    D5, #2171). They are now resolved on every access. Kept as module-level
+    shims because external importers (and several daemon tests) reference the
+    names. NOTE: importers must read them as module attributes
     (``daemon.DAEMON_STATE_FILE``); a ``from daemon import DAEMON_STATE_FILE``
     binds the value once and re-freezes it.
+
+    A former runtime-root shim (a duplicate of ``get_runtime_root()`` with no
+    production readers) was retired here (#3569); only the three
+    ``DAEMON_*_FILE`` names remain lazy module attributes.
     """
     resolver = _LAZY_PATH_RESOLVERS.get(name)
     if resolver is not None:

--- a/tests/architectural/test_sync_env_census.py
+++ b/tests/architectural/test_sync_env_census.py
@@ -12,10 +12,13 @@ reference set from the live tree and pins it to a frozen expected set. A removed
 reference shrinks the live set and turns this test red; a newly-introduced one
 grows it and also reds — so the census document stays honest in both directions.
 
-Retirement is out of scope (WS6 / INV-6): retire-candidates (e.g. the legacy
-``SPEC_KITTY_DIR`` module shim) are **documented, not deleted**, so they remain
-in the frozen set. The census with per-name verdicts lives at
-``docs/plans/code-quality/sync-env-census.md``.
+Retirement is out of scope for the Wave-4 mission itself (WS6 / INV-6):
+retire-candidates were **documented, not deleted**, by that mission, so they
+stayed in the frozen set until a deliberate WS6 follow-on retired them. The
+legacy ``SPEC_KITTY_DIR`` module shim was the sole retire-candidate; it was
+retired here (#3569) by removing it from ``_EXPECTED_ENV_REFS`` below — a
+deliberate, recorded removal, not a silent one. The census with per-name
+verdicts lives at ``docs/plans/code-quality/sync-env-census.md``.
 """
 
 from __future__ import annotations
@@ -42,12 +45,11 @@ _TOKEN = re.compile(r"SPEC_KITTY_[A-Z0-9_]+")
 #: Frozen contract (FR-007). Mirrors the census table in
 #: ``docs/plans/code-quality/sync-env-census.md``. Editing this set is a
 #: deliberate act: adding a name means a new reference landed on the surface;
-#: removing one means a reference was deleted — which WS6, not this mission,
-#: is allowed to do.
+#: removing one means a reference was deliberately retired (and the census doc
+#: updated in the same change) — see #3569, which retired ``SPEC_KITTY_DIR``.
 _EXPECTED_ENV_REFS: frozenset[str] = frozenset(
     {
         "SPEC_KITTY_CLI_VERSION",
-        "SPEC_KITTY_DIR",
         "SPEC_KITTY_ENABLE_SAAS_SYNC",
         "SPEC_KITTY_HOME",
         "SPEC_KITTY_NO_AUTO_CUTOVER",
@@ -86,13 +88,17 @@ def test_sync_surface_files_are_discovered() -> None:
 
 
 def test_no_spec_kitty_env_reference_was_deleted() -> None:
-    """FR-007: no ``SPEC_KITTY_*`` reference disappeared from the sync surface."""
+    """FR-007: no ``SPEC_KITTY_*`` reference disappeared from the sync surface
+    without a matching, deliberate ``_EXPECTED_ENV_REFS`` update.
+    """
     live = _scan_env_refs()
     missing = _EXPECTED_ENV_REFS - live
     assert not missing, (
-        "SPEC_KITTY_* reference(s) deleted from the sync surface (WS6 defers "
-        f"retirement; this mission deletes none): {sorted(missing)}. If a "
-        "removal is intended, it belongs to the WS6 follow-on, not here."
+        "SPEC_KITTY_* reference(s) deleted from the sync surface without an "
+        f"intentional retirement recorded here: {sorted(missing)}. A deliberate "
+        "retirement (like #3569's removal of SPEC_KITTY_DIR) must remove the "
+        "name from _EXPECTED_ENV_REFS above and update the census doc in the "
+        "same change; an accidental deletion should be reverted instead."
     )
 
 

--- a/tests/charter/test_missions_root_authority.py
+++ b/tests/charter/test_missions_root_authority.py
@@ -16,10 +16,15 @@ plan.md's Project Structure notes. ``builtin_missions_root()`` becomes a thin
 delegate (not a second co-equal authority); ``home.py``'s ``dev_roots``
 fallback calls the same authority.
 
-Full convergence onto ``doctrine.pack_paths.built_in_dir`` remains deferred to
-GitHub issue #3091 (``pack_paths`` has no ``missions/`` content directory
-today, per research.md D1) — this WP does NOT claim that convergence, and
-these tests do not exercise it.
+Full convergence onto ``doctrine.pack_paths.built_in_missions_root`` was
+completed by issue #3575: ``builtin_missions_root()`` now delegates straight
+to :func:`~doctrine.pack_paths.built_in_missions_root` (the single canonical
+source), rather than hopping through
+:meth:`~doctrine.missions.repository.MissionTemplateRepository.default_missions_root`.
+The equivalence assertions below still hold because
+``default_missions_root()`` is itself a thin wrapper over the same
+``pack_paths`` call (plus an existence check that ``builtin_missions_root()``
+does not replicate — see its docstring for that behaviour note).
 """
 
 from __future__ import annotations
@@ -31,6 +36,7 @@ import pytest
 
 from charter.mission_type_profile_repository import builtin_missions_root
 from doctrine.missions.repository import MissionTemplateRepository
+from doctrine.pack_paths import built_in_missions_root as pack_paths_built_in_missions_root
 from specify_cli.runtime import home as home_module
 
 pytestmark = [pytest.mark.unit]
@@ -39,6 +45,20 @@ pytestmark = [pytest.mark.unit]
 def test_builtin_missions_root_matches_promoted_authority() -> None:
     """T022: ``builtin_missions_root()`` is a thin delegate, not a rival authority."""
     assert builtin_missions_root() == MissionTemplateRepository.default_missions_root()
+
+
+def test_builtin_missions_root_delegates_directly_to_pack_paths() -> None:
+    """#3575: ``builtin_missions_root()`` now converges directly onto
+    ``pack_paths.built_in_missions_root()`` — the single canonical missions-root
+    authority — rather than hopping through ``default_missions_root()``.
+    """
+    root = builtin_missions_root()
+
+    assert root == pack_paths_built_in_missions_root()
+    assert root.is_dir(), (
+        "sanity: the canonical authority must resolve to the real built-in "
+        "missions directory in this editable-install test environment"
+    )
 
 
 def test_home_dev_roots_fallback_matches_promoted_authority(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,8 +54,8 @@ from tests.utils import REPO_ROOT, run, write_wp
 # Two layers are required:
 #   1. ``pytest_configure`` sets the HOME/XDG env vars *before collection* so
 #      that modules which bind a home-derived path at import time (e.g.
-#      ``specify_cli.sync.daemon.SPEC_KITTY_DIR = Path.home() / ".spec-kitty"``
-#      at module top level, ``daemon.py:94``) resolve into the isolated home.
+#      ``specify_cli.paths.get_runtime_root()``, which ``daemon.py`` calls
+#      lazily on every access) resolve into the isolated home.
 #   2. An autouse, function-scoped fixture re-asserts the ``Path.home``
 #      monkeypatch + env for every test, keyed by worker id, so call-time
 #      ``Path.home()`` reads are isolated too. Never session-only: a single
@@ -223,10 +223,11 @@ def pytest_configure(config: pytest.Config) -> None:
     os.environ.setdefault("SPEC_KITTY_ENABLE_SAAS_SYNC", "1")
 
     # WP04: isolate this worker's home BEFORE collection so modules that bind a
-    # home-derived path at import time (e.g. ``daemon.SPEC_KITTY_DIR`` at
-    # ``daemon.py:94``) resolve into the per-worker isolated home, never the
-    # developer's real ``~/.spec-kitty``. The autouse fixture below re-applies
-    # the same mapping per test for call-time reads.
+    # home-derived path at import time (e.g. ``daemon.py`` calling
+    # ``get_runtime_root()`` lazily on every access) resolve into the
+    # per-worker isolated home, never the developer's real ``~/.spec-kitty``.
+    # The autouse fixture below re-applies the same mapping per test for
+    # call-time reads.
     _apply_home_env(_worker_home_base(config))
 
     try:

--- a/tests/specify_cli/git/test_commit_helpers.py
+++ b/tests/specify_cli/git/test_commit_helpers.py
@@ -100,6 +100,114 @@ def test_safe_commit_happy_path(lane_repo: Path) -> None:
     assert "WP01: add alpha" in log
 
 
+def _install_warn_mode_guard_hook(repo: Path, warning_text: str) -> None:
+    """Install a pre-commit hook that mimics the spec-kitty commit guard in
+    warn mode (``commit_guard_hook.py``): it prints a ``[spec-kitty guard]
+    WARNING: ...`` line to stderr but exits 0 so the commit still succeeds.
+    """
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    hook_path = hooks_dir / "pre-commit"
+    hook_path.write_text(
+        f"#!/bin/sh\necho '[spec-kitty guard] WARNING: {warning_text}' 1>&2\nexit 0\n",
+        encoding="utf-8",
+    )
+    hook_path.chmod(0o755)
+
+
+def test_safe_commit_surfaces_warn_mode_guard_warning_on_success(
+    lane_repo: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #3580: a warn-mode commit-guard warning must reach the operator
+    even though the commit succeeds.
+
+    ``git commit`` is invoked with ``capture_output=True``; before the fix,
+    the captured stdout/stderr were only inspected on the *failure* path, so
+    a pre-commit hook's warn-mode warning (printed during a successful
+    commit) was silently discarded -- the operator only saw a bare success
+    message. This asserts the warning text reaches the operator-visible
+    logging channel (`specify_cli.git.commit_helpers`, WARNING level) on a
+    successful commit, and that warn-mode semantics are preserved: the
+    commit still succeeds.
+    """
+    warning_text = "WP03 touched files outside owned_files: docs/notes.md"
+    _install_warn_mode_guard_hook(lane_repo, warning_text)
+
+    target = lane_repo / "alpha.txt"
+    target.write_text("alpha v1\n", encoding="utf-8")
+
+    with caplog.at_level("WARNING", logger="specify_cli.git.commit_helpers"):
+        result = safe_commit(
+            repo_root=lane_repo,
+            worktree_root=lane_repo,
+            destination_ref="kitty/mission-test-01ABCDEF",
+            message="WP01: add alpha",
+            paths=(target,),
+        )
+
+    # Warn-mode still commits -- the defect is the swallowed signal, not the
+    # commit outcome.
+    assert isinstance(result, CommitResult)
+    assert len(result.sha) == 40
+
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    surfaced = "\n".join(record.getMessage() for record in warning_records)
+    assert "[spec-kitty guard] WARNING:" in surfaced
+    assert warning_text in surfaced
+    # Over-surfacing regression guard: exactly one WARNING for the one guard
+    # hook line -- git's own routine commit summary (stdout: "[branch sha]
+    # message", "N files changed", ...) must NOT ride along on the WARNING
+    # channel merged with the guard's stderr content.
+    assert len(warning_records) == 1, (
+        f"expected exactly one WARNING record for the guard's stderr output, "
+        f"got {len(warning_records)}: {[r.getMessage() for r in warning_records]!r}"
+    )
+    assert "file changed" not in surfaced, (
+        "git's routine stdout commit summary leaked into the WARNING channel"
+    )
+
+
+def test_safe_commit_does_not_warn_on_routine_successful_commit(
+    lane_repo: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression for the #3580 fix over-surfacing (review BLOCKER): a plain
+    successful commit with NO pre-commit hook installed must never emit a
+    WARNING on the ``specify_cli.git.commit_helpers`` logger.
+
+    ``git commit`` always writes a routine summary to stdout on success
+    (``[branch sha] message``, ``N files changed``, ``create mode ...``).
+    The first #3580 fix merged stdout+stderr into one ``combined`` string and
+    logged it at WARNING whenever it was non-empty on a successful commit --
+    which fired on *every* commit (there is no hook here, so the only output
+    is git's own routine stdout summary), defeating the purpose of surfacing
+    the genuine warn-mode guard warning. This test has no hook installed, so
+    it is red against the pre-fix code (which warns on git's routine stdout
+    summary) and green once WARNING is gated on non-empty stderr instead.
+    """
+    target = lane_repo / "alpha.txt"
+    target.write_text("alpha v1\n", encoding="utf-8")
+
+    with caplog.at_level("DEBUG", logger="specify_cli.git.commit_helpers"):
+        result = safe_commit(
+            repo_root=lane_repo,
+            worktree_root=lane_repo,
+            destination_ref="kitty/mission-test-01ABCDEF",
+            message="WP01: add alpha",
+            paths=(target,),
+        )
+
+    assert isinstance(result, CommitResult)
+    assert len(result.sha) == 40
+
+    warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warning_records == [], (
+        "a routine successful commit with no pre-commit hook must not emit "
+        f"any WARNING records; got {[r.getMessage() for r in warning_records]!r}"
+    )
+
+
 def test_safe_commit_accepts_realpath_under_symlinked_worktree(lane_repo: Path, tmp_path: Path) -> None:
     """Absolute paths resolved via the real path still normalize under a symlinked worktree."""
     repo_alias = tmp_path / "repo-alias"

--- a/tests/sync/test_daemon.py
+++ b/tests/sync/test_daemon.py
@@ -56,7 +56,6 @@ class TestDaemonFileLock:
         """Calling ensure_sync_daemon_running creates a lock file."""
         lock_file = tmp_path / "sync-daemon.lock"
         state_file = tmp_path / "sync-daemon"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
@@ -85,7 +84,6 @@ class TestDaemonFileLock:
         """Two concurrent callers should not both spawn; file lock serialises them."""
         lock_file = tmp_path / "sync-daemon.lock"
         state_file = tmp_path / "sync-daemon"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
@@ -193,7 +191,6 @@ class TestDaemonLogging:
         state_file = tmp_path / "sync-daemon"
         log_file = tmp_path / "sync-daemon.log"
         lock_file = tmp_path / "sync-daemon.lock"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", log_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
@@ -276,7 +273,6 @@ class TestHealthCheckRetryWindow:
         """The retry loop should wait at least 15 seconds total."""
         state_file = tmp_path / "sync-daemon"
         lock_file = tmp_path / "sync-daemon.lock"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
@@ -363,7 +359,6 @@ class TestDaemonVersionCheck:
     def test_version_mismatch_triggers_recycle(self, monkeypatch, tmp_path):
         state_file = tmp_path / "sync-daemon"
         lock_file = tmp_path / "sync-daemon.lock"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")
@@ -414,7 +409,6 @@ class TestDaemonVersionCheck:
     def test_version_match_reuses_daemon(self, monkeypatch, tmp_path):
         state_file = tmp_path / "sync-daemon"
         lock_file = tmp_path / "sync-daemon.lock"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
 

--- a/tests/sync/test_daemon_intent_gate.py
+++ b/tests/sync/test_daemon_intent_gate.py
@@ -106,7 +106,6 @@ class TestDecisionMatrix:
             ),
             patch("specify_cli.sync.daemon.DAEMON_STATE_FILE", fake_state_file),
             patch("specify_cli.sync.daemon.DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock"),
-            patch("specify_cli.sync.daemon.SPEC_KITTY_DIR", tmp_path),
         ):
             outcome = ensure_sync_daemon_running(
                 intent=DaemonIntent.REMOTE_REQUIRED,
@@ -125,7 +124,6 @@ class TestDecisionMatrix:
                 side_effect=RuntimeError("port unavailable"),
             ),
             patch("specify_cli.sync.daemon.DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock"),
-            patch("specify_cli.sync.daemon.SPEC_KITTY_DIR", tmp_path),
         ):
             outcome = ensure_sync_daemon_running(
                 intent=DaemonIntent.REMOTE_REQUIRED,

--- a/tests/sync/test_daemon_sync_disable_env.py
+++ b/tests/sync/test_daemon_sync_disable_env.py
@@ -56,7 +56,6 @@ class TestSyncDaemonHonorsDisableEnv:
         with (
             patch("specify_cli.sync.daemon._ensure_sync_daemon_running_locked", inner),
             patch("specify_cli.sync.daemon.DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock"),
-            patch("specify_cli.sync.daemon.SPEC_KITTY_DIR", tmp_path),
         ):
             outcome = ensure_sync_daemon_running(
                 intent=DaemonIntent.REMOTE_REQUIRED,
@@ -87,7 +86,6 @@ class TestSyncDaemonHonorsDisableEnv:
         with (
             patch("specify_cli.sync.daemon._ensure_sync_daemon_running_locked", inner),
             patch("specify_cli.sync.daemon.DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock"),
-            patch("specify_cli.sync.daemon.SPEC_KITTY_DIR", tmp_path),
         ):
             outcome = ensure_sync_daemon_running(
                 intent=DaemonIntent.REMOTE_REQUIRED,

--- a/tests/sync/test_issue_598_hang_fixes.py
+++ b/tests/sync/test_issue_598_hang_fixes.py
@@ -739,7 +739,6 @@ class TestDaemonBoundedFlock:
         state_file = tmp_path / "sync-daemon"
         lock_file = tmp_path / "sync-daemon.lock"
         log_file = tmp_path / "sync-daemon.log"
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", state_file)
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", lock_file)
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", log_file)
@@ -1083,7 +1082,6 @@ class TestFullQueueExpiredSessionIntegration:
         from specify_cli.sync import daemon
         from specify_cli.sync.config import BackgroundDaemonPolicy
 
-        monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", tmp_path)
         monkeypatch.setattr(daemon, "DAEMON_STATE_FILE", tmp_path / "sync-daemon")
         monkeypatch.setattr(daemon, "DAEMON_LOCK_FILE", tmp_path / "sync-daemon.lock")
         monkeypatch.setattr(daemon, "DAEMON_LOG_FILE", tmp_path / "sync-daemon.log")

--- a/tests/sync/test_spec_kitty_home_paths.py
+++ b/tests/sync/test_spec_kitty_home_paths.py
@@ -8,8 +8,11 @@ Every sync state surface must resolve under ``get_runtime_root().base``:
   ``~/.spec-kitty/...`` layout (NFR-001).
 
 Covers FR-001 (config), FR-004/FR-005 (queues + active scope), FR-006
-(daemon), FR-007 (clock), plus the lazy ``SPEC_KITTY_DIR`` shim (research.md
-D5) and the POSIX flat daemon layout (research.md D3).
+(daemon), FR-007 (clock), plus the POSIX flat daemon layout (research.md D3).
+
+The legacy lazy ``SPEC_KITTY_DIR`` module-attribute shim (research.md D5) was
+retired in #3569 — it duplicated ``get_runtime_root()`` with no production
+readers — so it is no longer covered here.
 """
 
 from __future__ import annotations
@@ -166,25 +169,7 @@ def test_daemon_root_is_flat_base(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert daemon._daemon_root() == base
 
 
-@pytest.mark.parametrize("env_set", [False, True])
-def test_spec_kitty_dir_shim_is_lazy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, env_set: bool) -> None:
-    """The retired ``SPEC_KITTY_DIR`` constant resolves lazily per access."""
-    # Other daemon tests use ``monkeypatch.setattr(daemon, "SPEC_KITTY_DIR", …)``.
-    # Because the name now lives only on the module ``__getattr__`` shim,
-    # monkeypatch's teardown can restore it as a *real* module attribute that
-    # would shadow the shim here. A fresh import / production process never has
-    # that real attribute. Pop only a *real* attribute from ``__dict__`` so the
-    # shim — not a frozen real attribute — is what we exercise. We must not use
-    # ``monkeypatch.delattr(..., raising=False)``: its ``hasattr`` guard is
-    # defeated by ``__getattr__`` (always True), so it would try the builtin
-    # ``delattr`` on a missing real attribute and raise ``AttributeError`` in
-    # clean/production module state.
-    daemon.__dict__.pop("SPEC_KITTY_DIR", None)
-    base = _configure_root(monkeypatch, tmp_path, env_set=env_set)
-    assert base == daemon.SPEC_KITTY_DIR
-
-
-def test_spec_kitty_dir_shim_rejects_unknown_attr() -> None:
+def test_daemon_module_getattr_rejects_unknown_attr() -> None:
     # Variable (not a constant) so this exercises the module __getattr__ shim
     # without tripping ruff B009.
     missing = "NOT_A_REAL_ATTRIBUTE"


### PR DESCRIPTION
## What changes for you

Four small, self-contained fixes from the `>= #3565` triage pass — two an operator notices directly, two internal convergences:

- **Printed commands you can paste and run.** Protected-branch commit refusals and work-package prompts named invocations that error out verbatim (`spec-kitty mission create --start-branch …`, `spec-kitty agent status`). They now print the real commands (`agent mission create --start-branch`, `agent tasks status`).
- **The commit guard's warning no longer vanishes.** A warn-mode guard warning was swallowed on a *successful* `safe-commit`/`spec-commit`; it's now surfaced (guard stderr only — git's routine summary is routed to debug so ordinary commits stay quiet).
- **Two internal convergences (no user-visible behavior change):** `builtin_missions_root()` now delegates to the canonical `pack_paths.built_in_missions_root()` authority (#3575), and the legacy `SPEC_KITTY_DIR` env shim on the sync surface is retired (#3569).

## Closes

Closes #3577
Closes #3580
Closes #3575
Closes #3569

## What's included

| Issue | Type | Change |
|-------|------|--------|
| **#3577** | Bug | Shipped surfaces named unrunnable invocations. Corrected `agent status` → `agent tasks status` in the three `task-prompt-template.md` sources, and `mission create --start-branch` → `agent mission create --start-branch` in the `spec-commit` **and** `safe-commit` protected-branch refusals (`commit_router.py`, `commit_helpers.py`). Verified: `agent status` is a command group with no board; `--start-branch` lives only on `agent mission create`. |
| **#3580** | Bug | `safe-commit`/`spec-commit` discarded the commit guard's warn-mode warning on a successful commit. Now surfaced — but **only the guard's stderr**, with git's routine stdout summary routed to `debug` (see review note below). |
| **#3575** | Task | Converged `builtin_missions_root()` to delegate directly to the canonical `pack_paths.built_in_missions_root()` authority; removed the stale deferral note (unblocked by completed #3091). Equivalence verified on healthy installs. |
| **#3569** | Task | Retired the legacy `SPEC_KITTY_DIR` lazy module-attribute shim on the sync surface. Zero production readers; dead test monkeypatches removed; the env-census guard updated to record the **deliberate** retirement (guard still reds on any silent deletion). |
| docs | — | Campsite fold: the review squad found the same defect class still on doc surfaces out of each issue's scope — corrected the wrong `mission create --start-branch` in `terminology.md` / `start-branch-coord-divergence.md` (+ derived retrieval-index abstract), and replaced the retired `SPEC_KITTY_DIR` example with `get_runtime_root()` in `testing-parallel.md`. |

## Review squad — blocker caught and fixed

The correctness lens proved the first cut of **#3580** over-surfaced: `git commit` writes a routine summary to **stdout** on every success, so the merged capture logged a WARNING on *every* commit across ~10 `safe_commit` call sites — training operators to ignore the exact channel the guard uses. Fixed by capturing stdout/stderr separately, warning only on non-empty **stderr**, and routing the routine summary to `debug`. A red-first **negative** test now pins that a plain (no-hook) commit emits zero warnings.

## Testing
- `ruff` clean on all changed source; terminology guard (`test_no_legacy_terminology.py`) green.
- `tests/specify_cli/git/` + `tests/git_ops/` → 321 passed; `tests/sync/` → 3406 passed; `tests/charter/` missions-root suites green; census guard green.
- No `src/specify_cli/__init__.py` change → no version bump required.

## Landing notes (maintainer folds)
- `docs(landing)`: regenerated the docs retrieval index after the #3569 doc edit (fixes the `DOCS-INDEX-DRIFT` / `docs-freshness` red).
- `docs(landing)`: added `[Unreleased] Fixed` changelog entries for the two user-facing bugs (#3577, #3580).
- **`Clean install verification (FR-010)`** red is the pre-existing **NFR-003 latency regression gate** flake (fails on `main` too; per flakiness policy, not retried-to-green and not folded).

## Follow-ups (out of scope — flagged by the squad, not folded)
- **#3575**: two "missions root" accessors now differ on fail-closed (`default_missions_root` raises `MissionsRootNotFound`) vs. fail-silent (this delegate returns an unchecked path). Safe today (no caller of the delegate catches the error), but worth collapsing to one guarded accessor, and pinning the documented missing-dir divergence with a test.
- The protected-branch refusal guidance is hardcoded in two sites (`commit_router.py`, `commit_helpers.py`); consolidating to one shared string would prevent a future one-site-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835091&installation_model_id=427282&pr_number=3601&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3601&signature=5c16caf535782c0f953720bfddb92ae42056831dd87ab15f5dea577c86ca7d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
