### PR TITLE
chore(version): open 3.2.6rc3 dev cycle (post-rc2)

### DIFF
--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.6rc2
+  version: 3.2.6rc3
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to the Spec Kitty CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 3.2.6rc3
+
+_The 3.2.6rc3 candidate cycle is open. Entries land here as missions merge._
+
 ## [3.2.6rc2] - 2026-08-20
 
 _The 3.2.6rc2 candidate shipped 2026-08-20 (rc1 shipped 2026-08-12)._

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5313,6 +5313,7 @@ pages:
     divio_type: "none"
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
+    - {slug: "unreleased-3-2-6rc3", text: "[Unreleased] - 3.2.6rc3", level: 2}
     - {slug: "3-2-6rc2-2026-08-20", text: "[3.2.6rc2] - 2026-08-20", level: 2}
     - {slug: "added", text: "✨ Added", level: 3}
     - {slug: "changed", text: "♻️ Changed", level: 3}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.6rc2"
+version = "3.2.6rc3"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2261,7 +2261,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.6rc2"
+version = "3.2.6rc3"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
Post-release housekeeping after cutting **v3.2.6rc2** (published to PyPI + [GitHub Release](https://github.com/Priivacy-ai/spec-kitty/releases/tag/v3.2.6rc2)).

Bumps the dev version to `3.2.6rc3` across `pyproject.toml`, `.kittify/metadata.yaml`, and `uv.lock`, and re-opens the `[Unreleased] - 3.2.6rc3` CHANGELOG section — this time *after* the tag, so `pyproject` matches the top heading and the release validator is happy (`--mode branch` → **All required checks passed**). Retrieval index regenerated; docs-freshness + terminology green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789882565&installation_model_id=427282&pr_number=3613&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3613&signature=70e8a1339e45962b3c44dddee87efdcfee8449df25a624414794efacac4193bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->