### PR TITLE
docs(architecture): profile-load reliability findings + design (epic #3809)

### DIFF
--- a/docs/architecture/charter-backend-service-future.md
+++ b/docs/architecture/charter-backend-service-future.md
@@ -1,0 +1,88 @@
+---
+title: Charter Backend Service (Future — Backlog)
+description: 'Preliminary design for a separate charter/doctrine resolution process exposed as a stable API/MCP endpoint, enabling remote compute, shared caching, and out-of-cycle context precomputation. Backlog scope — explicitly NOT 3.2.6.'
+doc_status: draft
+updated: '2026-08-30'
+related:
+- docs/architecture/profile-load-reliability.md
+- docs/architecture/governed-profile-invocation.md
+- docs/architecture/multi-agent-orchestration.md
+---
+# Charter Backend Service (Future — Backlog)
+
+> **Scope:** **BACKLOG — explicitly NOT 3.2.6.** This is a *preliminary* design sketch
+> for discussion, not committed work. The near-term stabilization that must land first
+> (activation-data fix + orchestrator-injects contract + `/spk-load-profile`) is specified
+> in [Profile-Load Reliability](profile-load-reliability.md) §4. This document describes
+> the **evolution** that the orchestrator-injects contract deliberately makes possible.
+
+## 1. Motivation
+
+Today, charter/doctrine resolution runs **in-process, per invocation**, via the
+`spec-kitty` CLI (`agent profile show`, `charter context`). That is correct for a single
+orchestrator, but it couples every resolution to a local checkout and pays a cold-start +
+environment-drift cost each call. A separate, long-lived **charter backend process** —
+reached through a stable API and/or MCP endpoint — unlocks capabilities the in-process
+model cannot offer:
+
+- **Remote compute** — resolution runs where the doctrine corpus and compute live, not on
+  every consumer's machine; thin clients (CI, IDE agents, headless/cron, other repos) call
+  the same authority.
+- **Shared caching** — a warm process caches compiled charters, DRG traversals, profile
+  lineage, and action-scoped context across invocations and across consumers, instead of
+  recompiling per CLI call.
+- **Out-of-cycle context precomputation** — the backend can precompute and refresh
+  action-scoped context and profile bundles *ahead of* a mission/squad run (on charter
+  change, on a schedule), so dispatch reads a ready artifact rather than resolving on the
+  critical path.
+
+## 2. Design constraints (carried from the near-term work)
+
+1. **Same resolution contract.** The backend sits behind the *identical* contract the
+   orchestrator already uses in [Profile-Load Reliability](profile-load-reliability.md)
+   §4.2 — request `(profile_id, action)` → resolved profile + compact context. Adopting
+   it must not touch delegate prompts.
+2. **Fail-loud, never fail-open.** Backend-down or profile-unresolved surfaces as a hard
+   error at the orchestrator (substitute / activate / abort) — never a silently unprofiled
+   delegate. This is the invariant Issue 1 violated.
+3. **Overlays applied server-side.** Resolution must apply overlays, `specializes_from`
+   lineage, and `enhances`/`overrides` — the raw-YAML fallback that skips these is not an
+   acceptable backend response.
+4. **Loopback-only, read-only by default.** If exposed over HTTP, bind to `127.0.0.1`
+   read-only (consistent with the repo's loopback-only control-plane policy); do not force
+   HTTPS on an intentionally-loopback transport. Remote exposure is an explicit,
+   authenticated opt-in, not the default.
+
+## 3. Transport options (to evaluate, not yet decided)
+
+| Option | Wins | New failure modes |
+|---|---|---|
+| **Local daemon + API** (precedent: `sync/daemon_protocol.py`, `core/loopback_http.py`, `auth/loopback/callback_server.py`) | Warm authority; kills cold-start + install/PYTHONPATH drift; one source of truth across harnesses | Daemon lifecycle (start/stop/ports); staleness on charter change (needs reload/invalidation); availability dependency; real-port tests must run serially |
+| **MCP endpoint** | Directly serves shell-less harnesses (tool result → context, no shell); uniform across MCP-capable agents | "Interactively-authenticated MCP servers may be absent in headless/cron" — trades the shell-less gap for an absent-in-headless gap |
+| **Remote service** | Remote compute; shared cache across machines/repos; centrally-refreshed doctrine for a multi-repo program | Network dependency; auth/tenancy; cache-coherence; larger security surface |
+
+A likely path is **local daemon first** (behind the §2 contract), with MCP and remote
+exposure as later transports over the same core — but this is open for design review.
+
+## 4. Open questions
+
+- **Cache invalidation** — how does the backend detect charter/pack/DRG changes and
+  invalidate compiled artifacts without serving stale doctrine?
+- **Consistency vs. freshness** — for a long squad run, does a delegate get a pinned
+  snapshot (deterministic) or the latest (fresh)? The near-term design pins at dispatch;
+  the backend should keep that default.
+- **Authority reconciliation** — one canonical "squad-eligible profiles" query lives where
+  (backend endpoint vs. charter data)? This is the seam gap from
+  [Profile-Load Reliability](profile-load-reliability.md) §2.4, promoted to a first-class
+  API concern.
+- **Degradation** — precise behavior when the backend is unreachable: the orchestrator
+  falls back to in-process CLI resolution (same contract) and never to unprofiled dispatch.
+- **Relationship to `orchestrator-api`** — does this reuse or extend the existing external
+  orchestrator-api surface, or stand alone?
+
+## 5. Non-goals
+
+- Not a replacement for the in-process CLI resolution path — that remains the default and
+  the degradation target.
+- Not a prerequisite for fixing squad profile loading — the near-term design stands alone.
+- Not in 3.2.6.

--- a/docs/architecture/charter-backend-service-future.md
+++ b/docs/architecture/charter-backend-service-future.md
@@ -71,10 +71,11 @@ exposure as later transports over the same core — but this is open for design 
 - **Consistency vs. freshness** — for a long squad run, does a delegate get a pinned
   snapshot (deterministic) or the latest (fresh)? The near-term design pins at dispatch;
   the backend should keep that default.
-- **Authority reconciliation** — one canonical "squad-eligible profiles" query lives where
-  (backend endpoint vs. charter data)? This is the seam gap from
-  [Profile-Load Reliability](profile-load-reliability.md) §2.4, promoted to a first-class
-  API concern.
+- **Authority reconciliation** — the canonical "squad-eligible profiles" query is
+  **authored in charter data near-term** ([Profile-Load Reliability](profile-load-reliability.md)
+  §4.2 / §6 D4); the only backlog-open question is whether the backend later **exposes** it as
+  an endpoint. This is the seam gap from Profile-Load Reliability §2.4, promoted to a
+  first-class API concern.
 - **Degradation** — precise behavior when the backend is unreachable: the orchestrator
   falls back to in-process CLI resolution (same contract) and never to unprofiled dispatch.
 - **Relationship to `orchestrator-api`** — does this reuse or extend the existing external

--- a/docs/architecture/charter-backend-service-future.md
+++ b/docs/architecture/charter-backend-service-future.md
@@ -1,6 +1,6 @@
 ---
 title: Charter Backend Service (Future — Backlog)
-description: 'Preliminary design for a separate charter/doctrine resolution process exposed as a stable API/MCP endpoint, enabling remote compute, shared caching, and out-of-cycle context precomputation. Backlog scope — explicitly NOT 3.2.6.'
+description: 'Preliminary backlog design for a separate charter/doctrine resolution process behind a stable API/MCP endpoint: remote compute, shared caching, out-of-cycle precompute. Not 3.2.6.'
 doc_status: draft
 updated: '2026-08-30'
 related:

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -68,6 +68,8 @@ boundary rule and layout).
 - [Understanding the org doctrine layer](org-doctrine-layer.md) — built-in/org/project doctrine resolution.
 - [Understanding Charter: synthesis, DRG, and governed context](charter-synthesis-drg.md).
 - [Understanding governed profile invocation](governed-profile-invocation.md) — standalone dispatch under governance.
+- [Profile-load reliability](profile-load-reliability.md) — why squads stopped loading charter agent profiles, and the 3.2.6 stabilization design.
+- [Charter backend service (future)](charter-backend-service-future.md) — preliminary backlog design for a deployable charter/doctrine resolution endpoint.
 - [Documentation Mission Guide](documentation-mission.md) — the Documentation Kitty mission.
 - [Understanding the retrospective learning loop](retrospective-learning-loop.md) — the four-category model.
 - [The Artifact Placement Seam](artifact-placement-seam.md) — the layer model deciding which physical tree a mission artifact resolves to, and where callers bypass it.

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -21,6 +21,13 @@ work makes possible is a **separate, backlog-scoped** design — see
 > charter API. The squad overturned an initial mis-attribution (see §2.4) and converged
 > on the activation-allowlist root cause with live-command and git evidence.
 
+> **Tracking.** Epic [#3809](https://github.com/Priivacy-ai/spec-kitty/issues/3809)
+> ("squads must never dispatch unprofiled"). Children: #3810 (activation-allowlist bug,
+> §4.1), #3811 (orchestrator-injects fail-loud contract, §4.2), #3812 (`/spk-load-profile`,
+> §4.3), #3813 (WP-prompt hygiene, §4.4), #3814 (research/doc template parity), #3816
+> (`directive:<id>` selector bug, §6 D1) — all milestone **3.2.6**; #3815 (charter-backend
+> design spike) in **Product backlog**.
+
 ## 1. Symptoms
 
 Squad delegates dispatched at a point-cut (per the `adversarial-squad` skill) were
