### PR TITLE
perf(runtime): read expected-artifacts.yaml once per gather, not twice (#3847)

### DIFF
--- a/src/charter/activation/mission_type_profiles.py
+++ b/src/charter/activation/mission_type_profiles.py
@@ -1152,8 +1152,8 @@ def _resolve_expected_artifacts_slot(
     # actual `dict[str, Any]` return type is invisible here too. The cast
     # documents the type `model_dump()` actually returns at runtime -- mypy
     # is not wrong about the code, only blind to it through this boundary
-    # (mirrors the identical rationale on `_resolve_org_manifest_mapping` in
-    # `runtime.next.runtime_bridge_io`).
+    # (mirrors the identical rationale on
+    # `charter.activation.manifest_loader._resolve_existing_org_roots`).
     return cast("_ExpectedArtifactsManifest", manifest.model_dump())
 
 

--- a/src/runtime/next/runtime_bridge_io.py
+++ b/src/runtime/next/runtime_bridge_io.py
@@ -84,7 +84,7 @@ import tempfile
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import yaml
 from mission_runtime import CommitTarget
@@ -922,66 +922,32 @@ def _presence_filenames_for(
     return frozenset(name_set.values())
 
 
-def _resolve_org_manifest_mapping(
-    mission_family: str, repo_root: Path | None
-) -> tuple[Mapping[str, Any] | None, list[Path]]:
-    """Return ``(mapping, org_roots)`` for *mission_family*'s org-tier
-    ``expected-artifacts.yaml``: the resolved mapping (or ``None`` when
-    *repo_root* is ``None``, resolves no existing org roots, or no org root has
-    a matching file), paired with the list of existing org roots that were
-    checked (``[]`` whenever the mapping is ``None``).
-
-    The ``org_roots`` are returned alongside the mapping so a caller that must
-    raise ``ManifestSchemaError`` can name the roots it checked in the origin
-    string, identically to resolver.py's org-tier construction, instead of
-    re-deriving them.
-
-    **WP02 (#3770) note:** :func:`_presence_filenames_for` no longer calls
-    this helper directly -- it now delegates its whole manifest load
-    (org-tier included) to :func:`charter.activation.manifest_loader.load_manifest`.
-    This helper's sole remaining caller is
-    :func:`_expected_artifacts_manifest_resolves`, which still needs the
-    bare "does an org file exist" boolean (not the loaded/validated
-    manifest) for the ``blocking_artifact_names`` tri-state (C-002).
-    """
-    if repo_root is None:
-        return None, []
-    from charter.drg import resolve_existing_org_roots  # noqa: PLC0415
-    from charter.activation.org_expected_artifacts import (  # noqa: PLC0415
-        resolve_org_expected_artifacts,
-    )
-
-    org_roots = resolve_existing_org_roots(repo_root)
-    if not org_roots:
-        return None, []
-    # `charter.*` is `follow_imports = "skip"` in [tool.mypy] (pyproject.toml)
-    # so unrelated pre-existing strict debt elsewhere in the charter package
-    # isn't walked by every importer's mypy run; that also erases
-    # `resolve_org_expected_artifacts`'s real `Mapping[str, Any] | None`
-    # return type to plain `Any` at this call boundary. The cast documents
-    # the type this function actually returns at runtime.
-    mapping = cast("Mapping[str, Any] | None", resolve_org_expected_artifacts(org_roots, mission_family))
-    return mapping, cast("list[Path]", org_roots)
-
-
 def _expected_artifacts_manifest_resolves(mission_family: str, repo_root: Path | None) -> bool:
     """True when an expected-artifacts manifest resolves for *mission_family*
     at either tier -- org first (FR-008), built-in fallback.
 
     The single per-:func:`gather_artifact_presence`-call source for
     ``ArtifactPresenceSnapshot.blocking_artifact_names``'s ``None`` vs. real
-    ``frozenset`` distinction (SPEC-FRESH-001, C-002) -- untouched by WP02:
-    still its own org-existence check via :func:`_resolve_org_manifest_mapping`
-    plus a bare built-in-tier presence check, independent of
-    :func:`_presence_filenames_for`'s (now authority-delegated) manifest load.
+    ``frozenset`` distinction (SPEC-FRESH-001, C-002).
+
+    **WP-dedup (#3847) note:** this used to re-read the manifest itself via
+    its own uncached ``_resolve_org_manifest_mapping`` (org tier) plus a bare
+    built-in-tier presence check -- independent of, and redundant with,
+    :func:`_presence_filenames_for`'s manifest load earlier in the same
+    :func:`gather_artifact_presence` call. It now reuses the SAME cached
+    authority :func:`_presence_filenames_for` already delegates to
+    (:func:`charter.activation.manifest_loader.load_manifest`), so the org
+    file (and the built-in tier) is read at most once per call instead of
+    twice. The tri-state contract is unchanged: ``load_manifest`` returns
+    ``None`` for genuine absence at both tiers (-> ``False`` here), a real
+    manifest for a valid, present manifest (-> ``True``), and raises
+    ``ManifestSchemaError``/``MalformedManifestError`` for a present-but-bad
+    manifest -- identical to the exceptions the old org/built-in reads
+    raised, just surfaced here instead of (redundantly) re-derived.
     """
-    org_mapping, _ = _resolve_org_manifest_mapping(mission_family, repo_root)
-    if org_mapping is not None:
-        return True
+    from charter.activation.manifest_loader import load_manifest  # noqa: PLC0415
 
-    from charter.missions import MissionTemplateRepository  # noqa: PLC0415
-
-    return MissionTemplateRepository.default().get_expected_artifacts(mission_family) is not None
+    return load_manifest(mission_family, repo_root=repo_root) is not None
 
 
 @dataclass(frozen=True)

--- a/tests/runtime/next/test_cli_guard_family.py
+++ b/tests/runtime/next/test_cli_guard_family.py
@@ -406,10 +406,12 @@ class TestAC1AC2ComposedActionGuardOrgTierConvergence:
 
 # ---------------------------------------------------------------------------
 # AC-8 -- ``resolve_org_roots`` (via ``resolve_existing_org_roots``, the
-# primitive ``_resolve_org_manifest_mapping`` actually calls) is invoked
-# with the real, non-``None`` ``repo_root`` the enclosing function already
-# holds -- at BOTH of ``_dn_dependency_gate``'s two distinct
-# ``_check_cli_guards`` call sites.
+# primitive the manifest-loader authority's org-tier resolution calls --
+# routed here through ``charter.activation.manifest_loader.load_manifest``,
+# not the retired ``_resolve_org_manifest_mapping`` this comment used to
+# name, #3847) is invoked with the real, non-``None`` ``repo_root`` the
+# enclosing function already holds -- at BOTH of ``_dn_dependency_gate``'s
+# two distinct ``_check_cli_guards`` call sites.
 # ---------------------------------------------------------------------------
 
 _CUSTOM_ORG_ONLY_FAMILY = "custom-onboarding-mission"
@@ -481,11 +483,19 @@ class TestAC8RepoRootThreadedThroughDnDependencyGate:
             current_step_id="implement",
         )
 
-        from charter import drg as charter_drg
+        # #3847: the org-root resolution this AC exercises now happens
+        # exclusively through `charter.activation.manifest_loader`'s cached
+        # authority (`_presence_filenames_for` -> `load_manifest`), which
+        # lazily imports `resolve_existing_org_roots` directly from its
+        # origin module (`charter.offering.drg.org_pack_config`) -- NOT
+        # through the `charter.drg` re-export the now-deleted
+        # `_resolve_org_manifest_mapping` used to call. Spy on the origin
+        # module so the patch is visible to that lazy import.
+        from charter.offering.drg import org_pack_config as charter_org_pack_config
 
-        real_resolve_existing_org_roots = charter_drg.resolve_existing_org_roots
+        real_resolve_existing_org_roots = charter_org_pack_config.resolve_existing_org_roots
         spy = MagicMock(side_effect=real_resolve_existing_org_roots)
-        monkeypatch.setattr(charter_drg, "resolve_existing_org_roots", spy)
+        monkeypatch.setattr(charter_org_pack_config, "resolve_existing_org_roots", spy)
 
         rb._dn_dependency_gate(ctx)
 
@@ -537,11 +547,19 @@ class TestAC8RepoRootThreadedThroughDnDependencyGate:
             current_step_id="specify",
         )
 
-        from charter import drg as charter_drg
+        # #3847: the org-root resolution this AC exercises now happens
+        # exclusively through `charter.activation.manifest_loader`'s cached
+        # authority (`_presence_filenames_for` -> `load_manifest`), which
+        # lazily imports `resolve_existing_org_roots` directly from its
+        # origin module (`charter.offering.drg.org_pack_config`) -- NOT
+        # through the `charter.drg` re-export the now-deleted
+        # `_resolve_org_manifest_mapping` used to call. Spy on the origin
+        # module so the patch is visible to that lazy import.
+        from charter.offering.drg import org_pack_config as charter_org_pack_config
 
-        real_resolve_existing_org_roots = charter_drg.resolve_existing_org_roots
+        real_resolve_existing_org_roots = charter_org_pack_config.resolve_existing_org_roots
         spy = MagicMock(side_effect=real_resolve_existing_org_roots)
-        monkeypatch.setattr(charter_drg, "resolve_existing_org_roots", spy)
+        monkeypatch.setattr(charter_org_pack_config, "resolve_existing_org_roots", spy)
 
         rb._dn_dependency_gate(ctx)
 

--- a/tests/runtime/next/test_presence_filenames.py
+++ b/tests/runtime/next/test_presence_filenames.py
@@ -124,3 +124,261 @@ class TestPresenceFilenamesRoutesThroughAuthority:
         _presence_filenames_for("software-dev")
 
         assert calls == [("software-dev", None)]
+
+
+# ---------------------------------------------------------------------------
+# #3847: characterize the `blocking_artifact_names` None-vs-frozenset
+# tri-state (C-002, #3729) through the REAL entry point
+# `gather_artifact_presence`, for every input class the planned dedup of
+# `_expected_artifacts_manifest_resolves` (reuse the cached `load_manifest`
+# authority instead of its own uncached `_resolve_org_manifest_mapping` +
+# bare built-in read) must preserve byte-exact. Characterization
+# (green-stays-green before AND after the dedup) -- not a regression pin for
+# a bug, per the module docstring's framing.
+# ---------------------------------------------------------------------------
+
+_TRISTATE_VALID_FAMILY = "tristate-valid-family"
+_TRISTATE_VALID_STEP = "tristate-step"
+_TRISTATE_VALID_YAML = f"""\
+schema_version: "1.0"
+mission_type: "{_TRISTATE_VALID_FAMILY}"
+manifest_version: "1"
+required_always: []
+required_by_step:
+  {_TRISTATE_VALID_STEP}:
+    - artifact_key: "output.tristate.main"
+      artifact_class: "output"
+      path_pattern: "tristate-artifact.md"
+      blocking: true
+optional_always: []
+"""
+
+# Mirrors TestGatherArtifactPresenceRaisesManifestSchemaErrorAtBothTiers's
+# built-in fixture shape (tests/runtime/next/test_pertype_presence_gate.py):
+# `not_a_real_field` trips `ExpectedArtifactManifest`'s `extra="forbid"`.
+_TRISTATE_SCHEMA_INVALID_FAMILY = "tristate-schema-invalid-family"
+_TRISTATE_SCHEMA_INVALID_YAML = f"""\
+schema_version: "1.0"
+mission_type: "{_TRISTATE_SCHEMA_INVALID_FAMILY}"
+manifest_version: "1"
+not_a_real_field: true
+"""
+
+_TRISTATE_MALFORMED_ORG_FAMILY = "tristate-malformed-org-family"
+_TRISTATE_MALFORMED_ORG_YAML = "schema_version: [unterminated flow seq\n"
+
+
+def _write_tristate_org_pack_config(repo_root: Path, *, packs: list[tuple[str, Path]]) -> None:
+    """Canonical ``charter_packs.org.packs`` shape (CR-04)."""
+    config_dir = repo_root / ".kittify"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["charter_packs:", "  org:", "    packs:"]
+    for name, local_path in packs:
+        lines.append(f"      - name: {name}")
+        lines.append(f"        local_path: {local_path}")
+    (config_dir / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_tristate_org_manifest(org_root: Path, mission_type: str, yaml_text: str) -> None:
+    target_dir = org_root / "missions" / mission_type
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "expected-artifacts.yaml").write_text(yaml_text, encoding="utf-8")
+
+
+@pytest.fixture
+def _tristate_valid_family_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from charter.missions import MissionTemplateRepository
+
+    missions_root = tmp_path / "missions-root-tristate-valid"
+    family_dir = missions_root / _TRISTATE_VALID_FAMILY
+    family_dir.mkdir(parents=True)
+    (family_dir / "expected-artifacts.yaml").write_text(_TRISTATE_VALID_YAML, encoding="utf-8")
+    monkeypatch.setattr(
+        MissionTemplateRepository,
+        "default",
+        classmethod(lambda cls: MissionTemplateRepository(missions_root)),
+    )
+
+
+@pytest.fixture
+def _tristate_schema_invalid_family_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from charter.missions import MissionTemplateRepository
+
+    missions_root = tmp_path / "missions-root-tristate-schema-invalid"
+    family_dir = missions_root / _TRISTATE_SCHEMA_INVALID_FAMILY
+    family_dir.mkdir(parents=True)
+    (family_dir / "expected-artifacts.yaml").write_text(
+        _TRISTATE_SCHEMA_INVALID_YAML, encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        MissionTemplateRepository,
+        "default",
+        classmethod(lambda cls: MissionTemplateRepository(missions_root)),
+    )
+
+
+class TestTristateCharacterizationThroughGatherArtifactPresence:
+    """#3847: pin ``ArtifactPresenceSnapshot.blocking_artifact_names``'s
+    None-vs-frozenset tri-state, plus the raise behavior, for all four input
+    classes -- exercised through ``gather_artifact_presence`` (the real
+    entry), not the helper in isolation. Must stay green both before and
+    after the dedup change."""
+
+    def setup_method(self) -> None:
+        from charter.activation.manifest_loader import clear_cache
+
+        clear_cache()
+
+    def teardown_method(self) -> None:
+        from charter.activation.manifest_loader import clear_cache
+
+        clear_cache()
+
+    def test_absent_at_both_tiers_yields_none(self, tmp_path: Path) -> None:
+        from runtime.next.runtime_bridge_io import gather_artifact_presence
+
+        feature_dir = tmp_path / "feature-absent"
+        feature_dir.mkdir()
+
+        snapshot = gather_artifact_presence(
+            feature_dir,
+            mission_family="totally-unregistered-tristate-family",
+            step_id="whatever",
+        )
+
+        assert snapshot.blocking_artifact_names is None
+
+    def test_present_and_valid_yields_real_frozenset(
+        self, tmp_path: Path, _tristate_valid_family_repo: None
+    ) -> None:
+        from runtime.next.runtime_bridge_io import gather_artifact_presence
+
+        feature_dir = tmp_path / "feature-valid"
+        feature_dir.mkdir()
+
+        snapshot = gather_artifact_presence(
+            feature_dir,
+            mission_family=_TRISTATE_VALID_FAMILY,
+            step_id=_TRISTATE_VALID_STEP,
+        )
+
+        assert snapshot.blocking_artifact_names is not None
+        assert isinstance(snapshot.blocking_artifact_names, frozenset)
+        assert snapshot.blocking_artifact_names == frozenset({"tristate-artifact.md"})
+
+    def test_present_and_malformed_org_manifest_raises(self, tmp_path: Path) -> None:
+        from charter.offering.missions.repository import MalformedManifestError
+        from runtime.next.runtime_bridge_io import gather_artifact_presence
+
+        project_root = tmp_path / "project-malformed"
+        project_root.mkdir()
+        org_root = tmp_path / "org-pack-malformed"
+        _write_tristate_org_manifest(
+            org_root, _TRISTATE_MALFORMED_ORG_FAMILY, _TRISTATE_MALFORMED_ORG_YAML
+        )
+        _write_tristate_org_pack_config(project_root, packs=[("acme", org_root)])
+        feature_dir = tmp_path / "feature-malformed"
+        feature_dir.mkdir()
+
+        with pytest.raises(MalformedManifestError):
+            gather_artifact_presence(
+                feature_dir,
+                mission_family=_TRISTATE_MALFORMED_ORG_FAMILY,
+                step_id="whatever",
+                repo_root=project_root,
+            )
+
+    def test_present_and_schema_invalid_raises_manifest_schema_error(
+        self, tmp_path: Path, _tristate_schema_invalid_family_repo: None
+    ) -> None:
+        from charter.activation.manifest_loader import ManifestSchemaError
+        from runtime.next.runtime_bridge_io import gather_artifact_presence
+
+        feature_dir = tmp_path / "feature-schema-invalid"
+        feature_dir.mkdir()
+
+        with pytest.raises(ManifestSchemaError) as exc_info:
+            gather_artifact_presence(
+                feature_dir,
+                mission_family=_TRISTATE_SCHEMA_INVALID_FAMILY,
+                step_id="whatever",
+            )
+
+        assert exc_info.value.mission_type == _TRISTATE_SCHEMA_INVALID_FAMILY
+
+
+# ---------------------------------------------------------------------------
+# #3847 dedup: the org-tier manifest read must happen exactly ONCE per
+# `gather_artifact_presence` call on the org happy path -- today it happens
+# twice (`_presence_filenames_for` via the cached `load_manifest` authority,
+# then again via `_expected_artifacts_manifest_resolves`'s own uncached
+# `_resolve_org_manifest_mapping`). RED before the dedup (2 reads), GREEN
+# after (1 read) -- pinned to #3847.
+# ---------------------------------------------------------------------------
+
+_DEDUP_ORG_FAMILY = "dedup-org-happy-path-family"
+_DEDUP_ORG_STEP = "dedup-step"
+_DEDUP_ORG_YAML = f"""\
+schema_version: "1.0"
+mission_type: "{_DEDUP_ORG_FAMILY}"
+manifest_version: "org-1"
+required_always: []
+required_by_step:
+  {_DEDUP_ORG_STEP}:
+    - artifact_key: "output.dedup.main"
+      artifact_class: "output"
+      path_pattern: "dedup-artifact.md"
+      blocking: true
+optional_always: []
+"""
+
+
+class TestExpectedArtifactsOrgReadDedup:
+    def setup_method(self) -> None:
+        from charter.activation.manifest_loader import clear_cache
+
+        clear_cache()
+
+    def teardown_method(self) -> None:
+        from charter.activation.manifest_loader import clear_cache
+
+        clear_cache()
+
+    @pytest.mark.regression
+    def test_org_manifest_read_exactly_once_per_gather_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import charter.activation.org_expected_artifacts as org_expected_artifacts_module
+        from runtime.next.runtime_bridge_io import gather_artifact_presence
+
+        project_root = tmp_path / "project-dedup"
+        project_root.mkdir()
+        org_root = tmp_path / "org-pack-dedup"
+        _write_tristate_org_manifest(org_root, _DEDUP_ORG_FAMILY, _DEDUP_ORG_YAML)
+        _write_tristate_org_pack_config(project_root, packs=[("acme", org_root)])
+        feature_dir = tmp_path / "feature-dedup"
+        feature_dir.mkdir()
+
+        calls: list[str] = []
+        original = org_expected_artifacts_module.resolve_org_expected_artifacts
+
+        def _counting(org_roots: list[Path], mission_type: str) -> object:
+            calls.append(mission_type)
+            return original(org_roots, mission_type)
+
+        monkeypatch.setattr(
+            org_expected_artifacts_module, "resolve_org_expected_artifacts", _counting
+        )
+
+        snapshot = gather_artifact_presence(
+            feature_dir,
+            mission_family=_DEDUP_ORG_FAMILY,
+            step_id=_DEDUP_ORG_STEP,
+            repo_root=project_root,
+        )
+
+        assert snapshot.blocking_artifact_names == frozenset({"dedup-artifact.md"})
+        assert len(calls) == 1, (
+            f"expected the org-tier manifest read exactly once per "
+            f"gather_artifact_presence call (#3847 dedup), got {len(calls)}"
+        )


### PR DESCRIPTION
## perf(runtime): read `expected-artifacts.yaml` once per gather, not twice

Closes #3847. Follow-up from the #3770/#3412 consolidation review (now merged).

### The redundancy

On the org happy path, `gather_artifact_presence` parsed a family's `expected-artifacts.yaml` **twice** per call:

- `_presence_filenames_for` loads the manifest via the **cached** authority `charter.activation.manifest_loader.load_manifest`.
- `_expected_artifacts_manifest_resolves` — the single source for `ArtifactPresenceSnapshot.blocking_artifact_names`'s `None`-vs-`frozenset` distinction — independently **re-read** via the uncached `_resolve_org_manifest_mapping` → `resolve_org_expected_artifacts`, plus a bare built-in `get_expected_artifacts` read.

### The fix

`_expected_artifacts_manifest_resolves` now reuses the cached loader:
`load_manifest(mission_family, repo_root=repo_root) is not None` — hitting the same process-global cache `_presence_filenames_for` already populated. The now-orphaned `_resolve_org_manifest_mapping` (its only caller) is deleted, along with its now-unused imports. The org file is parsed **once** per gather.

### Tri-state preserved exactly (#3729 / C-002)

This function feeds the `blocking_artifact_names` None-vs-`frozenset()` tri-state, which was a **non-goal** of the parent mission — so the change is characterization-gated to prove byte-identical semantics:

| input | tri-state result | 
|-------|------------------|
| absent (neither tier) | `None` (unchanged) |
| present + valid | real `frozenset` (unchanged) |
| present + YAML-broken / non-mapping / unreadable | raises `MalformedManifestError` (unchanged) |
| present + schema-invalid (`extra="forbid"`) | raises `ManifestSchemaError` — same net outcome; the raise simply surfaces at the resolves-check instead of downstream in `_presence_filenames_for` (the tri-state value never materialized wrong in either case) |

Four characterization tests pin each row (green-before **and** after), plus `test_org_manifest_read_exactly_once_per_gather_call` (the 2→1 read regression, `@regression` #3847).

### Notes for reviewers

- **AC-8 spy retarget**: the org-root-threading test (`test_cli_guard_family.py`) moved its `resolve_existing_org_roots` spy from the `charter.drg` re-export to the origin module `charter.offering.drg.org_pack_config`, because the authority lazily imports the helper from its origin — the asserted invariant (repo_root threaded at both `_dn_dependency_gate` call sites) is unchanged.
- **Scope**: `runtime/next/runtime_bridge_io.py` logic only (+ a comment cross-ref fix). The tri-state contract, guard-table, and every other surface are untouched.
- CI-only arch gates (`test_no_dead_symbols` — a symbol was removed —, `test_arch_shard_marker_completeness`, `test_golden_count_ban`) all green; ruff/mypy clean (the one `_internal_runtime/schema.py:30` mypy note is pre-existing, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NL6DT7jjh7iTJ1jiyBq5nZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791005016&installation_model_id=427282&pr_number=3848&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3848&signature=e91b2bb7803acc7f9416bf9b3926c8e32f2fb780c0a9125f471e9251d89627cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->