### PR TITLE
fix(release): drop premature rc3 changelog heading (unblocks v3.2.6rc2 publish)

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,10 +13,6 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 3.2.6rc3
-
-_The 3.2.6rc3 candidate cycle is open. Entries land here as missions merge._
-
 ## [3.2.6rc2] - 2026-08-20
 
 _The 3.2.6rc2 candidate shipped 2026-08-20 (rc1 shipped 2026-08-12)._

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5313,7 +5313,6 @@ pages:
     divio_type: "none"
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
-    - {slug: "unreleased-3-2-6rc3", text: "[Unreleased] - 3.2.6rc3", level: 2}
     - {slug: "3-2-6rc2-2026-08-20", text: "[3.2.6rc2] - 2026-08-20", level: 2}
     - {slug: "added", text: "✨ Added", level: 3}
     - {slug: "changed", text: "♻️ Changed", level: 3}


### PR DESCRIPTION
The `v3.2.6rc2` tag-push release [run 32421675651](https://github.com/Priivacy-ai/spec-kitty/actions/runs/32421675651) failed at **Validate release metadata** (before build — nothing published):

> ERROR: CHANGELOG.md latest release entry is '3.2.6rc3', but pyproject.toml declares '3.2.6rc2'.

`validate_release.py` (tag mode) requires the top CHANGELOG release section to equal `[project].version`. The `## [Unreleased] - 3.2.6rc3` heading I opened for the next cycle declared `3.2.6rc3`. This drops that premature heading so the top section is `## [3.2.6rc2] - 2026-08-20`, matching `pyproject` (`3.2.6rc2`).

Verified locally: `validate_release.py --mode tag --tag v3.2.6rc2` → **All required checks passed**. Retrieval index regenerated for the anchor change.

**After merge:** re-point the `v3.2.6rc2` tag to this commit and re-push to re-run the publish. The rc3 cycle heading will be re-added with the post-tag `pyproject`→`3.2.6rc3` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789855126&installation_model_id=427282&pr_number=3610&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3610&signature=ead3fd564820a1439cfc72202ff226f19ab628c336616cceade3535a782cf1e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->