### PR TITLE
docs(changelog): cut 3.2.6rc2 (date heading, open rc3 cycle)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,9 +13,13 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 3.2.6rc2
+## [Unreleased] - 3.2.6rc3
 
-_The 3.2.6rc2 candidate cycle is open (rc1 shipped 2026-08-12). Entries land here as missions merge._
+_The 3.2.6rc3 candidate cycle is open. Entries land here as missions merge._
+
+## [3.2.6rc2] - 2026-08-20
+
+_The 3.2.6rc2 candidate shipped 2026-08-20 (rc1 shipped 2026-08-12)._
 
 ### ✨ Added
 

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5313,7 +5313,8 @@ pages:
     divio_type: "none"
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
-    - {slug: "unreleased-3-2-6rc2", text: "[Unreleased] - 3.2.6rc2", level: 2}
+    - {slug: "unreleased-3-2-6rc3", text: "[Unreleased] - 3.2.6rc3", level: 2}
+    - {slug: "3-2-6rc2-2026-08-20", text: "[3.2.6rc2] - 2026-08-20", level: 2}
     - {slug: "added", text: "✨ Added", level: 3}
     - {slug: "changed", text: "♻️ Changed", level: 3}
     - {slug: "fixed", text: "🐛 Fixed", level: 3}


### PR DESCRIPTION
Dates the `3.2.6rc2` changelog heading (2026-08-20) ahead of tagging **v3.2.6rc2**, and opens a fresh `[Unreleased] - 3.2.6rc3` cycle. `pyproject` stays at `3.2.6rc2` (the tag target). Retrieval index regenerated for the shifted anchors; docs-freshness + terminology green.

**This is the pre-tag changelog cut.** After merge: tag `v3.2.6rc2` on the merge commit and push to trigger `release.yml` → PyPI `spec-kitty-cli==3.2.6rc2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789854520&installation_model_id=427282&pr_number=3609&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3609&signature=3ad9c4feef9d451bf1bac2f38f59db7f18cf54e4dce2754ee49cb11486a4ccfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->