### PR TITLE
test(acceptance): make 4 accept path-convention tests hermetic (#3016 residual)

### DIFF
--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -81,6 +81,23 @@ def _approve_wp(feature_repo: Path, mission_slug: str, wp_id: str) -> None:
     )
 
 
+def _seed_convention_dirs(feature_repo: Path, mission_slug: str) -> None:
+    """Seed the software-dev path-convention dirs so accept's path gate is
+    satisfied deterministically.
+
+    Without this, the gate's outcome depends on ambient mission-config
+    resolution (#3016 residual): it fires in a plain local ``pytest`` run but
+    no-ops in CI's remote-less fixture, making these accept tests non-hermetic.
+    Seeding a realistic software-dev layout (src/ tests/ docs/ + the mission's
+    contracts/) pins the gate to *satisfied* in every environment. The
+    negative-path test injects its own mission and is unaffected.
+    """
+    for rel in ("src", "tests", "docs", f"kitty-specs/{mission_slug}/contracts"):
+        target = feature_repo / rel
+        target.mkdir(parents=True, exist_ok=True)
+        (target / ".gitkeep").write_text("", encoding="utf-8")
+
+
 def _force_lane(feature_repo: Path, mission_slug: str, wp_id: str, to_lane: str) -> None:
     """Force ``wp_id`` into ``to_lane`` via the canonical status engine.
 
@@ -164,6 +181,7 @@ def test_accept_command_reports_approved_wps_without_closing(
 
     monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
     _write_acceptance_meta(feature_repo, mission_slug)
+    _seed_convention_dirs(feature_repo, mission_slug)
     write_wp(feature_repo, mission_slug, "planned", "WP02")
     run(["git", "add", "."], cwd=feature_repo)
     run(["git", "commit", "-m", "Add second WP and meta"], cwd=feature_repo)
@@ -250,6 +268,7 @@ def test_accept_no_commit_reports_merge_pending_without_mutation(
 
     monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
     _write_acceptance_meta(feature_repo, mission_slug)
+    _seed_convention_dirs(feature_repo, mission_slug)
     run(["git", "add", "."], cwd=feature_repo)
     run(["git", "commit", "-m", "Add meta"], cwd=feature_repo)
     _approve_wp(feature_repo, mission_slug, "WP01")
@@ -496,6 +515,7 @@ def test_accept_does_not_require_done_evidence_for_approved_wp(
 
     monkeypatch.setattr(status_emit, "_saas_fan_out", lambda *args, **kwargs: None)
     _write_acceptance_meta(feature_repo, mission_slug)
+    _seed_convention_dirs(feature_repo, mission_slug)
     run(["git", "add", "."], cwd=feature_repo)
     run(["git", "commit", "-m", "Add meta"], cwd=feature_repo)
 

--- a/tests/specify_cli/test_canonical_acceptance.py
+++ b/tests/specify_cli/test_canonical_acceptance.py
@@ -908,6 +908,14 @@ class TestStrictShellPidGate:
 
     def test_strict_accept_passes_for_done_wps_without_shell_pid(self, tmp_path: Path) -> None:
         feature_dir = _setup_feature(tmp_path, all_done=True, wp_ids=["WP01", "WP02"])
+        # Seed the software-dev path-convention dirs so accept's path gate is
+        # satisfied deterministically. Without this the gate's outcome depends on
+        # ambient mission-config resolution (#3016 residual) -- it fires in a plain
+        # local run but no-ops in CI's remote-less fixture (non-hermetic).
+        for _rel in ("src", "tests", "docs", "kitty-specs/099-test-feature/contracts"):
+            _dir = tmp_path / _rel
+            _dir.mkdir(parents=True, exist_ok=True)
+            (_dir / ".gitkeep").write_text("", encoding="utf-8")
         tasks_dir = feature_dir / "tasks"
         # Orchestrator-style: done WPs with NO shell_pid stamped.
         for wp in ["WP01", "WP02"]:


### PR DESCRIPTION
## What

Make 4 `accept` path-convention tests hermetic. Test-only change; no production code.

## Why

These tests passed in CI only by environmental accident. Accept's path-convention gate (`acceptance/summary_core.py:evaluate_path_conventions`) fires only when `mission.config.paths` is truthy; the mission is resolved by `get_mission_for_feature`, which walks up from `feature_dir` for a `.kittify`. The temp-repo fixture (`tests/_support/git_template`) seeds only a `README.md`, so:

- **Plain local `pytest`** → mission resolves *with* `paths` → gate blocks accept (`exit 1`, `Software Dev Kitty expects workspace path: src/ (not found)`).
- **CI's remote-less fixture** → mission resolves *without* `paths` → gate no-ops → accept succeeds.

Same commit (`59e7bea`), opposite result. Verified by instrumenting the gate (`paths={'workspace':'src/',...} src_exists=False`) and against CI's e2e xunit artifact (all 3 `test_acceptance_support` cases pass on the same commit). This is a **test-hermeticity residual of #3016**, not a red-main — gated CI is green.

## How

Seed a realistic software-dev layout (`src/ tests/ docs/` + the mission's `contracts/`) in each affected test before invoking `accept`, pinning the gate to *satisfied* in every environment. The negative-path test injects its own mission with explicit `paths` and is unaffected.

Fixes local reds:
- `test_canonical_acceptance.py::TestStrictShellPidGate::test_strict_accept_passes_for_done_wps_without_shell_pid`
- `test_acceptance_support.py::test_accept_command_reports_approved_wps_without_closing`
- `test_acceptance_support.py::test_accept_no_commit_reports_merge_pending_without_mutation`
- `test_acceptance_support.py::test_accept_does_not_require_done_evidence_for_approved_wp`

## Test

`PYTHONPATH=src pytest tests/cross_cutting/misc/test_acceptance_support.py tests/specify_cli/test_canonical_acceptance.py` → **42 passed** (was 4 failed locally). Ruff clean.

Context: https://github.com/Priivacy-ai/spec-kitty/issues/3016#issuecomment-5461231276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NL6DT7jjh7iTJ1jiyBq5nZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790583402&installation_model_id=427282&pr_number=3797&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3797&signature=aa67a6fa309896778448a93fea31a49aa77ee637664359e8411298222a2b0f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->