### PR TITLE
fix(dashboard): stop print from cropping page content (#323)

### DIFF
--- a/src/specify_cli/dashboard/static/dashboard/dashboard.css
+++ b/src/specify_cli/dashboard/static/dashboard/dashboard.css
@@ -1432,3 +1432,19 @@ body.modal-open {
         font-size: 0.75em;
     }
 }
+
+@media print {
+    /* The dashboard is a single-viewport app shell: body/.container/.main-content
+       all use height:100vh + overflow:hidden|auto so the SPA never scrolls the
+       page itself, only its internal panes. Printing captures exactly that fixed
+       viewport, so any content past one screen's worth of height is silently
+       clipped instead of flowing onto additional printed pages (#323). Reset the
+       shell to natural flow so print renders the full scrollable content. */
+    body,
+    .container,
+    .sidebar,
+    .main-content {
+        height: auto;
+        overflow: visible;
+    }
+}

--- a/tests/test_dashboard/test_static.py
+++ b/tests/test_dashboard/test_static.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.integration]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DASHBOARD_JS = REPO_ROOT / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.js"
+DASHBOARD_CSS = REPO_ROOT / "src" / "specify_cli" / "dashboard" / "static" / "dashboard" / "dashboard.css"
 
 
 def test_dashboard_template_references_static_assets():
@@ -36,6 +37,26 @@ def test_static_assets_exist():
     for asset in (css, js, logo):
         assert asset.exists(), f"{asset} should exist"
         assert asset.stat().st_size > 0, f"{asset} should not be empty"
+
+
+def test_dashboard_css_print_media_resets_shell_overflow():
+    """Regression for #323: the app-shell body/.container/.main-content stack uses
+    height:100vh + overflow:hidden|auto to keep the SPA single-viewport on screen.
+    Left as-is, that clips any content past one screen height when printed instead
+    of flowing it onto additional pages. A `@media print` block must reset those
+    elements to natural height/overflow so printed pages carry the full content.
+    """
+    css = DASHBOARD_CSS.read_text(encoding="utf-8")
+
+    print_media_start = css.find("@media print")
+    assert print_media_start != -1, "dashboard.css must define an @media print block"
+
+    print_media_end = css.find("\n}", print_media_start)
+    print_block = css[print_media_start:print_media_end]
+
+    for selector in ("body", ".container", ".sidebar", ".main-content"):
+        assert selector in print_block, f"@media print block must reset {selector}"
+    assert "overflow: visible" in print_block
 
 
 def test_dashboard_javascript_has_valid_syntax():


### PR DESCRIPTION
## Problem

The dashboard's app-shell (`body` / `.container` / `.sidebar` / `.main-content`) is built as a single-viewport SPA: `height: 100vh` + `overflow: hidden`/`auto` so the page itself never scrolls, only the sidebar and main-content panes scroll internally. There is no `@media print` stylesheet, so the browser's print renderer captures that same fixed viewport verbatim -- any content past one screen's worth of height inside `.main-content` is inside a scrollable pane that never gets a chance to flow onto additional printed pages. It's silently clipped, matching this issue's screenshots (bottom of the white container cropped, 2-3 lines lost).

## Repro

Loaded a real dashboard (`spec-kitty init` + `spec-kitty dashboard`) in a small viewport with the Diagnostics page open, then measured the active page's rendered bottom edge against `.main-content`'s bottom edge under `page.emulate_media("print")`: **257.8px of real content sat below the clipped edge** -- content that exists in the DOM and is fully rendered, just not visible because of `overflow: hidden`/`auto`.

## Fix

Added an `@media print` block (`dashboard.css`) resetting `body`, `.container`, `.sidebar`, `.main-content` to `height: auto` + `overflow: visible`, so print keeps the document's natural flow instead of the fixed-viewport SPA shell. Screen behavior is untouched -- the reset only applies inside the print media query.

## Verification

- Re-ran the same repro after the fix: `page.emulate_media("print")` now shows **0px clipped**, full Diagnostics content (including the "Refresh Diagnostics" button below the original fold) renders. Immediately switching back to `page.emulate_media("screen")` shows the original 257.8px clipped -- confirming the interactive single-viewport UI is unaffected.
- Added a regression test (`test_dashboard_css_print_media_resets_shell_overflow` in `tests/test_dashboard/test_static.py`) asserting the `@media print` block exists and resets all four shell selectors.
- Full `tests/test_dashboard/` suite: **170 passed**.
- `ruff check` clean.

Fixes #323

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789966296&installation_model_id=427282&pr_number=3648&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3648&signature=30e4c3cdbfe7db1e708fb6da3453a3a4f3df86f6c3474b57a18f16718fff0a48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->