### PR TITLE
test(sonar): clear new-code reliability asserts flagged on main

### DIFF
--- a/tests/doctrine/test_pack_manifest_schema.py
+++ b/tests/doctrine/test_pack_manifest_schema.py
@@ -123,7 +123,9 @@ class TestSchemaVersionAndRoundTrip:
         m = finalize_pack_manifest(
             PackManifest(generated_by="t", constituents=[_c(ArtifactKind.DIRECTIVE, "a")])
         )
-        assert dump_pack_manifest_bytes(m) == dump_pack_manifest_bytes(m)
+        first = dump_pack_manifest_bytes(m)
+        second = dump_pack_manifest_bytes(m)
+        assert first == second
 
     def test_builtin_variant_omits_fetched_nulls_on_all_pydantic_paths(self) -> None:
         manifest = PackManifest(source_type="built-in", constituents=[])

--- a/tests/specify_cli/compat/test_channel_aware_latest.py
+++ b/tests/specify_cli/compat/test_channel_aware_latest.py
@@ -130,9 +130,9 @@ class TestCacheVersionKey:
         assert rc_key != stable_key
 
     def test_prerelease_channel_key_is_deterministic(self) -> None:
-        assert _cache_version_key("2.0.11", prerelease=True) == _cache_version_key(
-            "2.0.11", prerelease=True
-        )
+        first = _cache_version_key("2.0.11", prerelease=True)
+        second = _cache_version_key("2.0.11", prerelease=True)
+        assert first == second
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sync/test_project_store_transactions.py
+++ b/tests/sync/test_project_store_transactions.py
@@ -326,13 +326,15 @@ def test_two_store_instances_serialize_shared_uuid_writes(
                     (PROJECT_UUID,),
                 )
                 first_entered.set()
-                assert release_first.wait(timeout=5)
+                if not release_first.wait(timeout=5):
+                    raise TimeoutError("release_first was not signaled within 5s")
         except BaseException as exc:  # pragma: no cover - asserted below
             failures.append(exc)
 
     def second_writer() -> None:
         try:
-            assert first_entered.wait(timeout=5)
+            if not first_entered.wait(timeout=5):
+                raise TimeoutError("first_entered was not signaled within 5s")
             second_attempting.set()
             with second.unit_of_work() as unit:
                 second_entered.set()
@@ -487,7 +489,8 @@ def test_busy_timeout_bounds_the_wait_under_contention(
                     (PROJECT_UUID,),
                 )
                 holder_entered.set()
-                assert release_holder.wait(timeout=10)
+                if not release_holder.wait(timeout=10):
+                    raise TimeoutError("release_holder was not signaled within 10s")
         except BaseException as exc:  # pragma: no cover - asserted below
             failures.append(exc)
 


### PR DESCRIPTION
## Why

SonarCloud's **new-code reliability** condition on `main` is failing the Quality Gate (rating **D**, threshold ≤ A). This is the *only* failing gate condition — coverage (92.2%), maintainability (A), security (A), duplication (0%), and hotspots (100%) all pass. The nightly `CI Quality` run is red solely because of this; push-triggered runs stay green because the `sonarcloud` job runs only on the nightly schedule.

The gate is driven by 8 new-code reliability findings. This PR clears the **5 test-side smells**. The **3 production findings** (`sync_doctor_core.py`, `event_journal/journal.py`, `sync/transport_attempts.py`, all "condition always evaluates true/false") were reviewed and are **Sonar dataflow false positives** — closure-mutated `nonlocal` and values sourced from SQLite rows that the analyzer can't constrain. Those are left for won't-fix triage in the Sonar UI; no correct guard is altered to appease the analyzer.

## What changed (behavior-preserving)

- **`tests/sync/test_project_store_transactions.py`** (S5915 — assert inside `try/except` that catches `AssertionError`): three concurrency-test worker threads used `assert <event>.wait(timeout=...)` inside an `except BaseException` handler whose whole job is to record failures for the main thread to assert on. Since `AssertionError` is a `BaseException`, the assert was swallowed by its own handler. Now raises `TimeoutError` instead — identical propagation into `failures`, but no self-caught assert.
- **`tests/specify_cli/compat/test_channel_aware_latest.py`** and **`tests/doctrine/test_pack_manifest_schema.py`** (S1764 — same actual and expected expression): determinism tests compared an identical call expression to itself. Split into two calls bound to `first`/`second`, which both satisfies Sonar and more honestly expresses "call twice, expect equal."

## Verification

- `ruff check` clean on all three files.
- `SPEC_KITTY_ENABLE_SAAS_SYNC=1 pytest tests/sync/test_project_store_transactions.py -n0` → **28 passed** (the three edited concurrency tests included).
- `pytest tests/specify_cli/compat/test_channel_aware_latest.py tests/doctrine/test_pack_manifest_schema.py` → **31 passed**.

## Sonar note

After merge, the 3 remaining production reliability findings still need **hotspot/false-positive triage in the Sonar UI** — they are correct code and should not be "fixed" in a follow-up. This PR alone should move new-code reliability back to A once the test findings clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791003549&installation_model_id=427282&pr_number=3846&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3846&signature=b0a8a28396a22930d890b67e8375f89d7b7d403a3c03726761ca980be1a208bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->