### PR TITLE
chore(intake): sort scan_for_plans directory children by filename, not full path

### DIFF
--- a/src/specify_cli/intake_sources.py
+++ b/src/specify_cli/intake_sources.py
@@ -206,7 +206,7 @@ def scan_for_plans(cwd: Path) -> list[tuple[Path, str, str | None]]:
                     except (ValueError, OSError):
                         continue
                     # Expand directory: collect all *.md files (non-recursive)
-                    for child in sorted(abs_path.iterdir()):
+                    for child in sorted(abs_path.iterdir(), key=lambda p: p.name):
                         try:
                             # T023: Symlink exclusion
                             if child.is_symlink():


### PR DESCRIPTION
Fixes #726.

**What changed:** `scan_for_plans()`'s directory-expansion loop now sorts children with `key=lambda p: p.name` instead of relying on `sorted()`'s default `Path` comparison (which sorts by full path).

**Why:** `sorted()` on `Path` objects compares the full absolute path. In the current flat-directory case this is equivalent to filename order, but if a child ever resolves with a differing parent component, the sort key silently becomes the full path rather than the filename — producing an order other than what the docstring promises ("in declaration order" / alphabetical within a directory).

**Compat impact:** none in normal operation — for children sharing the same parent directory, sorting by full path and by filename produce identical results.

**Validated:** `python3 -m py_compile` on the changed file (no syntax errors); the existing test `test_directory_candidate_md_files_sorted_alphabetically` in `tests/specify_cli/test_intake_sources.py` already covers the same-parent case and is unaffected by this change. This container has no `pytest`/`mypy` installed, so I could not run the full suite — relying on the existing test's coverage and manual reasoning above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789946867&installation_model_id=427282&pr_number=3634&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3634&signature=731fae9f7cdd74dce391d5d31e41b42175d64e2b49aa40867e115d42e5b268e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->