### PR TITLE
docs(charter): mandate closing-keyword issue linkage

### DIFF
--- a/.kittify/charter/charter.md
+++ b/.kittify/charter/charter.md
@@ -487,6 +487,11 @@ Operational reference:
 
 1. When an agent encounters pre-existing test failures while working in this repository, the agent MUST open a GitHub issue reporting them before treating those failures as accepted baseline context or continuing past them. The issue must include the command run, the relevant failure summary, and why the agent believes the failures are pre-existing rather than introduced by its current change.
 
+## Issue Closure Linkage Rule
+
+1. Any commit or pull request that fully resolves a tracked GitHub issue MUST include a closing keyword reference — `Fixes #N`, `Closes #N`, or `Resolves #N` — in the commit message body **and/or** the PR description, so GitHub auto-closes the issue when the change lands on `main`. A bare mention (`resolve #3513` in a subject line, `Refs #N`, or a plain `#N` reference) links the issue but never closes it.
+2. For partial fixes, do NOT use a closing keyword; use `Refs #N` plus an explicitly tracked follow-up (comment on the issue naming the remaining scope).
+
 ---
 
 ## Governance


### PR DESCRIPTION
## Summary

Adds an **Issue Closure Linkage Rule** to `.kittify/charter/charter.md` (after the Tracker Ticket Assignment and Pre-existing Failure Reporting rules):

1. Any commit/PR that fully resolves a tracked GitHub issue MUST include a closing keyword (`Fixes #N` / `Closes #N` / `Resolves #N`) in the commit message body and/or PR description, so GitHub auto-closes the issue on merge. Bare mentions (`resolve #3513` in a subject, `Refs #N`, plain `#N`) link but never close.
2. Partial fixes must NOT use a closing keyword — use `Refs #N` plus an explicitly tracked follow-up.

## Motivation

Issue [#3513](https://github.com/Priivacy-ai/spec-kitty/issues/3513) stayed open for days after its fix landed (`ac9700ef6`, `2218be1fe`) because both commits referenced it only as "resolve #3513" in subjects — no closing keyword, no auto-close. The charter had no rule covering this failure mode; it now does.

Fixes #3513

## Validation

- `pytest tests/architectural/test_no_legacy_terminology.py` — 10 passed (governance prose change)
- Charter amendment per the charter's own Amendment Process (maintainer PR)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790148764&installation_model_id=427282&pr_number=3709&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3709&signature=db2241a6f753dbbd6d41c8ea421a0a0266a89158fe8b3106561cda268032d372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->