### PR TITLE
fix(delivery): stop retrying HTTP 412 batch responses forever

### DIFF
--- a/src/specify_cli/delivery/receivers.py
+++ b/src/specify_cli/delivery/receivers.py
@@ -86,6 +86,12 @@ _OVERSIZED_ERROR = "payload too large (oversized, permanent)"
 _BATCH_OVERSIZED_ERROR = "batch payload too large; retry with a smaller batch"
 _TRANSPORT_ERROR_PREFIX = "transport failure"
 
+#: HTTP 412 on the batch endpoint means the server rejected ``_H_SYNC_PROTOCOL``
+#: (missing/mismatched version) — a CLI/server protocol skew that no retry can
+#: ever clear, unlike the other batch-level statuses (#1553).
+_PROTOCOL_MISMATCH_STATUS = 412
+_PROTOCOL_MISMATCH_ERROR = "spec-kitty is out of date with the server. Please upgrade: pip install --upgrade spec-kitty-cli"
+
 
 # -- §4 result vocabulary ------------------------------------------------------
 
@@ -614,11 +620,21 @@ def _http_error_text(http_status: int, body: Mapping[str, Any] | None) -> str:
 def _map_batch_failure(events: Sequence[OutboundEvent], *, http_status: int, body: Mapping[str, Any] | None) -> list[DeliveryResult]:
     """Classify a non-200 batch response.
 
-    Oversized/permanent → ``terminal_failed`` (FR-015); 400 content failure →
-    per-event ``rejected``; 401/403/408/429/5xx/other → ``transient`` for the whole
-    batch (do **not** poison per-event retry counts — spec "content rejection vs
-    transient failure").
+    Oversized/permanent → ``terminal_failed`` (FR-015); protocol mismatch (412) →
+    ``terminal_failed`` with an upgrade prompt (#1553 — a version skew a retry can
+    never fix); 400 content failure → per-event ``rejected``; 401/403/408/429/5xx/
+    other → ``transient`` for the whole batch (do **not** poison per-event retry
+    counts — spec "content rejection vs transient failure").
     """
+    if http_status == _PROTOCOL_MISMATCH_STATUS:
+        return _all_outcome(
+            events,
+            DeliveryOutcome.TERMINAL_FAILED,
+            http_status=http_status,
+            error=_PROTOCOL_MISMATCH_ERROR,
+            body=body,
+            effect_certainty=DeliveryEffectCertainty.TERMINAL,
+        )
     if _is_oversized(http_status, body) and len(events) == 1:
         return _all_outcome(
             events,

--- a/tests/delivery/test_receivers.py
+++ b/tests/delivery/test_receivers.py
@@ -379,6 +379,14 @@ def test_batch_level_failure_maps_transient_for_every_event(status_code: int) ->
     assert all(r.http_status == status_code for r in results)
 
 
+def test_protocol_mismatch_412_maps_terminal_failed_with_upgrade_prompt() -> None:
+    batch = [_event("01JMBY0000000000000000000Q"), _event("01JMBY0000000000000000000R")]
+    results = map_batch_response(batch, http_status=412, body={"error": "protocol version mismatch"})
+    assert all(r.outcome is DeliveryOutcome.TERMINAL_FAILED for r in results)
+    assert all(r.effect_certainty is DeliveryEffectCertainty.TERMINAL for r in results)
+    assert all("upgrade" in (r.error or "").lower() for r in results)
+
+
 def test_oversized_413_maps_terminal_failed() -> None:
     batch = [_event("01JMBY0000000000000000000N")]
     results = map_batch_response(batch, http_status=413, body={"error": "payload too large"})


### PR DESCRIPTION
## Problem

Closes #1553

The SaaS batch endpoint (`POST /api/v1/events/batch/`) returns HTTP 412 when the `X-Spec-Kitty-Sync-Protocol` header is missing or mismatched — a CLI/server protocol version skew. `map_batch_response` in `src/specify_cli/delivery/receivers.py` had no explicit case for 412, so it fell through to the generic 401/403/408/429/5xx "transient" bucket in `_map_batch_failure`. A transient outcome is retried forever by the dispatcher — but a 412 can never succeed without a CLI upgrade, so the CLI was retrying an unwinnable request indefinitely.

## Fix

`_map_batch_failure` now special-cases HTTP 412: it maps to `DeliveryOutcome.TERMINAL_FAILED` (`effect_certainty=TERMINAL`) with a clear, user-visible error string: "spec-kitty is out of date with the server. Please upgrade: pip install --upgrade spec-kitty-cli". `TERMINAL_FAILED` already routes through `ledger.record_terminal_failed`, which parks the event (retained, inspectable, never re-enqueued) instead of retrying it — the same mechanism used for oversized (413) and terminal-rejection batch failures. The message is surfaced to the user through the existing `last_error` reporting surface (`sync status` / `sync doctor`), so no new reporting path was needed.

Note: this repo's architecture has moved substantially since #1553 was filed — the old queue-backed `batch_sync` drain in `sync/batch.py` was retired by #3167, and batch delivery is now driven by `src/specify_cli/delivery/receivers.py` + `dispatcher.py` + the SQLite delivery ledger. The header name is also now `X-Spec-Kitty-Sync-Protocol` (not `X-SpecKitty-Compat` as the original issue text says). This PR implements the same intent — a 412 must never be silently retried forever — through the current architecture's actual terminal-failure mechanism, rather than the no-longer-existing queue/flag design the issue originally described.

## Verification

- `mypy --strict src/specify_cli/delivery/receivers.py`: clean.
- `ruff check`: clean on both changed files.
- New test `test_protocol_mismatch_412_maps_terminal_failed_with_upgrade_prompt` added to `tests/delivery/test_receivers.py`, asserting 412 maps to `TERMINAL_FAILED`/`TERMINAL` with an upgrade message.
- Full `tests/delivery/` suite: 278 passed (was 277; +1 new test), no regressions.
- Whole-tree `mypy --strict src`: 56 errors before and after (pre-existing, unrelated to this change) — no new errors introduced.

## Scope

Pure logic change in `receivers.py` (one new branch in `_map_batch_failure`) plus its test. No behavior change to any other status code; the existing `test_batch_level_failure_maps_transient_for_every_event` parametrization over `[401, 403, 500, 503]` is untouched and still passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789950678&installation_model_id=427282&pr_number=3637&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3637&signature=87f6f32c8c045fa8cf0f907fb80b7c606b5c5da08446fc5db5d9bebbedc4c014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->