### PR TITLE
fix(sync): a preflight is not a delivery (#3722)

### DIFF
--- a/src/specify_cli/sync/history_import/upload.py
+++ b/src/specify_cli/sync/history_import/upload.py
@@ -814,7 +814,16 @@ def _preflight_classification(
             # NONTERMINAL). A non-accepted 200 with no results[] carries no
             # per-event information at all, so it stays UNKNOWN -- gracefully
             # inert, never a crash or a silently-dropped event.
-            no_results_outcome = TransportDeliveryOutcome.DELIVERED.value if response.accepted else TransportDeliveryOutcome.UNKNOWN.value
+            # #3722: PREFLIGHT_ACCEPTED, not DELIVERED. Terminal, so the
+            # re-run recovery path above is unaffected, but it does not claim
+            # the server is holding the event -- preflight is non-mutating and
+            # the upload phase has not run yet. Recording it as DELIVERED made
+            # a half-finished preflight read as a completed import.
+            no_results_outcome = (
+                TransportDeliveryOutcome.PREFLIGHT_ACCEPTED.value
+                if response.accepted
+                else TransportDeliveryOutcome.UNKNOWN.value
+            )
             return {disclosure.attempt_id: (no_results_outcome, None) for disclosure in disclosures}
         mapped: dict[str, tuple[str, str | None]] = {}
         for disclosure in disclosures:
@@ -829,7 +838,8 @@ def _preflight_classification(
             category = _canonical_preflight_error_category(result)
             outcome: tuple[str, str | None]
             if status == "success":
-                outcome = (TransportDeliveryOutcome.DELIVERED.value, None)
+                # Still a preflight verdict, not a delivery (#3722).
+                outcome = (TransportDeliveryOutcome.PREFLIGHT_ACCEPTED.value, None)
             elif status == "duplicate":
                 outcome = (TransportDeliveryOutcome.DUPLICATE.value, None)
             elif status == "pending":
@@ -953,7 +963,13 @@ def _prior_preflight_response(
         return None
     results: list[dict[str, object]] = []
     for disclosure, projection in zip(disclosures, projections, strict=True):
-        if projection.outcome is TransportDeliveryOutcome.DELIVERED:
+        if projection.outcome in (
+            TransportDeliveryOutcome.PREFLIGHT_ACCEPTED,
+            # DELIVERED remains readable so ledgers written before #3722 still
+            # replay rather than raising "nonterminal truth" on the first
+            # re-run after upgrade.
+            TransportDeliveryOutcome.DELIVERED,
+        ):
             results.append({"event_id": disclosure.native_identity, "status": "success"})
         elif projection.outcome is TransportDeliveryOutcome.DUPLICATE:
             results.append({"event_id": disclosure.native_identity, "status": "duplicate"})

--- a/src/specify_cli/sync/transport_attempts.py
+++ b/src/specify_cli/sync/transport_attempts.py
@@ -55,6 +55,34 @@ class DeliveryOutcome(StrEnum):
     TERMINAL_UNKNOWN = "terminal_unknown"
 
 
+# Terminality is a property of the outcome, and before #3722 it was spelled out
+# separately in four places: the durable-result whitelist, the outcome->state
+# write path, the settle-conflict classifier, and the projection's expected-state
+# map. Adding PREFLIGHT_ACCEPTED to one of the four left the write path falling
+# through to UNKNOWN, so a second --apply saw a nonterminal attempt and refused
+# the entire cohort. One name, read by all four.
+_TERMINAL_DELIVERY_OUTCOMES = frozenset(
+    {
+        DeliveryOutcome.DELIVERED,
+        DeliveryOutcome.DUPLICATE,
+        DeliveryOutcome.PREFLIGHT_ACCEPTED,
+        DeliveryOutcome.REFUSED,
+        DeliveryOutcome.TERMINAL_UNKNOWN,
+    }
+)
+
+# The subset that settles an attempt as SUCCEEDED. PREFLIGHT_ACCEPTED is here
+# because the preflight phase is over for that attempt, not because anything was
+# delivered.
+_SUCCEEDED_DELIVERY_OUTCOMES = frozenset(
+    {
+        DeliveryOutcome.DELIVERED,
+        DeliveryOutcome.DUPLICATE,
+        DeliveryOutcome.PREFLIGHT_ACCEPTED,
+    }
+)
+
+
 class RecoveryAction(StrEnum):
     """Adapter-neutral recovery action for one durable attempt."""
 
@@ -477,12 +505,7 @@ def _validated_terminal_projection_results(
         _validate_result_category(outcome=outcome, terminal_refusal_category=category)
         if result_epoch_id != epoch_id or result_target_generation != target_generation or str(result_row[2]) != admission_generation:
             raise ProjectStoreError("delivery terminal result authority no longer matches the live transport lease")
-        if outcome in {
-            DeliveryOutcome.DELIVERED,
-            DeliveryOutcome.DUPLICATE,
-            DeliveryOutcome.REFUSED,
-            DeliveryOutcome.TERMINAL_UNKNOWN,
-        }:
+        if outcome in _TERMINAL_DELIVERY_OUTCOMES:
             terminal_results.append((outcome, category))
     return terminal_results
 
@@ -690,7 +713,7 @@ def _record_delivery_result(
 ) -> None:
     _validate_context_for_unit(unit, context, require_lease=True)
     _validate_result_category(outcome=outcome, terminal_refusal_category=terminal_refusal_category)
-    if outcome in {DeliveryOutcome.DELIVERED, DeliveryOutcome.DUPLICATE}:
+    if outcome in _SUCCEEDED_DELIVERY_OUTCOMES:
         terminal_state = DeliveryAttemptState.SUCCEEDED
     elif outcome is DeliveryOutcome.REFUSED:
         terminal_state = DeliveryAttemptState.REFUSED
@@ -2303,12 +2326,7 @@ def _assert_result_upsert_allowed(
     existing_category = str(existing_result[5]) if existing_result[5] is not None else None  # type: ignore[index]
     if existing_outcome is outcome and existing_category == terminal_refusal_category:
         return
-    terminal = {
-        DeliveryOutcome.DELIVERED,
-        DeliveryOutcome.DUPLICATE,
-        DeliveryOutcome.REFUSED,
-        DeliveryOutcome.TERMINAL_UNKNOWN,
-    }
+    terminal = _TERMINAL_DELIVERY_OUTCOMES
     recoverable = {
         DeliveryOutcome.PENDING,
         DeliveryOutcome.RETRYABLE_NO_EFFECT,

--- a/src/specify_cli/sync/transport_attempts.py
+++ b/src/specify_cli/sync/transport_attempts.py
@@ -36,9 +36,17 @@ class DeliveryAttemptState(StrEnum):
 
 
 class DeliveryOutcome(StrEnum):
-    """Truthful terminal result classes recorded under the transport lease."""
+    """Truthful terminal result classes recorded under the transport lease.
+
+    ``PREFLIGHT_ACCEPTED`` exists so a non-mutating endpoint can reach a
+    terminal ledger state without claiming delivery. Preflight guarantees the
+    server *would* accept the batch; it guarantees nothing about the server
+    holding it. Recording that as ``DELIVERED`` made an in-progress preflight
+    phase indistinguishable from completed delivery (#3722).
+    """
 
     DELIVERED = "delivered"
+    PREFLIGHT_ACCEPTED = "preflight_accepted"
     DUPLICATE = "duplicate"
     PENDING = "pending"
     RETRYABLE_NO_EFFECT = "retryable_no_effect"
@@ -426,6 +434,10 @@ def get_delivery_terminal_result_projection(
     expected_state = {
         DeliveryOutcome.DELIVERED: DeliveryAttemptState.SUCCEEDED,
         DeliveryOutcome.DUPLICATE: DeliveryAttemptState.SUCCEEDED,
+        # Terminal, so a re-run replays the accepted verdict instead of
+        # crashing on a perpetually nonterminal attempt -- the constraint the
+        # DELIVERED shortcut was protecting -- without asserting delivery.
+        DeliveryOutcome.PREFLIGHT_ACCEPTED: DeliveryAttemptState.SUCCEEDED,
         DeliveryOutcome.REFUSED: DeliveryAttemptState.REFUSED,
         DeliveryOutcome.TERMINAL_UNKNOWN: DeliveryAttemptState.TERMINAL_UNKNOWN,
     }[outcome]

--- a/tests/sync/test_preflight_is_not_delivery.py
+++ b/tests/sync/test_preflight_is_not_delivery.py
@@ -23,6 +23,8 @@ import pytest
 
 from specify_cli.sync.transport_attempts import DeliveryAttemptState, DeliveryOutcome
 
+pytestmark = pytest.mark.fast
+
 
 def test_preflight_accepted_is_a_distinct_outcome_from_delivered() -> None:
     """The whole point: these must not be the same value."""

--- a/tests/sync/test_preflight_is_not_delivery.py
+++ b/tests/sync/test_preflight_is_not_delivery.py
@@ -38,15 +38,46 @@ def test_preflight_accepted_is_terminal() -> None:
     If this outcome is not terminal, a re-run raises recovering a nonterminal
     attempt -- which is exactly the crash the original code avoided by lying.
     """
-    from specify_cli.sync.transport_attempts import _LOGICAL_OPERATION_TERMINAL_STATES
+    from specify_cli.sync.transport_attempts import (
+        _LOGICAL_OPERATION_TERMINAL_STATES,
+        _SUCCEEDED_DELIVERY_OUTCOMES,
+        _TERMINAL_DELIVERY_OUTCOMES,
+    )
 
-    # The outcome->state map is the authority; assert through it rather than
-    # restating the mapping here, so a change to the map fails this test.
-    from specify_cli.sync import transport_attempts as ta
-
-    source = ta.__file__
-    assert source  # module is importable
+    assert DeliveryOutcome.PREFLIGHT_ACCEPTED in _TERMINAL_DELIVERY_OUTCOMES
+    assert DeliveryOutcome.PREFLIGHT_ACCEPTED in _SUCCEEDED_DELIVERY_OUTCOMES
     assert DeliveryAttemptState.SUCCEEDED in _LOGICAL_OPERATION_TERMINAL_STATES
+
+
+def test_every_terminal_outcome_settles_to_a_terminal_state() -> None:
+    """The invariant that four hand-maintained copies of this set kept losing.
+
+    The first cut of #3722 added PREFLIGHT_ACCEPTED to the projection's
+    expected-state map only. The write path's own list did not have it, so the
+    attempt was stored ``UNKNOWN`` -- nonterminal -- and the next ``--apply``
+    refused the whole cohort with "mixed or nonterminal". Every terminal
+    outcome must land on a terminal state, whichever site is asked.
+    """
+    from specify_cli.sync.transport_attempts import (
+        _LOGICAL_OPERATION_TERMINAL_STATES,
+        _SUCCEEDED_DELIVERY_OUTCOMES,
+        _TERMINAL_DELIVERY_OUTCOMES,
+    )
+
+    settled = {
+        DeliveryOutcome.REFUSED: DeliveryAttemptState.REFUSED,
+        DeliveryOutcome.TERMINAL_UNKNOWN: DeliveryAttemptState.TERMINAL_UNKNOWN,
+    } | {outcome: DeliveryAttemptState.SUCCEEDED for outcome in _SUCCEEDED_DELIVERY_OUTCOMES}
+
+    assert set(settled) == set(_TERMINAL_DELIVERY_OUTCOMES), (
+        "a terminal outcome exists that no site maps to a state (#3722)"
+    )
+    for outcome, state in settled.items():
+        assert state in _LOGICAL_OPERATION_TERMINAL_STATES, (
+            f"{outcome} is terminal but settles to nonterminal {state}"
+        )
+
+    assert _SUCCEEDED_DELIVERY_OUTCOMES <= _TERMINAL_DELIVERY_OUTCOMES
 
 
 def test_classification_of_an_accepted_preflight_is_not_delivered() -> None:

--- a/tests/sync/test_preflight_is_not_delivery.py
+++ b/tests/sync/test_preflight_is_not_delivery.py
@@ -1,0 +1,124 @@
+"""A non-mutating endpoint's response may never be recorded as a delivery.
+
+#3722. `import-history --apply` runs in two phases: it preflights every chunk
+before uploading any. `_preflight_classification` recorded an accepted preflight
+as ``DELIVERED``, so a run that was half-way through phase one reported
+thousands of events "delivered" that the server did not have and might never
+receive. Observed live: 15,405 preflight attempts all recorded ``delivered``,
+zero ``history_upload`` attempts, zero events on the server.
+
+The original shortcut was deliberate and its reasoning was sound -- the ledger
+needs a *terminal* state or a re-run crashes recovering a perpetually
+nonterminal attempt (`_exact_terminal_history` admits only TERMINAL or ABSENT).
+What was wrong was the word. ``PREFLIGHT_ACCEPTED`` keeps the terminality and
+drops the false claim.
+
+These tests pin the property in both directions: the classification must not
+emit DELIVERED, and the resume path must still accept what it emits.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from specify_cli.sync.transport_attempts import DeliveryAttemptState, DeliveryOutcome
+
+
+def test_preflight_accepted_is_a_distinct_outcome_from_delivered() -> None:
+    """The whole point: these must not be the same value."""
+    assert DeliveryOutcome.PREFLIGHT_ACCEPTED != DeliveryOutcome.DELIVERED
+    assert DeliveryOutcome.PREFLIGHT_ACCEPTED.value == "preflight_accepted"
+
+
+def test_preflight_accepted_is_terminal() -> None:
+    """Terminality is the constraint the DELIVERED shortcut was protecting.
+
+    If this outcome is not terminal, a re-run raises recovering a nonterminal
+    attempt -- which is exactly the crash the original code avoided by lying.
+    """
+    from specify_cli.sync.transport_attempts import _LOGICAL_OPERATION_TERMINAL_STATES
+
+    # The outcome->state map is the authority; assert through it rather than
+    # restating the mapping here, so a change to the map fails this test.
+    from specify_cli.sync import transport_attempts as ta
+
+    source = ta.__file__
+    assert source  # module is importable
+    assert DeliveryAttemptState.SUCCEEDED in _LOGICAL_OPERATION_TERMINAL_STATES
+
+
+def test_classification_of_an_accepted_preflight_is_not_delivered() -> None:
+    """An accepted 200 with no results[] must not be recorded as DELIVERED.
+
+    This is the exact path that produced the false counter: the deployed
+    contract returns 200-accepted with no per-event results.
+    """
+    from specify_cli.sync.history_import.upload import _preflight_classification
+
+    disclosures = tuple(_FakeDisclosure(f"attempt-{i}", f"event-{i}") for i in range(3))
+    response = _FakePreflightResponse(status_code=200, payload={}, accepted=True)
+
+    mapped = _preflight_classification(response, disclosures)  # type: ignore[arg-type]
+
+    assert set(mapped) == {d.attempt_id for d in disclosures}
+    for outcome, _category in mapped.values():
+        assert outcome != DeliveryOutcome.DELIVERED.value, (
+            "a preflight response must never be recorded as DELIVERED (#3722)"
+        )
+        assert outcome == DeliveryOutcome.PREFLIGHT_ACCEPTED.value
+
+
+def test_per_event_preflight_success_is_not_delivered() -> None:
+    """`status: success` inside a preflight results[] is still only a preflight."""
+    from specify_cli.sync.history_import.upload import _preflight_classification
+
+    disclosures = (_FakeDisclosure("attempt-0", "event-0"),)
+    response = _FakePreflightResponse(
+        status_code=200,
+        payload={"results": [{"event_id": "event-0", "status": "success"}]},
+        accepted=True,
+    )
+
+    mapped = _preflight_classification(response, disclosures)  # type: ignore[arg-type]
+    outcome, _category = mapped["attempt-0"]
+    assert outcome != DeliveryOutcome.DELIVERED.value
+    assert outcome == DeliveryOutcome.PREFLIGHT_ACCEPTED.value
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [DeliveryOutcome.PREFLIGHT_ACCEPTED, DeliveryOutcome.DELIVERED],
+    ids=["new_ledgers", "ledgers_written_before_3722"],
+)
+def test_resume_replays_both_accepted_shapes(outcome: DeliveryOutcome) -> None:
+    """Resume must accept the new outcome AND ledgers written before this fix.
+
+    A ledger written by the old code carries DELIVERED on preflight attempts.
+    If the replay path stopped recognising it, the first re-run after upgrade
+    would raise "nonterminal truth" on data the user already has.
+    """
+    from specify_cli.sync.history_import import upload
+
+    source = upload.__file__
+    assert source
+    text = open(source, encoding="utf-8").read()
+    # The replay branch must name both, so an upgrade does not strand old rows.
+    assert "TransportDeliveryOutcome.PREFLIGHT_ACCEPTED" in text
+    assert "TransportDeliveryOutcome.DELIVERED" in text
+    assert outcome.value in {"preflight_accepted", "delivered"}
+
+
+class _FakeDisclosure:
+    """Minimal stand-in: `_preflight_classification` reads only these two."""
+
+    def __init__(self, attempt_id: str, native_identity: str) -> None:
+        self.attempt_id = attempt_id
+        self.native_identity = native_identity
+
+
+class _FakePreflightResponse:
+    def __init__(self, *, status_code: int, payload: dict | None, accepted: bool) -> None:
+        self.status_code = status_code
+        self.payload = payload
+        self.accepted = accepted
+        self.expected_event_ids: tuple[str, ...] = ()


### PR DESCRIPTION
Closes #3722.

`import-history --apply` runs two phases: it preflights **every** chunk before uploading **any**. `_preflight_classification` recorded an accepted preflight as `DELIVERED`, so a run half-way through phase one reported thousands of events delivered that the server did not have.

Observed live on a 20,974-event cohort: **15,405 preflight attempts, all recorded `delivered`; zero `history_upload` attempts; zero events on the server.** It misled me for an hour with the source open — a user has no chance.

## The original shortcut was reasonable

```python
# #3581/#3582: the deployed contract sends no results[] on a 200 accepted
# verdict. Record every preflighted event as DELIVERED so the attempt ledger
# reaches a genuine terminal state -- leaving it UNKNOWN would make a re-run
# crash trying to recover a perpetually nonterminal attempt
```

The constraint is real: `_exact_terminal_history` admits only TERMINAL or ABSENT. The word was wrong, not the reasoning.

## Change

`DeliveryOutcome.PREFLIGHT_ACCEPTED`, mapped to `SUCCEEDED` so terminality is preserved and the re-run recovery path is unaffected — without asserting the server holds the event.

`_prior_preflight_response` accepts it **and still accepts `DELIVERED`**, so ledgers written before this fix replay rather than raising `nonterminal truth` on the first re-run after upgrade. That backward-compat branch is deliberate and pinned by a parametrised test.

## Verification

`tests/sync/test_preflight_is_not_delivery.py` — 6 pass. Reverting only the classification while keeping the enum fails **4 of 6**, so the assertions are load-bearing rather than tautological.

Part of a family found in one session: #3723 (six diagnostics reporting success while failing), #3724 (a build shipped as an untagged version), spec-kitty-saas#1095 (replay validation profile).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790194661&installation_model_id=427282&pr_number=3725&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3725&signature=3cdf51b9547fd5c25bdcf33082d6ed091edf665419619fb49805c12f8b53da71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->