### PR TITLE
fix(upgrade): rewrite protected command files

### DIFF
--- a/src/specify_cli/upgrade/migrations/m_2_1_4_enforce_command_file_state.py
+++ b/src/specify_cli/upgrade/migrations/m_2_1_4_enforce_command_file_state.py
@@ -245,6 +245,17 @@ def _agent_root_to_key(agent_root: str) -> str | None:
     return AGENT_DIR_TO_KEY.get(agent_root)
 
 
+def _write_generated_file(path: Path, content: str) -> None:
+    """Rewrite a generated command file and leave it write-protected."""
+    if path.exists():
+        path.chmod(path.stat().st_mode | 0o222)
+    try:
+        path.write_text(content, encoding="utf-8")
+    finally:
+        if path.exists():
+            path.chmod(path.stat().st_mode & ~0o222)
+
+
 # ---------------------------------------------------------------------------
 # Migration class
 # ---------------------------------------------------------------------------
@@ -367,7 +378,7 @@ class EnforceCommandFileStateMigration(BaseMigration):
                     continue
 
                 try:
-                    output_path.write_text(rendered, encoding="utf-8")
+                    _write_generated_file(output_path, rendered)
                     changes.append(f"Wrote prompt: {rel_path}")
                 except OSError as exc:
                     errors.append(f"Failed to write {rel_path}: {exc}")
@@ -384,7 +395,7 @@ class EnforceCommandFileStateMigration(BaseMigration):
 
                 shim_content = _render_shim(command, agent_key)
                 try:
-                    output_path.write_text(shim_content, encoding="utf-8")
+                    _write_generated_file(output_path, shim_content)
                     changes.append(f"Wrote shim: {rel_path}")
                 except OSError as exc:
                     errors.append(f"Failed to write {rel_path}: {exc}")

--- a/tests/upgrade/migrations/test_m_2_1_4_read_only_commands.py
+++ b/tests/upgrade/migrations/test_m_2_1_4_read_only_commands.py
@@ -1,0 +1,49 @@
+"""Regression tests for rewriting generated command files in migration 2.1.4."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.shims import registry as shims_registry
+from specify_cli.upgrade.migrations import m_2_1_4_enforce_command_file_state as migration
+
+pytestmark = pytest.mark.fast
+
+
+def test_apply_rewrites_and_reprotects_existing_command_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Generated prompt and shim files remain replaceable after write protection."""
+    templates_dir = tmp_path / "templates"
+    (templates_dir / "plan").mkdir(parents=True)
+    (templates_dir / "plan" / "prompt.md").write_text("template\n", encoding="utf-8")
+
+    command_dir = tmp_path / ".claude" / "commands"
+    command_dir.mkdir(parents=True)
+    prompt_path = command_dir / "spec-kitty.plan.md"
+    shim_path = command_dir / "spec-kitty.implement.md"
+    for path in (prompt_path, shim_path):
+        path.write_text("stale\n", encoding="utf-8")
+        path.chmod(0o444)
+
+    monkeypatch.setattr(
+        migration, "get_agent_dirs_for_project", lambda _project: [(".claude", "commands")]
+    )
+    monkeypatch.setattr(migration, "_get_runtime_command_templates_dir", lambda: templates_dir)
+    monkeypatch.setattr(
+        migration, "_render_full_prompt", lambda *_args, **_kwargs: "current prompt\n"
+    )
+    monkeypatch.setattr(migration, "_render_shim", lambda *_args: "current shim\n")
+    monkeypatch.setattr(shims_registry, "PROMPT_DRIVEN_COMMANDS", {"plan"})
+    monkeypatch.setattr(shims_registry, "CLI_DRIVEN_COMMANDS", {"implement"})
+
+    result = migration.EnforceCommandFileStateMigration().apply(tmp_path)
+
+    assert result.success is True
+    assert result.errors == []
+    assert prompt_path.read_text(encoding="utf-8") == "current prompt\n"
+    assert shim_path.read_text(encoding="utf-8") == "current shim\n"
+    assert prompt_path.stat().st_mode & 0o222 == 0
+    assert shim_path.stat().st_mode & 0o222 == 0


### PR DESCRIPTION
## Summary

- Allow migration 2.1.4 to refresh generated command files after the runtime write-protects them.
- Restore each file's read-only mode after writing prompts and shims.
- Add regression coverage for both generated command types.

## Why Now

`spec-kitty upgrade` currently fails on subsequent runs with `EACCES` because generated command files use mode `0444`.

## Effect on Existing Projects

- Runtime / compatibility: no API change.
- Upgrade / migration: existing generated command files can now be refreshed.
- Operator / reviewer impact: upgrades no longer require a manual `chmod` workaround.

## Validation

- [x] Targeted migration tests: 8 passed.
- [x] Ruff check and `git diff --check` passed.
- [x] Backward compatibility considered.
- [x] Strict mypy was checked; its eight findings reproduce unchanged on `origin/main`.

## Tickets / Contracts

| Reference | Relationship |
| --- | --- |
| #3651 | Closes |

Closes #3651

## AI Assistance

Codex assisted with implementation and testing. The diff was reviewed, the failure was captured before the fix, and the targeted tests and lint checks were run after the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790007798&installation_model_id=427282&pr_number=3670&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3670&signature=f54b90698689dd11b63d2684effa5705bfd63c056336ca36b6165915be13af51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->