### PR TITLE
test(agent): decouple mission-command tests from the ambient checkout branch (#3776 follow-up)

### DIFF
--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -13,6 +13,7 @@ from ulid import ULID
 
 from specify_cli.cli.commands.agent.mission import CommitToBranchResult, app
 from specify_cli.coordination.commit_router import CommitRouterResult
+from specify_cli.core.checkout_identity import CheckoutIdentity, Intent
 
 pytestmark = [pytest.mark.integration, pytest.mark.git_repo]
 
@@ -1240,6 +1241,24 @@ requirement_refs:
                 "specify_cli.cli.commands.agent.mission._show_branch_context",
                 return_value=(None, "main"),
             ),
+            # ``finalize-tasks`` enforces write-ownership via
+            # ``resolve_checkout_identity(Path.cwd(), Intent.WRITE)`` — it refuses
+            # unless the invoking checkout owns its canonical target. That reads
+            # the AMBIENT checkout, not the mocked ``locate_project_root``: green
+            # in a ``main`` CI checkout (its ``.git`` is a directory → self-owned),
+            # but a linked worktree (``.git`` is a pointer file → foreign) is
+            # refused with CHECKOUT_WRITE_OWNERSHIP_REFUSED. Pin a self-owned
+            # identity so the test is deterministic regardless of the worktree it
+            # runs in.
+            patch(
+                "specify_cli.cli.commands.agent.mission_finalize.resolve_checkout_identity",
+                return_value=CheckoutIdentity(
+                    invoking_root=tmp_path,
+                    canonical_target=tmp_path,
+                    is_owner=True,
+                    intent=Intent.WRITE,
+                ),
+            ),
             patch(
                 "specify_cli.coordination.commit_router.commit_for_mission",
                 return_value=CommitRouterResult(
@@ -1285,6 +1304,14 @@ class TestSetupPlanCommand:
             lambda *args, **kwargs: GitPreflightResult(repo_root=tmp_path),
         )
 
+    # ``setup-plan`` resolves the invoking checkout's branch via
+    # ``get_current_branch(resolve_checkout_identity(Path.cwd()).invoking_root)``
+    # (the FR-006/#3124 honest branch-match), NOT the mocked ``_show_branch_context``.
+    # That reads the AMBIENT checkout, so ``current_branch`` came out as whatever
+    # branch the worktree running the test happened to be on — green in a ``main``
+    # CI checkout, red in any non-``main`` worktree. Pin ``get_current_branch`` to
+    # ``main`` so the resolution is deterministic.
+    @patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main")
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.cli.commands.agent.mission._find_feature_directory")
     @patch("specify_cli.cli.commands.agent.mission._show_branch_context", return_value=(None, "main"))
@@ -1295,6 +1322,7 @@ class TestSetupPlanCommand:
         mock_show_branch: Mock,
         mock_find: Mock,
         mock_locate: Mock,
+        mock_get_current_branch: Mock,
         tmp_path: Path,
     ) -> None:
         """Should scaffold plan template and output JSON format."""

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -1249,7 +1249,12 @@ requirement_refs:
             # but a linked worktree (``.git`` is a pointer file → foreign) is
             # refused with CHECKOUT_WRITE_OWNERSHIP_REFUSED. Pin a self-owned
             # identity so the test is deterministic regardless of the worktree it