@@ -179,7 +186,7 @@ hybrid §4.2:123 already names, but both narrow it:
      found"** for every directive ID tested (agent-profile / tactic / section selectors
      work; the *directive* selector does not). This makes "inject IDs, not bodies"
      (§4.2:121) a **dead end** — delegates cannot expand injected directive IDs. Fix the
-     selector, or inject directive bodies. **Needs its own ticket.**
+     selector, or inject directive bodies. **Filed as #3816 (3.2.6, P1, Bug).**
   2. **Sequencing dependency: §4.1 must land before any §4.2 injection rollout.** Injecting
      a resolved roster *today* would freeze the current 23-of-25 allowlist (daphne/randy
      de-activated) into every delegate with **no runtime recovery** — converting Issue 1
@@ -227,10 +234,10 @@ free-text positional is the wrong shape. **§4.3 is amended:**
   **seed of §4.2** (one source consumed by the skill roster, the guard, and the injector).
 - **Do not mark Issue 1 closed on §4.1 alone** — close it on §4.2; track §4.1 as mitigation.
 
-### New tickets surfaced by the dialectic (not in the original set)
+### New tickets surfaced by the dialectic (filed post-review)
 - **[Bug]** `charter context --include directive:<id>` selector returns `EXIT 1` for valid
-  directive IDs (D1.i above) — blocks the inject-IDs compaction strategy.
-- **[Constraint on #3811]** the fail-loud contract's guard and injector must consume one
-  canonical squad-eligible query (D4) — fold into #3810/#3811 acceptance criteria.
-- **[Constraint on #3812]** `/spk-load-profile` reconciles with `dispatch --profile` and
-  keeps a load-only path (D3) — fold into #3812 acceptance criteria.
+  directive IDs (D1.i above) — blocks the inject-IDs compaction strategy. **Filed #3816.**
+- **[Constraint]** the fail-loud contract's guard and injector must consume one canonical
+  squad-eligible query (D4) — **folded into #3810/#3811 acceptance criteria.**
+- **[Constraint]** `/spk-load-profile` reconciles with `dispatch --profile` and keeps a
+  load-only path (D3) — **folded into #3812 acceptance criteria.**

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -45,6 +45,7 @@ The loading **mechanism is healthy**. In live testing, 7/7 *activated* profiles 
 code or template regression.
 
 ### 2.1 The gate
+
 `src/specify_cli/cli/commands/profiles_cmd.py:337` (FR-014, introduced in #1636
 `488fe34e0c`) refuses any profile absent from the charter's `activated_agent_profiles`
 allowlist:
@@ -59,6 +60,7 @@ missing**. Count check: **25 source profiles, 23 activated → the 2 omitted are
 2 the squad skill recommends.**
 
 ### 2.2 The regression commit
+
 `9a99801f1b` (2026-08-08, *"feat(charter): activate writing-comms & diagramming doctrine
 set"*) first **materialized** the allowlist (23 entries) in
 `.kittify/charter/charter.yaml:1744`, silently omitting `doctrine-daphne` and
@@ -67,11 +69,13 @@ built-in profiles resolved (NFR-001 back-compat), so squads worked before that d
 matches "recently stopped."
 
 ### 2.3 It ships upstream
+
 `src/charter/packs/default.yaml:187` — the built-in default charter pack — carries the
 same allowlist and **also omits both profiles**. **Every new project inherits the gap**,
 not just this dogfooding checkout.
 
 ### 2.4 The seam gap (why it's silent)
+
 The `adversarial-squad` skill (`SKILL.md:43,47`) **hardcodes** the persona names
 `doctrine-daphne` and `randy-reducer` with no reconciliation against the activated set.
 Its fallback clause sanctions reading the raw YAML **only for "a read-only harness that
@@ -108,6 +112,7 @@ Three coordinated changes. The activation-data fix restores squads immediately; 
 orchestrator-injects contract closes the failure **class**.
 
 ### 4.1 Fix the activation data (close by construction)
+
 Activate the two doctrine lenses everywhere the allowlist is authored:
 - This project: `spec-kitty charter activate agent-profile doctrine-daphne randy-reducer`
   (or edit `charter.yaml` + `charter sync`).
@@ -117,6 +122,7 @@ Activate the two doctrine lenses everywhere the allowlist is authored:
   lenses). This closes the defect class per directive 043 (close-by-construction).
 
 ### 4.2 Orchestrator-resolves-then-injects (the durable seam fix)
+
 Make the **orchestrator** — the one context that reliably *can* resolve — load each lens
 **once**, with overlays / `specializes_from` lineage / `enhances`/`overrides` applied, and
 **inject the resolved profile + compact action context inline** into each delegate prompt.
@@ -132,6 +138,7 @@ Consequences:
   tactic stays **allowed where available**, never **required**.
 
 ### 4.3 The `/spk-load-profile <id> <instructions>` primitive
+
 Consolidate `spk-doctrine-profile-load` + the `ad-hoc-profile-load` alias into a single
 dispatch primitive `/spk-load-profile <name|id> <instructions>` that both **resolves** the
 profile and **carries the task** the profiled agent runs — the surface the orchestrator
@@ -140,6 +147,7 @@ test-locked — redirect, never delete). *(New surface: `/spk-load-profile` does
 today.)*
 
 ### 4.4 WP-prompt hygiene (LOW, optional)
+
 If pursued, rename WP-template references `/ad-hoc-profile-load → /spk-load-profile`,
 **keeping the leading slash**, and:
 - **Exclude** the alias-*declaring* surfaces (`spk-doctrine-profile-load/SKILL.md:35`,
@@ -174,6 +182,7 @@ Four dialectic squads (thesis ↔ antithesis, 8 profile-loaded delegates) stress
 **amends** the sections named. Confidence figures are the delegates' own.
 
 ### D1 — Resolution locus (§4.2): **hybrid, sharpened**
+
 Thesis (inject, 0.8) and antithesis (live-resolve, HIGH-on-facts) agree the answer is the
 hybrid §4.2:123 already names, but both narrow it:
 - **Injection carries a fail-loud FLOOR** — resolved profile identity + boundaries + proof
@@ -196,6 +205,7 @@ hybrid §4.2:123 already names, but both narrow it:
      self-heals once §4.1 lands; an injected one cannot.
 
 ### D2 — Backend service (§4.2-future / charter-backend-service-future.md): **keep backlog** (0.8 / 0.85, convergent)
+
 Both sides independently affirm the existing scope filing. The backend is the *right*
 boundary and *right to defer*. Hard gates before it leaves backlog:
 - Land §4.1 + §4.2 **first** — the backend fixes zero Issue-1 defects; a warm cache over
@@ -211,6 +221,7 @@ boundary and *right to defer*. Hard gates before it leaves backlog:
   checkout, not CWD — the environment-drift motivation is real but not yet urgent.)*
 
 ### D3 — `/spk-load-profile` shape (§4.3): **consolidate, but reconcile with `spec-kitty dispatch`**
+
 Thesis (0.72) and antithesis (moderate-high) converge: consolidation's atomicity win is
 real **for the orchestrator-emitted dispatch case**, but a naive `<id> <instructions>`
 free-text positional is the wrong shape. **§4.3 is amended:**
@@ -225,6 +236,7 @@ free-text positional is the wrong shape. **§4.3 is amended:**
   independently of task text.
 
 ### D4 — Issue 1 fix (§4.1 vs §4.2): **data-first, seam-closes** (0.85 / 0.85, convergent on sequencing)
+
 - **§4.1 data fix is the correct PRIMARY *first* move** — smallest surface, clears the
   freeze, restores squads, and (with the guard) discharges directive 043 for these two
   instances. Apply at **both** authoring sites (`charter.yaml` + `default.yaml:187`).
@@ -237,6 +249,7 @@ free-text positional is the wrong shape. **§4.3 is amended:**
 - **Do not mark Issue 1 closed on §4.1 alone** — close it on §4.2; track §4.1 as mitigation.
 
 ### New tickets surfaced by the dialectic (filed post-review)
+
 - **[Bug]** `charter context --include directive:<id>` selector returns `EXIT 1` for valid
   directive IDs (D1.i above) — blocks the inject-IDs compaction strategy. **Filed #3816.**
 - **[Constraint]** the fail-loud contract's guard and injector must consume one canonical

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -157,3 +157,80 @@ contract** without touching delegates. See
 > **Freeze note.** The `adversarial-squad` skill and charter packs are doctrine surfaces;
 > some changes may fall under the 3.2.x doctrine-surface freeze (`pr:deferred`). Sequence
 > the data fix (§4.1) first — it restores squads with the least surface.
+
+## 6. Dialectic review outcomes (2026-08-30)
+
+Four dialectic squads (thesis ↔ antithesis, 8 profile-loaded delegates) stress-tested the
+§4/§5 design. All four converged; none required synthesizer escalation. This section
+**amends** the sections named. Confidence figures are the delegates' own.
+
+### D1 — Resolution locus (§4.2): **hybrid, sharpened**
+Thesis (inject, 0.8) and antithesis (live-resolve, HIGH-on-facts) agree the answer is the
+hybrid §4.2:123 already names, but both narrow it:
+- **Injection carries a fail-loud FLOOR** — resolved profile identity + boundaries + proof
+  of successful resolution, **pinned at dispatch**. This is what makes "never dispatch
+  unprofiled" true and is the *only* path for CLI-less/shell-less/headless harnesses.
+- **On-demand pulls stay `required-capable`, not merely "allowed where available"** — a
+  delegate that needs an unanticipated tactic/body must be able to pull it live where the
+  harness permits; otherwise the on-demand path silently degrades on exactly the harnesses
+  that need it. Do **not** freeze *everything*.
+- **Two new must-fix findings (live-verified by the antithesis):**
+  1. **`spec-kitty charter context --include directive:<id>` returns `EXIT 1` "No directive
+     found"** for every directive ID tested (agent-profile / tactic / section selectors
+     work; the *directive* selector does not). This makes "inject IDs, not bodies"
+     (§4.2:121) a **dead end** — delegates cannot expand injected directive IDs. Fix the
+     selector, or inject directive bodies. **Needs its own ticket.**
+  2. **Sequencing dependency: §4.1 must land before any §4.2 injection rollout.** Injecting
+     a resolved roster *today* would freeze the current 23-of-25 allowlist (daphne/randy
+     de-activated) into every delegate with **no runtime recovery** — converting Issue 1
+     from "silent unprofiled" into "silently *wrong* roster, permanently." A live delegate
+     self-heals once §4.1 lands; an injected one cannot.
+
+### D2 — Backend service (§4.2-future / charter-backend-service-future.md): **keep backlog** (0.8 / 0.85, convergent)
+Both sides independently affirm the existing scope filing. The backend is the *right*
+boundary and *right to defer*. Hard gates before it leaves backlog:
+- Land §4.1 + §4.2 **first** — the backend fixes zero Issue-1 defects; a warm cache over
+  the same omitted allowlist is "faster and more consistently wrong."
+- **Design cache-invalidation before any cache is trusted** — a warm authority serving
+  stale doctrine violates the fail-loud invariant. This must land *on paper first*.
+- **Never a hard dependency** — degradation always falls back to in-process resolution,
+  never to unprofiled dispatch.
+- **Promotion triggers (a number, not an argument):** (1) measured resolution latency
+  materially on the dispatch critical path; (2) ≥2 repos in one program sharing a
+  centrally-refreshed corpus; (3) a real shell-less fleet dispatched by a non-orchestrator
+  surface. *(Live corroboration: a delegate's own CLI resolved doctrine from a sibling fork
+  checkout, not CWD — the environment-drift motivation is real but not yet urgent.)*
+
+### D3 — `/spk-load-profile` shape (§4.3): **consolidate, but reconcile with `spec-kitty dispatch`**
+Thesis (0.72) and antithesis (moderate-high) converge: consolidation's atomicity win is
+real **for the orchestrator-emitted dispatch case**, but a naive `<id> <instructions>`
+free-text positional is the wrong shape. **§4.3 is amended:**
+- **`spec-kitty dispatch` already carries load+task** (task positional, `--profile` flag —
+  `dispatch.py:225-232`). `/spk-load-profile` must be a **redirect/emitter over
+  `dispatch --profile` + the §4.2 inject contract, not a third resolution engine**
+  (directive 044 — else it duplicates `dispatch`).
+- **`<instructions>` must be passed structurally, not as a bare positional tail** — mirror
+  `dispatch`'s inversion, so there is no `<id> <instructions>` whitespace-split ambiguity.
+- **Keep a load-only interactive path** — the "adopt a profile" trigger has no single task;
+  `<instructions>` is optional, and pure-load must stay first-class and testable
+  independently of task text.
+
+### D4 — Issue 1 fix (§4.1 vs §4.2): **data-first, seam-closes** (0.85 / 0.85, convergent on sequencing)
+- **§4.1 data fix is the correct PRIMARY *first* move** — smallest surface, clears the
+  freeze, restores squads, and (with the guard) discharges directive 043 for these two
+  instances. Apply at **both** authoring sites (`charter.yaml` + `default.yaml:187`).
+- **§4.2 is the actual *class* close** — data alone leaves the fail-open fallback and the
+  two-list drift intact; the class recurs on the next `charter sync`/de-activation.
+- **Critical guard-design refinement (both delegates):** the §4.1 regression guard **must
+  derive its lens list from a single canonical "squad-eligible profiles" query**, not a
+  hand-copied list — otherwise it becomes a *third* drift-prone copy. That query is the
+  **seed of §4.2** (one source consumed by the skill roster, the guard, and the injector).
+- **Do not mark Issue 1 closed on §4.1 alone** — close it on §4.2; track §4.1 as mitigation.
+
+### New tickets surfaced by the dialectic (not in the original set)
+- **[Bug]** `charter context --include directive:<id>` selector returns `EXIT 1` for valid
+  directive IDs (D1.i above) — blocks the inject-IDs compaction strategy.
+- **[Constraint on #3811]** the fail-loud contract's guard and injector must consume one
+  canonical squad-eligible query (D4) — fold into #3810/#3811 acceptance criteria.
+- **[Constraint on #3812]** `/spk-load-profile` reconciles with `dispatch --profile` and
+  keeps a load-only path (D3) — fold into #3812 acceptance criteria.

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -1,0 +1,159 @@
+---
+title: Profile-Load Reliability (Squads & WP Prompts)
+description: 'Why adversarial/research squads stopped loading charter agent profiles, and the near-term stabilization design: orchestrator-resolves-then-injects, fail-loud dispatch, and the /spk-load-profile primitive.'
+doc_status: active
+updated: '2026-08-30'
+related:
+- docs/architecture/governed-profile-invocation.md
+- docs/architecture/multi-agent-orchestration.md
+- docs/architecture/charter-backend-service-future.md
+---
+# Profile-Load Reliability (Squads & WP Prompts)
+
+This document records a corroborated investigation into why **research / adversarial
+squads recently stopped loading charter agent profiles**, and defines the **near-term
+(3.2.6-scope) stabilization design**. The deployable charter-backend evolution that this
+work makes possible is a **separate, backlog-scoped** design — see
+[Charter Backend Service (Future)](charter-backend-service-future.md).
+
+> **Provenance.** Root cause established 2026-08-30 by a five-agent corroboration squad
+> (researcher, debugger, reviewer, architect lenses), each profile-loaded through the
+> charter API. The squad overturned an initial mis-attribution (see §2.4) and converged
+> on the activation-allowlist root cause with live-command and git evidence.
+
+## 1. Symptoms
+
+Squad delegates dispatched at a point-cut (per the `adversarial-squad` skill) were
+expected to load a doctrine lens via the charter API and act under it. Recently, delegates
+assigned certain lenses acted **unprofiled** — no initialization, boundaries, directives,
+or tactics applied — while nothing errored visibly at the orchestrator.
+
+## 2. Root cause — a charter activation-allowlist gap (Issue 1)
+
+The loading **mechanism is healthy**. In live testing, 7/7 *activated* profiles resolved
+`EXIT 0` through `spec-kitty agent profile show <id>`, and `spec-kitty charter context
+--action <x> --json` never failed. The failure is a **data + fail-open** defect, not a
+code or template regression.
+
+### 2.1 The gate
+`src/specify_cli/cli/commands/profiles_cmd.py:337` (FR-014, introduced in #1636
+`488fe34e0c`) refuses any profile absent from the charter's `activated_agent_profiles`
+allowlist:
+
+```
+Error: profile 'doctrine-daphne' is not activated.
+```
+
+The two source files exist (`packs/built-in/agent_profiles/doctrine-daphne.agent.yaml`,
+`…/randy-reducer.agent.yaml`) and are declared DRG nodes — they are **de-activated, not
+missing**. Count check: **25 source profiles, 23 activated → the 2 omitted are exactly the
+2 the squad skill recommends.**
+
+### 2.2 The regression commit
+`9a99801f1b` (2026-08-08, *"feat(charter): activate writing-comms & diagramming doctrine
+set"*) first **materialized** the allowlist (23 entries) in
+`.kittify/charter/charter.yaml:1744`, silently omitting `doctrine-daphne` and
+`randy-reducer`. The parent commit had **no allowlist key** → three-state `None` → *all*
+built-in profiles resolved (NFR-001 back-compat), so squads worked before that date. This
+matches "recently stopped."
+
+### 2.3 It ships upstream
+`src/charter/packs/default.yaml:187` — the built-in default charter pack — carries the
+same allowlist and **also omits both profiles**. **Every new project inherits the gap**,
+not just this dogfooding checkout.
+
+### 2.4 The seam gap (why it's silent)
+The `adversarial-squad` skill (`SKILL.md:43,47`) **hardcodes** the persona names
+`doctrine-daphne` and `randy-reducer` with no reconciliation against the activated set.
+Its fallback clause sanctions reading the raw YAML **only for "a read-only harness that
+cannot invoke the CLI."** A *de-activation* `EXIT 1` is a **different failure mode the
+clause does not cover** — so a compliant delegate has no sanctioned recovery and proceeds
+**unprofiled**. There is no canonical "squad-eligible profiles" query; the skill roster
+and the activation set drifted apart the moment the allowlist was compiled.
+
+> **Adjudicated divergence.** An initial trace blamed #1840 `60f038cee2` (2026-07-28) for
+> flipping the load instruction from a YAML read to a CLI call. The debugger and architect
+> lenses refuted this: #1840 **strengthened** the instruction (it never removed loading);
+> the CLI works for any *activated* profile. The true cause is the 2026-08-08 allowlist.
+> A secondary, narrower contributor remains for genuinely CLI-less harnesses: #1840's
+> fallback YAML path has since drifted across two relocations.
+
+## 3. Secondary finding — WP-prompt naming hygiene (Issue 2, LOW)
+
+- **`ad-hoc-load` does not exist anywhere** (0 hits). It is a conflation; the real token
+  is `/ad-hoc-profile-load`.
+- `/ad-hoc-profile-load` is a **deliberately maintained, test-locked** (`tests/doctrine/
+  test_spk_skill_pack.py:127`) compatibility alias for canonical
+  `spk-doctrine-profile-load`. It **resolves correctly** — nothing is broken. This is
+  canonical-naming drift (LOW), not a defect.
+- Software-dev WP source templates reference the legacy alias
+  (`packs/built-in/missions/software-dev/templates/task-prompt-template.md:31`, the
+  `implement`/`review`/`tasks(-packages)` prompts, `reviewer-implementer-role-separation.
+  tactic.yaml:26`, and the rc35 handoff migration).
+- **`research` and `documentation` task-prompt templates carry no profile-load section at
+  all** — a real cross-mission-type inconsistency, but *additive*, not a rename target.
+
+## 4. Near-term stabilization design (3.2.6 scope)
+
+Three coordinated changes. The activation-data fix restores squads immediately; the
+orchestrator-injects contract closes the failure **class**.
+
+### 4.1 Fix the activation data (close by construction)
+Activate the two doctrine lenses everywhere the allowlist is authored:
+- This project: `spec-kitty charter activate agent-profile doctrine-daphne randy-reducer`
+  (or edit `charter.yaml` + `charter sync`).
+- Upstream default pack: add both to `src/charter/packs/default.yaml:187`.
+- **Regression guard:** a test asserting *every lens the `adversarial-squad` skill names
+  resolves `EXIT 0`* (or, equivalently, source-profile-count parity for squad-eligible
+  lenses). This closes the defect class per directive 043 (close-by-construction).
+
+### 4.2 Orchestrator-resolves-then-injects (the durable seam fix)
+Make the **orchestrator** — the one context that reliably *can* resolve — load each lens
+**once**, with overlays / `specializes_from` lineage / `enhances`/`overrides` applied, and
+**inject the resolved profile + compact action context inline** into each delegate prompt.
+Consequences:
+- Removes the subagent's dependency on **any** runtime call (CLI *or* backend). Works for
+  read-only, shell-less, headless, and stale-cached-copy harnesses alike.
+- **Fail-loud by construction:** an unresolved / de-activated lens errors *at the
+  orchestrator*, which substitutes, activates, or aborts — a delegate can **never** be
+  dispatched unprofiled. This is what converts Issue 1's class from "silent unprofiled" to
+  "loud at dispatch."
+- Use `charter context`'s existing `mode: compact`; inject profile-init + boundaries +
+  directive **IDs**, not full bodies. Keep a *hybrid*: a runtime pull for an on-demand
+  tactic stays **allowed where available**, never **required**.
+
+### 4.3 The `/spk-load-profile <id> <instructions>` primitive
+Consolidate `spk-doctrine-profile-load` + the `ad-hoc-profile-load` alias into a single
+dispatch primitive `/spk-load-profile <name|id> <instructions>` that both **resolves** the
+profile and **carries the task** the profiled agent runs — the surface the orchestrator
+emits under §4.2. Retain the two existing names as **redirecting aliases** (they are
+test-locked — redirect, never delete). *(New surface: `/spk-load-profile` does not exist
+today.)*
+
+### 4.4 WP-prompt hygiene (LOW, optional)
+If pursued, rename WP-template references `/ad-hoc-profile-load → /spk-load-profile`,
+**keeping the leading slash**, and:
+- **Exclude** the alias-*declaring* surfaces (`spk-doctrine-profile-load/SKILL.md:35`,
+  `src/doctrine/skills/README.md:116`) — they are test-locked; editing them goes red.
+- Do it via a **new forward migration**, not by editing the shipped rc35 migration in
+  place (mutating emitted text diverges already-migrated installs).
+- Gate on `pytest tests/doctrine/test_spk_skill_pack.py`.
+- The research/documentation missing-section gap is a **separate additive** item.
+
+## 5. Scope boundary
+
+| In 3.2.6 | Backlog (NOT 3.2.6) |
+|---|---|
+| §4.1 activation-data fix + regression guard | Deployable charter backend service (API/MCP) |
+| §4.2 orchestrator-injects contract + fail-loud dispatch | Remote compute / shared cache / out-of-cycle context precompute |
+| §4.3 `/spk-load-profile` consolidation | — |
+| §4.4 WP-prompt hygiene (optional, LOW) | — |
+
+The backend evolution is deliberately **out of 3.2.6**. §4.2 is intentionally a transport
+change the *orchestrator* owns, so a future backend slots in behind the **same resolution
+contract** without touching delegates. See
+[Charter Backend Service (Future)](charter-backend-service-future.md).
+
+> **Freeze note.** The `adversarial-squad` skill and charter packs are doctrine surfaces;
+> some changes may fall under the 3.2.x doctrine-surface freeze (`pr:deferred`). Sequence
+> the data fix (§4.1) first — it restores squads with the least surface.

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -22,11 +22,13 @@ work makes possible is a **separate, backlog-scoped** design — see
 > on the activation-allowlist root cause with live-command and git evidence.
 
 > **Tracking.** Epic [#3809](https://github.com/Priivacy-ai/spec-kitty/issues/3809)
-> ("squads must never dispatch unprofiled"). Children: #3810 (activation-allowlist bug,
-> §4.1), #3811 (orchestrator-injects fail-loud contract, §4.2), #3812 (`/spk-load-profile`,
-> §4.3), #3813 (WP-prompt hygiene, §4.4), #3814 (research/doc template parity), #3816
-> (`directive:<id>` selector bug, §6 D1) — all milestone **3.2.6**; #3815 (charter-backend
-> design spike) in **Product backlog**.
+> ("squads must never dispatch unprofiled"). Children in **3.2.6**: #3810 (activation-
+> allowlist bug, §4.1), #3811 (orchestrator-injects fail-loud contract, §4.2), #3812
+> (`/spk-load-profile`, §4.3), #3813 (WP-prompt hygiene, §4.4), #3816 (`directive:<id>`
+> selector bug, §6 D1). In **Product backlog**: #3815 (charter-backend design spike) and
+> #3814 (research/doc template parity — demoted post scope-review as purely additive).
+> Hard dependency edges are encoded on the issues: #3810→#3811→#3812→#3813/#3814
+> (#3816 is a *soft* compaction edge on #3811, not a hard block).
 
 ## 1. Symptoms
 

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -1,6 +1,6 @@
 ---
 title: Profile-Load Reliability (Squads & WP Prompts)
-description: 'Why adversarial/research squads stopped loading charter agent profiles, and the near-term stabilization design: orchestrator-resolves-then-injects, fail-loud dispatch, and the /spk-load-profile primitive.'
+description: 'Why adversarial and research squads stopped loading charter agent profiles, and the 3.2.6 fix: resolve-then-inject, fail-loud dispatch, and a /spk-load-profile primitive.'
 doc_status: active
 updated: '2026-08-30'
 related:

--- a/docs/architecture/profile-load-reliability.md
+++ b/docs/architecture/profile-load-reliability.md
@@ -16,8 +16,8 @@ squads recently stopped loading charter agent profiles**, and defines the **near
 work makes possible is a **separate, backlog-scoped** design — see
 [Charter Backend Service (Future)](charter-backend-service-future.md).
 
-> **Provenance.** Root cause established 2026-08-30 by a five-agent corroboration squad
-> (researcher, debugger, reviewer, architect lenses), each profile-loaded through the
+> **Provenance.** Root cause established 2026-08-30 by five agents across four lenses
+> (researcher, debugger, reviewer, architect), each profile-loaded through the
 > charter API. The squad overturned an initial mis-attribution (see §2.4) and converged
 > on the activation-allowlist root cause with live-command and git evidence.
 
@@ -27,7 +27,7 @@ work makes possible is a **separate, backlog-scoped** design — see
 > (`/spk-load-profile`, §4.3), #3813 (WP-prompt hygiene, §4.4), #3816 (`directive:<id>`
 > selector bug, §6 D1). In **Product backlog**: #3815 (charter-backend design spike) and
 > #3814 (research/doc template parity — demoted post scope-review as purely additive).
