### PR TITLE
ci(protect-main): accept rebase-merged PR commits via PR association

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -26,6 +26,8 @@ on:
 
 permissions:
   contents: read
+  # Needed to resolve a pushed commit's PR association (rebase-merge detection).
+  pull-requests: read
 
 jobs:
   check-merge-compliance:
@@ -40,6 +42,8 @@ jobs:
         env:
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           HEAD_COMMITTER_NAME: ${{ github.event.head_commit.committer.name }}
+          HEAD_SHA: ${{ github.event.head_commit.id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Skip check for repository initialization (first commit)
           if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
@@ -69,11 +73,29 @@ jobs:
             exit 0
           fi
 
-          # Check if this is a squash/rebase merge. GitHub appends the PR
-          # number as an end-of-subject suffix; issue references in prose do
+          # Check if this is a squash merge. GitHub appends the PR number as an
+          # end-of-subject suffix on squash merges; issue references in prose do
           # not count as PR merge evidence.
           if [[ "$COMMIT_SUBJECT" =~ \(#[0-9]+\)$ ]]; then
-            echo "✅ Commit is from a squash/rebase merge (PR reference suffix)"
+            echo "✅ Commit is from a squash merge (PR reference suffix)"
+            exit 0
+          fi
+
+          # Check if this is a rebase-and-merge (an intentional convention here).
+          # Rebase merge replays the PR's own commits verbatim -- no "(#PR)"
+          # suffix, and the committer is the original author -- so the commit is
+          # indistinguishable from a direct push by content alone. The reliable
+          # signal is the commit's PR association: a rebase-merged commit belongs
+          # to a pull request that was merged into main; a genuine direct push
+          # does not. MERGED_PR_FOR_HEAD may be pre-supplied (tests inject it);
+          # otherwise resolve it from the commits->pulls API.
+          MERGED_PR_FOR_HEAD="${MERGED_PR_FOR_HEAD:-}"
+          if [[ -z "$MERGED_PR_FOR_HEAD" && -n "${HEAD_SHA:-}" ]]; then
+            PULLS_JSON="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" 2>/dev/null || echo '[]')"
+            MERGED_PR_FOR_HEAD="$(echo "$PULLS_JSON" | jq -r 'first(.[] | select(.merged_at != null and .base.ref == "main") | .number) // empty')"
+          fi
+          if [[ -n "$MERGED_PR_FOR_HEAD" ]]; then
+            echo "✅ Commit belongs to merged PR #${MERGED_PR_FOR_HEAD} into main (rebase merge)"
             exit 0
           fi
 

--- a/tests/release/test_protect_main_workflow.py
+++ b/tests/release/test_protect_main_workflow.py
@@ -41,7 +41,12 @@ def _protect_main_script() -> str:
     )
 
 
-def _run_protect_main(tmp_path: Path, message: str, committer: str = "A Contributor") -> subprocess.CompletedProcess[str]:
+def _run_protect_main(
+    tmp_path: Path,
+    message: str,
+    committer: str = "A Contributor",
+    merged_pr: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
         {
@@ -50,6 +55,11 @@ def _run_protect_main(tmp_path: Path, message: str, committer: str = "A Contribu
             "GITHUB_STEP_SUMMARY": str(tmp_path / "summary.md"),
         }
     )
+    # The workflow resolves MERGED_PR_FOR_HEAD from the commits->pulls API when
+    # unset; injecting it directly exercises the rebase-merge decision without a
+    # live API call (HEAD_SHA is left unset, so the API branch is never entered).
+    if merged_pr is not None:
+        env["MERGED_PR_FOR_HEAD"] = merged_pr
     return subprocess.run(
         ["bash"],
         input=f"set -euo pipefail\n{_protect_main_script()}",
@@ -85,6 +95,38 @@ def test_protect_main_accepts_pr_merge_subjects(tmp_path: Path, message: str) ->
 )
 def test_protect_main_rejects_issue_references_outside_subject_suffix(tmp_path: Path, message: str) -> None:
     result = _run_protect_main(tmp_path, message)
+
+    assert result.returncode == 1
+    assert "Direct push to main branch detected" in result.stderr + result.stdout
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "fix(landing): raise a typed error when the pre-image restore fails",
+        "feat: a rebase-merged commit keeps its original subject\n\nNo PR suffix here.",
+    ],
+)
+def test_protect_main_accepts_rebase_merge_when_commit_belongs_to_merged_pr(
+    tmp_path: Path, message: str
+) -> None:
+    # Rebase-and-merge replays the PR's commits verbatim (no "(#PR)" suffix,
+    # author is the committer). The workflow accepts them via the commit's PR
+    # association, injected here as MERGED_PR_FOR_HEAD.
+    result = _run_protect_main(tmp_path, message, merged_pr="3791")
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "rebase merge" in result.stdout
+
+
+def test_protect_main_rejects_rebase_shaped_subject_with_no_merged_pr(tmp_path: Path) -> None:
+    # The same rebase-shaped subject with NO PR association is a genuine direct
+    # push and must still be rejected -- content alone never grants acceptance.
+    result = _run_protect_main(
+        tmp_path,
+        "fix(landing): raise a typed error when the pre-image restore fails",
+        merged_pr="",
+    )
 
     assert result.returncode == 1
     assert "Direct push to main branch detected" in result.stderr + result.stdout


### PR DESCRIPTION
## What this fixes

**Rebase-and-merge — this repo's intended merge convention — was red-maining the `Protect Main Branch` guard.** When a PR is rebase-merged, the guard's `check-merge-compliance` job flags the resulting commit as a **direct push** and fails on `main`. It just happened on #3791's merge: `main`'s head `fix(landing): …` was reported as "Direct push to main branch detected!" even though it went through a reviewed, green PR.

**Why:** the guard's existing "squash/rebase" rule only matched the `(#PR)` suffix GitHub appends on **squash** merges. A **rebase** merge replays the PR's own commits verbatim — no suffix, and the committer is the original author — so by commit content alone it's indistinguishable from a genuine direct push.

## The fix

Add the one signal that *does* distinguish them: the commit's **PR association**. The guard now resolves the pushed HEAD via the `commits/{sha}/pulls` API and accepts it when it belongs to a pull request **merged into `main`**. A real direct push — a novel commit that belongs to no merged PR — still fails closed, so the no-direct-push protection is intact.

- `pull-requests: read` permission + `HEAD_SHA`/`GH_TOKEN` on the step.
- The decision is injectable via `MERGED_PR_FOR_HEAD`, so the shell logic stays unit-tested without a live API call.

## Tests

`tests/release/test_protect_main_workflow.py` gains coverage: a suffix-less rebase subject is **accepted** when the commit belongs to a merged PR, and the **same subject is still rejected** with no PR association (content never grants acceptance). All 9 cases pass locally.

No changelog entry — this is internal CI/workflow tooling, not shipped-product behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790574029&installation_model_id=427282&pr_number=3796&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3796&signature=4297451ac08d75d2658355c2bdfa6080c99a905022ebe1ea1e5e7ea9966c761f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->