-            # runs in.
+            # runs in. This only removes the incidental ownership gate so the
+            # requirement-refs parse under test is reachable — the ownership-refusal
+            # behaviour itself is guarded separately by
+            # ``tests/specify_cli/core/test_checkout_identity.py`` (and the
+            # architectural fail-closed single-channel tests), which this pin does
+            # not weaken.
             patch(
                 "specify_cli.cli.commands.agent.mission_finalize.resolve_checkout_identity",
                 return_value=CheckoutIdentity(
@@ -1311,6 +1316,13 @@ class TestSetupPlanCommand:
     # branch the worktree running the test happened to be on — green in a ``main``
     # CI checkout, red in any non-``main`` worktree. Pin ``get_current_branch`` to
     # ``main`` so the resolution is deterministic.
+    #
+    # This is a scaffold-shape test: with the pin, ``current_branch == "main"`` is a
+    # tautology, NOT the branch-honesty guard. The real invoking-vs-primary
+    # derivation contract (FR-006/#3124) is verified separately by
+    # ``tests/specify_cli/cli/commands/agent/test_setup_plan_branch_match.py``,
+    # which uses real ``git worktree add`` lanes with ``get_current_branch``
+    # deliberately UNPATCHED.
     @patch("specify_cli.cli.commands.agent.mission.get_current_branch", return_value="main")
     @patch("specify_cli.cli.commands.agent.mission.locate_project_root")
     @patch("specify_cli.cli.commands.agent.mission._find_feature_directory")

--- a/tests/specify_cli/cli/commands/agent/test_issue_3466_finalize_target_branch_override.py
+++ b/tests/specify_cli/cli/commands/agent/test_issue_3466_finalize_target_branch_override.py
@@ -134,7 +134,10 @@ def _run_finalize_with_override(
     # sees an owned checkout — as it does in a ``main`` CI checkout. Without the
     # chdir the invoking cwd is whatever worktree runs the suite, so a linked
     # worktree is refused with CHECKOUT_WRITE_OWNERSHIP_REFUSED (green on CI's
-    # own checkout, red in any linked worktree).
+    # own checkout, red in any linked worktree). This is a shared helper: the
+    # chdir is inert for the callers that assert exit-1 revert/error paths (they
+    # never reach the ownership gate) — it only un-blocks the ``exit_code == 0``
+    # callers, and their git-state assertions already pass an explicit ``cwd=repo``.
     with (
         contextlib.chdir(repo),
         patch(

--- a/tests/specify_cli/cli/commands/agent/test_issue_3466_finalize_target_branch_override.py
+++ b/tests/specify_cli/cli/commands/agent/test_issue_3466_finalize_target_branch_override.py
@@ -29,6 +29,7 @@ feature branch as HEAD. It runs the real ``finalize-tasks`` CLI command
 
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 from pathlib import Path
@@ -126,7 +127,16 @@ def _scaffold_mission_pinned_to_main(repo: Path) -> Path:
 def _run_finalize_with_override(
     repo: Path, target_branch_override: str, *, mission_slug: str = MISSION_SLUG
 ) -> Result:
+    # ``finalize-tasks`` enforces write-ownership from the AMBIENT invoking
+    # checkout (``resolve_checkout_identity(Path.cwd(), Intent.WRITE)``), not the
+    # mocked ``locate_project_root``. ``repo`` is a standalone git repo (its
+    # ``.git`` is a directory → self-owned); run inside it so the ownership check
+    # sees an owned checkout — as it does in a ``main`` CI checkout. Without the
+    # chdir the invoking cwd is whatever worktree runs the suite, so a linked
+    # worktree is refused with CHECKOUT_WRITE_OWNERSHIP_REFUSED (green on CI's
+    # own checkout, red in any linked worktree).
     with (
+        contextlib.chdir(repo),
         patch(
             "specify_cli.cli.commands.agent.mission.locate_project_root",
             return_value=repo,


### PR DESCRIPTION
**Test-hardening follow-up to #3776: removes a latent test fragility that red-mains the suite in any linked git worktree.** No product change.

## The fragility

Four `setup-plan` / `finalize-tasks` tests were coupled to the branch of whatever checkout ran the suite. They pass on CI — the checkout is `main` and its `.git` is a directory, so it is a self-owned checkout — but fail in any **linked git worktree** (`.git` is a pointer file → a foreign checkout), so running the suite from a worktree turned them red for reasons unrelated to the code under test. This was flagged while landing #3776 (which fixed the same class in the mission-create tests).

## Root cause

`branch-context`, `setup-plan`, and `finalize-tasks` deliberately resolve the **invoking** checkout's branch and write-ownership from `Path.cwd()` (via `resolve_checkout_identity`, FR-006/#3124) — so a lane worktree reports its own branch and ownership, not the primary's. These unit tests mock `locate_project_root` / `_show_branch_context` but not that ambient read, so the resolved branch (and the write-ownership verdict) leaked in from the host checkout.

## The fix (test-only)

- **`TestSetupPlanCommand::test_scaffolds_plan_template_json`** — `current_branch` comes from `get_current_branch(resolve_checkout_identity(Path.cwd()).invoking_root)`, not the mocked `_show_branch_context`. Pin `mission.get_current_branch` to `main`.
- **`TestFinalizeTasksCommand::test_uses_wp_frontmatter_requirement_refs_when_tasks_md_missing_refs`** — the write-ownership guard `resolve_checkout_identity(Path.cwd(), WRITE)` refuses a foreign checkout (`CHECKOUT_WRITE_OWNERSHIP_REFUSED`). Pin a self-owned `CheckoutIdentity`.
- **`test_issue_3466_finalize_target_branch_override`** (two `exit_code == 0` cases) — same write-ownership refusal. The `protected_target_repo` fixture already builds a real standalone repo, so run the shared `_run_finalize_with_override` helper *inside* it (`contextlib.chdir(repo)`) — a self-owned cwd, exactly as on CI. The file's other tests (which assert revert/error paths) are unaffected.

## Scope & verification

- **Test-only. No `src/` change.** The commands' `Path.cwd()`-based identity resolution is intended behavior and is left untouched.
- Each fixed test now passes from **both** a `main` checkout and a linked worktree.
- Completeness: swept every test that invokes these three commands and mocks `locate_project_root` (~25 files) from a non-`main` worktree; these four were the only fragility-class failures. `ruff` + `commitlint` clean.
- Out of scope: `test_doc_generators.py::test_sphinx_generation_end_to_end` fails locally for a missing-sphinx reason (environmental, green on CI), unrelated to this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505001&installation_model_id=427282&pr_number=3778&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3778&signature=c42fe8d5eb1122287b8ecfb74941bdec6dfb23b5f5365b1a1aa825651f72fe78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->