-> Hard dependency edges are encoded on the issues: #3810→#3811→#3812→#3813/#3814
+> Hard dependency edges are encoded on the issues: #3810→#3811→#3812→#3813 (#3814 is a latent backlog edge — applies only if scheduled)
 > (#3816 is a *soft* compaction edge on #3811, not a hard block).
 
 ## 1. Symptoms
@@ -70,14 +70,16 @@ matches "recently stopped."
 
 ### 2.3 It ships upstream
 
-`src/charter/packs/default.yaml:187` — the built-in default charter pack — carries the
-same allowlist and **also omits both profiles**. **Every new project inherits the gap**,
+`src/charter/activation/packs/default.yaml:187` — the built-in default charter pack — carries its own
+narrower (16-entry) allowlist that **also omits both profiles**. **Every new project inherits the gap**,
 not just this dogfooding checkout.
 
 ### 2.4 The seam gap (why it's silent)
 
-The `adversarial-squad` skill (`SKILL.md:43,47`) **hardcodes** the persona names
-`doctrine-daphne` and `randy-reducer` with no reconciliation against the activated set.
+The `adversarial-squad` skill
+(`src/charter/offering/skills/adversarial-squad/SKILL.md`, `randy-reducer` at line 43,
+`doctrine-daphne` at line 47) **hardcodes** those persona names with no reconciliation
+against the activated set.
 Its fallback clause sanctions reading the raw YAML **only for "a read-only harness that
 cannot invoke the CLI."** A *de-activation* `EXIT 1` is a **different failure mode the
 clause does not cover** — so a compliant delegate has no sanctioned recovery and proceeds
@@ -116,10 +118,10 @@ orchestrator-injects contract closes the failure **class**.
 Activate the two doctrine lenses everywhere the allowlist is authored:
 - This project: `spec-kitty charter activate agent-profile doctrine-daphne randy-reducer`
   (or edit `charter.yaml` + `charter sync`).
-- Upstream default pack: add both to `src/charter/packs/default.yaml:187`.
+- Upstream default pack: add both to `src/charter/activation/packs/default.yaml:187`.
 - **Regression guard:** a test asserting *every lens the `adversarial-squad` skill names
   resolves `EXIT 0`* (or, equivalently, source-profile-count parity for squad-eligible
-  lenses). This closes the defect class per directive 043 (close-by-construction).
+  lenses). This discharges directive 043 (close-by-construction) for these two instances; the failure **class** closes on §4.2 — see §6 D4.
 
 ### 4.2 Orchestrator-resolves-then-injects (the durable seam fix)
 
