### PR TITLE
chore(mypy): remove 4 still-valid redundant-cast findings from #3325

### DIFF
--- a/src/specify_cli/tracker/config.py
+++ b/src/specify_cli/tracker/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, Final, cast
+from typing import Any, ClassVar, Final
 
 from ruamel.yaml import YAML
 
@@ -260,7 +260,7 @@ def require_repo_root() -> Path:
     repo_root = locate_project_root(Path.cwd())
     if repo_root is None:
         raise TrackerConfigError("Not inside a spec-kitty project. Run this command from a project with .kittify/.")
-    return cast(Path, repo_root)
+    return repo_root
 
 
 def _config_path(repo_root: Path) -> Path:

--- a/src/specify_cli/tracker/local_service.py
+++ b/src/specify_cli/tracker/local_service.py
@@ -86,7 +86,7 @@ def _render_refusal(verdict: TrackerEgressVerdict) -> str:
     them; it is not a path-local message string (FR-012).
     """
     if not verdict.remedies:
-        return cast("str", verdict.message)
+        return verdict.message
     remedy_lines = "\n".join(f"  - {remedy}" for remedy in verdict.remedies)
     return f"{verdict.message}\nRemedies:\n{remedy_lines}"
 
@@ -316,7 +316,7 @@ class LocalTrackerService:
 
     def map_list(self) -> list[dict[str, Any]]:
         _, _, store = self._load_runtime()
-        return cast(list[dict[str, Any]], store.list_mappings())
+        return store.list_mappings()
 
     # ------------------------------------------------------------------
     # private helpers
@@ -339,15 +339,12 @@ class LocalTrackerService:
         server_url = str(credentials.get("server_url") or credentials.get("base_url") or "")
         username = str(credentials.get("username") or credentials.get("email") or "")
         team_slug = str(credentials.get("team_slug") or "")
-        return cast(
-            Path,
-            default_tracker_db_path(
-                provider=str(config.provider),
-                workspace=str(config.workspace),
-                server_url=server_url,
-                username=username,
-                team_slug=team_slug,
-            ),
+        return default_tracker_db_path(
+            provider=str(config.provider),
+            workspace=str(config.workspace),
+            server_url=server_url,
+            username=username,
+            team_slug=team_slug,
         )
 
     def _build_engine(self, config: TrackerProjectConfig, credentials: dict[str, Any], store: TrackerSqliteStore) -> Any:


### PR DESCRIPTION
#3325 listed 10 pre-existing redundant-cast findings from whole-tree mypy --strict. Re-running that same command now (with mypy actually installed, unlike when the earlier two PRs against this repo were prepared) shows only 4 of those 10 locations still hold a redundant cast; the other 6 (consent.py, saas_client.py x2, activate.py x2, deactivate.py) were already resolved by unrelated work since the issue was filed. Whole-tree mypy --strict also now flags 6 new pre-existing redundant-cast locations not in the issue's original list (mission_type.py x2, project_store.py x3, owner.py) -- out of scope here since the issue didn't name them.

This PR removes the 4 still-valid ones:
- tracker/config.py:263 -- require_repo_root() already narrows locate_project_root()'s `Path | None` to `Path` via the preceding `if repo_root is None: raise` guard.
- tracker/local_service.py:89 -- TrackerEgressVerdict.message is declared `str`, no Any in the chain.
- tracker/local_service.py:319 -- TrackerSqliteStore.list_mappings() is declared `-> list[dict[str, Any]]`, matching the cast's target exactly.
- tracker/local_service.py:342 -- default_tracker_db_path() is declared `-> Path`.

Verified with a real mypy --strict run (not just py_compile, unlike the previous two PRs against this repo): whole-tree error count drops from 54 to 50, both touched files are clean, and no new errors appear elsewhere. ruff check is clean. The 43 existing tests under tests/sync/tracker/test_local_service.py and tests/specify_cli/tracker all still pass.

Refs #3325 — partial cleanup only; remaining issue scope stays open -- not using "Fixes" since 6 of the original 10 checklist items were already resolved elsewhere (not by this PR) and 6 new pre-existing redundant-cast locations exist that the issue never listed; the tracker item remains open.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789947702&installation_model_id=427282&pr_number=3635&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3635&signature=42476950a3912dc8efa560d40bb8caef50ca8abd37c18c700e1c0c096f20bdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->