### PR TITLE
fix(charter_runtime): resolve pre-existing mypy --strict findings in …

### DIFF
--- a/src/specify_cli/charter_runtime/preflight/runner.py
+++ b/src/specify_cli/charter_runtime/preflight/runner.py
@@ -237,7 +237,7 @@ def _build_checks(freshness: CharterFreshness) -> list[CharterPreflightCheck]:
         result.append(
             CharterPreflightCheck(
                 name=layer_key,
-                state=state,  # type: ignore[arg-type]
+                state=state,
                 detail=str(detail),
                 remediation=str(remediation) if remediation else None,
             )
@@ -467,7 +467,8 @@ def refresh_references_if_needed(repo_root: Path, cause: str) -> bool:
     """
     from .references_refresh import refresh_references_if_needed as _refresh_references
 
-    return _refresh_references(repo_root, cause)
+    result: bool = _refresh_references(repo_root, cause)
+    return result
 
 
 def _attempt_auto_refresh(

--- a/src/specify_cli/charter_runtime/preflight/runner.py
+++ b/src/specify_cli/charter_runtime/preflight/runner.py
@@ -44,11 +44,11 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from specify_cli.charter_runtime.freshness import compute_freshness
 
-from .result import CharterPreflightCheck, CharterPreflightResult
+from .result import CharterPreflightCheck, CharterPreflightResult, CheckState
 
 if TYPE_CHECKING:  # pragma: no cover — used only for type hints.
     from specify_cli.charter_runtime.freshness import CharterFreshness
@@ -237,7 +237,7 @@ def _build_checks(freshness: CharterFreshness) -> list[CharterPreflightCheck]:
         result.append(
             CharterPreflightCheck(
                 name=layer_key,
-                state=state,
+                state=cast(CheckState, state),
                 detail=str(detail),
                 remediation=str(remediation) if remediation else None,
             )


### PR DESCRIPTION
## What this does

Makes `charter_runtime/preflight/runner.py` pass `mypy --strict` cleanly, clearing the two pre-existing findings tracked in #3513. **Type-annotations only — no runtime behavior changes.** No user-facing or operator-facing impact; this is internal type hygiene, so there is no changelog entry.

The two findings (surfaced during mission `charter-preflight-missing-charter-advisory` WP01 and filed rather than fixed as a drive-by):

1. **`_build_checks()`** passed a plain `str` `state` into the `CharterPreflightCheck(state=...)` field, which is typed as the `CheckState` Literal.
2. **`refresh_references_if_needed()`** returned `Any` (a deferred import's inferred type) from a function declared `-> bool`.

## The fix

- **`state`:** narrow it explicitly with `cast(CheckState, state)` at the call site. The runtime coercion (`str(sub.get("state", "invalid"))`) and the fail-closed `"invalid"` default are unchanged.
- **return value:** pin the delegated call through an annotated local (`result: bool = _refresh_references(...); return result`), matching the existing `widen/prereq.py:_check_health` precedent.

## Landing note (maintainer)

The original contributor change *removed* the `# type: ignore[arg-type]` on the `state=` line. That is clean under the **isolated two-file** invocation in the issue (`mypy --strict runner.py hook.py`, where `follow_imports=skip` makes the imported types `Any`, so the ignore reads as unused) — but **CI runs `mypy --strict` over the whole tree**, where the real `CheckState` Literal is visible and `state` is a `str`, so removing the ignore **reintroduced a genuine `arg-type` error** (whole-tree count 40 → 41). Replaced that with a `cast`, which is clean in **both** invocations. Kept the contributor's return-pin verbatim.

Verified locally on the rebased tip: two-file `mypy --strict` = **0 errors** (#3513 resolved); whole-tree `mypy --strict` = **40 errors, runner.py clean** (no CI regression); `ruff` clean. Rebased onto current `upstream/main`.

Fixes #3513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
