### PR TITLE
fix(agent): align mission-create-on-primary tests with the protected-branch guard (#3779)

### DIFF
--- a/tests/agent/cli/commands/test_feature_slug_validation.py
+++ b/tests/agent/cli/commands/test_feature_slug_validation.py
@@ -70,13 +70,20 @@ def test_mission_slug_with_uppercase_rejected():
 
 
 def test_valid_kebab_case_slugs_accepted(tmp_path, monkeypatch):
-    """Valid kebab-case slugs should be accepted."""
+    """Valid kebab-case slugs should be accepted.
+
+    Slug format is the behavior under test, so the repo is created on a
+    non-protected feature branch: the coord-primary-partition-lock guard refuses
+    to land planning artifacts on a protected primary branch, and that refusal
+    would mask whether the slug itself was accepted. Creating on a feature branch
+    keeps this test scoped to slug validation (a valid slug creates the mission).
+    """
     # Arrange
     monkeypatch.chdir(tmp_path)
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True, capture_output=True)
-    subprocess.run(["git", "checkout", "-b", "main"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "feat/slug-validation"], cwd=tmp_path, check=True, capture_output=True)
     kittify_dir = tmp_path / ".kittify"
     kittify_dir.mkdir()
     (kittify_dir / "config.yaml").write_text(

--- a/tests/agent/test_agent_feature.py
+++ b/tests/agent/test_agent_feature.py
@@ -237,9 +237,15 @@ class TestBranchContextCommand:
         self,
         mock_locate: Mock,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Do not treat a feature branch as primary just because origin/HEAD is absent."""
         mock_locate.return_value = tmp_path
+        # branch-context resolves branch identity from the invoking checkout
+        # (Path.cwd()), not from the mocked project root — it is invocation-owned
+        # state (see mission_branch_context.py). Run from inside the test repo so
+        # the real git resolution under test reads this repo's branch.
+        monkeypatch.chdir(tmp_path)
         subprocess.run(
             ["git", "init", "--initial-branch=main"],
             cwd=tmp_path,

--- a/tests/agent/test_create_feature_branch.py
+++ b/tests/agent/test_create_feature_branch.py
@@ -113,9 +113,40 @@ def test_create_feature_on_2x_with_main_also_existing(tmp_path, monkeypatch):
     assert meta["target_branch"] == "2.x"
 
 
+def _head_commit_subject(repo: Path) -> str:
+    """Return the subject line of the current HEAD commit."""
+    return run_command(["git", "log", "-1", "--format=%s"], cwd=repo, capture=True)[1].strip()
+
+
+def _assert_protected_branch_refusal(result, repo: Path, protected_branch: str) -> None:
+    """Assert a structured protected-branch refusal that names the --start-branch remedy.
+
+    The coord-primary-partition-lock guard refuses to land planning artifacts on
+    a protected primary branch; the sanctioned flow is ``--start-branch``. This
+    helper keeps the two primary-branch cases (main/master) asserting the same
+    shipped contract without duplicating the literal error substrings. It also
+    confirms the guard blocked the commit (HEAD is unchanged) — the load-bearing
+    invariant, distinct from whether the untracked scaffold is swept from disk.
+    """
+    assert result.exit_code != 0, f"Create on protected '{protected_branch}' must be refused: {result.output}"
+    payload = json.loads(result.output)
+    error = payload["error"]
+    assert "protected branch" in error, error
+    assert protected_branch in error, error
+    assert "--start-branch" in error, error
+    # The guard blocked the meta.json commit: no mission commit lands on the branch.
+    assert _head_commit_subject(repo) == "Initial", _head_commit_subject(repo)
+
+
 @pytest.mark.usefixtures("_git_identity")
-def test_create_feature_on_main_records_target_branch(tmp_path, monkeypatch):
-    """create on main records target_branch='main'."""
+def test_create_feature_on_main_refused_by_protected_branch_guard(tmp_path, monkeypatch):
+    """create on the protected primary branch 'main' is refused (must use --start-branch).
+
+    The coord-primary-partition-lock guard (see mission_creation.py WP02) forbids
+    landing planning artifacts on a protected branch. Recording ``main`` as the
+    target by committing meta.json onto ``main`` was the pre-guard behavior; the
+    shipped contract now refuses it and points at the ``--start-branch`` flow.
+    """
     # Arrange
     from typer.testing import CliRunner
     from specify_cli.cli.commands.agent.mission import app
@@ -129,16 +160,12 @@ def test_create_feature_on_main_records_target_branch(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(app, ["create", "test-feature", "--json"])
     # Assert
-    assert result.exit_code == 0, f"Command failed: {result.output}"
-    slugs = _get_mission_slugs(repo)
-    assert len(slugs) == 1
-    meta = _read_meta(repo, slugs[0])
-    assert meta["target_branch"] == "main"
+    _assert_protected_branch_refusal(result, repo, "main")
 
 
 @pytest.mark.usefixtures("_git_identity")
-def test_create_feature_on_master_records_target_branch(tmp_path, monkeypatch):
-    """create on master records target_branch='master'."""
+def test_create_feature_on_master_refused_by_protected_branch_guard(tmp_path, monkeypatch):
+    """create on the protected primary branch 'master' is refused (must use --start-branch)."""
     # Arrange
     from typer.testing import CliRunner
     from specify_cli.cli.commands.agent.mission import app
@@ -152,11 +179,7 @@ def test_create_feature_on_master_records_target_branch(tmp_path, monkeypatch):
     runner = CliRunner()
     result = runner.invoke(app, ["create", "test-feature", "--json"])
     # Assert
-    assert result.exit_code == 0, f"Command failed: {result.output}"
-    slugs = _get_mission_slugs(repo)
-    assert len(slugs) == 1
-    meta = _read_meta(repo, slugs[0])
-    assert meta["target_branch"] == "master"
+    _assert_protected_branch_refusal(result, repo, "master")
 
 
 @pytest.mark.usefixtures("_git_identity")
@@ -186,23 +209,39 @@ def test_create_feature_on_custom_branch_records_target_branch(tmp_path, monkeyp
 
 
 @pytest.mark.usefixtures("_git_identity")
-def test_create_feature_with_explicit_target_branch_flag(tmp_path, monkeypatch):
-    """--target-branch flag overrides current branch."""
+def test_create_feature_target_branch_mismatch_is_refused(tmp_path, monkeypatch):
+    """--target-branch pointing away from the checkout is refused (no create-time split-brain).
+
+    Pre-guard, ``--target-branch 2.x`` while parked on another branch recorded
+    ``2.x`` yet committed meta.json onto the checkout branch — the create-time
+    split-brain the coord-primary-partition-lock WP02 fix closed
+    (mission_creation.py:198-209). The shipped contract now refuses the mismatch:
+    the meta.json commit must land on the resolved target branch, so the operator
+    must be checked out on it.
+    """
     from typer.testing import CliRunner
     from specify_cli.cli.commands.agent.mission import app
 
     repo = _init_repo(tmp_path, "main")
     _setup_kittify(repo)
+    # A non-protected feature branch keeps the default topology single_branch, so
+    # the refusal is the crisp safe_commit branch-coherence error (no coordination
+    # branch is involved) rather than the protected-branch guard.
+    run_command(["git", "checkout", "-b", "feat/target-mismatch"], cwd=repo)
     monkeypatch.chdir(repo)
 
     runner = CliRunner()
     result = runner.invoke(app, ["create", "test-feature", "--json", "--target-branch", "2.x"])
 
-    assert result.exit_code == 0, f"Command failed: {result.output}"
-    slugs = _get_mission_slugs(repo)
-    assert len(slugs) == 1
-    meta = _read_meta(repo, slugs[0])
-    assert meta["target_branch"] == "2.x"
+    assert result.exit_code != 0, f"target/checkout mismatch must be refused: {result.output}"
+    payload = json.loads(result.output)
+    # A structured error is surfaced (the meta.json commit is refused rather than
+    # silently landing on the wrong branch); we assert the load-bearing invariant
+    # rather than a brittle message substring.
+    assert payload["error"], payload
+    # The split-brain is closed by construction: the guard blocked the commit, so
+    # no mission commit lands on the checkout branch (HEAD unchanged from Initial).
+    assert _head_commit_subject(repo) == "Initial", _head_commit_subject(repo)
 
 
 @pytest.mark.usefixtures("_git_identity")


### PR DESCRIPTION
## Fixes #3779 — `integration-tests-agent` red on `main`

Five tests in `tests/agent/` expected the **pre-guard** behavior where `spec-kitty agent mission create` on a protected primary branch (`main`/`master`), or with a `--target-branch` pointing away from the checkout, committed `meta.json` and succeeded. The coord-primary-partition-lock guard now correctly **refuses** that (planning artifacts must land on a feature branch / the resolved target), and these tests were never updated — so `integration-tests-agent` is red on `main` and **every open PR inherits a false red** via the `quality-gate` aggregate.

### Root cause: tests stale, not guard over-broad

Verified the sanctioned flow (`--start-branch` / a feature-branch checkout) and confirmed the guard is behaving as designed. No source/guard change — this is a test-only alignment.

### What changed (5 tests, 3 files)

- `test_create_feature_on_main` / `on_master` → assert the structured **protected-branch refusal** that names the `--start-branch` remedy, via a shared helper.
- `test_create_feature_with_explicit_target_branch_flag` → renamed to `..._target_branch_mismatch_is_refused`; asserts a `--target-branch`/checkout mismatch is refused (no create-time split-brain).
- `test_feature_slug_validation::test_valid_kebab_case_slugs_accepted` → drives the sanctioned create flow.
- `test_branch_context_uses_main…` → runs from inside the test repo so branch-context resolves the temp repo's branch (invocation-owned state), not the runner's checkout.

The **load-bearing invariant** each refusal test asserts is that the guard blocked the commit — `HEAD` is unchanged, so no mission commit lands on the wrong branch — rather than a brittle message substring or a disk-cleanup check. This is not green-washing: no `skip`/`xfail`; each test still exercises the real `mission create` flow and asserts a real shipped contract. The protected-branch guard's purpose (never commit planning artifacts to `main`) is untouched and still exercised.

### Verification

All five target tests green locally; `ruff` clean. Surfaced while landing #3774 (mission `mission-completion-terminal-state`), whose own changes are green — these baseline reds are unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790506945&installation_model_id=427282&pr_number=3781&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3781&signature=88dc19304a49ed3b11124337efb9ae6d5f4922107a30d4089df0ea2244ff3bf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->