### PR TITLE
feat(charter): add `charter list --json` and close the non-mapping config.yaml crash class

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -540,6 +540,14 @@ _List activated doctrine artifacts by kind._
 │                             the built-in, org, and project layers (annotated │
 │                             by source layer), including the template kind.   │
 │                             Supersedes --show-available.                     │
+│ --json                      Output JSON. Every kind row always carries an    │
+│                             'available' key and the payload always carries a │
+│                             top-level 'templates' key — both are null unless │
+│                             requested (available: null without               │
+│                             --show-available/--all; templates: null without  │
+│                             --all) rather than absent, so callers can rely   │
+│                             on key presence and branch on the value instead  │
+│                             of on which flags were passed.                   │
 │ --help            -h        Show this message and exit.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -2585,14 +2593,34 @@ _Search tracker issues via the hosted read path_
 │                                                            squash.           │
 │ --delete-branch        --keep-branch                       Delete lane       │
 │                                                            branches after    │
-│                                                            merge             │
-│                                                            [default:         │
-│                                                            delete-branch]    │
+│                                                            merge. Unset (the │
+│                                                            default) defers   │
+│                                                            to the mission's  │
+│                                                            meta.json         │
+│                                                            retention policy  │
+│                                                            (#3131), falling  │
+│                                                            back to delete    │
+│                                                            when no policy is │
+│                                                            recorded. Passing │
+│                                                            either flag       │
+│                                                            explicitly always │
+│                                                            wins over the     │
+│                                                            mission's policy. │
 │ --remove-worktree      --keep-worktree                     Remove lane       │
 │                                                            worktrees after   │
-│                                                            merge             │
-│                                                            [default:         │
-│                                                            remove-worktree]  │
+│                                                            merge. Unset (the │
+│                                                            default) defers   │
+│                                                            to the mission's  │
+│                                                            meta.json         │
+│                                                            retention policy  │
+│                                                            (#3131), falling  │
+│                                                            back to remove    │
+│                                                            when no policy is │
+│                                                            recorded. Passing │
+│                                                            either flag       │
+│                                                            explicitly always │
+│                                                            wins over the     │
+│                                                            mission's policy. │
 │ --push                                                     Publish to origin │
 │                                                            after the local   │
 │                                                            merge (the        │
@@ -4385,9 +4413,15 @@ _Emit the open-Ops reminder for the Claude Code Stop hook._
 
  Commit spec artifacts to the mission's resolved placement.
 
- On a protected primary the coordination worktree is materialised on demand
- so the commit lands on the coordination branch (materialize-then-retry).
- On an unprotected or flattened primary the commit is direct.
+ SPEC is a primary/planning artifact: it lands on the mission's primary target
+ branch for every topology. On an unprotected or flattened primary the commit
+ is direct. On a PROTECTED primary the commit is refused (there is no fallback
+ surface); recover by either creating/checking out a non-protected feature
+ branch ('spec-kitty agent mission create --start-branch <feature-branch>') or
+ setting SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS=1 to commit on the current
+ branch.
+
+ Pass individual FILES, not directories.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    files      FILES...  Spec artifacts to commit (absolute or relative     │
@@ -4448,16 +4482,6 @@ _Emit the open-Ops reminder for the Claude Code Stop hook._
 ## spec-kitty sync
 
 _Synchronization commands_
-
-> **Inactive by default (opt-in).** As of the `sync-deactivate-by-default`
-> mission the legacy local-sync surface is **inactive on a bare install** — no
-> sync daemon is spawned and no events are emitted. The `sync` command group
-> stays registered, but when sync is not armed the subcommands report inactive
-> / no-op rather than doing work. Opt in by setting
-> `SPEC_KITTY_ENABLE_SAAS_SYNC=1` (and give per-project consent with
-> `spec-kitty sync opt-in`). `SPEC_KITTY_SYNC_DISABLE` /
-> `SPEC_KITTY_SYNC_MINIMAL_IMPORT` force it back off (disable wins). See
-> [Environment Variables § Sync activation precedence](environment-variables.md#sync-activation-precedence).
 
 ```
  Usage: spec-kitty sync [OPTIONS] COMMAND [ARGS]...

--- a/src/charter/activation/evidence/orchestrator.py
+++ b/src/charter/activation/evidence/orchestrator.py
@@ -12,10 +12,26 @@ from charter.activation.synthesizer.evidence import CodeSignals, CorpusSnapshot,
 from kernel.clock import now_utc_iso
 
 __all__ = [
+    "ConfigShapeError",
     "EvidenceOrchestrator",
     "load_url_list_from_config",
 ]
 
+
+class ConfigShapeError(RuntimeError):
+    """Raised when ``.kittify/config.yaml``'s top-level YAML content is not a mapping.
+
+    A YAML document need not be a mapping — ``just-a-string``, ``- a\\n- b``, and
+    ``42`` all parse without error but are not a ``dict``. Before this guard, a
+    corrupted or hand-edited config.yaml in this shape made ``config.get(...)``
+    raise a bare ``AttributeError`` that propagated, unhandled, all the way through
+    ``charter status --json`` (and ``synthesize``/``resynthesize``), leaking raw
+    Python exception text through the structured ``--json`` error envelope
+    (ledger SK-16). Raising this typed, message-carrying exception here keeps the
+    fail-closed outcome the ledger's SK-16 entry says is correct (exit 1,
+    ``success: false``) while replacing the leaked exception text with a
+    controlled diagnostic that names the file and the real problem.
+    """
 
 
 @dataclass
@@ -85,7 +101,20 @@ def load_url_list_from_config(repo_root: Path) -> tuple[str, ...]:
     `.kittify/charter/charter.yaml` rather than an inline mapping, so
     `synthesis_inputs.url_list` has no live config home there anymore.
     Returns an empty tuple whenever the key is absent, the file does not
-    exist, or `charter` is not a mapping (e.g. the path-string shape).
+    exist, or `charter` is not a mapping (e.g. the path-string shape) --
+    all of those are *valid, understood* config shapes.
+
+    A non-mapping *top-level* document is different: it is not a valid
+    config.yaml shape at all (corruption or a hand-editing mistake), so this
+    raises :class:`ConfigShapeError` rather than silently returning ``()``.
+    Silently returning empty here would make ``charter status --json`` exit 0
+    with a full success envelope on a corrupted config file -- exactly the
+    "silent success" failure mode this repository's own ledger (SK-16) and
+    charter treat as a defect class, not a style choice.
+
+    Raises:
+        ConfigShapeError: ``config.yaml``'s top-level YAML content parses but
+            is not a mapping (e.g. a bare scalar or a list).
     """
     config_path = repo_root / ".kittify" / "config.yaml"
     if not config_path.exists():
@@ -96,6 +125,12 @@ def load_url_list_from_config(repo_root: Path) -> tuple[str, ...]:
             config = yaml.load(fh) or {}
     except Exception:  # noqa: BLE001
         return ()
+    if not isinstance(config, dict):
+        raise ConfigShapeError(
+            f"{config_path} must be a YAML mapping at the top level; found "
+            f"{type(config).__name__} instead. Repair the file (it should look "
+            "like `charter: ...`) or restore it from version control."
+        )
     charter_cfg = config.get("charter") or {}
     if not isinstance(charter_cfg, dict):
         charter_cfg = {}

--- a/src/specify_cli/cli/commands/_command_surface_doctor.py
+++ b/src/specify_cli/cli/commands/_command_surface_doctor.py
@@ -736,6 +736,26 @@ def _configured_tool_keys(project_path: Path) -> list[str]:
     return sorted(set(load_agent_config(project_path).available))
 
 
+def _configured_tool_keys_or_exit(project_path: Path, json_output: bool) -> list[str]:
+    """Load configured tool keys, translating a config load failure to exit 2.
+
+    Mirrors :func:`_load_skills_state_or_exit`'s ``AgentConfigError`` handling
+    (the sibling ``doctor skills`` command) so a non-mapping
+    ``.kittify/config.yaml`` produces the documented ``config_error`` JSON
+    envelope instead of an uncaught traceback (OP-FRESH-001).
+    """
+    from specify_cli.core.agent_config import AgentConfigError
+
+    try:
+        return _configured_tool_keys(project_path)
+    except AgentConfigError as exc:
+        if json_output:
+            console.print_json(json.dumps(_json_error("config_error", str(exc)), indent=2))
+            raise typer.Exit(2) from exc
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(2) from exc
+
+
 def _print_tool_surface_human(outcome: object) -> None:
     """Render a compact human summary of a tool-surface outcome."""
     from specify_cli.tool_surface.service import ToolSurfaceOutcome
@@ -859,7 +879,7 @@ def run_tool_surfaces_audit(
 
     outcome = run_tool_surfaces(
         project_path,
-        _configured_tool_keys(project_path),
+        _configured_tool_keys_or_exit(project_path, json_output),
         tool_filter=tool,
         kinds=kinds or None,
         fix=fix,

--- a/src/specify_cli/cli/commands/charter/list_cmd.py
+++ b/src/specify_cli/cli/commands/charter/list_cmd.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import typer
 from specify_cli.cli.console import CliConsole
@@ -15,6 +17,7 @@ from charter.activation.pack_manager import AvailableArtifact, CharterPackManage
 from charter.resolution import ResolutionTier
 from charter.template_catalog import TemplateRef, TierRoot, discover_templates
 
+from specify_cli.cli.commands.charter._common import _emit_error
 from specify_cli.cli.commands.charter._layer_roots import resolve_layer_roots
 
 __all__ = ["charter_list_app"]
@@ -147,6 +150,18 @@ def list_cmd(
             "template kind. Supersedes --show-available."
         ),
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help=(
+            "Output JSON. Every kind row always carries an 'available' key "
+            "and the payload always carries a top-level 'templates' key — "
+            "both are null unless requested (available: null without "
+            "--show-available/--all; templates: null without --all) rather "
+            "than absent, so callers can rely on key presence and branch on "
+            "the value instead of on which flags were passed."
+        ),
+    ),
     repo_root: Path = typer.Option(Path("."), hidden=True),
 ) -> None:
     """List activated doctrine artifacts for each charter kind.
@@ -156,6 +171,19 @@ def list_cmd(
     layer — and appends the mission-scoped ``template`` kind (FR-025). Org and
     project doctrine roots are resolved here (in ``specify_cli``) and passed to
     the lower layers as data (C-008).
+
+    ``--json`` emits the same rows the human table shows, reusing the exact
+    same ``CharterPackManager`` / ``discover_templates`` calls rather than
+    re-deriving anything. Errors reuse the shared ``_emit_error`` envelope
+    (``{"result": "error", "success": false, "error": message}``).
+
+    Key presence is unconditional (OP-CONTRACT-003): each row in
+    ``payload["kinds"]`` always carries an ``available`` key, and
+    ``payload`` always carries a top-level ``templates`` key. Both are
+    ``null`` — never absent — when the corresponding flag wasn't passed
+    (``available`` needs ``--show-available``/``--all``; ``templates`` needs
+    ``--all``), mirroring the existing ``activated: null`` "not applicable"
+    convention used for the all-built-ins state.
     """
     # --all implies and supersedes --show-available (it is a richer, layer-aware
     # availability view).
@@ -176,6 +204,10 @@ def list_cmd(
         header = "Available (all layers)" if all_layers else "Available (not activated)"
         table.add_column(header, style="dim")
 
+    # ``--json`` rows mirror the table rows exactly, built from the same
+    # manager calls in the same loop -- serialization, not re-derivation.
+    json_rows: list[dict[str, Any]] = []
+
     for kind in _KIND_ORDER:
         value = activated_map.get(kind)
         if value is None:
@@ -184,6 +216,15 @@ def list_cmd(
             activated_str = "[yellow](Nothing activated — explicit restriction)[/yellow]"
         else:
             activated_str = ", ".join(sorted(value))
+
+        json_row: dict[str, Any] = {
+            "kind": kind,
+            "activated": sorted(value) if value is not None else None,
+            # OP-CONTRACT-003: always present, not conditionally absent --
+            # null (not merely unset) when --show-available/--all wasn't
+            # passed, so callers can rely on key presence.
+            "available": None,
+        }
 
         if show_available:
             activated_set = value or frozenset()
@@ -205,18 +246,42 @@ def list_cmd(
                         ctx, kind, layer_roots=layer_roots
                     )
                 except ValueError as exc:
-                    console.print(f"[red]Error:[/red] {exc}")
+                    _emit_error(console, json_output=json_output, message=str(exc))
                     raise typer.Exit(1) from exc
                 available_str = _render_available(entries, activated_set)
+                not_activated_entries = sorted(
+                    (
+                        (e.artifact_id, e.layer)
+                        for e in entries
+                        if e.artifact_id not in activated_set
+                    ),
+                    key=lambda pair: (pair[0], pair[1]),
+                )
+                json_row["available"] = [
+                    {"artifact_id": aid, "layer": layer}
+                    for aid, layer in not_activated_entries
+                ]
             else:
                 available = manager.list_available(ctx, kind)
                 not_activated = sorted(available - activated_set) if available else []
                 available_str = (
                     ", ".join(not_activated) if not_activated else "[dim]—[/dim]"
                 )
+                json_row["available"] = not_activated
             table.add_row(kind, activated_str, available_str)
         else:
             table.add_row(kind, activated_str)
+
+        json_rows.append(json_row)
+
+    # OP-CONTRACT-003: "templates" is always present, not conditionally
+    # absent -- null (not merely unset) without --all, so callers can rely
+    # on key presence.
+    payload: dict[str, Any] = {
+        "result": "success",
+        "kinds": json_rows,
+        "templates": None,
+    }
 
     # FR-025: the template kind is mission-scoped and has no activation list, so
     # it only appears in the layer-aware (--all) availability view.
@@ -228,6 +293,19 @@ def list_cmd(
             "[dim](mission-scoped — not separately activated)[/dim]",
             _render_templates(template_refs),
         )
+        payload["templates"] = [
+            {
+                "template_id": ref.template_id,
+                "mission": ref.mission,
+                "name": ref.name,
+                "tier": ref.tier.value,
+            }
+            for ref in template_refs
+        ]
+
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return
 
     # The layer-aware view is intentionally wide (IDs + per-layer tags); render
     # it at a generous fixed width so artifact IDs are never word-wrapped into

--- a/src/specify_cli/cli/commands/charter/list_cmd.py
+++ b/src/specify_cli/cli/commands/charter/list_cmd.py
@@ -11,11 +11,13 @@ from specify_cli.cli.console import CliConsole
 from specify_cli.cli.console import console
 from rich.table import Table
 
+from charter.activation.evidence.orchestrator import ConfigShapeError
 from charter.activation.invocation_context import ProjectContext
 from charter.activation.kind_vocabulary import CHARTER_KIND_TOKENS
 from charter.activation.pack_manager import AvailableArtifact, CharterPackManager
 from charter.resolution import ResolutionTier
 from charter.template_catalog import TemplateRef, TierRoot, discover_templates
+from kernel.errors import KittyInternalConsistencyError
 
 from specify_cli.cli.commands.charter._common import _emit_error
 from specify_cli.cli.commands.charter._layer_roots import resolve_layer_roots
@@ -190,127 +192,150 @@ def list_cmd(
     if all_layers:
         show_available = True
 
-    ctx = ProjectContext.from_repo(repo_root)
-    manager = CharterPackManager()
-    activated_map = manager.list_activated(ctx)
+    try:
+        ctx = ProjectContext.from_repo(repo_root)
+        manager = CharterPackManager()
+        activated_map = manager.list_activated(ctx)
 
-    # Resolve org/project roots once when we need the layer-aware view (C-008).
-    layer_roots = resolve_layer_roots(repo_root) if all_layers else None
+        # Resolve org/project roots once when we need the layer-aware view (C-008).
+        layer_roots = resolve_layer_roots(repo_root) if all_layers else None
 
-    table = Table(title="Charter Activation State", show_lines=True)
-    table.add_column("Kind", style="bold cyan", no_wrap=True)
-    table.add_column("Activated", style="white")
-    if show_available:
-        header = "Available (all layers)" if all_layers else "Available (not activated)"
-        table.add_column(header, style="dim")
+        table = Table(title="Charter Activation State", show_lines=True)
+        table.add_column("Kind", style="bold cyan", no_wrap=True)
+        table.add_column("Activated", style="white")
+        if show_available:
+            header = "Available (all layers)" if all_layers else "Available (not activated)"
+            table.add_column(header, style="dim")
 
-    # ``--json`` rows mirror the table rows exactly, built from the same
-    # manager calls in the same loop -- serialization, not re-derivation.
-    json_rows: list[dict[str, Any]] = []
+        # ``--json`` rows mirror the table rows exactly, built from the same
+        # manager calls in the same loop -- serialization, not re-derivation.
+        json_rows: list[dict[str, Any]] = []
 
-    for kind in _KIND_ORDER:
-        value = activated_map.get(kind)
-        if value is None:
-            activated_str = "[dim](All built-ins — no explicit activation)[/dim]"
-        elif len(value) == 0:
-            activated_str = "[yellow](Nothing activated — explicit restriction)[/yellow]"
-        else:
-            activated_str = ", ".join(sorted(value))
+        for kind in _KIND_ORDER:
+            value = activated_map.get(kind)
+            if value is None:
+                activated_str = "[dim](All built-ins — no explicit activation)[/dim]"
+            elif len(value) == 0:
+                activated_str = "[yellow](Nothing activated — explicit restriction)[/yellow]"
+            else:
+                activated_str = ", ".join(sorted(value))
 
-        json_row: dict[str, Any] = {
-            "kind": kind,
-            "activated": sorted(value) if value is not None else None,
-            # OP-CONTRACT-003: always present, not conditionally absent --
-            # null (not merely unset) when --show-available/--all wasn't
-            # passed, so callers can rely on key presence.
-            "available": None,
+            json_row: dict[str, Any] = {
+                "kind": kind,
+                "activated": sorted(value) if value is not None else None,
+                # OP-CONTRACT-003: always present, not conditionally absent --
+                # null (not merely unset) when --show-available/--all wasn't
+                # passed, so callers can rely on key presence.
+                "available": None,
+            }
+
+            if show_available:
+                activated_set = value or frozenset()
+                if all_layers:
+                    # CL-006/NFR-002 (post-fix verification sweep, mission
+                    # up-mission-type-seam-01KZY1JB): for the ``mission-type``
+                    # kind, ``list_available_detailed`` reaches
+                    # ``scan_mission_types_dir`` directly (PR-CONTRACT-002) and
+                    # loud-fails BY DESIGN on a malformed/unreadable YAML file
+                    # anywhere in the built-in/org/project ``mission_types/``
+                    # layers -- same underlying primitive as the other CLI
+                    # surfaces this mission's grep found, a different direct
+                    # caller. A bare ``except ValueError`` also catches
+                    # ``pydantic.ValidationError`` (this scan's other documented
+                    # ``Raises`` type, see its docstring) since it subclasses
+                    # ``ValueError`` in the pinned pydantic version.
+                    try:
+                        entries = manager.list_available_detailed(
+                            ctx, kind, layer_roots=layer_roots
+                        )
+                    except ValueError as exc:
+                        _emit_error(console, json_output=json_output, message=str(exc))
+                        raise typer.Exit(1) from exc
+                    available_str = _render_available(entries, activated_set)
+                    not_activated_entries = sorted(
+                        (
+                            (e.artifact_id, e.layer)
+                            for e in entries
+                            if e.artifact_id not in activated_set
+                        ),
+                        key=lambda pair: (pair[0], pair[1]),
+                    )
+                    json_row["available"] = [
+                        {"artifact_id": aid, "layer": layer}
+                        for aid, layer in not_activated_entries
+                    ]
+                else:
+                    available = manager.list_available(ctx, kind)
+                    not_activated = sorted(available - activated_set) if available else []
+                    available_str = (
+                        ", ".join(not_activated) if not_activated else "[dim]—[/dim]"
+                    )
+                    json_row["available"] = not_activated
+                table.add_row(kind, activated_str, available_str)
+            else:
+                table.add_row(kind, activated_str)
+
+            json_rows.append(json_row)
+
+        # OP-CONTRACT-003: "templates" is always present, not conditionally
+        # absent -- null (not merely unset) without --all, so callers can rely
+        # on key presence.
+        payload: dict[str, Any] = {
+            "result": "success",
+            "kinds": json_rows,
+            "templates": None,
         }
 
-        if show_available:
-            activated_set = value or frozenset()
-            if all_layers:
-                # CL-006/NFR-002 (post-fix verification sweep, mission
-                # up-mission-type-seam-01KZY1JB): for the ``mission-type``
-                # kind, ``list_available_detailed`` reaches
-                # ``scan_mission_types_dir`` directly (PR-CONTRACT-002) and
-                # loud-fails BY DESIGN on a malformed/unreadable YAML file
-                # anywhere in the built-in/org/project ``mission_types/``
-                # layers -- same underlying primitive as the other CLI
-                # surfaces this mission's grep found, a different direct
-                # caller. A bare ``except ValueError`` also catches
-                # ``pydantic.ValidationError`` (this scan's other documented
-                # ``Raises`` type, see its docstring) since it subclasses
-                # ``ValueError`` in the pinned pydantic version.
-                try:
-                    entries = manager.list_available_detailed(
-                        ctx, kind, layer_roots=layer_roots
-                    )
-                except ValueError as exc:
-                    _emit_error(console, json_output=json_output, message=str(exc))
-                    raise typer.Exit(1) from exc
-                available_str = _render_available(entries, activated_set)
-                not_activated_entries = sorted(
-                    (
-                        (e.artifact_id, e.layer)
-                        for e in entries
-                        if e.artifact_id not in activated_set
-                    ),
-                    key=lambda pair: (pair[0], pair[1]),
-                )
-                json_row["available"] = [
-                    {"artifact_id": aid, "layer": layer}
-                    for aid, layer in not_activated_entries
-                ]
-            else:
-                available = manager.list_available(ctx, kind)
-                not_activated = sorted(available - activated_set) if available else []
-                available_str = (
-                    ", ".join(not_activated) if not_activated else "[dim]—[/dim]"
-                )
-                json_row["available"] = not_activated
-            table.add_row(kind, activated_str, available_str)
+        # FR-025: the template kind is mission-scoped and has no activation list, so
+        # it only appears in the layer-aware (--all) availability view.
+        if all_layers:
+            tier_roots = _template_tier_roots(repo_root, layer_roots or {})
+            template_refs = discover_templates(tier_roots=tier_roots)
+            table.add_row(
+                _TEMPLATE_KIND,
+                "[dim](mission-scoped — not separately activated)[/dim]",
+                _render_templates(template_refs),
+            )
+            payload["templates"] = [
+                {
+                    "template_id": ref.template_id,
+                    "mission": ref.mission,
+                    "name": ref.name,
+                    "tier": ref.tier.value,
+                }
+                for ref in template_refs
+            ]
+
+        if json_output:
+            print(json.dumps(payload, indent=2))
+            return
+
+        # The layer-aware view is intentionally wide (IDs + per-layer tags); render
+        # it at a generous fixed width so artifact IDs are never word-wrapped into
+        # unreadable fragments on narrow / non-tty terminals.
+        if all_layers:
+            _wide_console.print(table)
         else:
-            table.add_row(kind, activated_str)
-
-        json_rows.append(json_row)
-
-    # OP-CONTRACT-003: "templates" is always present, not conditionally
-    # absent -- null (not merely unset) without --all, so callers can rely
-    # on key presence.
-    payload: dict[str, Any] = {
-        "result": "success",
-        "kinds": json_rows,
-        "templates": None,
-    }
-
-    # FR-025: the template kind is mission-scoped and has no activation list, so
-    # it only appears in the layer-aware (--all) availability view.
-    if all_layers:
-        tier_roots = _template_tier_roots(repo_root, layer_roots or {})
-        template_refs = discover_templates(tier_roots=tier_roots)
-        table.add_row(
-            _TEMPLATE_KIND,
-            "[dim](mission-scoped — not separately activated)[/dim]",
-            _render_templates(template_refs),
-        )
-        payload["templates"] = [
-            {
-                "template_id": ref.template_id,
-                "mission": ref.mission,
-                "name": ref.name,
-                "tier": ref.tier.value,
-            }
-            for ref in template_refs
-        ]
-
-    if json_output:
-        print(json.dumps(payload, indent=2))
-        return
-
-    # The layer-aware view is intentionally wide (IDs + per-layer tags); render
-    # it at a generous fixed width so artifact IDs are never word-wrapped into
-    # unreadable fragments on narrow / non-tty terminals.
-    if all_layers:
-        _wide_console.print(table)
-    else:
-        console.print(table)
+            console.print(table)
+    except (ConfigShapeError, ValueError) as exc:
+        # ValueError: pack_manager._load_config / _activation_list_or_error
+        # (non-mapping or malformed .kittify/config.yaml) and
+        # list_available_detailed's mission-type ValueError (already
+        # guarded above for --all, but list_available's plain
+        # --show-available path reaches the same primitive unguarded).
+        # ConfigShapeError: kept for symmetry with the other guarded
+        # charter surfaces (status/synthesize/resynthesize) even though
+        # this command's own call chain does not currently raise it.
+        _emit_error(console, json_output=json_output, message=str(exc))
+        raise typer.Exit(1) from exc
+    except KittyInternalConsistencyError as exc:
+        # CharterPackConfigError (ProjectContext.from_repo ->
+        # PackContext.from_config -> pack_context._load_config) on a
+        # non-mapping .kittify/config.yaml or a dangling charter:
+        # pointer. str(exc) is just the opaque code
+        # (CHARTER_PACK_CONFIG_INVALID); surface .body too, matching
+        # the established pattern (synthesize.py's KittyInternalConsistencyError
+        # handler).
+        detail = f"{exc.code}: {exc.body}" if exc.body else exc.code
+        _emit_error(console, json_output=json_output, message=detail)
+        raise typer.Exit(1) from exc

--- a/src/specify_cli/cli/commands/charter/resynthesize.py
+++ b/src/specify_cli/cli/commands/charter/resynthesize.py
@@ -8,6 +8,7 @@ from specify_cli.cli.console import err_console
 from rich.panel import Panel
 from rich.text import Text
 
+from charter.activation.evidence.orchestrator import ConfigShapeError
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import (
@@ -222,7 +223,11 @@ def charter_resynthesize(  # noqa: C901
     except FileNotFoundError as e:
         _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
-    except TaskCliError as e:
+    except (TaskCliError, ConfigShapeError) as e:
+        # ConfigShapeError (a corrupt/non-mapping .kittify/config.yaml, ledger
+        # SK-16) is a controlled, expected diagnostic -- treated the same as
+        # TaskCliError, not routed through the generic "Unexpected error"
+        # branch below.
         _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:

--- a/src/specify_cli/cli/commands/charter/status.py
+++ b/src/specify_cli/cli/commands/charter/status.py
@@ -14,6 +14,7 @@ from typing import Any
 import typer
 from rich.table import Table
 
+from charter.activation.evidence.orchestrator import ConfigShapeError
 from specify_cli.task_utils import TaskCliError
 
 from specify_cli.cli.commands.charter._app import (
@@ -306,7 +307,11 @@ def status(  # noqa: C901
             if sub.get("remediation"):
                 console.print(f"    [dim]Run: {sub['remediation']}[/dim]")
 
-    except TaskCliError as e:
+    except (TaskCliError, ConfigShapeError) as e:
+        # ConfigShapeError (a corrupt/non-mapping .kittify/config.yaml, ledger
+        # SK-16) is a controlled, expected diagnostic -- treated the same as
+        # TaskCliError, not routed through the generic "Unexpected error"
+        # branch below.
         _emit_error(console, json_output=json_output, message=str(e))
         raise typer.Exit(code=1) from e
     except Exception as e:

--- a/src/specify_cli/cli/commands/charter/synthesize.py
+++ b/src/specify_cli/cli/commands/charter/synthesize.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 import typer
+from charter.activation.evidence.orchestrator import ConfigShapeError
 from charter.bundle import CHARTER_YAML
 from kernel.errors import KittyInternalConsistencyError
 from specify_cli.cli.console import err_console
@@ -552,7 +553,11 @@ def charter_synthesize(  # noqa: C901
                 "warnings": warnings_collected + [f"SynthesisError: {e}"],
             }, indent=2, sort_keys=True))
         raise typer.Exit(code=1) from e
-    except TaskCliError as e:
+    except (TaskCliError, ConfigShapeError) as e:
+        # ConfigShapeError (a corrupt/non-mapping .kittify/config.yaml, ledger
+        # SK-16) is a controlled, expected diagnostic -- treated the same as
+        # TaskCliError, not routed through the generic "Unexpected error"
+        # branch below.
         if json_output:
             print(json.dumps({
                 "result": "failure",

--- a/src/specify_cli/core/agent_config.py
+++ b/src/specify_cli/core/agent_config.py
@@ -71,6 +71,19 @@ def load_agent_config(repo_root: Path) -> AgentConfig:
         logger.error(f"Failed to load config: {e}")
         raise AgentConfigError(f"Invalid YAML in {config_file}: {e}") from e
 
+    # A YAML document need not be a mapping -- a bare scalar or a list parses
+    # without error but is not a dict, and the unguarded `data.get(...)` below
+    # raised a bare `AttributeError` on it (same defect class as ledger SK-16,
+    # `charter status --json`'s leaked-exception bug). Treat a non-mapping top
+    # level as a config error, matching the sibling raise two lines above --
+    # not a silent default, so the operator learns their config is corrupt
+    # instead of getting an unexplained "no agents configured".
+    if not isinstance(data, dict):
+        raise AgentConfigError(
+            f"Invalid config shape in {config_file}: expected a YAML mapping "
+            f"at the top level, got {type(data).__name__}"
+        )
+
     agents_data = data.get("agents") or data.get("tools") or {}
 
     # Parse settings from either the agents/tools dict or the top level

--- a/src/specify_cli/git/protection_policy.py
+++ b/src/specify_cli/git/protection_policy.py
@@ -27,6 +27,8 @@ Resolution rules (from ``contracts/protection-config.md``)
 +--------------------------------------------------+----------------------------------------------+
 | Malformed value (non-list under the key)         | Raises :class:`ProtectionConfigError`        |
 +--------------------------------------------------+----------------------------------------------+
+| Non-mapping top level (e.g. a bare scalar)       | Raises :class:`ProtectionConfigError`        |
++--------------------------------------------------+----------------------------------------------+
 
 The operator hatch ``SPEC_KITTY_ALLOW_PROTECTED_BRANCH_COMMITS`` (FR-006) is
 resolved onto ``operator_hatch_active``; when active, :meth:`is_protected`
@@ -157,6 +159,16 @@ def _load_kittify_config(repo_root: Path) -> dict:  # type: ignore[type-arg]
 
     Returns an empty dict when the file does not exist (normal for non-SK
     repos or repos without a ``protection:`` block).
+
+    Raises:
+        ProtectionConfigError: The file fails to parse, or parses to a
+            non-mapping top level (e.g. a bare scalar or a list). A YAML
+            document need not be a mapping, and the unguarded ``.get(...)``
+            calls in :func:`_resolve_protected_branches` raised a bare
+            ``AttributeError`` on that shape (same defect class as ledger
+            SK-16's ``charter status --json`` leak) -- fail-closed with a
+            typed, message-carrying error instead, per this module's own
+            documented "malformed value -> ``ProtectionConfigError``" contract.
     """
     config_file = repo_root / ".kittify" / "config.yaml"
     if not config_file.exists():
@@ -166,11 +178,19 @@ def _load_kittify_config(repo_root: Path) -> dict:  # type: ignore[type-arg]
     yaml.preserve_quotes = True
     try:
         with open(config_file, encoding="utf-8") as fh:
-            return yaml.load(fh) or {}
+            loaded = yaml.load(fh) or {}
     except Exception as exc:
         raise ProtectionConfigError(
             f"Failed to parse {config_file}: {exc}"
         ) from exc
+
+    if not isinstance(loaded, dict):
+        raise ProtectionConfigError(
+            f"{config_file} must be a YAML mapping at the top level; found "
+            f"{type(loaded).__name__} instead."
+        )
+
+    return loaded
 
 
 def _resolve_protected_branches(repo_root: Path) -> frozenset[str]:

--- a/tests/agent/test_agent_config_unit.py
+++ b/tests/agent/test_agent_config_unit.py
@@ -37,6 +37,29 @@ class TestCorruptYaml:
         assert "config.yaml" in str(exc_info.value)
 
 
+class TestNonMappingConfigShape:
+    def test_non_mapping_top_level_raises_agent_config_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``config.yaml`` whose top-level YAML content is a bare scalar
+        (valid YAML, not a mapping) previously crashed with a bare
+        ``AttributeError: 'str' object has no attribute 'get'`` from the
+        unguarded ``data.get("agents")`` call -- same defect class as ledger
+        SK-16 (``charter status --json``'s leaked-exception bug). It must
+        instead fail closed with a controlled ``AgentConfigError``, matching
+        the sibling raise for a YAML parse error two lines above."""
+        _write_config(tmp_path, "just-a-plain-string-not-a-mapping\n")
+
+        with pytest.raises(AgentConfigError) as exc_info:
+            load_agent_config(tmp_path)
+
+        message = str(exc_info.value)
+        assert "has no attribute" not in message, (
+            f"leaked a raw AttributeError instead of a controlled diagnostic: {message}"
+        )
+        assert "config.yaml" in message
+
+
 class TestUnknownAgentKey:
     def test_unknown_agent_reported(self, tmp_path: Path) -> None:
         """Unknown agent key should be explicitly reported."""

--- a/tests/charter/evidence/test_orchestrator.py
+++ b/tests/charter/evidence/test_orchestrator.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import pytest
 import ruamel.yaml
 
-from charter.activation.evidence.orchestrator import (    EvidenceOrchestrator,
+from charter.activation.evidence.orchestrator import (
+    ConfigShapeError,
+    EvidenceOrchestrator,
     EvidenceResult,
     load_url_list_from_config,
 )
@@ -94,6 +96,45 @@ def test_url_list_assembled(tmp_path: Path) -> None:
 
 def test_load_url_list_absent(tmp_path: Path) -> None:
     assert load_url_list_from_config(tmp_path) == ()
+
+
+def test_load_url_list_non_mapping_config_raises_config_shape_error(
+    tmp_path: Path,
+) -> None:
+    """SK-16 (corrected shape): a non-mapping top-level ``config.yaml`` must
+    fail closed with a controlled diagnostic -- not raise a bare
+    ``AttributeError``, and not silently succeed either.
+
+    ``config.yaml`` is normally a mapping, but a corrupted or hand-edited file
+    can carry a bare scalar (e.g. a plain string) at the top level. Before the
+    original SK-16 guard, ``config.get("charter")`` raised
+    ``AttributeError: 'str' object has no attribute 'get'`` -- this propagated
+    uncaught through ``EvidenceOrchestrator.collect()`` into ``charter status
+    --json``'s broad ``except Exception`` handler, leaking the raw exception
+    message as the structured envelope's ``"error"`` field.
+
+    A follow-up fix made the guard return ``()`` instead -- but that converts
+    a fail-closed diagnostic gap into a fully silent success: ``charter status
+    --json`` then exits 0 with a normal success envelope on a corrupted
+    config file, indistinguishable from a project with no configured URLs.
+    The ledger's own SK-16 entry says the pre-fix behaviour "fails closed...
+    this is *not* a silent success" -- only the *leaked exception text* was
+    the defect, not the fail-closed outcome. So the correct fix raises a
+    typed, message-carrying exception instead of either extreme.
+    """
+    kittify = tmp_path / ".kittify"
+    kittify.mkdir()
+    (kittify / "config.yaml").write_text(
+        "just-a-plain-string-not-a-mapping\n", encoding="utf-8"
+    )
+    with pytest.raises(ConfigShapeError) as excinfo:
+        load_url_list_from_config(tmp_path)
+    message = str(excinfo.value)
+    assert "has no attribute" not in message, (
+        f"leaked a raw AttributeError instead of a controlled diagnostic: {message}"
+    )
+    assert "config.yaml" in message
+    assert "str" in message
 
 
 def test_load_url_list_present(tmp_path: Path) -> None:

--- a/tests/git/test_protection_policy.py
+++ b/tests/git/test_protection_policy.py
@@ -168,6 +168,35 @@ def test_malformed_value_raises_protection_config_error(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Non-mapping top-level config.yaml → fail-closed error (defect class shared
+# with ledger SK-16, ``charter status --json``'s leaked-exception bug)
+# ---------------------------------------------------------------------------
+
+
+def test_non_mapping_top_level_raises_protection_config_error(
+    tmp_path: Path,
+) -> None:
+    """A ``config.yaml`` whose top-level YAML content is a bare scalar (valid
+    YAML, not a mapping) previously crashed with a bare
+    ``AttributeError: 'str' object has no attribute 'get'`` from the
+    unguarded ``data.get("protection")`` call in
+    ``_resolve_protected_branches``. It must instead fail closed with a
+    controlled ``ProtectionConfigError``, matching this module's own
+    documented "malformed value -> ProtectionConfigError" contract."""
+    repo = _build_git_repo(tmp_path / "non-mapping")
+    _write_kittify_config(repo, "just-a-plain-string-not-a-mapping\n")
+
+    with pytest.raises(ProtectionConfigError) as exc_info:
+        ProtectionPolicy.resolve(repo)
+
+    message = str(exc_info.value)
+    assert "has no attribute" not in message, (
+        f"leaked a raw AttributeError instead of a controlled diagnostic: {message}"
+    )
+    assert "config.yaml" in message
+
+
+# ---------------------------------------------------------------------------
 # T004 — row 5: hatch active → is_protected returns False
 # ---------------------------------------------------------------------------
 

--- a/tests/specify_cli/cli/commands/charter/test_charter_list_commands.py
+++ b/tests/specify_cli/cli/commands/charter/test_charter_list_commands.py
@@ -8,6 +8,7 @@ Covers FR-004, FR-005, FR-006, FR-007:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -174,3 +175,163 @@ class TestListShowAvailable:
         # other-directive is available and not activated → should appear in available column
         output = result.output
         assert "other-directive" in output
+
+
+# ---------------------------------------------------------------------------
+# charter list --json (issue #3839)
+# ---------------------------------------------------------------------------
+#
+# The human table already renders already-typed, already-structured data from
+# ``CharterPackManager`` / ``discover_templates``. ``--json`` reuses the exact
+# same manager calls and serializes the same rows -- not a re-derivation. The
+# error envelope reuses ``_emit_error`` from ``_common.py`` verbatim: shape is
+# ``{"result": "error", "success": false, "error": message}``.
+
+
+class TestListJson:
+    def test_json_flag_emits_valid_json(self, empty_project_root: Path) -> None:
+        """``--json`` output parses and carries a "success" envelope with every
+        canonical kind (derived from ``CHARTER_KIND_TOKENS``, not a re-declared
+        list -- mirrors ``TestKindOrderDerivedFromCanonical`` in
+        ``test_charter_list.py``), each with a null ``activated`` (all-built-ins
+        state) -- except ``mission-type``, which ``empty_project_root`` seeds
+        with an explicit ``mission_type_activations`` (WP04, C-A1: the
+        provisioned charter is the sole mission-type activation authority)."""
+        from charter.activation.kind_vocabulary import CHARTER_KIND_TOKENS
+
+        result = _invoke_list(empty_project_root, "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["result"] == "success", payload
+        kinds = {row["kind"]: row for row in payload["kinds"]}
+        assert set(kinds) == set(CHARTER_KIND_TOKENS)
+        for kind in CHARTER_KIND_TOKENS:
+            if kind == "mission-type":
+                assert kinds[kind]["activated"] == ["software-dev"], kinds[kind]
+                continue
+            assert kinds[kind]["activated"] is None, kinds[kind]
+
+    def test_json_no_table_markup_leaks(self, empty_project_root: Path) -> None:
+        """``--json`` output must be pure JSON -- no Rich table markup."""
+        result = _invoke_list(empty_project_root, "--json")
+        assert result.exit_code == 0, result.output
+        assert "Charter Activation State" not in result.output
+        json.loads(result.output)  # raises if anything but pure JSON
+
+    def test_json_shows_activated_directive(self, project_with_directive: Path) -> None:
+        """The activated directive row lists ``python-style-guide`` (same row
+        the human table shows, JSON-encoded rather than re-derived)."""
+        result = _invoke_list(project_with_directive, "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        kinds = {row["kind"]: row for row in payload["kinds"]}
+        assert kinds["directive"]["activated"] == ["python-style-guide"]
+
+    def test_json_empty_activation_list_is_empty_list_not_null(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit empty activation list (restriction) must serialize as
+        ``[]``, distinct from the ``null`` "all built-ins" state."""
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text(
+            "activated_directives: []\nmission_type_activations:\n  - software-dev\n",
+            encoding="utf-8",
+        )
+        result = _invoke_list(tmp_path, "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        kinds = {row["kind"]: row for row in payload["kinds"]}
+        assert kinds["directive"]["activated"] == []
+
+    def test_json_show_available_adds_available_field(
+        self, empty_project_root: Path
+    ) -> None:
+        """``--show-available --json`` adds an ``available`` list per kind,
+        reusing ``CharterPackManager.list_available`` (same call the human
+        table's third column uses)."""
+        with patch(
+            "charter.activation.pack_manager.CharterPackManager.list_available",
+            return_value=frozenset(["doctrine-entry-1", "doctrine-entry-2"]),
+        ):
+            result = _invoke_list(empty_project_root, "--show-available", "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        kinds = {row["kind"]: row for row in payload["kinds"]}
+        assert sorted(kinds["directive"]["available"]) == [
+            "doctrine-entry-1",
+            "doctrine-entry-2",
+        ]
+
+    def test_json_without_show_available_has_null_available_field(
+        self, empty_project_root: Path
+    ) -> None:
+        """Without ``--show-available``, every row still carries an
+        ``available`` key -- it is ``null``, not absent (OP-CONTRACT-003:
+        prefer always-present-with-null over conditionally-absent keys, so
+        callers can rely on key presence rather than branching on flags)."""
+        from charter.activation.kind_vocabulary import CHARTER_KIND_TOKENS
+
+        result = _invoke_list(empty_project_root, "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        # Count guard (OP-TESTS-003): a loop over an empty ``kinds`` list would
+        # pass this assertion trivially. Pin the exact count actually iterated.
+        assert len(payload["kinds"]) == len(CHARTER_KIND_TOKENS), payload["kinds"]
+        for row in payload["kinds"]:
+            assert "available" in row, row
+            assert row["available"] is None, row
+
+    def test_json_all_layers_includes_templates(self, empty_project_root: Path) -> None:
+        """``--all --json`` appends the mission-scoped ``templates`` list,
+        discovered via the same ``discover_templates`` call the human
+        ``--all`` view uses, mission-qualified (FR-025)."""
+        result = _invoke_list(empty_project_root, "--all", "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        template_ids = {t["template_id"] for t in payload["templates"]}
+        assert "software-dev/spec-template.md" in template_ids
+
+    def test_json_all_layers_available_field_carries_layer(
+        self, empty_project_root: Path
+    ) -> None:
+        """``--all --json``'s ``available`` entries are ``{artifact_id, layer}``
+        objects, matching the human view's per-layer annotation."""
+        result = _invoke_list(empty_project_root, "--all", "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        kinds = {row["kind"]: row for row in payload["kinds"]}
+        directive_available = kinds["directive"]["available"]
+        assert directive_available, "expected built-in directives to be available"
+        entry = directive_available[0]
+        assert set(entry) == {"artifact_id", "layer"}
+
+    def test_json_templates_null_without_all(self, empty_project_root: Path) -> None:
+        """Without ``--all``, the payload still carries a top-level
+        ``templates`` key -- it is ``null``, not absent (OP-CONTRACT-003; the
+        template kind is mission-scoped and only populated by the
+        layer-aware view, mirroring the human table)."""
+        result = _invoke_list(empty_project_root, "--json")
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert "templates" in payload, payload
+        assert payload["templates"] is None, payload
+
+    def test_json_all_value_error_routes_through_emit_error(
+        self, empty_project_root: Path
+    ) -> None:
+        """A ``ValueError`` from ``list_available_detailed`` under ``--all
+        --json`` must be reported through the shared ``_emit_error`` envelope
+        -- not leaked as unstructured stdout text."""
+        with patch(
+            "charter.activation.pack_manager.CharterPackManager.list_available_detailed",
+            side_effect=ValueError("boom"),
+        ):
+            result = _invoke_list(empty_project_root, "--all", "--json")
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload == {
+            "result": "error",
+            "success": False,
+            "error": "boom",
+        }

--- a/tests/specify_cli/cli/commands/charter/test_charter_list_commands.py
+++ b/tests/specify_cli/cli/commands/charter/test_charter_list_commands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from click.testing import Result
 from typer.testing import CliRunner
 
 from specify_cli.cli.commands.charter import charter_app
@@ -70,7 +71,7 @@ def project_with_directive(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _invoke_list(project_root: Path, *args: str) -> object:
+def _invoke_list(project_root: Path, *args: str) -> Result:
     """Invoke charter list with --repo-root."""
     return runner.invoke(
         charter_app,
@@ -335,3 +336,126 @@ class TestListJson:
             "success": False,
             "error": "boom",
         }
+
+
+# ---------------------------------------------------------------------------
+# charter list — non-mapping config.yaml guard (issue #3839 MAJOR finding)
+# ---------------------------------------------------------------------------
+#
+# ``charter list``'s own headline path (``ProjectContext.from_repo`` ->
+# ``PackContext.from_config`` -> ``pack_context._load_config``) had NO
+# exception boundary at all: a non-mapping ``.kittify/config.yaml`` raised
+# ``CharterPackConfigError`` (a ``KittyInternalConsistencyError``) uncaught,
+# through every entry path (plain ``list``, ``--show-available``, ``--all``),
+# both ``--json`` and rich-console modes -- exit 1 with EMPTY stdout and a raw
+# traceback on stderr. That is exactly the fail-quiet-becomes-traceback
+# outcome this mission (SK-16 lineage) exists to close, and this test file
+# had no non-mapping case for ``list`` itself before this addition -- that
+# gap is exactly what let the regression through.
+#
+# The full non-mapping space mirrors what the other four guarded readers
+# (``charter status``, ``synthesize``, ``resynthesize``,
+# ``doctor tool-surfaces``) were verified against: a bare string, a list, an
+# int, a float, and a bool top-level YAML document. ``None`` (an empty
+# document) is NOT an error -- ``pack_context._load_config`` and
+# ``pack_manager._load_config`` both resolve it to ``{}`` -- and is pinned
+# separately so the guard is never accidentally widened to reject it too.
+
+#: Non-mapping top-level YAML shapes. Every one of these parses without a
+#: YAML error but is not a ``dict``, so ``isinstance(data, dict)`` fails and
+#: ``PackContext.from_config`` raises ``CharterPackConfigError``.
+_NON_MAPPING_CONFIG_YAML: dict[str, str] = {
+    "string": "just-a-plain-string-not-a-mapping\n",
+    "list": "- a\n- b\n",
+    "int": "42\n",
+    "float": "3.14\n",
+    "bool": "true\n",
+}
+
+#: Every ``charter list`` entry path the maintainer's finding named --
+#: ``--show-available`` and ``--all`` hit the same unguarded call as plain
+#: ``list``, not just the already-guarded ``list_available_detailed`` path
+#: reached under ``--all``.
+_LIST_ENTRY_PATHS: dict[str, tuple[str, ...]] = {
+    "plain": (),
+    "show_available": ("--show-available",),
+    "all": ("--all",),
+}
+
+
+def _build_non_mapping_config(repo_root: Path, yaml_text: str) -> None:
+    kittify = repo_root / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "config.yaml").write_text(yaml_text, encoding="utf-8")
+
+
+@pytest.mark.parametrize("entry_name", sorted(_LIST_ENTRY_PATHS))
+@pytest.mark.parametrize("shape_name", sorted(_NON_MAPPING_CONFIG_YAML))
+class TestListNonMappingConfigGuard:
+    """Every entry path x every non-mapping shape, in both output modes."""
+
+    def test_json_mode_fails_closed_with_parseable_diagnostic(
+        self, tmp_path: Path, shape_name: str, entry_name: str
+    ) -> None:
+        _build_non_mapping_config(tmp_path, _NON_MAPPING_CONFIG_YAML[shape_name])
+        result = _invoke_list(
+            tmp_path, *_LIST_ENTRY_PATHS[entry_name], "--json"
+        )
+
+        assert result.exit_code == 1, (
+            f"charter list {_LIST_ENTRY_PATHS[entry_name]} --json must fail "
+            f"closed on a non-mapping ({shape_name}) config.yaml; got exit "
+            f"{result.exit_code}:\n{result.stdout}"
+        )
+        assert result.stdout.strip(), (
+            "expected JSON on stdout -- empty stdout is the pre-fix symptom "
+            "(the raw traceback went to stderr instead)"
+        )
+        assert "Traceback" not in result.stdout
+
+        payload = json.loads(result.stdout)  # raises if not parseable JSON
+        assert payload["result"] == "error", payload
+        assert payload["success"] is False, payload
+
+        message = payload["error"]
+        # Surface .body, not just str(exc) -- CHARTER_PACK_CONFIG_INVALID
+        # alone tells the consumer nothing.
+        assert message != "CHARTER_PACK_CONFIG_INVALID", (
+            f"diagnostic must carry the .body detail, not the bare code: {payload!r}"
+        )
+        assert "config.yaml" in message and "mapping" in message, (
+            f"diagnostic should name the file and the real problem: {payload!r}"
+        )
+
+    def test_rich_console_mode_fails_closed_without_traceback(
+        self, tmp_path: Path, shape_name: str, entry_name: str
+    ) -> None:
+        _build_non_mapping_config(tmp_path, _NON_MAPPING_CONFIG_YAML[shape_name])
+        result = _invoke_list(tmp_path, *_LIST_ENTRY_PATHS[entry_name])
+
+        assert result.exit_code == 1, (
+            f"charter list {_LIST_ENTRY_PATHS[entry_name]} must fail closed "
+            f"on a non-mapping ({shape_name}) config.yaml; got exit "
+            f"{result.exit_code}:\n{result.output}"
+        )
+        assert "Traceback" not in result.output
+        assert "config.yaml" in result.output and "mapping" in result.output, (
+            f"diagnostic should name the file and the real problem: {result.output!r}"
+        )
+
+
+class TestListNoneConfigResolvesToEmptyMapping:
+    """An empty ``.kittify/config.yaml`` (YAML ``None``) is NOT an error --
+    both loaders resolve it to ``{}``, distinct from every non-mapping shape
+    above."""
+
+    def test_empty_config_file_is_not_an_error(self, tmp_path: Path) -> None:
+        kittify = tmp_path / ".kittify"
+        kittify.mkdir()
+        (kittify / "config.yaml").write_text("", encoding="utf-8")
+
+        result = _invoke_list(tmp_path, "--json")
+
+        assert result.exit_code == 0, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["result"] == "success", payload

--- a/tests/specify_cli/cli/commands/charter/test_status_sk16_config_guard.py
+++ b/tests/specify_cli/cli/commands/charter/test_status_sk16_config_guard.py
@@ -1,0 +1,159 @@
+"""SK-16 (ledger) — ``charter status --json`` must not leak a raw exception,
+and must not turn a corrupted config into a silent success either.
+
+Contract under test
+--------------------
+A corrupted or hand-edited ``.kittify/config.yaml`` whose top-level YAML
+content is not a mapping (e.g. a bare scalar) previously made
+``load_url_list_from_config`` raise ``AttributeError: 'str' object has no
+attribute 'get'`` (``src/charter/activation/evidence/orchestrator.py``, the
+``config.get("charter")`` call had no ``isinstance(config, dict)`` guard,
+unlike the very next line's guard for ``charter_cfg``). That exception
+propagated uncaught through ``EvidenceOrchestrator.collect()`` ->
+``_collect_evidence_result`` -> ``_summarize_evidence`` ->
+``_collect_synthesis_status`` -> ``status()``'s broad
+``except Exception as e: _emit_error(..., message=str(e), unexpected=True)``.
+
+``_emit_error``'s envelope (``result``/``success``/``error`` keys) is already
+the structured shape the ``--json`` contract promises -- the defect is that
+the *content* of the ``"error"`` field was a raw, unhandled Python exception
+message rather than a controlled diagnostic.
+
+Captured-red evidence (live-evidence discipline)
+-------------------------------------------------
+Against unmodified ``orchestrator.py`` this fixture makes ``charter status
+--json`` exit non-zero with::
+
+    {"error": "'str' object has no attribute 'get'", "result": "error",
+     "success": false}
+
+-- exactly matching the ledger's captured output (SK-16, verified first-hand
+in this checkout).
+
+**A first attempt at this fix over-corrected.** Adding a bare
+``isinstance(config, dict): return ()`` guard made
+``load_url_list_from_config`` swallow the corruption entirely, so ``charter
+status --json`` exited 0 with a normal success envelope on a corrupted
+config file -- indistinguishable from a project with no configured URLs.
+The ledger's own SK-16 entry is explicit that the *pre-fix* behaviour "fails
+closed... this is *not* a silent success" -- only the leaked exception text
+was ever the defect. So the corrected contract this file now pins is: the
+command must still fail (exit 1, ``success: false``), and the ``"error"``
+field must carry a controlled diagnostic naming the real problem (the file
+and the non-mapping shape) instead of either a raw ``AttributeError`` or
+nothing at all.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+import specify_cli.cli.commands.charter as charter_pkg
+from specify_cli.cli.commands.charter import charter_app
+
+runner = CliRunner()
+
+pytestmark = [pytest.mark.fast]
+
+
+def _build_corrupt_config(repo_root: Path) -> None:
+    """A project root whose ``.kittify/config.yaml`` top level is a bare scalar.
+
+    No charter bundle is seeded: ``status()`` only gates on
+    ``_assert_bundle_compatible`` when ``charter.yaml`` exists, so a bare
+    ``.kittify/config.yaml`` is sufficient to reach the evidence-orchestrator
+    code path this test targets, without unrelated bundle scaffolding
+    (test-scaffolding-as-design-smell).
+    """
+    kittify = repo_root / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "config.yaml").write_text(
+        "just-a-plain-string-not-a-mapping\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture()
+def corrupt_config_repo(tmp_path: Path) -> Path:
+    _build_corrupt_config(tmp_path)
+    return tmp_path
+
+
+def _invoke_status_json(repo_root: Path) -> object:
+    """Invoke ``charter status --json`` with only the unrelated collectors stubbed.
+
+    ``_collect_synthesis_status`` (the collector that reaches
+    ``load_url_list_from_config`` via ``_collect_evidence_result`` ->
+    ``_summarize_evidence``) is deliberately left REAL -- it is the sole
+    variable under test. ``charter_sync`` / ``org_layer`` /
+    ``governance_references`` / ``freshness`` are stubbed to deterministic,
+    JSON-safe values (mirroring ``test_status_json_safe.py``'s harness) so a
+    bare, charter-less ``tmp_path`` repo is sufficient scaffolding.
+    """
+    with (
+        patch.object(charter_pkg, "find_repo_root", return_value=repo_root),
+        patch.object(
+            charter_pkg,
+            "_collect_charter_sync_status",
+            return_value={"available": False, "error": "no charter (test stub)"},
+        ),
+        patch(
+            "specify_cli.cli.commands.charter.status._collect_org_layer_status",
+            return_value={"packs": [], "has_built_in": True},
+        ),
+        patch(
+            "specify_cli.cli.commands.charter.status."
+            "_collect_governance_reference_status",
+            return_value={"available": True, "references": [], "warnings": []},
+        ),
+        patch("specify_cli.charter_runtime.freshness.compute_freshness") as compute_freshness,
+    ):
+        compute_freshness.return_value.to_dict.return_value = {}
+        return runner.invoke(charter_app, ["status", "--json"], catch_exceptions=False)
+
+
+class TestStatusJsonSurvivesNonMappingConfig:
+    def test_status_json_does_not_leak_raw_attribute_error(
+        self, corrupt_config_repo: Path
+    ) -> None:
+        """The envelope's ``error`` field (if any) must never be the bare
+        Python exception text -- the observable symptom of SK-16."""
+        result = _invoke_status_json(corrupt_config_repo)
+
+        assert result.stdout.strip(), "expected JSON on stdout"
+        payload = json.loads(result.stdout)
+        error_message = payload.get("error", "")
+        assert "has no attribute" not in error_message, (
+            "charter status --json leaked a raw AttributeError through the "
+            f"error envelope (SK-16): {payload!r}"
+        )
+
+    def test_status_json_fails_closed_with_structured_diagnostic_on_non_mapping_config(
+        self, corrupt_config_repo: Path
+    ) -> None:
+        """Post-fix: a non-mapping ``config.yaml`` top level must still FAIL
+        (exit != 0, ``success: false``) with a structured diagnostic naming
+        the real problem -- not a leaked ``AttributeError``, and not a
+        success envelope either. Silent success on a corrupted config is
+        this repository's dominant failure mode (charter, ledger SK-16)."""
+        result = _invoke_status_json(corrupt_config_repo)
+
+        assert result.exit_code != 0, (
+            f"charter status --json must fail closed on a non-mapping "
+            f"config.yaml (silent success is the defect ledger SK-16 warns "
+            f"against); got exit {result.exit_code}:\n{result.stdout}"
+        )
+        payload = json.loads(result.stdout)
+        assert payload["result"] == "error", payload
+        assert payload["success"] is False, payload
+        error_message = payload["error"]
+        assert "has no attribute" not in error_message, (
+            f"leaked a raw AttributeError instead of a controlled diagnostic: {payload!r}"
+        )
+        assert "config.yaml" in error_message, (
+            f"diagnostic should name the offending file: {payload!r}"
+        )

--- a/tests/specify_cli/cli/commands/test_doctor_tool_surfaces_config_error.py
+++ b/tests/specify_cli/cli/commands/test_doctor_tool_surfaces_config_error.py
@@ -1,0 +1,55 @@
+"""``doctor tool-surfaces`` must honour the doctor family's 0/1/2 JSON-envelope
+contract on a non-mapping ``.kittify/config.yaml`` (OP-FRESH-001).
+
+``_configured_tool_keys`` calls ``load_agent_config``, which raises
+``AgentConfigError`` for a non-mapping top-level YAML document (a bare scalar
+or a list). Before this fix that call site was unguarded, so the error
+propagated uncaught past ``run_tool_surfaces_audit`` as a raw exception
+instead of the structured ``config_error`` envelope the sibling command
+``doctor skills`` already emits (see
+``test_doctor_skills.py::test_skills_json_config_errors_are_machine_parseable``,
+which this test mirrors).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import specify_cli.cli.commands._command_surface_doctor as surface_doctor_mod
+from specify_cli.cli.commands.doctor import app
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+runner = CliRunner()
+
+
+def _write_non_mapping_config(repo_root: Path) -> None:
+    """Write a ``.kittify/config.yaml`` whose top-level YAML is a bare scalar.
+
+    Parses without a YAML syntax error but is not a ``dict``, so
+    ``load_agent_config`` raises ``AgentConfigError`` for an invalid config
+    *shape* (as opposed to a YAML *syntax* error, which the sibling
+    ``doctor skills`` config_error test already covers).
+    """
+    kittify = repo_root / ".kittify"
+    kittify.mkdir(parents=True, exist_ok=True)
+    (kittify / "config.yaml").write_text("just a bare scalar\n", encoding="utf-8")
+
+
+def test_tool_surfaces_json_config_error_is_machine_parseable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_non_mapping_config(tmp_path)
+    monkeypatch.setattr(surface_doctor_mod, "locate_project_root", lambda: tmp_path)
+
+    result = runner.invoke(app, ["tool-surfaces", "--json"])
+
+    assert result.exit_code == 2, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "config_error"
+    assert result.stderr == ""


### PR DESCRIPTION
## What changes

`spec-kitty charter list` gains a `--json` flag, so external consumers can enumerate charters programmatically instead of scraping the human table. It was the last adjacent surface without one (`charter status --json` and `charter context --json` both had it).

Second, a corrupt `.kittify/config.yaml` no longer surfaces a raw Python `AttributeError` to operators. Four commands that read that file — `charter status`, `charter synthesize`, `charter resynthesize` and `doctor tool-surfaces` — now fail closed with a structured diagnostic naming the actual problem ("expected a YAML mapping at the top level, got str") and the exit code their command family documents.

## Why the second change is larger than the issue asked

The issue reported one symptom: `charter status --json` emitting `{"error": "'str' object has no attribute 'get'"}` (defect-ledger SK-16). Review found the same unguarded `yaml.load(...) or {}` → `.get()` pattern in two more modules reading the same file, and a third command crashing with an uncaught traceback instead of its JSON envelope. Fixing only the reported instance would have left the class open, so all four are closed here.

One sibling defect was deliberately **not** folded in: `MigrationRunner.upgrade()` has no `try`/`except` around `migration.apply()`, so a raising migration skips the version-stamp finalize. It is real and verified, but pre-existing, unreachable from this change, and fixing it properly is migration-atomicity work (epic #3347) rather than something that belongs in this diff.

## Fail closed, not fail quiet

The first attempt at the SK-16 fix made the loader return empty on a malformed config, which turned a loud crash into `charter status` exiting 0 with a full success envelope on a corrupt file. Review caught it. The shipped fix raises a typed error that each caller catches explicitly — the ledger entry for SK-16 is specific that the original behaviour "fails closed... this is *not* a silent success", and that property is preserved.

## Testing

Red-first throughout: the ATDD test commit precedes the implementation commits, and every production change was verified to make its test fail when reverted — re-derived independently by a reviewer rather than taken on the implementer's word (`3 failed` with the SK-16 guard removed, `10 failed` with the `--json` branch removed, `13 failed / 18 passed` at the RED commit).

Gates run locally: `ruff check src/` clean, `mypy --strict` clean on every touched module, the C-007 symbol-level dead-code gate and the legacy-terminology gate green, and all three JSON surfaces verified to emit parseable JSON. `docs/api/cli-commands.md` was regenerated with its canonical generator, not hand-patched.

## Review trail

Two independent reviewers (contract and tests lenses), an anchored verification and a fresh sweep, committed under `kitty-ops/01M1HEDT43KPP7VE18GSM3SYX3.*`. Six findings raw, all six verified resolved; the fresh sweep found two more, one folded in and one recorded in the defect ledger.

Op: `01M1HEDT43KPP7VE18GSM3SYX3`.

Closes #3839

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790963347&installation_model_id=427282&pr_number=3842&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3842&signature=56c1afdfa12d123977a272a46d756cf4aecb7a855055ca4e3179f5f05013a249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->