@@ -127,15 +129,19 @@ Make the **orchestrator** — the one context that reliably *can* resolve — lo
 **once**, with overlays / `specializes_from` lineage / `enhances`/`overrides` applied, and
 **inject the resolved profile + compact action context inline** into each delegate prompt.
 Consequences:
-- Removes the subagent's dependency on **any** runtime call (CLI *or* backend). Works for
+- Removes the subagent's **mandatory** dependency on a runtime call (CLI *or* backend) — the
+  injected floor is self-contained; on-demand pulls remain `required-capable` per §6 D1. Works for
   read-only, shell-less, headless, and stale-cached-copy harnesses alike.
 - **Fail-loud by construction:** an unresolved / de-activated lens errors *at the
   orchestrator*, which substitutes, activates, or aborts — a delegate can **never** be
   dispatched unprofiled. This is what converts Issue 1's class from "silent unprofiled" to
   "loud at dispatch."
+- **Provenance:** injected delegates run as sub-invocations under the orchestrator's own Op
+  trail ([governed profile invocation](governed-profile-invocation.md)) — they open no
+  separate Op, keeping the audit record uniform with the `dispatch --profile` path (§4.3).
 - Use `charter context`'s existing `mode: compact`; inject profile-init + boundaries +
   directive **IDs**, not full bodies. Keep a *hybrid*: a runtime pull for an on-demand
