### PR TITLE
chore(ignore): ignore per-repo .kittify/.kitty.env operator env file

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -56,3 +56,5 @@ desktop.ini
 *.log
 *.db
 *.sqlite
+
+.kittify/.kitty.env

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ pytest-of-*/
 
 # Build-time PlantUML jar (downloaded + sha256-verified in CI/tests, never committed)
 /plantuml.jar
+
+# Spec Kitty per-repo operator env file (may carry secrets)
+.kittify/.kitty.env


### PR DESCRIPTION
## Summary

Adds `.kittify/.kitty.env` to both `.gitignore` and `.claudeignore`. This is the per-repo Spec Kitty operator env file — it may carry secrets and is local-only state, so it should never be committed or shipped to agent copies.

## Changes
- `.gitignore`: ignore `.kittify/.kitty.env`
- `.claudeignore`: ignore `.kittify/.kitty.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835113&installation_model_id=427282&pr_number=3602&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3602&signature=09d4fb25638ecb9e38f18c1c7418b0d37c292f3babb48da13743bba86def4d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->