### PR TITLE
test(acceptance): cover _git_head_of's detached-HEAD sentinel path (#2909)

### DIFF
--- a/tests/acceptance/test_gate_execution_context.py
+++ b/tests/acceptance/test_gate_execution_context.py
@@ -27,11 +27,13 @@ import pytest
 
 from mission_runtime import MissionArtifactKind, TopologySurface
 from specify_cli.acceptance.execution_context import (
+    _DETACHED_HEAD_SENTINEL,
     CannotEvaluate,
     CannotEvaluateReason,
     GateExecutionContext,
     GateSurfaceRefMismatch,
     LifecyclePhase,
+    _git_head_of,
     build_gate_execution_context,
     declared_home_surface,
 )
@@ -243,6 +245,28 @@ def test_assert_at_ref_passes_on_agreement() -> None:
     """C5: when the surface is at its ref, the gate proceeds (no raise)."""
     ctx = _plain_context(surface=Path("/p"), surface_kind=TopologySurface.COORD, ref="sha-abc")
     ctx.assert_at_ref(head_of=lambda _s: "sha-abc")  # must not raise
+
+
+def test_git_head_of_detached_checkout_returns_sentinel(tmp_path: Path) -> None:
+    """A detached checkout resolves to the ``"HEAD"`` sentinel (#2909 item 1).
+
+    ``git symbolic-ref --short HEAD`` fails on a detached checkout; the caller's own
+    no-branch fallback in ``gates_core._acceptance_gate_context`` is the same literal
+    ``"HEAD"``, so this is the value that makes "no expectation" compare equal on
+    both sides of :meth:`GateExecutionContext.assert_at_ref`.
+    """
+    repo = ctf._make_git_repo(tmp_path)
+    commit_sha = ctf._git(repo, "rev-parse", "HEAD")
+    ctf._git(repo, "checkout", "--detach", commit_sha)
+
+    assert _git_head_of(repo) == _DETACHED_HEAD_SENTINEL
+
+
+def test_git_head_of_attached_checkout_returns_branch_name(tmp_path: Path) -> None:
+    """Companion sanity check: an attached checkout resolves the real branch, not the sentinel."""
+    repo = ctf._make_git_repo(tmp_path)
+
+    assert _git_head_of(repo) == "main"
 
 
 # ===========================================================================


### PR DESCRIPTION
Refs #2909 (item 1 only — the detached-HEAD sentinel gap; item 2, the end-to-end branch flow-through test, and item 3, the hygiene note, are not addressed by this PR).

`_git_head_of` in `src/specify_cli/acceptance/execution_context.py` runs `git symbolic-ref --short HEAD`; on a detached checkout (`returncode != 0`) it falls back to the `_DETACHED_HEAD_SENTINEL` (`"HEAD"`). That branch had no direct test.

Adds two focused tests in `tests/acceptance/test_gate_execution_context.py`:
- a real detached-HEAD checkout (via `coord_topology_fixture._make_git_repo` + `git checkout --detach`) asserting `_git_head_of` returns the sentinel
- a companion attached-checkout case asserting the real branch name is returned, so the sentinel assertion isn't vacuous

No production code changed. `pytest tests/acceptance/test_gate_execution_context.py -q` passes (27/27). `ruff check` clean on the changed file; the pre-existing `ruff format` and `mypy --strict` findings in this file (an unrelated `type: ignore` on line ~226 and several long-line formatting diffs) predate this change and are unaffected by it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789953590&installation_model_id=427282&pr_number=3640&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3640&signature=ad2d0f93e32760cb8326d8740079a8bc466a066fafda73740658b3668c9bfc2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->