-  tactic stays **allowed where available**, never **required**.
+  tactic stays **allowed where available** (sharpened to `required-capable` in §6 D1).
 
 ### 4.3 The `/spk-load-profile <id> <instructions>` primitive
 
@@ -144,7 +150,8 @@ dispatch primitive `/spk-load-profile <name|id> <instructions>` that both **reso
 profile and **carries the task** the profiled agent runs — the surface the orchestrator
 emits under §4.2. Retain the two existing names as **redirecting aliases** (they are
 test-locked — redirect, never delete). *(New surface: `/spk-load-profile` does not exist
-today.)*
+today.)* Per §6 D3 this is a redirect/emitter over `dispatch --profile`, **not** a third
+resolution engine (directive 044).
 
 ### 4.4 WP-prompt hygiene (LOW, optional)
 
@@ -184,7 +191,7 @@ Four dialectic squads (thesis ↔ antithesis, 8 profile-loaded delegates) stress
 ### D1 — Resolution locus (§4.2): **hybrid, sharpened**
 
 Thesis (inject, 0.8) and antithesis (live-resolve, HIGH-on-facts) agree the answer is the
-hybrid §4.2:123 already names, but both narrow it:
+hybrid §4.2 already names, but both narrow it:
 - **Injection carries a fail-loud FLOOR** — resolved profile identity + boundaries + proof
   of successful resolution, **pinned at dispatch**. This is what makes "never dispatch
   unprofiled" true and is the *only* path for CLI-less/shell-less/headless harnesses.
