### PR TITLE
test(agent): repair 5 stale mission-create tests unmasked by #3673 (restore integration-tests-agent green)

### DIFF
--- a/tests/agent/cli/commands/test_feature_slug_validation.py
+++ b/tests/agent/cli/commands/test_feature_slug_validation.py
@@ -73,6 +73,11 @@ def test_valid_kebab_case_slugs_accepted(tmp_path, monkeypatch):
     """Valid kebab-case slugs should be accepted."""
     # Arrange
     monkeypatch.chdir(tmp_path)
+    # The repo is created on ``main`` (protected); each accepted slug commits its
+    # mission meta.json there. The operator-owned-repo escape hatch is the ONE
+    # sanctioned waiver (#3673 made the protected-branch refusal fail loud rather
+    # than the pre-fix contextlib.suppress that let create silently no-op).
+    monkeypatch.setenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", "1")
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True, capture_output=True)

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -237,6 +237,7 @@ class TestBranchContextCommand:
         self,
         mock_locate: Mock,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Do not treat a feature branch as primary just because origin/HEAD is absent."""
         mock_locate.return_value = tmp_path
@@ -252,6 +253,14 @@ class TestBranchContextCommand:
         subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
         subprocess.run(["git", "commit", "-m", "Initial"], cwd=tmp_path, check=True, capture_output=True)
         subprocess.run(["git", "switch", "-c", "feat/checkout-upsell"], cwd=tmp_path, check=True, capture_output=True)
+
+        # ``branch-context`` resolves branch identity from the invoking checkout
+        # (``resolve_checkout_identity(Path.cwd(), ...)``), NOT from the mocked
+        # ``locate_project_root`` (which re-anchors linked worktrees to the
+        # primary checkout for shared metadata reads). The test must therefore
+        # run *inside* the repo it built, or the command reads the ambient
+        # checkout's branch instead of ``feat/checkout-upsell``.
+        monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(app, ["branch-context", "--json"])
 

--- a/tests/agent/test_create_feature_branch.py
+++ b/tests/agent/test_create_feature_branch.py
@@ -123,6 +123,12 @@ def test_create_feature_on_main_records_target_branch(tmp_path, monkeypatch):
     repo = _init_repo(tmp_path, "main")
     _setup_kittify(repo)
     monkeypatch.chdir(repo)
+    # Creating on a protected ``main`` branch commits meta.json to it; the
+    # documented operator escape hatch is the ONE sanctioned waiver (the test
+    # repo IS the solo operator who owns main). Without it, safe_commit rightly
+    # refuses the protected-branch commit (#3673 made this refusal fail loud
+    # instead of the pre-fix contextlib.suppress that let it silently succeed).
+    monkeypatch.setenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", "1")
     # Assumption check
     assert (repo / ".kittify").exists()
     # Act
@@ -146,6 +152,9 @@ def test_create_feature_on_master_records_target_branch(tmp_path, monkeypatch):
     repo = _init_repo(tmp_path, "master")
     _setup_kittify(repo)
     monkeypatch.chdir(repo)
+    # ``master`` is a protected branch too; same operator-owned-repo waiver as
+    # the ``main`` case above (see that test for the #3673 rationale).
+    monkeypatch.setenv("SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS", "1")
     # Assumption check
     assert (repo / ".kittify").exists()
     # Act
@@ -186,23 +195,39 @@ def test_create_feature_on_custom_branch_records_target_branch(tmp_path, monkeyp
 
 
 @pytest.mark.usefixtures("_git_identity")
-def test_create_feature_with_explicit_target_branch_flag(tmp_path, monkeypatch):
-    """--target-branch flag overrides current branch."""
+def test_create_feature_target_branch_not_checked_out_fails_loud(tmp_path, monkeypatch):
+    """``--target-branch X`` requires the invoking checkout to be on X — fail-loud otherwise.
+
+    ``--target-branch`` names where planning artifacts land (``planning_branch =
+    target_branch`` in ``mission_creation.py``), not merely a merge-target label.
+    On ``main`` with ``--target-branch 2.x`` the placement seam routes the
+    ``meta.json`` commit to ``2.x`` and ``safe_commit`` refuses because HEAD is
+    still ``main`` — surfacing the actionable "checkout 2.x first" remedy. The
+    modern way to create a mission on a different branch is ``--start-branch``
+    (switch first), not this flag.
+
+    Regression guard for #3673: pre-fix, this commit was wrapped in
+    ``contextlib.suppress(Exception)``, so the refusal was swallowed and create
+    "succeeded" (exit 0) with ``target_branch=2.x`` written to disk but never
+    committed. This test used to assert that silent success; #3673 made the
+    refusal fail loud, and this guard now pins the loud behavior.
+    """
     from typer.testing import CliRunner
     from specify_cli.cli.commands.agent.mission import app
 
     repo = _init_repo(tmp_path, "main")
     _setup_kittify(repo)
+    # ``2.x`` exists as a real branch so the refusal is the actionable
+    # "checkout 2.x first" message — not the topology-mint error you get when the
+    # target branch does not exist at all (a distinct, message-quality concern).
+    run_command(["git", "branch", "2.x"], cwd=repo)
     monkeypatch.chdir(repo)
 
     runner = CliRunner()
     result = runner.invoke(app, ["create", "test-feature", "--json", "--target-branch", "2.x"])
 
-    assert result.exit_code == 0, f"Command failed: {result.output}"
-    slugs = _get_mission_slugs(repo)
-    assert len(slugs) == 1
-    meta = _read_meta(repo, slugs[0])
-    assert meta["target_branch"] == "2.x"
+    assert result.exit_code != 0, f"Expected fail-loud refusal, got success: {result.output}"
+    assert "expected '2.x'" in result.output, result.output
 
 
 @pytest.mark.usefixtures("_git_identity")


### PR DESCRIPTION
**Restores `main` to green: `integration-tests-agent` (and the `quality-gate` aggregate) have been red since 2026-08-26.** No product behavior changes — this repairs five stale tests that were passing only by accident.

## What was broken

`integration-tests-agent` went red with five failures in the mission-create path — protected-branch commit refusals and a branch-context mismatch. The agent shard is path-filtered (`src/specify_cli/cli/commands/agent/**`), so nothing ran it between the change that exposed these (#3673, 2026-08-23) and the first later PR to touch that path (#3733, 2026-08-26) — that innocent PR wore the pre-existing failure.

## Root cause

#3673 (*fix(mission): fail loudly instead of silently succeeding*) removed a `contextlib.suppress(Exception)` wrapper around the `meta.json` commit in `create_mission_core`. Before that, when the protected-branch guard legitimately refused a commit (or a topology precondition failed), the exception was **swallowed** — `mission create` returned exit 0 having written `meta.json` to disk but never committed it. These five tests asserted `exit_code == 0` and read `meta.json` off disk, so they passed against behavior that was actually broken. #3673 made the refusal loud; the tests then failed honestly.

## The fix — all five are stale tests; the product is correct

- **Create on a protected branch** (`on_main`, `on_master`, valid-slug acceptance): committing a mission's planning artifacts to `main`/`master` is a real protected-branch commit. These now set the documented operator escape hatch `SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS=1` — the same waiver the sibling `tests/agent/test_implement_command.py` already uses — because the throwaway test repo *is* the solo operator who owns `main`.
- **Branch-context** (`..._has_no_origin_head`): the command resolves branch identity from the invoking checkout (`resolve_checkout_identity(Path.cwd())`, a deliberate worktree-correctness seam), not the mocked project root. The test now `chdir`s into the repo it builds so it reads `feat/checkout-upsell` instead of the ambient checkout.
- **Explicit `--target-branch`**: asserted retired flat-era semantics. Under the current model `planning_branch = target_branch`, so `--target-branch 2.x` while on `main` routes the commit to `2.x` and `safe_commit` refuses with an actionable "checkout 2.x first" (the modern way to create on another branch is `--start-branch`). Rewritten (and renamed) as a fail-loud regression guard for #3673.

## Scope & verification

- **Test-only. No `src/` change.** The mission-create behavior these now exercise is the intended, already-shipped behavior.
- The three touched files pass (17 tests); `ruff` clean; `commitlint` clean.
- Separately noted for a follow-up (not fixed here, out of scope): a couple of `setup-plan`/`finalize-tasks` tests are latently coupled to the ambient checkout branch name (same class as the branch-context bug). They are **green on CI** (the checkout is `main`) and only fail in a non-`main` local worktree, so they are not part of this red-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790502356&installation_model_id=427282&pr_number=3776&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3776&signature=3a1657fb123fd811b2b957c9051968cfcace3445f32e9a534f5cb75565d259a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->