### PR TITLE
fix(charter): gitignore .kittify/lint-report.json (#3435)

### DIFF
--- a/src/specify_cli/state/contract.py
+++ b/src/specify_cli/state/contract.py
@@ -165,6 +165,23 @@ STATE_SURFACES: tuple[StateSurface, ...] = (
         creation_trigger="spec-kitty merge",
     ),
     StateSurface(
+        name="charter_lint_report",
+        path_pattern=".kittify/lint-report.json",
+        root=StateRoot.PROJECT,
+        format=StateFormat.JSON,
+        authority=AuthorityClass.LOCAL_RUNTIME,
+        git_class=GitClass.IGNORED,
+        owner_module="charter_runtime/lint/engine",
+        creation_trigger="spec-kitty charter lint",
+        notes=(
+            "Machine-local decay-scan diagnostic; never commit (#3435). "
+            "sync/lint_report_staging.py copies its contents into the "
+            "TRACKED kitty-specs/<mission>/ dossier on record — that staged "
+            "copy is a separate, intentionally-committed artifact, not this "
+            "surface."
+        ),
+    ),
+    StateSurface(
         name="sync_local_commit_state",
         path_pattern=".kittify/sync-state.json",
         root=StateRoot.PROJECT,

--- a/src/specify_cli/upgrade/migrations/m_3_2_6_lint_report_gitignore_backfill.py
+++ b/src/specify_cli/upgrade/migrations/m_3_2_6_lint_report_gitignore_backfill.py
@@ -1,0 +1,86 @@
+"""Migration: backfill ``.kittify/lint-report.json`` gitignore coverage (#3435).
+
+``spec-kitty charter lint`` writes its decay-scan report to
+``.kittify/lint-report.json`` as a side effect of what is otherwise a
+read-only diagnostic. That surface is registered ``IGNORED`` in the state
+contract (``charter_lint_report``), so a fresh ``spec-kitty init`` gitignores
+it -- but already-initialised projects had no backfill for it. Running
+``charter lint`` on such a project leaves the report untracked, which then
+trips ``record-analysis``'s dirty-tree guard on a file the operator never
+knowingly created.
+
+Sibling to ``3.2.4_runtime_dirs_gitignore_backfill`` (#2384) and
+``3.2.5_agents_skills_gitignore_backfill`` (#2412). Following the same
+precedent, the entry is **hardcoded here** rather than sourced from the live
+contract so the migration's behaviour is frozen and deterministic regardless
+of future contract changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.gitignore_manager import GitignoreManager
+
+from ..registry import MigrationRegistry
+from .base import BaseMigration, MigrationResult
+
+_LINT_REPORT_ENTRY = ".kittify/lint-report.json"
+# A hand-added entry without the leading directory dedup concern doesn't apply
+# here (this is a single file, not a directory), but keep the same
+# any-equivalent-form check shape as the sibling migrations for consistency.
+_EQUIVALENT_ENTRIES: frozenset[str] = frozenset({_LINT_REPORT_ENTRY})
+
+
+def _read_gitignore_entries(project_path: Path) -> set[str]:
+    gitignore_path = project_path / ".gitignore"
+    if not gitignore_path.exists():
+        return set()
+    return {
+        line.strip()
+        for line in gitignore_path.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def _is_missing(present: set[str]) -> bool:
+    return _EQUIVALENT_ENTRIES.isdisjoint(present)
+
+
+@MigrationRegistry.register
+class LintReportGitignoreBackfillMigration(BaseMigration):
+    """Ensure ``.kittify/lint-report.json`` is gitignored."""
+
+    migration_id = "3.2.6_lint_report_gitignore_backfill"
+    description = "Backfill .kittify/lint-report.json gitignore coverage"
+    target_version = "3.2.6"
+
+    def detect(self, project_path: Path) -> bool:
+        return _is_missing(_read_gitignore_entries(project_path))
+
+    def can_apply(self, project_path: Path) -> tuple[bool, str]:
+        if not project_path.exists():
+            return False, f"Project path does not exist: {project_path}"
+        return True, ""
+
+    def apply(self, project_path: Path, dry_run: bool = False) -> MigrationResult:
+        missing = _is_missing(_read_gitignore_entries(project_path))
+
+        if dry_run:
+            if missing:
+                return MigrationResult(
+                    success=True,
+                    changes_made=[f"Would add {_LINT_REPORT_ENTRY} to .gitignore"],
+                )
+            return MigrationResult(success=True, changes_made=[])
+
+        if not missing:
+            return MigrationResult(
+                success=True, changes_made=["gitignore entry already present"]
+            )
+
+        GitignoreManager(project_path).ensure_entries([_LINT_REPORT_ENTRY])
+        return MigrationResult(
+            success=True,
+            changes_made=[f"Added gitignore entry: {_LINT_REPORT_ENTRY}"],
+        )

--- a/tests/specify_cli/test_state_contract.py
+++ b/tests/specify_cli/test_state_contract.py
@@ -212,6 +212,7 @@ def test_runtime_gitignore_entries_exact():
         ".kittify/dossiers/",
         ".kittify/encoding-provenance/",
         ".kittify/events/",
+        ".kittify/lint-report.json",
         ".kittify/logs/",
         ".kittify/merge-state.json",
         ".kittify/migrations/",

--- a/tests/specify_cli/upgrade/migrations/test_m_3_2_6_lint_report_gitignore.py
+++ b/tests/specify_cli/upgrade/migrations/test_m_3_2_6_lint_report_gitignore.py
@@ -1,0 +1,128 @@
+"""Regression tests for the ``.kittify/lint-report.json`` gitignore backfill (#3435).
+
+``spec-kitty charter lint`` writes this report as a side effect of what is
+advertised as a read-only diagnostic. On an already-initialised project
+lacking the gitignore entry, the report shows up untracked and trips
+``record-analysis``'s dirty-tree guard on a file the operator never
+knowingly created.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from kernel.clock import now_utc
+from pathlib import Path
+
+import pytest
+
+from specify_cli.upgrade.migrations import auto_discover_migrations
+from specify_cli.upgrade.registry import MigrationRegistry
+from specify_cli.upgrade.migrations.m_3_2_6_lint_report_gitignore_backfill import (
+    LintReportGitignoreBackfillMigration,
+    _LINT_REPORT_ENTRY,
+)
+from specify_cli.upgrade.metadata import ProjectMetadata
+from specify_cli.upgrade.runner import MigrationRunner
+
+pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
+
+
+def _init_git_repo(project_root: Path) -> None:
+    subprocess.run(["git", "-C", str(project_root), "init", "-q"], check=True)
+
+
+def _write_gitignore(project_root: Path, *entries: str) -> None:
+    project_root.joinpath(".gitignore").write_text(
+        "# Added by Spec Kitty CLI (auto-managed)\n" + "\n".join(entries) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_metadata(project_root: Path, version: str) -> None:
+    ProjectMetadata(version=version, initialized_at=now_utc()).save(
+        project_root / ".kittify"
+    )
+
+
+def _read_gitignore(project_root: Path) -> str:
+    return project_root.joinpath(".gitignore").read_text(encoding="utf-8")
+
+
+def test_apply_adds_entry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    LintReportGitignoreBackfillMigration().apply(tmp_path)
+
+    assert _LINT_REPORT_ENTRY in _read_gitignore(tmp_path)
+
+
+def test_detect_true_when_missing(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/logs/")  # unrelated entry only
+
+    assert LintReportGitignoreBackfillMigration().detect(tmp_path) is True
+
+
+def test_detect_false_when_present(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _LINT_REPORT_ENTRY)
+
+    assert LintReportGitignoreBackfillMigration().detect(tmp_path) is False
+
+
+def test_apply_reports_added_entry(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/logs/")
+
+    result = LintReportGitignoreBackfillMigration().apply(tmp_path)
+
+    assert result.changes_made == [f"Added gitignore entry: {_LINT_REPORT_ENTRY}"]
+
+
+def test_dry_run_reports_without_mutating(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, ".kittify/logs/")
+
+    result = LintReportGitignoreBackfillMigration().apply(tmp_path, dry_run=True)
+
+    assert result.success
+    assert result.changes_made == [f"Would add {_LINT_REPORT_ENTRY} to .gitignore"]
+    assert _LINT_REPORT_ENTRY not in _read_gitignore(tmp_path)
+
+
+def test_dry_run_reports_no_changes_when_already_present(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _LINT_REPORT_ENTRY)
+
+    result = LintReportGitignoreBackfillMigration().apply(tmp_path, dry_run=True)
+
+    assert result.success
+    assert result.changes_made == []
+
+
+def test_apply_is_idempotent(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_gitignore(tmp_path, _LINT_REPORT_ENTRY)
+
+    first = LintReportGitignoreBackfillMigration().apply(tmp_path)
+    second = LintReportGitignoreBackfillMigration().apply(tmp_path)
+
+    assert first.success
+    assert second.success
+    assert _read_gitignore(tmp_path).count(_LINT_REPORT_ENTRY) == 1
+
+
+def test_backfill_fires_on_already_current_3_2_6_project(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    _write_metadata(tmp_path, "3.2.6")
+    _write_gitignore(tmp_path, ".kittify/logs/")  # logs present, lint-report absent
+
+    MigrationRegistry.clear()
+    auto_discover_migrations()
+    result = MigrationRunner(tmp_path).upgrade("3.2.6", include_worktrees=False)
+
+    assert result.success
+    assert (
+        LintReportGitignoreBackfillMigration.migration_id in result.migrations_applied
+    )
+    assert _LINT_REPORT_ENTRY in _read_gitignore(tmp_path)


### PR DESCRIPTION
Fixes #3435.

## Problem

`spec-kitty charter lint` writes `.kittify/lint-report.json` as a side effect of what's advertised as a read-only diagnostic. That path was never registered as a state surface, so:

- a fresh `spec-kitty init` never gitignored it, and
- no migration backfilled it into already-initialised projects.

The result: the report shows up as untracked, and a later `spec-kitty agent mission record-analysis` refuses to run because of its dirty-tree guard — on a file the operator never knowingly created.

## Fix

- Registered `.kittify/lint-report.json` as a `PROJECT`-rooted, `IGNORED` state surface (`charter_lint_report`) in `src/specify_cli/state/contract.py`. This flows into `get_runtime_gitignore_entries()`, so a fresh `spec-kitty init` now covers it.
- Added `m_3_2_6_lint_report_gitignore_backfill.py`, an upgrade migration that backfills the `.gitignore` entry on already-initialised projects, following the same hardcoded-entry pattern as the `3.2.4_runtime_dirs` and `3.2.5_agents_skills` gitignore-backfill migrations (frozen/deterministic regardless of future contract changes).
- Updated `tests/specify_cli/test_state_contract.py`'s exact-entries assertion and added a dedicated migration test file mirroring the existing `test_m_3_2_4_runtime_dirs_gitignore.py` structure (detect/apply/dry-run/idempotency/end-to-end-upgrade coverage).

Note: `sync/lint_report_staging.py` separately copies this report's contents into the **tracked** `kitty-specs/<mission>/` dossier when a mission records analysis — that's an intentional, different, already-committed artifact. This fix only concerns the canonical machine-local copy at the repo root.

## Verification

- `mypy --strict` on the two changed source files in isolation shows one `Class cannot subclass "BaseMigration"` error — this is the known false positive from isolated two/few-file invocation (`follow_imports=skip` makes the imported base class `Any`; the same error reproduces identically on the pre-existing sibling migration file). Whole-tree `mypy --strict src/specify_cli src/charter src/doctrine` (CI's actual invocation) shows **54 errors in 22 files, none in the files this PR touches** — identical to the count on `origin/main` before this change, confirmed via `git stash`.
- `ruff check` clean on all four changed/added files.
- New migration test file: 8/8 passing (detect true/false, apply adds entry, dry-run doesn't mutate, dry-run reports no-op when already present, idempotency, end-to-end via `MigrationRunner.upgrade`).
- `tests/specify_cli/test_state_contract.py` and `tests/specify_cli/test_gitignore_contract.py`: full pass.
- Manually reproduced the original bug end-to-end in a scratch repo: created `.kittify/lint-report.json` untracked, ran the new migration, confirmed `git status --short` no longer lists it as untracked.
- `tests/architectural/` not run locally (missing `pytestarch` dependency in this environment, `ModuleNotFoundError`) — leaving CI to gate that suite.

Operator merges — I do not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789952675&installation_model_id=427282&pr_number=3639&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3639&signature=a810780f6cfcd4433199b79a897d8fe4091a0c5dbcf173336b1356b403b144ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->