### PR TITLE
ci: complete pr:skip-ci coverage (drift-detector shim + docs-build-pr guard)

### DIFF
--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -53,6 +53,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr:deferred') && !contains(github.event.pull_request.labels.*.name, 'pr:skip-ci') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/drift-detector.yml
+++ b/.github/workflows/drift-detector.yml
@@ -31,19 +31,38 @@ jobs:
   drift-detector:
     name: drift-detector
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr:deferred') && !contains(github.event.pull_request.labels.*.name, 'pr:skip-ci') }}
     timeout-minutes: 5
     steps:
+      # Always-green shim (pr:skip-ci / pr:deferred): `drift-detector` is the
+      # REQUIRED status check this workflow offers to branch protection (see
+      # header). A job-level `if:` skip would leave that required context
+      # UNSATISFIED and block merge, so instead the job always runs and
+      # short-circuits its work when a skip label is present — the context
+      # reports success either way. On push events no PR labels exist, so
+      # `skip` is always false and the detector runs normally.
+      - name: Resolve skip label
+        id: guard
+        run: |
+          echo "skip=${{ contains(github.event.pull_request.labels.*.name, 'pr:deferred') || contains(github.event.pull_request.labels.*.name, 'pr:skip-ci') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Short-circuit (pr:skip-ci / pr:deferred present)
+        if: steps.guard.outputs.skip == 'true'
+        run: echo "pr:skip-ci/pr:deferred present — drift-detector short-circuited to green (required-check parity)."
+
       - name: Checkout
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/checkout@v6
 
       - name: Install uv
+        if: steps.guard.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
       - name: Install dependencies (frozen)
+        if: steps.guard.outputs.skip != 'true'
         run: uv sync --frozen --extra test
 
       - name: Run canonical-registry drift detector
+        if: steps.guard.outputs.skip != 'true'
         run: uv run pytest tests/sync/test_diagnose.py::TestCanonicalRegistryRecognition -v


### PR DESCRIPTION
## Summary

The `pr:skip-ci` / `pr:deferred` skip mechanism already guards 11 PR workflows (including the always-run `ci-windows`, `drift-detector`, `ui-e2e` and all of `ci-quality`). This PR closes the two remaining gaps in that coverage.

## Changes

1. **`drift-detector.yml` — always-green shim.** `drift-detector` is the *required* status check this workflow offers to branch protection. Its previous job-level `if:` skip left the required context **unsatisfied** on skip-labelled PRs, blocking merge. Now the job always runs and short-circuits its heavy steps (checkout/install/detector) when `pr:skip-ci`/`pr:deferred` is present, so the required context reports green either way. Push events carry no PR labels, so the detector runs normally on `main`.

2. **`docs-build-pr.yml` — skip guard.** This was the only PR-triggered doc workflow missing the canonical guard. Added the same job-level guard `docs-freshness.yml` uses.

## Verification

Narrow architectural guards over the modeled workflow set (full `tests/architectural/` intentionally not run locally per repo policy):
- `test_workflow_coherence.py` — 16 passed
- `test_src_filter_coverage.py` + `test_ci_corpus_trigger_completeness.py` — 14 passed
- `test_ci_collection_completeness.py` — 50 passed
- No test references `docs-build-pr.yml`; YAML parses for both files.

## Notes for reviewers / Sonar

Workflow YAML only — no new-code coverage surface. This PR is intentionally **not** labelled `pr:skip-ci` so the CI suites run against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789835125&installation_model_id=427282&pr_number=3603&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3603&signature=76774119a6fcd253a4bfebf225cc0c49753298aa560f6757bc3370f7ea3c41f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->