### PR TITLE
test(acceptance): cover #2909 item 2 — real-git branch forwarding through _check_lane_gates

### DIFF
--- a/tests/acceptance/test_gate_execution_context.py
+++ b/tests/acceptance/test_gate_execution_context.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pytest
 
 from mission_runtime import MissionArtifactKind, TopologySurface
+from specify_cli.acceptance import _resolve_git_context
 from specify_cli.acceptance.execution_context import (
     CannotEvaluate,
     CannotEvaluateReason,
@@ -38,6 +39,7 @@ from specify_cli.acceptance.execution_context import (
 from specify_cli.acceptance.gates_core import (
     AcceptanceCheckDiagnostic,
     _acceptance_gate_context,
+    _check_lane_gates,
     _evaluate_acceptance_matrix,
 )
 from specify_cli.acceptance.matrix import (
@@ -504,6 +506,84 @@ def test_gec2_real_cross_checkout_branch_drift_gate_refuses(
     assert any("GATE_SURFACE_REF_MISMATCH" in issue for issue in activity_issues), activity_issues
     # Names both real sides of the drift: expected the mission branch, found "main".
     assert any(mission_branch in issue for issue in activity_issues), activity_issues
+    assert any("'main'" in issue for issue in activity_issues), activity_issues
+    # It is NOT a verdict — no pass/fail verdict issue was recorded.
+    assert not any("verdict is" in issue for issue in activity_issues)
+
+
+def test_resolve_git_context_branch_forwards_through_check_lane_gates(
+    flat_topology_mission: ctf.FlatTopologyContext, tmp_path: Path
+) -> None:
+    """#2909 item 2: the invocation-checkout ``branch`` is not dropped mid-chain.
+
+    ``test_gec2_real_cross_checkout_branch_drift_gate_refuses`` proves GEC-2/C5 at
+    the ``_evaluate_acceptance_matrix(branch=...)`` entry point directly, and
+    ``test_trio_pure_cores.py`` characterizes (with mocked I/O) that
+    ``collect_feature_summary`` calls ``_resolve_git_context`` and threads its
+    ``branch`` into ``_check_lane_gates``. Neither proves, with REAL git, that a
+    ``branch`` genuinely resolved off a real invocation checkout's HEAD
+    (``_resolve_git_context``) survives the ``_check_lane_gates(branch=branch)``
+    hop on its way to the acceptance-matrix gate. This test closes that gap: if
+    ``_check_lane_gates`` (or ``_evaluate_branch_gate`` inside it) dropped the
+    ``branch`` kwarg mid-chain, this gate would silently judge the drifted
+    surface instead of refusing — the exact regression #2909 asks to be closed
+    against.
+
+    (``collect_feature_summary`` itself is not used as the entry point here: it
+    also drives WP-metadata collection, which — separately from anything #2909
+    asks for — does not support being invoked from a linked worktree. That gap is
+    out of scope for this branch-forwarding test.)
+    """
+    ctx = flat_topology_mission
+    mission_branch = f"kitty/mission-{ctx.slug}"
+    # A real branch, not yet checked out anywhere, cut from the SAME commit the
+    # main checkout (still on "main") sits at — a genuine member of
+    # {target_branch, mission_branch}, so `_evaluate_branch_gate` legitimately
+    # lets this invocation through to the acceptance-matrix gate.
+    ctf._git(ctx.repo, "branch", mission_branch)
+    # A genuine linked worktree, actually checked out on the mission branch —
+    # this is the invocation checkout `_resolve_git_context` reads HEAD from.
+    # The main checkout is untouched: still on "main".
+    linked_worktree = tmp_path / "linked-worktree"
+    ctf._git(ctx.repo, "worktree", "add", str(linked_worktree), mission_branch)
+
+    # A PASS matrix on the genuine primary surface: if `branch` were dropped
+    # anywhere in the chain, this would be read and judged, silently ignoring
+    # the real cross-checkout drift.
+    _seed_matrix(
+        ctx.primary_feature_dir, verdict="pass", marker="E2E-CROSS-CHECKOUT-PASS"
+    )
+
+    branch, _worktree_root, _primary_repo_root, _git_dirty = _resolve_git_context(
+        linked_worktree
+    )
+    # `_resolve_git_context` read the invocation checkout's real HEAD.
+    assert branch == mission_branch
+
+    activity_issues: list[str] = []
+    skipped: list[AcceptanceCheckDiagnostic] = []
+    blocked: list[AcceptanceCheckDiagnostic] = []
+    _check_lane_gates(
+        linked_worktree,
+        ctx.primary_feature_dir,
+        branch,
+        activity_issues,
+        skipped,
+        blocked,
+        mutate_matrix=False,
+    )
+
+    # The branch reached the acceptance-matrix gate: it refused the drift
+    # instead of judging the seeded PASS matrix.
+    assert any(
+        c.check == "acceptance_matrix_cannot_evaluate" for c in blocked
+    ), blocked
+    assert any(
+        "GATE_SURFACE_REF_MISMATCH" in issue for issue in activity_issues
+    ), activity_issues
+    assert any(
+        mission_branch in issue for issue in activity_issues
+    ), activity_issues
     assert any("'main'" in issue for issue in activity_issues), activity_issues
     # It is NOT a verdict — no pass/fail verdict issue was recorded.
     assert not any("verdict is" in issue for issue in activity_issues)


### PR DESCRIPTION
## What

Closes #2909 (item 1 is covered by PR #3640): adds an integration test proving the invocation-checkout `branch` survives the forwarding chain

```
_resolve_git_context (real git HEAD) -> _check_lane_gates(branch=branch) -> _evaluate_acceptance_matrix(branch=branch) -> _acceptance_gate_context(..., branch=branch)
```

using a **real** cross-checkout drift (a linked `git worktree` genuinely checked out on the mission branch, while the main checkout stays on `main`) — not a synthetic branch string. This exercises the exact production trigger the GEC-2/C5 ref-agreement gate exists for: if any hop in the chain silently dropped the `branch` kwarg, this test would catch it (the gate would judge the drifted surface instead of refusing).

New test: `test_resolve_git_context_branch_forwards_through_check_lane_gates` in `tests/acceptance/test_gate_execution_context.py`, added next to the existing `test_gec2_real_cross_checkout_branch_drift_gate_refuses` (which proves the same real-git drift one hop lower, entering directly at `_evaluate_acceptance_matrix`). Reuses the existing `flat_topology_mission` fixture and `_seed_matrix` helper verbatim — no new scaffolding.

## Scope note (honesty about what this does NOT cover)

`collect_feature_summary` (the actual top-level public entry point named in the issue) is deliberately **not** used as the test's entry point. Invoking it from a linked worktree hits a pre-existing, unrelated bug: `build_work_package_state` (`src/specify_cli/acceptance/summary_core.py`) calls `wp.path.relative_to(repo_root)` using the *invocation* `repo_root` (the linked worktree), but `wp.path` resolves against the *primary* repo root — these differ for a cross-worktree invocation, raising `ValueError`. That bug is orthogonal to #2909's branch-forwarding question and out of scope here; I'm flagging it in this PR body rather than silently working around it. A characterization test already covers (with mocked I/O) that `collect_feature_summary` calls `_resolve_git_context` and threads its `branch` into `_check_lane_gates` (`tests/characterization/test_trio_pure_cores.py`), so combined with this PR's real-git coverage one level down, the forwarding chain is proven end to end without needing to fix that unrelated bug in this PR.

Item 3 of #2909 was explicitly "context only, not necessarily its own work" per the issue text — not addressed here.

## Verification

- `pytest tests/acceptance/test_gate_execution_context.py -q` — 26/26 pass (25 pre-existing + 1 new).
- `ruff check` — clean on the changed file.
- `mypy --strict src/specify_cli src/charter src/doctrine tests/acceptance/test_gate_execution_context.py` — 54 errors before and after this change (whole-tree baseline unchanged, compared via `git stash`); no new errors introduced.
- `ruff format --check` reports the same pre-existing reformat diff on this file with and without this change (confirmed via `git stash` comparison) — a local ruff-version/config artifact unrelated to this diff, not something this PR introduces.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789954768&installation_model_id=427282&pr_number=3641&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3641&signature=5ed9eed77864eaec3ad9f9e8c833e6543d0cb9766d1d46ae654309c2e72ae3cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->