### PR TITLE
docs(orientation): refresh the stale AGENTS.md orientation stamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,7 +612,7 @@ When user's request matches a skill, invoke via Skill tool. When in doubt, invok
 - Save/resume context → `/context-save` / `/context-restore`
 
 <!-- spec-kitty:orientation -->
-**Spec Kitty v3.2.0rc39** — project: unknown (healthy)
+**Spec Kitty v3.2.7rc1** — project: spec-kitty (healthy)
 
 Two usage patterns:
 - **Full mission** (spec → plan → tasks → implement → review → merge):
@@ -625,6 +625,6 @@ Two usage patterns:
   `spec-kitty dispatch "<request verbatim>" --profile <profile-id>`
   Reason: `spec-kitty dispatch` loads governance context, routes the request,
   and opens the Op. Skipping it produces ungoverned, untracked responses.
-  After finishing the work, close the Op:
-  `spec-kitty profile-invocation complete --invocation-id <id> --outcome <done|failed|abandoned>`
+  After finishing the work, close the Op with the command printed in the capsule
+  (`spec-kitty profile-invocation complete --invocation-id <id> --outcome <done|failed|abandoned>`).
 <!-- /spec-kitty:orientation -->


### PR DESCRIPTION
Refreshes the committed `spec-kitty:orientation` block in AGENTS.md (CLAUDE.md symlink target) from a stale **v3.2.0rc39 / project: unknown** snapshot to the current **v3.2.7rc1 / project: spec-kitty (healthy)**, via `spec-kitty upgrade`'s surface-repair leg. Cosmetic — the block is auto-refreshed live by the SessionStart hook — but keeps the committed surface honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791090479&installation_model_id=427282&pr_number=3873&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3873&signature=72b3224894615dce88e6345636a68f21f8bc6ff7f6b6c9aec4a5ec3e7de6f6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->