### PR TITLE
docs: remove dead /release skill reference from contributing.md

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -418,9 +418,7 @@ When working on spec-kitty:
 
 ## Release Process
 
-Spec Kitty follows a structured release process using GitHub Actions for automated PyPI publishing.
-
-> **For AI agents**: Use the `/release` skill (`.claude/skills/release/SKILL.md`) for a step-by-step guide.
+Spec Kitty follows a structured release process using GitHub Actions for automated PyPI publishing. The "Quick Release" and "Full Release" sections below are the canonical, step-by-step runbook for AI agents and humans alike — there is no separate `/release` skill.
 
 ### Branch Strategy
 


### PR DESCRIPTION
Fixes #3363.

**What changed:** Removed the dead link to `.claude/skills/release/SKILL.md` in CONTRIBUTING.md.

**Why:** That skill file doesn't exist and no `/release` skill is registered anywhere in the repo. The inline Quick Release / Full Release steps in the same doc already serve as the canonical runbook, so pointing at a nonexistent skill was misleading rather than useful.

**Compatibility / migration impact:** None -- docs-only change, no code or behavior affected.

**How validated:** Confirmed via a repo-wide grep that no other file references `.claude/skills/release/SKILL.md` except two historical snapshots (an old CHANGELOG entry and a past mission's research.md), which are frozen history and out of scope to edit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789939260&installation_model_id=427282&pr_number=3631&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3631&signature=3221d1730471c05226a529b72bdc19441492c20062cf8e1e3585fcca90d426ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->