### PR TITLE
test(sync): bounded-wait + pragma-ordering regression for project-store lock (#3625)

### DIFF
--- a/src/specify_cli/sync/project_store.py
+++ b/src/specify_cli/sync/project_store.py
@@ -627,6 +627,16 @@ class ProjectSyncStore:
             # changed from inside a transaction. The WAL switch itself is
             # done through _ensure_wal_journal_mode, not a bare PRAGMA: it
             # needs a lock class busy_timeout does not cover (see there).
+            #
+            # NOTE (#3625): busy_timeout bounds the wait on the in-daemon
+            # write-lock contention that shows up as "project sync store is
+            # locked" on large stores. Narrowing the lock *window* itself
+            # (the work held between BEGIN IMMEDIATE and commit, which scales
+            # with body-drain size) would change body-drain transaction scope
+            # and is deferred until a tens-of-MB repro can validate it does
+            # not regress atomicity or WAL-checkpoint behavior. The bounded
+            # wait guaranteed here is locked in by
+            # tests/sync/test_project_store_transactions.py.
             connection.execute(f"PRAGMA busy_timeout = {int(lock_timeout_seconds * 1000)}")
             _ensure_wal_journal_mode(connection, lock_timeout_seconds)
             connection.execute("PRAGMA foreign_keys = ON")

--- a/tests/sync/test_project_store_transactions.py
+++ b/tests/sync/test_project_store_transactions.py
@@ -6,6 +6,7 @@ import multiprocessing
 import os
 import sqlite3
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -446,6 +447,121 @@ def test_independent_processes_serialize_shared_uuid_writes(
         )
         == 2
     )
+
+
+def test_busy_timeout_bounds_the_wait_under_contention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#3625: a competing writer waits up to the timeout, then fails — never hangs.
+
+    ``busy_timeout`` (project_store.py) turns a contended ``BEGIN IMMEDIATE``
+    into a *bounded* wait instead of an immediate ``ProjectStoreLockedError``.
+    This pins that: while one unit_of_work holds the write lock, a second
+    acquisition with a small timeout blocks for roughly the timeout and then
+    raises — it must neither raise instantly (proving the pragma is in force)
+    nor block forever (proving the wait is bounded).
+    """
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
+    holder_store = ProjectSyncStore(PROJECT_UUID)
+    waiter_store = ProjectSyncStore(PROJECT_UUID)
+    with holder_store.unit_of_work():
+        pass  # establish the store (WAL + schema) before contending
+
+    holder_entered = threading.Event()
+    release_holder = threading.Event()
+    failures: list[BaseException] = []
+
+    def holder() -> None:
+        try:
+            with holder_store.unit_of_work() as unit:
+                unit.execute(
+                    "INSERT INTO capture_sequences (project_uuid, next_sequence) VALUES (?, 1)",
+                    (PROJECT_UUID,),
+                )
+                holder_entered.set()
+                assert release_holder.wait(timeout=10)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    holder_thread = threading.Thread(target=holder)
+    holder_thread.start()
+    assert holder_entered.wait(timeout=5)
+
+    wait_budget = 0.5
+    started = time.monotonic()
+    with (
+        pytest.raises(ProjectStoreLockedError),
+        waiter_store.unit_of_work(lock_timeout_seconds=wait_budget),
+    ):
+        pytest.fail("a held write lock must never expose a second unit of work")
+    elapsed = time.monotonic() - started
+
+    release_holder.set()
+    holder_thread.join(timeout=5)
+    assert not holder_thread.is_alive()
+    assert failures == []
+
+    # It WAITED (bounded by busy_timeout) rather than failing instantly...
+    assert elapsed >= wait_budget * 0.5
+    # ...and the wait was BOUNDED — no indefinite hang.
+    assert elapsed < 5.0
+
+
+class _RecordingConnection:
+    """Delegates to a real sqlite3 connection, logging executed SQL text."""
+
+    def __init__(self, real: sqlite3.Connection, log: list[str]) -> None:
+        self._real = real
+        self._log = log
+
+    def execute(self, sql: str, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+        self._log.append(sql)
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+def _first_index_containing(statements: list[str], needle: str) -> int:
+    for index, statement in enumerate(statements):
+        if needle in statement.lower():
+            return index
+    raise AssertionError(f"no executed statement contained {needle!r}: {statements}")
+
+
+def test_busy_timeout_pragma_precedes_begin_immediate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#3625 ordering guard: ``PRAGMA busy_timeout`` must run before ``BEGIN IMMEDIATE``.
+
+    The bounded-wait guarantee only holds if the timeout pragma is installed
+    on the connection before the transaction attempts to acquire the write
+    lock. This records the actual statement order on a live connection and
+    fails if a refactor reorders the pragma after ``BEGIN IMMEDIATE``.
+    """
+    monkeypatch.setenv("SPEC_KITTY_HOME", str(tmp_path / "runtime"))
+    store = ProjectSyncStore(PROJECT_UUID)
+    with store.unit_of_work():
+        pass  # initialize first, so the recording captures the steady-state path
+
+    statements: list[str] = []
+    real_connect = sqlite3.connect
+
+    def recording_connect(*args: Any, **kwargs: Any) -> Any:
+        return _RecordingConnection(real_connect(*args, **kwargs), statements)
+
+    monkeypatch.setattr(
+        "specify_cli.sync.project_store.sqlite3.connect",
+        recording_connect,
+    )
+    with store.unit_of_work():
+        pass
+
+    busy_index = _first_index_containing(statements, "busy_timeout")
+    begin_index = _first_index_containing(statements, "begin immediate")
+    assert busy_index < begin_index
 
 
 def test_unit_of_work_accepts_only_store_derived_connection_lifecycle() -> None:


