### PR TITLE
fix(ci): unbreak mypy in lint-feedback (stale src/doctrine target) + clear repo-wide ruff nits

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -908,7 +908,7 @@ jobs:
         continue-on-error: true
         run: |
           set -o pipefail
-          if uv run python -m mypy --strict src/specify_cli src/charter src/doctrine 2>&1 | tee out/reports/static-analysis/mypy-report.txt; then
+          if uv run python -m mypy --strict src/specify_cli src/charter src/doctrine.py 2>&1 | tee out/reports/static-analysis/mypy-report.txt; then
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_failures=true" >> "$GITHUB_OUTPUT"

--- a/tests/cross_cutting/misc/test_acceptance_support.py
+++ b/tests/cross_cutting/misc/test_acceptance_support.py
@@ -824,7 +824,7 @@ def test_lenient_downgrades_path_conventions_to_warning(
     assert any("expects" in warning for warning in lenient.warnings)
 
 
-def _software_dev_fake_mission() -> "object":
+def _software_dev_fake_mission() -> object:
     from types import SimpleNamespace
 
     return SimpleNamespace(
@@ -918,11 +918,13 @@ def test_malformed_override_fails_closed(feature_repo: Path, mission_slug: str) 
     _set_path_conventions(feature_repo, "not-a-mapping")
 
     fake_mission = _software_dev_fake_mission()
-    with patch("specify_cli.acceptance.get_mission_for_feature", return_value=fake_mission):
-        with pytest.raises(PathConventionsConfigError, match="must be a mapping"):
-            acc.collect_feature_summary(
-                feature_repo, mission_slug, strict_metadata=True, mutate_matrix=False
-            )
+    with (
+        patch("specify_cli.acceptance.get_mission_for_feature", return_value=fake_mission),
+        pytest.raises(PathConventionsConfigError, match="must be a mapping"),
+    ):
+        acc.collect_feature_summary(
+            feature_repo, mission_slug, strict_metadata=True, mutate_matrix=False
+        )
 
 
 # --- Direct canonical-surface unit coverage (restored from #2167 review) -----

--- a/tests/sync/test_preflight_is_not_delivery.py
+++ b/tests/sync/test_preflight_is_not_delivery.py
@@ -74,7 +74,7 @@ def test_every_terminal_outcome_settles_to_a_terminal_state() -> None:
     settled = {
         DeliveryOutcome.REFUSED: DeliveryAttemptState.REFUSED,
         DeliveryOutcome.TERMINAL_UNKNOWN: DeliveryAttemptState.TERMINAL_UNKNOWN,
-    } | {outcome: DeliveryAttemptState.SUCCEEDED for outcome in _SUCCEEDED_DELIVERY_OUTCOMES}
+    } | dict.fromkeys(_SUCCEEDED_DELIVERY_OUTCOMES, DeliveryAttemptState.SUCCEEDED)
 
     assert set(settled) == set(_TERMINAL_DELIVERY_OUTCOMES), (
         "a terminal outcome exists that no site maps to a state (#3722)"
@@ -141,7 +141,8 @@ def test_resume_replays_both_accepted_shapes(outcome: DeliveryOutcome) -> None:
 
     source = upload.__file__
     assert source
-    text = open(source, encoding="utf-8").read()
+    with open(source, encoding="utf-8") as _fh:
+        text = _fh.read()
     # The replay branch must name both, so an upgrade does not strand old rows.
     assert "TransportDeliveryOutcome.PREFLIGHT_ACCEPTED" in text
     assert "TransportDeliveryOutcome.DELIVERED" in text


### PR DESCRIPTION
## What / why

Clears the repo-wide `lint-feedback` advisory noise (surfaced on #3842 and every other PR), and fixes one real regression behind it.

**The regression:** the M2/#3800 relocation moved the `src/doctrine` package into `src/charter/offering`, but `ci-quality.yml`'s lint step still ran `mypy --strict … src/doctrine` — which now aborts with `cannot read file 'src/doctrine': No such file or directory`. **mypy therefore never actually runs in `lint-feedback` on any PR.** Retargeted to the surviving CR-06 shim `src/doctrine.py` (verified `mypy --strict` clean); `src/charter` already covers the relocated offering package, so no type coverage is lost.

**The nits:** 4 pre-existing repo-wide ruff findings (`UP037`, `C420`, `SIM117`, `SIM115`) in two unrelated test files — auto-fixed / hand-fixed, behavior-preserving, touched tests still pass.

No user-facing change → no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791029264&installation_model_id=427282&pr_number=3854&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3854&signature=772e95af56c010b6fcd703b6c73d9e10d314e822ed9a8674ff8278f43142316a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->