### PR TITLE
docs(3.2.6): record release DAG discharged + fix dangling doctrine→charter related-edge

### DIFF
--- a/docs/changelog/release-notes-3.2.6rc1.md
+++ b/docs/changelog/release-notes-3.2.6rc1.md
@@ -4,7 +4,7 @@ description: 'Internal Release Candidate notes for spec-kitty-cli 3.2.6rc1: an o
 doc_status: active
 type: reference
 audience: docs/context/audience/internal/maintainer.md
-updated: '2026-08-12'
+updated: '2026-09-03'
 related:
 - docs/changelog/CHANGELOG.md
 - docs/changelog/index.md
@@ -16,6 +16,9 @@ _For the existing Spec Kitty operator/maintainer deciding whether to pull this c
 
 > [!WARNING]
 > **`3.2.6rc1` is a Release Candidate — an internal, delta build published for validation, NOT an official `3.2.6` release.** It ships as a GitHub _prerelease_ and to PyPI as a PEP 440 prerelease, so ordinary installers skip it unless you explicitly opt in with `--pre`. Do **not** use it for production or general rollout. The last official release remains `v3.2.5`; when `3.2.6` is finalized its changelog section supersedes this candidate.
+
+> [!NOTE]
+> **Update 2026-09-03 — the release-critical work that remained after this candidate has fully landed.** At rc1 time, a set of release-blocking bugs (the 3.2.6 execution DAG, tracker #3692) still gated the final tag. That book is now empty — all twenty DAG nodes are closed, #3692 is closed, and the milestone stands at 0 remaining work items. This candidate's highlights below are the rc1 snapshot; the finalized `3.2.6` changelog section is the authoritative record of everything the release ships.
 
 ## Install for testing
 

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -9489,6 +9489,7 @@ pages:
     abstract: "Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items."
     anchors:
     - {slug: "intent-of-3-2-x", text: "Intent of 3.2.x", level: 2}
+    - {slug: "addendum-2026-09-03-3-2-6-release-dag-fully-discharged-3692-closed", text: "Addendum 2026-09-03 — 3.2.6 release DAG fully discharged (#3692 closed)", level: 2}
     - {slug: "addendum-2026-08-12-release-posture-refresh-ci-green-except-the-standing-sonar-backlog", text: "Addendum 2026-08-12 — release-posture refresh (CI green except the standing Sonar backlog)", level: 2}
     - {slug: "addendum-2026-07-30-verified-status-re-read-spine-re-anchoring", text: "Addendum 2026-07-30 — verified status re-read + spine re-anchoring", level: 2}
     - {slug: "addendum-2026-08-01-write-path-topology-scoping-gap-design-spike-3129", text: "Addendum 2026-08-01 — write-path topology scoping gap (design-spike #3129)", level: 2}

--- a/docs/plans/3-2-x-executive-overview.md
+++ b/docs/plans/3-2-x-executive-overview.md
@@ -2,7 +2,7 @@
 title: '3.2.x Executive Overview'
 description: 'Executive/stakeholder synthesis of 3.2.x goals and progress since the 3.2.4 release — from a PO, C-suite, and customer point of view.'
 doc_status: active
-updated: '2026-07-30'
+updated: '2026-09-03'
 related:
 - docs/changelog/3.2.x.md
 - docs/plans/3-2-x-milestone-roadmap.md
@@ -34,7 +34,10 @@ Since 3.2.4 we shipped one full release (3.2.5) and have a rich sixth (3.2.6) in
 has single sources of truth, our governance layer now genuinely drives the product, and
 our doctrine is becoming independently shippable. Two honest caveats: **3.2.6 is not yet
 releasable** (our release gate is red by policy — see [Risk](#release-readiness--risk-candid)),
-and the *remaining* work is small and well-understood rather than open-ended.
+and the *remaining* work is small and well-understood rather than open-ended. *(Update
+2026-09-03: the first caveat has since cleared — 3.2.6's release-blocking bug book is fully
+discharged and the milestone is code-complete; see [Release readiness &
+risk](#release-readiness--risk-candid).)*
 
 ## What 3.2.x is for (in business terms)
 
@@ -90,6 +93,21 @@ to stand alone as an independent package, and the last real gap is making our go
 layer the single, stable entry point that external adopters build against.
 
 ## Release readiness & risk (candid)
+
+> **Update 2026-09-03 — the release-blocking book is now empty.** The 3.2.6 release
+> DAG (tracker #3692) is fully discharged: all twenty release-critical bugs across
+> mission-completion, review-verdict, merge/retention, accept-portability,
+> commit-boundary, upgrade, charter/doctrine, and diagnostic clusters have landed, and
+> #3692 is closed. The milestone stands at 66 closed / 0 remaining work items, and no
+> open PR gates the tag. The "not tag-ready / CI red 10+ runs" posture below was written
+> 2026-07-30 and is **superseded** on the functional axis — the classification question it
+> named resolved in the milestone's favour (see the milestone roadmap's
+> [2026-08-12](3-2-x-milestone-roadmap.md#addendum-2026-08-12--release-posture-refresh-ci-green-except-the-standing-sonar-backlog)
+> and [2026-09-03](3-2-x-milestone-roadmap.md#addendum-2026-09-03--326-release-dag-fully-discharged-3692-closed)
+> addenda). What remains is the standing SonarCloud maintainability backlog, tracked
+> separately as scoped cycle debt, not a release-blocking regression.
+
+*Historical posture (2026-07-30), retained for context:*
 
 - **3.2.6 is not tag-ready.** Our mainline CI has been red for 10+ consecutive runs. This
   is **partly by design** — our policy is that mainline honestly reflects known

--- a/docs/plans/3-2-x-milestone-roadmap.md
+++ b/docs/plans/3-2-x-milestone-roadmap.md
@@ -2,7 +2,7 @@
 title: 3.2.x Milestone — Roadmap
 description: 'Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items.'
 doc_status: active
-updated: '2026-08-12'
+updated: '2026-09-03'
 related:
 - docs/changelog/index.md
 - docs/plans/index.md
@@ -20,6 +20,33 @@ related:
 ## Intent of 3.2.x
 
 3.2.x is the **stabilization + structural debt paydown** cycle: (G1) deepen Doctrine/Charter/DRG impact on runtime execution, (G2) strangle the core domains — naming, identity, read/write paths — onto canonical SSOTs by *adopting* the existing execution-context machinery rather than building new construction, and (G3) land the DevEx enablers that make (G1)/(G2) enforceable. No new shadow paths. The milestone stays open until all three goals hold (full declaration: [`docs/release-goals/3.2.x.md`](../changelog/3.2.x.md)). Everything experience-shaped — UX, dashboard, SaaS tie-in — is deliberately deferred to 3.3.x, which builds on the SSOTs this cycle establishes. The SaaS deferral covers the hosted *product launch* (the #1800 / #1091 / #3322 epics, all milestone 3.3.x), **not** the core **sync and consent integrity P0s** (#3178 / #3278 / #3307), which are in-cycle 3.2.x stabilization work; the [SaaS & Hosted Sync — Domain Plan](domains/saas-hosted-sync-domain-plan.md) is the domain's canonical map of that split.
+
+## Addendum 2026-09-03 — 3.2.6 release DAG fully discharged (#3692 closed)
+
+*Read-only reconciliation against live GitHub state on 2026-09-03. Supersedes the
+"Ownership gap / ~19 unowned issues" red flag that the 3.2.6 execution DAG (#3692)
+carried through its 2026-08-26 regeneration.*
+
+**Every node in the 3.2.6 release DAG is now CLOSED.** The tracker issue #3692
+("3.2.6 release DAG and execution order") enumerated the milestone's release-blocking
+book across seven clusters — all twenty issues are discharged:
+
+- mission-completion / lane integrity — #3590, #2945, #3281, #2947
+- review-verdict integrity — #3235
+- merge recovery & retention — #3579, #3131
+- accept portability — #3016
+- commit-boundary completeness — #2693, #3716, #2739
+- upgrade missions — #3282, #2265, #2316
+- charter / doctrine integrity — #3702, #3704, #3705, #3728, #2940
+- diagnostic cleanliness — #3435
+
+**Milestone posture:** 3.2.6 stands at 66 closed / 0 remaining work items; the only
+issue that was still "open" on the milestone was the #3692 tracker itself, now closed.
+No open PR gates the tag — the current open PRs carry the 3.2.7 milestone or none, and
+none close a 3.2.6 DAG node. The 08-12 addendum below judged an rc cuttable on
+code-health grounds; that judgement now extends to the final tag on the functional
+axis: the release-blocking bug book is empty. Sonar's standing backlog (below) and the
+broader 3.2.x cycle exit criteria remain their own, separately-tracked concerns.
 
 ## Addendum 2026-08-12 — release-posture refresh (CI green except the standing Sonar backlog)
 

--- a/docs/plans/engineering-notes/agent-knowledge-canonical-homes.md
+++ b/docs/plans/engineering-notes/agent-knowledge-canonical-homes.md
@@ -6,7 +6,7 @@ updated: '2026-07-22'
 related:
 - docs/plans/engineering-notes/index.md
 - docs/context/orchestration.md
-- src/doctrine/skills/spec-kitty-charter-doctrine/references/doctrine-artifact-structure.md
+- src/charter/offering/skills/spec-kitty-charter-doctrine/references/doctrine-artifact-structure.md
 ---
 # Agent knowledge: canonical homes for rules, practices, reference, and learned facts
 


### PR DESCRIPTION
## What changes for the reader

Anyone reading the 3.2.x planning docs to judge **3.2.6 release readiness** was being told the wrong thing: three docs still carried the 2026-07-30 posture *"3.2.6 is not tag-ready / mainline CI red 10+ runs."* That is stale. The 3.2.6 execution DAG (tracker #3692) is **fully discharged** — all twenty release-blocking issues have landed, the milestone stands at **66 closed / 0 remaining work items**, and #3692 is now closed. This PR makes the docs say so, and fixes a pre-existing docs-freshness red on `main` found in passing.

## The docs-freshness fix (commit 1)

`docs-freshness` was **red on `main`** (not from any recent feature PR): the `Related-edge validator (R2, --strict)` step reported one dangling edge. `docs/plans/engineering-notes/agent-knowledge-canonical-homes.md` still pointed its `related:` edge at the pre-rename `src/doctrine/skills/.../doctrine-artifact-structure.md`, which the doctrine→charter code-topology move relocated to `src/charter/offering/skills/.../doctrine-artifact-structure.md`. The path-filtered PR docs job does not run R2 `--strict`, so it slipped onto `main`. Commit 1 repoints the edge to the canonical charter offering source — R2 back to **0 dangling**.

## The roadmap refresh (commit 2)

Dated `2026-09-03` additions, recording only the discharged 3.2.6 posture against verified live tracker state — **no cycle-framing rewritten** (G1/G2/G3, degod waves, and the broader 3.2.x exit criteria are untouched; the standing SonarCloud maintainability backlog stays separately tracked):

- **`milestone-roadmap.md`** — new addendum recording the DAG discharge, superseding the "ownership gap / ~19 unowned issues" red flag from the 08-26 regeneration.
- **`executive-overview.md`** — the "Release readiness & risk" caveat and the "Bottom line" note marked superseded on the functional axis.
- **`release-notes-3.2.6rc1.md`** — a forward-note that the release-critical work outstanding at rc1 has since landed; the final 3.2.6 changelog is authoritative. The immutable rc1 record itself is left intact.
- Regenerates `3-2-docs-retrieval-index.yaml` for the new addendum anchor.

## Verification

- R2 related-edge validator (`--strict`): **0 dangling** (was 1).
- `check_docs_freshness.py --ci`: **errors=0** (only external-URL link-health warnings remain).
- `markdownlint-cli2@0.18.1` on all four edited files: **0 errors**.
- Terminology guard (`test_no_legacy_terminology.py`): **10 passed**.
- Two commits, each individually green on the docs gates (rebase-merge model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791051692&installation_model_id=427282&pr_number=3857&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3857&signature=dbcc3ceab24d872d2ae057e0b605084f4083bc3e0f92cb1932186ff4bc59134f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->