@@ -194,9 +201,9 @@ hybrid §4.2:123 already names, but both narrow it:
   that need it. Do **not** freeze *everything*.
 - **Two new must-fix findings (live-verified by the antithesis):**
   1. **`spec-kitty charter context --include directive:<id>` returns `EXIT 1` "No directive
-     found"** for every directive ID tested (agent-profile / tactic / section selectors
+     found"** for every directive ID tested (agent-profile and tactic selectors
      work; the *directive* selector does not). This makes "inject IDs, not bodies"
-     (§4.2:121) a **dead end** — delegates cannot expand injected directive IDs. Fix the
+     (§4.2) a **dead end** — delegates cannot expand injected directive IDs. Fix the
      selector, or inject directive bodies. **Filed as #3816 (3.2.6, P1, Bug).**
   2. **Sequencing dependency: §4.1 must land before any §4.2 injection rollout.** Injecting
      a resolved roster *today* would freeze the current 23-of-25 allowlist (daphne/randy
@@ -237,7 +244,7 @@ free-text positional is the wrong shape. **§4.3 is amended:**
 
 ### D4 — Issue 1 fix (§4.1 vs §4.2): **data-first, seam-closes** (0.85 / 0.85, convergent on sequencing)
 
-- **§4.1 data fix is the correct PRIMARY *first* move** — smallest surface, clears the
+- **§4.1 data fix is the correct primary *first* move** — smallest surface, clears the
   freeze, restores squads, and (with the guard) discharges directive 043 for these two
   instances. Apply at **both** authoring sites (`charter.yaml` + `default.yaml:187`).
 - **§4.2 is the actual *class* close** — data alone leaves the fail-open fallback and the

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -4416,6 +4416,16 @@ pages:
     - {slug: "step-implement", text: "Step: implement", level: 3}
     - {slug: "step-review", text: "Step: review", level: 3}
     - {slug: "step-retrospect", text: "Step: retrospect", level: 3}
+  - path: "docs/architecture/charter-backend-service-future.md"
+    title: "Charter Backend Service (Future — Backlog)"
+    divio_type: "none"
+    abstract: "Preliminary backlog design for a separate charter/doctrine resolution process behind a stable API/MCP endpoint: remote compute, shared caching, out-of-cycle precompute. Not 3.2.6."
+    anchors:
+    - {slug: "1-motivation", text: "1. Motivation", level: 2}
+    - {slug: "2-design-constraints-carried-from-the-near-term-work", text: "2. Design constraints (carried from the near-term work)", level: 2}
+    - {slug: "3-transport-options-to-evaluate-not-yet-decided", text: "3. Transport options (to evaluate, not yet decided)", level: 2}
+    - {slug: "4-open-questions", text: "4. Open questions", level: 2}
+    - {slug: "5-non-goals", text: "5. Non-goals", level: 2}
   - path: "docs/architecture/charter-pack-usage-journey.md"
     title: "Charter Pack Usage Journey: Apply, Generate, and the Dispatch Safety Net"
     divio_type: "none"
@@ -5036,6 +5046,30 @@ pages:
     - {slug: "uv-tool-2", text: "uv tool", level: 3}
     - {slug: "recommendation", text: "Recommendation", level: 2}
     - {slug: "see-also", text: "See also", level: 2}
+  - path: "docs/architecture/profile-load-reliability.md"
+    title: "Profile-Load Reliability (Squads & WP Prompts)"
+    divio_type: "none"
+    abstract: "Why adversarial and research squads stopped loading charter agent profiles, and the 3.2.6 fix: resolve-then-inject, fail-loud dispatch, and a /spk-load-profile primitive."
+    anchors:
+    - {slug: "1-symptoms", text: "1. Symptoms", level: 2}
+    - {slug: "2-root-cause-a-charter-activation-allowlist-gap-issue-1", text: "2. Root cause — a charter activation-allowlist gap (Issue 1)", level: 2}
+    - {slug: "2-1-the-gate", text: "2.1 The gate", level: 3}
+    - {slug: "2-2-the-regression-commit", text: "2.2 The regression commit", level: 3}
+    - {slug: "2-3-it-ships-upstream", text: "2.3 It ships upstream", level: 3}
+    - {slug: "2-4-the-seam-gap-why-it-s-silent", text: "2.4 The seam gap (why it's silent)", level: 3}
+    - {slug: "3-secondary-finding-wp-prompt-naming-hygiene-issue-2-low", text: "3. Secondary finding — WP-prompt naming hygiene (Issue 2, LOW)", level: 2}
+    - {slug: "4-near-term-stabilization-design-3-2-6-scope", text: "4. Near-term stabilization design (3.2.6 scope)", level: 2}
+    - {slug: "4-1-fix-the-activation-data-close-by-construction", text: "4.1 Fix the activation data (close by construction)", level: 3}
+    - {slug: "4-2-orchestrator-resolves-then-injects-the-durable-seam-fix", text: "4.2 Orchestrator-resolves-then-injects (the durable seam fix)", level: 3}
+    - {slug: "4-3-the-spk-load-profile-primitive", text: "4.3 The `/spk-load-profile <id> <instructions>` primitive", level: 3}
+    - {slug: "4-4-wp-prompt-hygiene-low-optional", text: "4.4 WP-prompt hygiene (LOW, optional)", level: 3}
+    - {slug: "5-scope-boundary", text: "5. Scope boundary", level: 2}
+    - {slug: "6-dialectic-review-outcomes-2026-08-30", text: "6. Dialectic review outcomes (2026-08-30)", level: 2}
+    - {slug: "d1-resolution-locus-4-2-hybrid-sharpened", text: "D1 — Resolution locus (§4.2): **hybrid, sharpened**", level: 3}
+    - {slug: "d2-backend-service-4-2-future-charter-backend-service-future-md-keep-backlog-0-8-0-85-convergent", text: "D2 — Backend service (§4.2-future / charter-backend-service-future.md): **keep backlog** (0.8 / 0.85, convergent)", level: 3}
+    - {slug: "d3-spk-load-profile-shape-4-3-consolidate-but-reconcile-with-spec-kitty-dispatch", text: "D3 — `/spk-load-profile` shape (§4.3): **consolidate, but reconcile with `spec-kitty dispatch`**", level: 3}
+    - {slug: "d4-issue-1-fix-4-1-vs-4-2-data-first-seam-closes-0-85-0-85-convergent-on-sequencing", text: "D4 — Issue 1 fix (§4.1 vs §4.2): **data-first, seam-closes** (0.85 / 0.85, convergent on sequencing)", level: 3}
+    - {slug: "new-tickets-surfaced-by-the-dialectic-filed-post-review", text: "New tickets surfaced by the dialectic (filed post-review)", level: 3}
   - path: "docs/architecture/retrospective-learning-loop.md"
     title: "Understanding the Retrospective Learning Loop"
     divio_type: "none"

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1496,6 +1496,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/architecture/charter-backend-service-future.md
+  tag: current
+  divio_type: none
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/architecture/charter-pack-usage-journey.md
   tag: current
   divio_type: none
@@ -1667,6 +1673,12 @@
 - path: docs/architecture/pip-vs-pipx-vs-uv.md
   tag: current
   divio_type: explanation
+  owning_workstream: none
+  current_target: true
+  notes: null
+- path: docs/architecture/profile-load-reliability.md
+  tag: current
+  divio_type: none
   owning_workstream: none
   current_target: true
   notes: null


### PR DESCRIPTION
## Impact

Research and adversarial **squads had been dispatching their delegates unprofiled** —
running with no doctrine lens, no boundaries, no directives — and **nothing errored**, so
the loss was silent. This PR is the corroborated **design record** that pins the root cause
and specifies the 3.2.6 fix. It is the reference the epic **#3809** issues implement
against. Docs only — no code or behavior change ships here.

## Root cause (five agents across four lenses)

The charter's `activated_agent_profiles` allowlist (materialized in `9a99801f1b`, 2026-08-08;
also the built-in default pack `src/charter/activation/packs/default.yaml:187`) omits
`doctrine-daphne` + `randy-reducer` — the two lenses the `adversarial-squad` skill hardcodes.
The FR-014 activation gate (`profiles_cmd.py:337`) returns `EXIT 1` for a de-activated
profile, the skill's raw-YAML fallback only covers CLI-less harnesses, so a compliant
delegate has no sanctioned recovery and proceeds **unprofiled**. It ships to every new
project. The resolution *mechanism* is healthy — this is a **data + fail-open** defect.

