### PR TITLE
fix(ci): scope strict docs gates to PR changes

### DIFF
--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -77,16 +77,17 @@ jobs:
         run: uv python install 3.11
       - name: Install project
         run: uv sync
-      # Diff-scope flag (#3147, B-WP02): on `pull_request`, scope the two
-      # blocking dead-link/related-edge gates below to the PR's own changed
-      # docs/**/*.md files via `--changed-from <base-sha>`, so a docs PR is no
-      # longer failed for pre-existing broken links it never touched. On
-      # `push` (the unfiltered push:main backstop, FR-005/M3) the flag is
-      # empty — those steps run whole-tree exactly as before, `min_files=1`
-      # floor intact. Fail-closed keys on git base RESOLVABILITY (B-WP02): a
-      # resolved diff that touches zero docs files (common — this workflow
-      # also triggers on non-`.md` paths like `src/specify_cli/**`) exits 0,
-      # never errors; only an unresolvable/unfetched base does.
+      # Diff-scope flag (#3147, #3316): on `pull_request`, scope the four
+      # blocking per-page gates below (related edges, audience references,
+      # descriptions, and body links) to the PR's own changed docs/**/*.md
+      # files via `--changed-from <base-sha>`, so a docs PR is no longer failed
+      # for a pre-existing violation it never touched. On `push` (the
+      # unfiltered push:main backstop, FR-005/M3) the flag is empty — those
+      # steps run whole-tree exactly as before, with their coverage floors
+      # intact. Fail-closed keys on git base RESOLVABILITY (B-WP02): a resolved
+      # diff that touches zero docs files (common — this workflow also triggers
+      # on non-`.md` paths like `src/specify_cli/**`) exits 0, never errors;
+      # only an unresolvable/unfetched base does.
       - name: Compute diff-scope flag (PR only)
         id: diffscope
         run: |
@@ -106,9 +107,9 @@ jobs:
       # must resolve to a persona under docs/context/audience/. --strict reds CI
       # on any dangling reference (mirror of the related-edge resolver).
       - name: Audience resolver (NFR-002, --strict)
-        run: uv run python scripts/docs/audience_resolver.py --strict --repo-root .
+        run: uv run python scripts/docs/audience_resolver.py --strict --repo-root . ${{ steps.diffscope.outputs.flag }}
       - name: Description-length gate (NFR-003, --strict)
-        run: uv run python scripts/docs/description_length_check.py --strict --repo-root .
+        run: uv run python scripts/docs/description_length_check.py --strict --repo-root . ${{ steps.diffscope.outputs.flag }}
       - name: Relative body-link gate (WP18, --check)
         run: uv run python scripts/docs/relative_link_fixer.py --check --repo-root . ${{ steps.diffscope.outputs.flag }}
       # Structural docs lint (FR-008): index completeness, point-in-time

--- a/scripts/docs/_guards.py
+++ b/scripts/docs/_guards.py
@@ -17,8 +17,9 @@ This is a distinct contract from ``redirect_stub_generator.assert_non_vacuous``
 and are intentionally left alone.
 
 This module also carries :func:`resolve_changed_files`, the shared diff-scope
