### PR TITLE
docs(retrospective): record the #3059 width=120 decision with rationale

### DIFF
--- a/src/specify_cli/retrospective/writer.py
+++ b/src/specify_cli/retrospective/writer.py
@@ -195,9 +195,20 @@ def _atomic_write_yaml(data: dict[str, Any], canonical: Path, target_dir: Path) 
     function) — asserted below so a future caller that passes a divergent
     directory fails loudly instead of silently fsyncing the wrong directory.
 
-    Width stays 120 here (not the kernel's wider 4096 default): retrospective
-    records intentionally keep the narrower wrap; widening it is a separate,
-    open decision tracked by #3059.
+    Width stays 120 here (not the kernel's wider 4096 default) — deliberately,
+    per the #3059 decision. The kernel default exists for writers whose
+    scalars must never fragment (hashes, round-trip-sensitive frontmatter);
+    retrospective.yaml is the opposite case, a git-committed document meant
+    to be read directly, carrying prose fields up to 2000 chars (``Finding.note``,
+    ``GenFinding.details``, proposal ``rationale``) that would otherwise land
+    as one unreadable line. Wrapping at 120 keeps those fields reviewable in
+    a diff or terminal; the #3057 normalizer (invoked inside
+    ``write_mapping_atomic``) strips the trailing-whitespace artifact that
+    wrapping produces, so the two are a deliberate pairing, not competing
+    patches. ``test_atomic_write_yaml_strips_trailing_whitespace_from_wrapped_scalars``
+    (tests/retrospective/test_writer_atomicity.py) asserts the wrap actually
+    happens at 120 and would need updating if this width ever changes — do
+    not raise it to 4096 to "align" with the kernel default.
 
     Raises:
         WriterError: On any IO or serialization error.  The tempfile is


### PR DESCRIPTION
Closes #3059.

#3059 asked whether `_atomic_write_yaml`'s `width=120` override in the retrospective writer (the lone outlier vs. the kernel `write_mapping_atomic` default of `width=4096` used by every other YAML writer in the repo) is deliberate or accidental — it carried no comment or test defending it, so a later reader could "fix" it either direction without knowing the tradeoff.

**Decision: deliberate — keep 120.** `retrospective.yaml` is a git-committed, human-read document with prose fields up to 2000 chars (`Finding.note`, `GenFinding.details`, proposal `rationale`) that the kernel's wide default would flatten into single unreadable lines. `tests/retrospective/test_writer_atomicity.py::test_atomic_write_yaml_strips_trailing_whitespace_from_wrapped_scalars` already asserts the wrap happens at 120 as a precondition and pairs it with the #3057 trailing-whitespace normalizer — proving the width and the normalizer are a deliberate combination, not two patches fighting each other.

This PR replaces the placeholder "widening it is a separate, open decision tracked by #3059" comment with the actual rationale above, docstring-only, no behavior change.

**Verification:**
- `mypy --strict src/specify_cli/retrospective/writer.py`: clean.
- `ruff check src/specify_cli/retrospective/writer.py`: clean.
- `pytest tests/retrospective/test_writer_atomicity.py`: 14 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789948759&installation_model_id=427282&pr_number=3636&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3636&signature=f50275e1a080b824de592cb7ce79e36a4693c283762ba3f8948e146408db3823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->