### PR DESCRIPTION
## What

Test-only regression coverage for the SQLite lock behavior behind #3625
(`project sync store is locked` noise on large stores), plus a code comment
recording the deliberately-deferred residual.

**This does NOT fully close #3625.** The productive half of the fix —
`PRAGMA busy_timeout` set before `BEGIN IMMEDIATE` — already landed on `main`
(`sync/project_store.py:572` read-only verify, `:630` `unit_of_work`). This PR
pins that behavior with a bounded-wait regression test and defers the remaining
window-narrowing work. Reference #3625 without `Closes` — the residual stays open.

## Why test-only (scoping)

The remaining ask in #3625 is "narrow the in-daemon write-lock window on large
stores." That window is the work held between `BEGIN IMMEDIATE` and `commit`
during the body-drain, and it scales with store size. Restructuring it (splitting
the drain into smaller transactions) changes body-drain **transaction scope** —
exactly the class of change that needs a tens-of-MB store to validate it does
not regress atomicity or WAL-checkpoint behavior. No large-store repro is
available (the #3564/#3620 forensics flagged in-daemon vs cross-process
contention as UNVERIFIED). Making that change blind is higher risk than the
P3/low-severity noise it removes, so it is deferred behind a repro as its own
follow-up. What is safe and worth doing now is pinning the already-landed
bounded-wait so a future removal of the pragma is caught.

## Changes

- `tests/sync/test_project_store_transactions.py` (existing `pytest.mark.fast` file):
  - `test_busy_timeout_bounds_the_wait_under_contention` — while one
    `unit_of_work` holds the write lock, a second acquisition with a small
    timeout waits ~timeout and then raises `ProjectStoreLockedError`: it must
    neither raise instantly (proves the pragma is in force) nor hang (proves the
    wait is bounded). Real SQLite on `tmp_path` + `threading.Event` for
    deterministic contention — no real ports/daemons.
  - `test_busy_timeout_pragma_precedes_begin_immediate` — records live statement
    order via a delegating recording connection and asserts
    `PRAGMA busy_timeout` runs before `BEGIN IMMEDIATE` (ordering-regression guard).
- `sync/project_store.py` — one comment (comment-only, no behavior change) at the
  `busy_timeout` seam recording that window-narrowing is deferred pending a
  large-store repro, referencing #3625.

No `# noqa` / `# type: ignore`. No `len(...) == N` golden-count assertions
(set/threshold assertions only). No pyproject version bump. No CHANGELOG entry
(test-only, no user-facing behavior change). `admission_operations.perform` is
untouched (stays whitelisted as unwired).

## Gate results (actual)

- **New tests (`-n0`, isolated — timing-sensitive):** `2 passed in 1.04s`;
  full file `28 passed in 51.24s`.
- **`ruff check` (both changed files):** `All checks passed!`
- **`mypy src/specify_cli/sync/project_store.py`:** 3 pre-existing
  `no-any-return` errors at `:526/:531/:536` (path-resolver helpers, unrelated to
  this diff). Confirmed identical on `upstream/main` base — this PR's source edit
  is comment-only and introduces no mypy errors. (Bare per-file mypy without the
  repo's full config surfaces these; they are baseline, not attributable here.)

## Residual

#3625 should be **downgraded/kept open** (window-narrowing deferred pending a
tens-of-MB repro), not closed. The noise is de-risked and the bounded-wait is
now regression-guarded.

Draft — operator merges. From the review+design squad.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790353022&installation_model_id=427282&pr_number=3765&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3765&signature=b4c00bac543c440d6b8d2c75871ffca2d0fbadc368362cfd707a16a968882c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->