### PR TITLE
test(regression): relocate #3307 and #3425 guards out of tests/regression/ on green

### DIFF
--- a/tests/runtime/test_setup_plan_sync_evidence.py
+++ b/tests/runtime/test_setup_plan_sync_evidence.py
@@ -123,11 +123,13 @@ def _build_minimal_repo(tmp_path: Path, mission_slug: str) -> Path:
 #
 # ``TestAuthenticatedSetupPlanLandsInScoped::test_authenticated_setup_plan_lands_in_scoped``
 # was extracted to
-# ``tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py``
-# (2026-08-14 landing fold) — it is a red-first reproduction of open bug #3425
-# (un-migrated hosts raise ``LegacyQueueMigrationRequiredError`` before any
-# queue write is attempted), not a stale test of this module. See that
-# module's docstring for the mechanism.
+# ``tests/specify_cli/cli/commands/agent/test_issue_3425_setup_plan_legacy_layout_silent_capture.py``
+# (2026-08-14 landing fold; relocated out of ``tests/regression/`` once the
+# reproduction turned green — see that module's exit-rule note) — it is a
+# regression guard for fixed bug #3425 (un-migrated hosts raised
+# ``LegacyQueueMigrationRequiredError`` before any queue write was attempted),
+# not a stale test of this module. See that module's docstring for the
+# mechanism.
 
 
 # ---------------------------------------------------------------------------
@@ -336,11 +338,13 @@ class TestSetupPlanPreflightIntegration:
 
     ``test_setup_plan_refuses_on_daemon_owner_mismatch`` and
     ``test_setup_plan_authenticated_coherent_succeeds`` were extracted to
-    ``tests/regression/test_issue_3425_setup_plan_legacy_layout_silent_capture.py``
-    (2026-08-14 landing fold) — both are red-first reproductions of open bug
-    #3425 (the FR-011 auth-refusal gate fires before the boundary preflight
-    can be exercised on an un-migrated host), not stale tests of this class.
-    See that module's docstring for the mechanism.
+    ``tests/specify_cli/cli/commands/agent/test_issue_3425_setup_plan_legacy_layout_silent_capture.py``
+    (2026-08-14 landing fold; relocated out of ``tests/regression/`` once the
+    reproduction turned green — see that module's exit-rule note) — both are
+    regression guards for fixed bug #3425 (the FR-011 auth-refusal gate fired
+    before the boundary preflight could be exercised on an un-migrated host),
+    not stale tests of this class. See that module's docstring for the
+    mechanism.
     """
 
     def test_setup_plan_refuses_on_orphan_owner_record(

--- a/tests/specify_cli/cli/commands/agent/test_issue_3307_cli_emits_contract_invalid_unforced_rollback.py
+++ b/tests/specify_cli/cli/commands/agent/test_issue_3307_cli_emits_contract_invalid_unforced_rollback.py
@@ -1,34 +1,31 @@
-"""Red-first reproduction of #3307 — the CLI emits ``force=False`` for
+"""Regression guard for #3307 — the CLI must emit ``force=True`` for
 review-rejection rollbacks that the vendored ``spec-kitty-events`` contract
-declares invalid without ``force=True``.
+declares invalid without it.
 
-Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3307
+Fixed: https://github.com/Priivacy-ai/spec-kitty/issues/3307
 
-Root cause: two independently-authored ``validate_transition`` functions with the
-same name and opposite answers.
+Root cause was two independently-authored ``validate_transition`` functions with
+the same name and opposite answers.
 
 * ``build_transition_plan`` (``src/specify_cli/cli/commands/agent/tasks_transition_core.py``)
   asks the CLI-LOCAL FSM (``specify_cli.status``) whether a backward review-rejection
-  edge is legal force-free given the evidence carried at the plan layer, and emits
-  ``emit_force=False`` when it is.
+  edge is legal force-free given the evidence carried at the plan layer.
 * The SHARED, vendored ``spec_kitty_events.validate_transition`` — the contract
   package both this repo and ``spec-kitty-saas`` pin (``spec-kitty-events==6.1.0``)
   — declares exactly these "review-rejection family" backward edges invalid unless
-  ``force=True``. The CLI emit path never calls the shared validator, so
-  contract-invalid events are produced and queued silently and are only rejected
-  later at sync time (10 real ``in_review -> planned`` events were rejected by the
-  SaaS ingestion endpoint in the reported case).
+  ``force=True``. Before the fix, the CLI emit path never consulted the shared
+  validator, so contract-invalid events were produced and queued silently and
+  were only rejected later at sync time (10 real ``in_review -> planned`` events
+  were rejected by the SaaS ingestion endpoint in the reported case).
+
+``build_transition_plan`` now also asks the shared wire contract
+(``_wire_contract_allows_force_free``) and only stays force-free when both the
+local FSM and the shared contract agree; otherwise it emits ``force=True``.
 
 This drives the REAL emit-decision function (``build_transition_plan``) and then
 validates the wire payload it would emit against the REAL shared contract
-validator — proving the CLI emits events its own vendored dependency rejects.
-
-Desired post-fix outcome (either maintainer resolution turns this green): every
-event ``build_transition_plan`` emits for these edges must be accepted by the
-shared ``spec_kitty_events`` contract — whether by emitting ``force=True`` (make
-the CLI conform) or by amending the shared contract to carry a wire-representable
-evidence exemption and having the CLI emit that evidence (issue #3307 options a/b).
-This test pins the conformance contract, not the chosen mechanism.
+validator — pinning the conformance contract as a permanent guard against the
+defect recurring, not the chosen mechanism.
 """
 
 from __future__ import annotations