## Design (stress-tested by 4 dialectic squads, all convergent — §6)

- **§4.1** activation-data fix + regression guard (restores squads immediately; the guard
  sources its lens list from one canonical squad-eligible query, not a hand-copied roster).
- **§4.2** orchestrator-resolves-then-injects, **fail-loud** — the orchestrator resolves each
  lens once and injects a self-contained floor inline, so a delegate can *never* be
  dispatched unprofiled. Closes the failure **class** (§4.1 alone does not).
- **§4.3** `/spk-load-profile` as a thin redirect/emitter over `dispatch --profile`, not a
  third resolution engine.
- **Backend** (`charter-backend-service-future.md`) deliberately **backlog** — explicitly not
  3.2.6, gated on cache-invalidation-first + measured promotion triggers.

## Tracking

Epic **#3809** — children #3810–#3813, #3816 (3.2.6); #3814, #3815 (backlog). Hard dependency
edges #3810→#3811→#3812→#3813 are encoded on the issues.

## Adds

- `docs/architecture/profile-load-reliability.md` — root cause, adjudicated divergence, the
  3.2.6 stabilization design (§4), and the dialectic-review outcomes (§6).
- `docs/architecture/charter-backend-service-future.md` — preliminary **backlog** design for a
  deployable charter backend (API/MCP), explicitly out of 3.2.6.

## Landing notes

Landed via the maintainer runbook. Folds on top of the original commits:

- Registered both pages (index + page-inventory + docs-retrieval-index) and trimmed the two
  frontmatter descriptions into the SEO band — clearing `build` / `docs-freshness` /
  `fast-tests-docs` / `quality-gate`.
- Ran a **profile-loaded adversarial review squad** (debugger / architect / paula-patterns /
  reviewer-renata, opus-tier). All findings folded — the load-bearing one being a **MAJOR**
  dead file path (`src/charter/packs/default.yaml` → `src/charter/activation/packs/default.yaml`)
  that two lenses independently caught, plus §4↔§6 coherence, an Op-trail provenance gap, an
  SSOT authorship-boundary clarification, and citation/wording hygiene.

No changelog entry: these are internal architecture design records (working engineering
material), not a user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