-resolver both blocking docs gates use for their ``--changed-from`` mode
-(#3147, WP02). **B-WP02 (BLOCKER, see
+resolver used by the related-edge, relative-link, audience, and description
+blocking gates for their ``--changed-from`` mode (#3147, #3316). **B-WP02
+(BLOCKER, see
 ``kitty-specs/ci-scoping-gate-reliability-01KZP80D/investigate-squad-findings.md``):
 the fail-closed trigger is git base RESOLVABILITY, never changed-set
 emptiness.** ``docs-freshness.yml`` fires on many non-``.md`` paths

--- a/scripts/docs/audience_resolver.py
+++ b/scripts/docs/audience_resolver.py
@@ -23,6 +23,11 @@ breakage that stops matching ``audience:`` values — goes **RED** rather than
 silently reporting "0 dangling" over 0 examined. ``checked_count`` is emitted
 so a "0 dangling" result can never mean "0 checked".
 
+``--changed-from BASE_REF`` restricts the walk to changed ``docs/**/*.md``
+files on PRs. That mode intentionally skips the non-vacuity floor for a
+resolved empty docs diff and fails closed only when the Git base cannot be
+resolved. Without the flag, the whole-tree behavior and floor are unchanged.
+
 The resolver never mutates the docs tree and depends only on the standard
 library plus ``ruamel.yaml`` (already a project dependency). It is wired
 ``--strict`` on PR in ``docs-freshness.yml``; exit ``1`` on any dangling
@@ -42,7 +47,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final
 
-from scripts.docs._guards import assert_examined_floor
+from scripts.docs._guards import (
+    GitDiffError,
+    assert_examined_floor,
+    resolve_changed_files,
+)
 from scripts.docs._inventory import parse_frontmatter
 
 __all__ = [
@@ -53,6 +62,7 @@ __all__ = [
     "build_parser",
     "main",
     "resolve_audiences",
+    "resolve_audiences_diff_scoped",
 ]
 
 DEFAULT_DOCS_ROOT: Final[str] = "docs"
@@ -130,14 +140,11 @@ def resolve_audiences(
 
     if docs_root.exists() and docs_root.is_dir():
         for md_path in sorted(docs_root.rglob("*.md")):
-            values = _read_audience(md_path)
-            if not values:
-                continue
-            from_rel = _repo_relative(md_path, repo_root)
-            for value in values:
-                checked_count += 1
-                if _is_reference(value) and not _resolves(value, repo_root, catalog):
-                    dangling.append(DanglingReference(from_path=from_rel, to_path=value))
+            file_checked, file_dangling = _audiences_in_file(
+                md_path, repo_root, catalog
+            )
+            checked_count += file_checked
+            dangling.extend(file_dangling)
 
     assert_examined_floor(
         checked_count,
@@ -149,6 +156,55 @@ def resolve_audiences(
 
     dangling.sort(key=lambda ref: (ref.from_path, ref.to_path))
     return AudienceReport(checked_count=checked_count, dangling_references=dangling)
+
+
+def resolve_audiences_diff_scoped(
+    *,
+    docs_root: Path,
+    repo_root: Path,
+    changed_files: list[str],
+    catalog_root: Path | None = None,
+) -> AudienceReport:
+    """Resolve ``audience:`` values only in changed ``docs_root`` Markdown.
+
+    Each in-scope page is checked whole-file. Deleted paths and changed files
+    outside ``docs_root/**/*.md`` are skipped. Unlike the whole-tree walk, this
+    mode deliberately has no non-vacuity floor: a successfully resolved diff
+    with no in-scope docs is a clean pass.
+    """
+    catalog = (catalog_root or repo_root / DEFAULT_CATALOG_ROOT).resolve()
+    docs_root_rel = _repo_relative(docs_root, repo_root)
+    checked_count = 0
+    dangling: list[DanglingReference] = []
+
+    for rel in sorted(changed_files):
+        if not (rel.startswith(f"{docs_root_rel}/") and rel.endswith(".md")):
+            continue
+        md_path = repo_root / rel
+        if not md_path.is_file():
+            continue
+        file_checked, file_dangling = _audiences_in_file(md_path, repo_root, catalog)
+        checked_count += file_checked
+        dangling.extend(file_dangling)
+
+    dangling.sort(key=lambda ref: (ref.from_path, ref.to_path))
+    return AudienceReport(checked_count=checked_count, dangling_references=dangling)
+
+
+def _audiences_in_file(
+    md_path: Path, repo_root: Path, catalog: Path
+) -> tuple[int, list[DanglingReference]]:
+    """Check all ``audience:`` values in one Markdown page."""
+    values = _read_audience(md_path)
+    if not values:
+        return 0, []
+    from_rel = _repo_relative(md_path, repo_root)
+    dangling = [
+        DanglingReference(from_path=from_rel, to_path=value)
+        for value in values
+        if _is_reference(value) and not _resolves(value, repo_root, catalog)
+    ]
+    return len(values), dangling
 
 
 def _read_audience(md_path: Path) -> list[str]:
@@ -227,17 +283,40 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit non-zero when any dangling 'audience:' reference is found.",
     )
+    parser.add_argument(
+        "--changed-from",
+        metavar="BASE_REF",
+        default=None,
+        help=(
+            "Diff-scope the walk to docs-root *.md files changed since "
+            "BASE_REF. Fails closed only when BASE_REF cannot be resolved; "
+            "a resolved diff with zero in-scope docs files is a clean pass."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns the process exit code."""
     args = build_parser().parse_args(argv)
-    report = resolve_audiences(
-        docs_root=args.docs_root,
-        repo_root=args.repo_root,
-        catalog_root=args.catalog_root,
-    )
+    if args.changed_from is not None:
+        try:
+            changed = resolve_changed_files(args.repo_root, args.changed_from)
+        except GitDiffError as exc:
+            sys.stderr.write(f"{_GATE_NAME}: ERROR: {exc}\n")
+            return 2
+        report = resolve_audiences_diff_scoped(
+            docs_root=args.docs_root,
+            repo_root=args.repo_root,
+            changed_files=changed,
+            catalog_root=args.catalog_root,
+        )
+    else:
+        report = resolve_audiences(
+            docs_root=args.docs_root,
+            repo_root=args.repo_root,
+            catalog_root=args.catalog_root,
+        )
     _emit(report, as_json=args.json)
     if args.strict and report.dangling_references:
         return 1

--- a/scripts/docs/description_length_check.py
+++ b/scripts/docs/description_length_check.py
@@ -16,6 +16,12 @@ walk ``docs_root.rglob("*.md")`` itself, and its sibling in
 diverged and the SEO gate spent months guarding 16 of 674 pages while reporting
 green. There is now exactly one authority.
 
+``--changed-from BASE_REF`` limits reported violations to changed, published
+Markdown pages on PRs while retaining the complete published corpus as the
+comparison context for uniqueness. A changed page that duplicates an unchanged
+page therefore still fails, but a violation confined to an unchanged page does
+not. Without the flag, the whole-tree behavior is unchanged.
+
 A violation is one of:
 
 * ``missing``     — no ``description`` key, or it is blank;
@@ -39,10 +45,9 @@ Exit codes:
 ===  =========================================================================
 0    No violations, or violations under the default report-only mode.
 1    ``--strict`` and at least one violation.
-2    The gate could not establish a trustworthy page set (:class:`CoverageError`)
-     — an empty or collapsed resolution. This is *not* a content violation but a
-     malfunction of the gate itself, so it fails regardless of ``--strict``: a
-     gate that validates zero pages must fail, not pass.
+2    The gate could not establish a trustworthy page set (:class:`CoverageError`),
+     or ``--changed-from`` could not resolve its Git base. Both are gate
+     malfunctions and fail regardless of ``--strict``.
 ===  =========================================================================
 
 Depends only on the standard library plus ``ruamel.yaml`` (via
@@ -60,6 +65,7 @@ from pathlib import Path
 from typing import Final
 
 from scripts.docs import seo_postprocess
+from scripts.docs._guards import GitDiffError, resolve_changed_files
 from scripts.docs._inventory import parse_frontmatter
 from scripts.docs._published_pages import (
     MINIMUM_EXPECTED_PAGES,
@@ -80,6 +86,7 @@ __all__ = [
     "check_description_length",
     "main",
     "validate_descriptions",
+    "validate_descriptions_diff_scoped",
 ]
 
 DEFAULT_DOCS_ROOT: Final[str] = "docs"
@@ -245,6 +252,59 @@ def validate_descriptions(
     )
     violations.sort(key=lambda v: (v.path, v.reason))
     return LengthReport(checked_count=len(descriptions), violations=violations)
+
+
+def validate_descriptions_diff_scoped(
+    *,
+    docs_root: Path,
+    repo_root: Path,
+    changed_files: list[str],
+    docfx_config: Path | None = None,
+) -> LengthReport:
+    """Validate only changed, published Markdown pages.
+
+    Per-page violations are reported only for changed files under ``docs_root``.
+    Uniqueness still compares those pages with the complete published corpus,
+    so a changed description cannot duplicate an unchanged peer unnoticed.
+    Deleted paths and resolved diffs with no changed docs produce an empty
+    report. Changed but unpublished pages are excluded by the shared page-set
+    authority; no non-vacuity floor is applied to the changed subset itself.
+    """
+    docs_root_rel = _repo_relative(docs_root, repo_root)
+    changed_docs = {
+        rel
+        for rel in changed_files
+        if rel.startswith(f"{docs_root_rel}/")
+        and rel.endswith(".md")
+        and (repo_root / rel).is_file()
+    }
+    if not changed_docs:
+        return LengthReport()
+
+    # The shared resolver remains the publication authority and enforces the
+    # complete corpus floor in production. No additional non-vacuity floor is
+    # applied to the changed subset: zero published pages in a resolved PR diff
+    # is a valid scoped result.
+    page_set = _resolve_page_set(docs_root=docs_root, docfx_config=docfx_config)
+    descriptions = _collect_descriptions(
+        sorted(page_set.pages), docs_root=docs_root, repo_root=repo_root
+    )
+    scoped_paths = changed_docs.intersection(descriptions)
+    if not scoped_paths:
+        return LengthReport()
+
+    all_per_page = _per_page_violations(descriptions)
+    all_flagged = {violation.path for violation in all_per_page}
+    violations = [
+        violation for violation in all_per_page if violation.path in scoped_paths
+    ]
+    violations.extend(
+        violation
+        for violation in _duplicate_violations(descriptions, flagged=all_flagged)
+        if violation.path in scoped_paths
+    )
+    violations.sort(key=lambda violation: (violation.path, violation.reason))
+    return LengthReport(checked_count=len(scoped_paths), violations=violations)
 
 
 def _resolve_page_set(*, docs_root: Path, docfx_config: Path | None) -> PublishedPageSet:
@@ -416,18 +476,45 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Exit non-zero when any description is missing, boilerplate, out-of-band, or duplicated.",
     )
+    parser.add_argument(
+        "--changed-from",
+        metavar="BASE_REF",
+        default=None,
+        help=(
+            "Diff-scope violations to published docs-root *.md files changed "
+            "since BASE_REF. Fails closed only when BASE_REF cannot be "
+            "resolved; a resolved diff with zero in-scope docs files is a "
+            "clean pass."
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns the process exit code."""
     args = build_parser().parse_args(argv)
+    changed: list[str] | None = None
+    if args.changed_from is not None:
+        try:
+            changed = resolve_changed_files(args.repo_root, args.changed_from)
+        except GitDiffError as exc:
+            sys.stderr.write(f"description_length_check: ERROR: {exc}\n")
+            return EXIT_COVERAGE_FAILURE
+
     try:
-        report = validate_descriptions(
-            docs_root=args.docs_root,
-            repo_root=args.repo_root,
-            docfx_config=args.docfx_config,
-        )
+        if changed is None:
+            report = validate_descriptions(
+                docs_root=args.docs_root,
+                repo_root=args.repo_root,
+                docfx_config=args.docfx_config,
+            )
+        else:
+            report = validate_descriptions_diff_scoped(
+                docs_root=args.docs_root,
+                repo_root=args.repo_root,
+                changed_files=changed,
+                docfx_config=args.docfx_config,
+            )
     except CoverageError as exc:
         sys.stderr.write(f"description_length_check: COVERAGE FAILURE: {exc}\n")
         return EXIT_COVERAGE_FAILURE

--- a/tests/docs/test_audience_resolves.py
+++ b/tests/docs/test_audience_resolves.py
@@ -25,6 +25,7 @@ from scripts.docs.audience_resolver import (
     main,
     resolve_audiences,
 )
+from tests.docs.conftest import commit_all_changes, init_git_repo_with_base
 
 pytestmark = pytest.mark.architectural
 
@@ -191,3 +192,108 @@ def test_report_only_exit_zero_even_when_dangling(tmp_path: Path) -> None:
     exit_code = main(["--repo-root", str(repo), "--docs-root", str(repo / "docs")])
 
     assert exit_code == 0
+
+
+class TestDiffScopeAudienceCLI:
+    """``--changed-from`` behavior through :func:`main` over real git repos."""
+
+    def test_changed_dangling_reference_reds(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _stage_catalog(repo)
+        base_sha = init_git_repo_with_base(repo)
+        _write(
+            repo / "docs" / "changed.md",
+            ["audience:", f"  - {_MISSING_REL}"],
+            body="changed",
+        )
+        commit_all_changes(repo, "add dangling audience reference")
+
+        exit_code = main(
+            [
+                "--repo-root",
+                str(repo),
+                "--docs-root",
+                str(repo / "docs"),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 1
+
+    def test_unchanged_preexisting_dangling_reference_passes(
+        self, tmp_path: Path
+    ) -> None:
+        repo = _stage_repo(
+            tmp_path,
+            audience=["audience:", f"  - {_MISSING_REL}"],
+            dangling=True,
+        )
+        base_sha = init_git_repo_with_base(repo)
+        _write(
+            repo / "docs" / "changed.md",
+            [f"audience: {_PERSONA_REL}"],
+            body="changed",
+        )
+        commit_all_changes(repo, "add clean audience reference")
+
+        exit_code = main(
+            [
+                "--repo-root",
+                str(repo),
+                "--docs-root",
+                str(repo / "docs"),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 0
+
+    def test_resolved_zero_docs_passes(self, tmp_path: Path) -> None:
+        repo = _stage_repo(
+            tmp_path,
+            audience=["audience:", f"  - {_MISSING_REL}"],
+            dangling=True,
+        )
+        base_sha = init_git_repo_with_base(repo)
+        (repo / "README.md").write_text("# changed\n", encoding="utf-8")
+        commit_all_changes(repo, "change non-docs file")
+
+        exit_code = main(
+            [
+                "--repo-root",
+                str(repo),
+                "--docs-root",
+                str(repo / "docs"),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 0
+
+    def test_unresolvable_base_errors(self, tmp_path: Path) -> None:
+        repo = _stage_repo(
+            tmp_path,
+            audience=[f"audience: {_PERSONA_REL}"],
+            dangling=False,
+        )
+        init_git_repo_with_base(repo)
+
+        exit_code = main(
+            [
+                "--repo-root",
+                str(repo),
+                "--docs-root",
+                str(repo / "docs"),
+                "--strict",
+                "--changed-from",
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            ]
+        )
+
+        assert exit_code not in (0, 1)

--- a/tests/docs/test_description_length_gate.py
+++ b/tests/docs/test_description_length_gate.py
@@ -43,6 +43,7 @@ from scripts.docs.description_length_check import (
 # first. Reaching the gate's own assertion directly is the only way to prove it
 # is load-bearing rather than decorative.
 from scripts.docs.description_length_check import _assert_coverage  # noqa: E402
+from tests.docs.conftest import commit_all_changes, init_git_repo_with_base
 
 pytestmark = pytest.mark.architectural
 
@@ -376,6 +377,165 @@ def test_live_tree_covers_the_adr_subtree() -> None:
 
     assert adr_pages, "no ADR pages on disk — the scope assertion would pass vacuously"
     assert report.checked_count > len(adr_pages)
+
+
+# --- diff scope: PRs report only changed published pages (#3316) ------------
+
+
+def _stub_published_pages(
+    monkeypatch: pytest.MonkeyPatch, *relative_paths: str
+) -> None:
+    """Stub the published-page authority with the named repo-relative pages."""
+    page_set = PublishedPageSet(
+        pages=frozenset(Path("docs") / relative for relative in relative_paths),
+        source_globs=("**.md",),
+        exclusions=(),
+    )
+
+    def _resolve_page_set(**_kwargs: object) -> PublishedPageSet:
+        return page_set
+
+    monkeypatch.setattr(
+        "scripts.docs.description_length_check._resolve_page_set",
+        _resolve_page_set,
+    )
+
+
+class TestDiffScopeDescriptionCLI:
+    """``--changed-from`` behavior through :func:`main` over real git repos."""
+
+    def test_changed_length_violation_reds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        docs = tmp_path / "docs"
+        _write_page(docs / "existing.md", _desc(100))
+        base_sha = init_git_repo_with_base(tmp_path)
+        _write_page(docs / "changed.md", _desc(49))
+        commit_all_changes(tmp_path, "add short description")
+        _stub_published_pages(monkeypatch, "existing.md", "changed.md")
+
+        exit_code = main(
+            [
+                "--docs-root",
+                str(docs),
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 1
+
+    def test_unchanged_preexisting_violation_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        docs = tmp_path / "docs"
+        _write_page(docs / "preexisting.md", _desc(49))
+        base_sha = init_git_repo_with_base(tmp_path)
+        _write_page(docs / "changed.md", _desc(100))
+        commit_all_changes(tmp_path, "add valid description")
+        _stub_published_pages(monkeypatch, "preexisting.md", "changed.md")
+
+        exit_code = main(
+            [
+                "--docs-root",
+                str(docs),
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 0
+
+    def test_changed_duplicate_compares_with_unchanged_peer(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        docs = tmp_path / "docs"
+        shared = _desc(120)
+        _write_page(docs / "existing.md", shared)
+        base_sha = init_git_repo_with_base(tmp_path)
+        _write_page(docs / "changed.md", shared)
+        commit_all_changes(tmp_path, "add duplicate description")
+        _stub_published_pages(monkeypatch, "existing.md", "changed.md")
+
+        exit_code = main(
+            [
+                "--docs-root",
+                str(docs),
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+                "--json",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["checked_count"] == 1
+        assert payload["violations"] == [
+            {
+                "length": 120,
+                "path": "docs/changed.md",
+                "peers": ["docs/existing.md"],
+                "reason": "duplicate",
+            }
+        ]
+
+    def test_resolved_zero_docs_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        docs = tmp_path / "docs"
+        _write_page(docs / "preexisting.md", _desc(49))
+        base_sha = init_git_repo_with_base(tmp_path)
+        (tmp_path / "README.md").write_text("# changed\n", encoding="utf-8")
+        commit_all_changes(tmp_path, "change non-docs file")
+        _stub_published_pages(monkeypatch, "preexisting.md")
+
+        exit_code = main(
+            [
+                "--docs-root",
+                str(docs),
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+                "--changed-from",
+                base_sha,
+            ]
+        )
+
+        assert exit_code == 0
+
+    def test_unresolvable_base_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        docs = tmp_path / "docs"
+        _write_page(docs / "existing.md", _desc(100))
+        init_git_repo_with_base(tmp_path)
+        _stub_published_pages(monkeypatch, "existing.md")
+
+        exit_code = main(
+            [
+                "--docs-root",
+                str(docs),
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+                "--changed-from",
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            ]
+        )
+
+        assert exit_code not in (0, 1)
 
 
 # --- main: the report-only / --strict exit contract (preserved) ------------

--- a/tests/docs/test_docs_freshness_invariant.py
+++ b/tests/docs/test_docs_freshness_invariant.py
@@ -29,17 +29,18 @@ fact is unobservable from CI and is asserted nowhere here — do not add a
 ``required == {...}`` assertion (it would also conflict with ui-e2e.yml's
 "Required-check contract" comment).
 
-Property 4 (#3147, WP02 T011) pins the diff-scope wiring added to narrow the
-two blocking dead-link/related-edge gate steps to the PR's own changed
+Property 4 (#3147, WP02 T011; extended by #3316) pins the diff-scope
+wiring that narrows all four blocking per-page gates to the PR's own changed
 ``docs/**/*.md`` files (see ``scripts/docs/_guards.py:resolve_changed_files``
 and the B-WP02 fail-closed-on-resolvability contract in
 ``kitty-specs/ci-scoping-gate-reliability-01KZP80D/investigate-squad-findings.md``):
 the checkout step must fetch full history (``fetch-depth: 0``, required for the
-base commit to resolve) and the two gate steps must receive a diff-scope flag
-derived from ``github.event.pull_request.base.sha``. Properties 1-3 above are
-otherwise UNCHANGED by WP02 — the PR ``paths:`` allowlist and the unfiltered
-``push: main`` backstop are exactly what they were before diff-scoping; WP02
-narrows *which files are examined*, never *whether the gate triggers*.
+base commit to resolve) and the related-edge, relative-link, audience, and
+description gate steps must receive a diff-scope flag derived from
+``github.event.pull_request.base.sha``. Properties 1-3 above remain unchanged —
+the PR ``paths:`` allowlist and the unfiltered ``push: main`` backstop are
+exactly what they were before diff-scoping; scoping narrows *which files are
+examined*, never *whether the gate triggers*.
 """
 
 from __future__ import annotations
@@ -212,30 +213,24 @@ def test_diffscope_flag_derives_from_pr_base_sha() -> None:
     assert "pull_request" in run
 
 
-def test_related_and_body_link_gates_receive_diffscope_flag() -> None:
-    """Property 4c (#3147): both blocking dead-link gates receive the flag.
+def test_all_blocking_per_page_gates_receive_diffscope_flag() -> None:
+    """Property 4c (#3147, #3316): all four per-page gates receive the flag.
 
-    Only the two gates #3147 targets (related-edge validator, relative
-    body-link gate) are diff-scoped — the other docs-freshness steps
-    (description-length, structural lint, changelog/contributing sync,
-    slash-command freshness, the freshness orchestrator) are explicitly out of
-    scope (WP02 spec) and must NOT reference the flag.
+    The related-edge and relative body-link gates gained diff scoping in #3147;
+    #3316 extends the same contract to their audience and description siblings.
+    Other docs-freshness steps remain whole-tree.
     """
     workflow = _load_workflow(_WORKFLOW)
-    assert _step_run_contains(workflow, "Related-edge validator", "steps.diffscope.outputs.flag"), (
-        "Related-edge validator step must pass steps.diffscope.outputs.flag"
+    expected_steps = (
+        "Related-edge validator",
+        "Audience resolver",
+        "Description-length gate",
+        "Relative body-link gate",
     )
-    assert _step_run_contains(workflow, "Relative body-link gate", "steps.diffscope.outputs.flag"), (
-        "Relative body-link gate step must pass steps.diffscope.outputs.flag"
-    )
-
-
-def test_description_length_gate_stays_out_of_diff_scope() -> None:
-    """Out-of-scope guard: the description-length gate is NOT diff-scoped (WP02 spec)."""
-    workflow = _load_workflow(_WORKFLOW)
-    assert not _step_run_contains(workflow, "Description-length gate", "steps.diffscope.outputs.flag"), (
-        "Description-length gate is explicitly out of #3147's scope — must not carry the flag"
-    )
+    for step_name in expected_steps:
+        assert _step_run_contains(
+            workflow, step_name, "steps.diffscope.outputs.flag"
+        ), f"{step_name} step must pass steps.diffscope.outputs.flag"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/docs/test_guards.py
+++ b/tests/docs/test_guards.py
@@ -10,10 +10,10 @@ and the ``gate``/``noun``/``fr_id``/``extra`` parameterization surfacing in
 the message — are covered independently of either caller.
 
 The second half exercises :func:`scripts.docs._guards.resolve_changed_files`,
-the shared diff-scope resolver both blocking docs gates' ``--changed-from``
-mode is built on. **B-WP02 is the load-bearing distinction pinned here:**
-fail-closed keys on git base RESOLVABILITY (a non-zero ``git`` return code),
-never on the resolved changed-set being empty.
+the shared diff-scope resolver used by all four blocking per-page gates'
+``--changed-from`` modes. **B-WP02 is the load-bearing distinction pinned
+here:** fail-closed keys on git base RESOLVABILITY (a non-zero ``git`` return
+code), never on the resolved changed-set being empty.
 """
 
 from __future__ import annotations

--- a/tests/docs/test_rulers_blocking.py
+++ b/tests/docs/test_rulers_blocking.py
@@ -23,10 +23,13 @@ The non-uniform flip:
 Each clean-tree counterpart asserts the gate is **green** on a correct tree, so
 the RED is attributable to the seeded violation and not a perpetually-red gate.
 
-**Diff-scope proof (#3147, WP02 T012).** The bottom section proves the
-diff-scoped ``--changed-from`` mode both R2 (related-validator) and the
-body-link gate carry, through the SAME CLI path ``docs-freshness.yml`` invokes
-on ``pull_request``, over real (throwaway) git repos. Per B-WP02 in
+**Diff-scope proof (#3147, WP02 T012).** The bottom section preserves the
+original diff-scoped ``--changed-from`` proof for R2 (related-validator) and
+the body-link gate through the SAME CLI path ``docs-freshness.yml`` invokes on
+``pull_request``, over real (throwaway) git repos. The sibling audience and
+description gates added to that wiring by #3316 carry the same four-case proof
+in ``test_audience_resolves.py`` and ``test_description_length_gate.py``.
+Per B-WP02 in
 ``kitty-specs/ci-scoping-gate-reliability-01KZP80D/investigate-squad-findings.md``
 this is a **four**-case proof, not three — the fourth (resolved-zero-docs) is
 the load-bearing distinction the naive "empty changed-set -> ERROR" reading


### PR DESCRIPTION
## Summary

- Diff-scope the strict audience-reference and description metadata gates to changed `docs/**/*.md` pages on pull requests, avoiding false reds from untouched violations.
- Reuse the shared Git diff resolver and preserve whole-tree behavior on `push: main`.
- Keep description uniqueness corpus-aware: a changed page still fails when it duplicates an unchanged published peer, while only changed-page violations are reported.

## Why Now

The two sibling gates still had the whole-tree PR over-fire fixed for the related-edge and body-link gates in #3312.

## Effect on Existing Projects

CI-only change. There is no runtime, compatibility, or migration impact; the unfiltered `push: main` backstop remains unchanged.

## Validation

- RED-first coverage: 10 focused cases failed against the original behavior, then passed after implementation.
- `PWHEADLESS=1 uv run pytest -q tests/docs` — `1625 passed, 6 skipped`.
- Whole-tree strict gates — 145 audience values / 0 dangling; 772 pages / 0 violations.
- Scoped CLI smoke against current `upstream/main` — 0 in-scope pages / clean exit for both gates.
- Ruff and Mypy strict passed; both commits are SSH-signed.

Closes #3316

AI assistance disclosure: Kiro was used for codebase analysis, test design, implementation, test execution, and read-only review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789937914&installation_model_id=427282&pr_number=3630&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3630&signature=989f11772b9727567cb0498d50fc4987515fb90fcd84d7e11d303aab8548a409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->