@@ -40,7 +37,7 @@ from specify_cli.status import ReviewResult
 from spec_kitty_events import validate_transition as shared_validate_transition
 from spec_kitty_events.status import StatusTransitionPayload
 
-pytestmark = pytest.mark.regression
+pytestmark = pytest.mark.fast
 
 _REVIEW_RESULT = ReviewResult(
     reviewer="claude",

--- a/tests/specify_cli/cli/commands/agent/test_issue_3425_setup_plan_legacy_layout_silent_capture.py
+++ b/tests/specify_cli/cli/commands/agent/test_issue_3425_setup_plan_legacy_layout_silent_capture.py
@@ -1,7 +1,7 @@
-"""Regression contract for #3425 — a fresh, un-migrated host must journal its
+"""Regression guard for #3425 — a fresh, un-migrated host must journal its
 setup-plan capture instead of silently swallowing it.
 
-Open P0: https://github.com/Priivacy-ai/spec-kitty/issues/3425
+Fixed: https://github.com/Priivacy-ai/spec-kitty/issues/3425
 
 Correct root cause (the swallowed error is the **journal guard**, not a queue
 default-path helper):
@@ -58,7 +58,7 @@ from unittest.mock import patch
 import pytest
 import typer
 
-pytestmark = pytest.mark.regression
+pytestmark = pytest.mark.integration
 
 MODULE = "specify_cli.cli.commands.agent.mission"
 


### PR DESCRIPTION
Fixes #3184

## What

`tests/regression/` held two files carrying `@pytest.mark.regression` — `test_issue_3307_...py` and `test_issue_3425_...py` — that both now pass on `main`. Per `tests/regression/README.md`'s exit rule, a red-first reproduction leaves the suite once its defect is fixed; it does not stay as directory debt.

This is the same underlying problem #3184 was filed against (the directory holding things it shouldn't), just recurring in a different shape: the issue's original ~15 unmarked files have already been cleaned up by other work (only 2 files remain, `baselines/`, `conftest.py`, `README.md`), but these 2 *marked* files were never relocated after their fixes landed.

## Verification that each is actually green (not stale-but-still-red)

- **#3307**: `build_transition_plan` (`tasks_transition_core.py`) already calls `_wire_contract_allows_force_free` and only stays force-free when both the local FSM and the shared `spec_kitty_events` contract agree — the fix described in the test's docstring is live in the code (confirmed by reading the function, not just by the test passing).
- **#3425**: the setup-plan auto-cutover to `project_only` before any legacy persist is in place; issue #3425 is already closed on GitHub, consistent with the test being green. (#3307 is still open on GitHub despite the fix being live in code — flagging that mismatch here rather than silently closing it myself, since I don't have merge/close rights.)

Ran both files with `pytest -v`: 7/7 pass.

## What changed

- Moved both files to `tests/specify_cli/cli/commands/agent/` — the functional home of the modules they exercise (`tasks_transition_core.py`, `mission.setup_plan`), alongside their existing sibling tests.
- Dropped `@pytest.mark.regression`; added canonical marks matching their new siblings: `fast` for the #3307 test (pure-function, no I/O — matches `test_tasks_transition_core.py`'s own marker), `integration` for the #3425 test (drives `setup_plan` against a real `tmp_path` filesystem, no real git — matches `test_setup_plan_read_surface.py`'s category, minus `git_repo` since this one does no real git subprocess calls).
- Updated each docstring's framing from "red-first reproduction of an open bug" to "regression guard for a fixed bug", past-tense where the description was of the pre-fix behavior.
- Updated two stale cross-reference comments in `tests/runtime/test_setup_plan_sync_evidence.py` that still pointed at the old `tests/regression/...` path for the #3425 tests.

Left `tests/regression/baselines/issue_2985_red_first.md` and `conftest.py` untouched — out of scope for this issue.

## Verification

- `pytest tests/specify_cli/cli/commands/agent/test_issue_3307_... test_issue_3425_...` (new location): 7/7 pass.
- `pytest tests/runtime/test_setup_plan_sync_evidence.py`: 3/3 pass (comment-only change there).
- `ruff check` clean on all three touched files.
- Full `tests/specify_cli/cli/commands/agent/` run: 37 failed / 1629 passed on this branch — verified the identical 37 failures (unrelated CLI golden-contract/help-surface tests) are already red on `origin/main` before this change, so this PR introduces no regressions.
- Could not run `tests/architectural/` locally — `pytestarch` isn't installed in my environment (`ModuleNotFoundError: No module named 'pytestarch'`), so I couldn't self-check the architectural gate; flagging this so CI is the actual check here, not a local rerun.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789951722&installation_model_id=427282&pr_number=3638&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3638&signature=b431639d0492e66268560028e08a878c05b2997e5c6ad3f111e2738800f307d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->