### PR TITLE
docs(roadmap): re-anchor 3.2.x plans to current milestone taxonomy + add 4.0.0 goal declaration

### DIFF
--- a/docs/changelog/4.0.0.md
+++ b/docs/changelog/4.0.0.md
@@ -42,8 +42,8 @@ With 3.2.x's **core-domain single-sources-of-truth** substantially in place and 
 clean, 4.0.0 turns to **hosted collaboration and next-generation product capabilities** — the
 hosted Team Kitty surface (sync, consent/identity, auth, launch) and the charter/runtime depth
 that builds on the stabilized core. It is also the intended landing zone for the **open-core
-structural strangler** that 3.2.x exists to finish but that now sits, unscheduled, in Product
-backlog. Same discipline as the prior cycles: **no new shadow paths** — route or extract onto
+structural strangler** that 3.2.x exists to finish — committed to this cycle by operator
+decision (2026-09-04). Same discipline as the prior cycles: **no new shadow paths** — route or extract onto
 an existing authority, never build a parallel one.
 
 ## Goals
@@ -80,13 +80,12 @@ Deepen the governance and runtime surfaces the stabilized core now supports:
 - **Infrastructure-to-logic separation** — inject ports for FS, Clock, GitOps, SaaSQueue,
   Renderer; keep the core pure and stub-testable. Epic **#2173** (moved 3.2.x → 4.0.0).
 
-### G3 — Finish the open-core structural strangler (proposed)
+### G3 — Finish the open-core structural strangler
 
 The G1/G2 strangler spine the 3.2.x cycle exists to finish — see
-[Candidate scope pending a release-milestone decision](#candidate-scope-pending-a-release-milestone-decision)
-— is the natural structural foundation for 4.0.0's hosted and next-gen work. It is **not yet
-committed to this milestone**: it currently sits in Product backlog and needs an explicit
-operator disposition. Homed here as candidate scope so the decision has a target.
+[Structural strangler spine — committed to 4.0.0](#structural-strangler-spine--committed-to-400-2026-09-04)
+— is the structural foundation for 4.0.0's hosted and next-gen work. **Committed to 4.0.0 by
+operator decision (2026-09-04):** the spine epics now carry milestone 4.0.0 on the live tracker.
 
 ## Committed scope (verified milestone `4.0.0`, 2026-09-04)
 
@@ -106,32 +105,31 @@ These epics and P0s carry milestone 4.0.0 on the live tracker:
 *Verify live state via `gh issue view <n> --repo Priivacy-ai/spec-kitty` before acting; the
 milestone description carries the one-line pointer back here.*
 
-## Candidate scope pending a release-milestone decision
+## Structural strangler spine — committed to 4.0.0 (2026-09-04)
 
-The open-core structural strangler spine now sits in **Product backlog** (validated, but on
-no committed release). Exit criterion 8 of the 3.2.x roadmap ("nothing rides into 3.3.x
-silently") fired in a blind spot: this work rode into Product backlog silently instead. Each
-epic needs an explicit operator call — **close / pull into 4.0.0 / mark as accepted backlog
-structural debt** — rather than remaining implicitly "3.2.x-cycle work" while off every
-release:
+The open-core structural strangler spine — the G1/G2 structural work the 3.2.x cycle exists to
+finish — is **committed to 4.0.0 by operator decision (2026-09-04)**. It had sat in Product
+backlog (validated, but on no committed release — exit criterion 8's anti-drift guard fired in
+a blind spot, and the work rode into Product backlog silently instead of onto a release). The
+epics below now carry milestone 4.0.0 on the live tracker:
 
-| Epic | Role | Live milestone |
+| Epic | Role | Milestone |
 |---|---|---|
-| **#1619** | mission-execution-context root (P0) | Product backlog |
-| **#1797** | degod / unshim delivery | Product backlog |
-| **#1868** | seam-binding enabler (WS4 / WS6) | Product backlog |
-| **#1746** | Mission Clarity Layer (P1) | Product backlog |
-| **#2160** | coord-artifact authority (P0) | Product backlog |
-| **#1676** | deterministic structured authoring (P0) | Product backlog |
-| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds | Product backlog |
-| **#2539** | pack trust / verified distribution | Product backlog |
-| **#645 / #3179** | stable public API surface for doctrine & charter | Product backlog |
+| **#1619** | mission-execution-context root (P0) | 4.0.0 |
+| **#1797** | degod / unshim delivery | 4.0.0 |
+| **#1868** | seam-binding enabler (WS4 / WS6) | 4.0.0 |
+| **#1746** | Mission Clarity Layer (P1) | 4.0.0 |
+| **#2160** | coord-artifact authority (P0) | 4.0.0 |
+| **#1676** | deterministic structured authoring (P0) | 4.0.0 |
+| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds | 4.0.0 |
+| **#2539** | pack trust / verified distribution | 4.0.0 |
+| **#645 / #3179** | stable public API surface for doctrine & charter | 4.0.0 |
 
 **Security-debt coupling.** The 21 SonarCloud security findings (the sole failing quality
 gate — 17 `S6350` subprocess + 3 `S2083` path-traversal, all pre-dating any current release
-candidate) map almost 1:1 onto the deferred degod slices above, so the security backlog and
-this structural remediation are stranded on the same unscheduled work. The 3 `S2083` blockers
-are a called-out ~90-min targeted fix independent of any wave.
+candidate) map almost 1:1 onto the degod slices above, so the security backlog rides with this
+structural remediation — now both scheduled in 4.0.0. The 3 `S2083` blockers remain a
+called-out ~90-min targeted fix that can land independent of any wave.
 
 ## Non-goals
 
@@ -151,8 +149,8 @@ are a called-out ~90-min targeted fix independent of any wave.
       fail-closed-by-default rollout.
 - [ ] Charter authoring/lifecycle (#2519) and the infra ports (#2173) land against the
       stabilized core with no new shadow path.
-- [ ] The candidate structural spine has an explicit release disposition (committed, closed,
-      or accepted backlog debt) — no epic is left implicitly "cycle work" while off every release.
+- [ ] The structural strangler spine (committed to 4.0.0 on 2026-09-04) lands or is explicitly
+      re-dispositioned — no epic left implicitly "cycle work" while off a release.
 
 ## Emergent patches
 

--- a/docs/changelog/4.0.0.md
+++ b/docs/changelog/4.0.0.md
@@ -1,0 +1,172 @@
+---
+title: '4.0.0 — Hosted collaboration & the open-core structural finish'
+description: 'Declaration of intent for the 4.0.0 cycle: hosted collaboration (sync, consent, auth) plus the open-core structural strangler finish deferred from 3.2.x.'
+doc_status: active
+type: explanation
+audience: docs/context/audience/internal/maintainer.md
+updated: '2026-09-04'
+related:
+- docs/changelog/3.2.x.md
+- docs/changelog/release-goals.md
+- docs/changelog/index.md
+- docs/plans/3-2-x-milestone-roadmap.md
+- docs/plans/domains/saas-hosted-sync-domain-plan.md
+- docs/plans/domains/doctrine-charter-domain-plan.md
+---
+# 4.0.0 — Hosted collaboration & the open-core structural finish
+
+**Milestone:** [`4.0.0`](https://github.com/Priivacy-ai/spec-kitty/milestone/8) (open) ·
+**Status:** declared (not yet active) · **Declared:** 2026-09-04 ·
+**Supersedes** the retired [`3.3.x`](https://github.com/Priivacy-ai/spec-kitty/milestone/5)
+declaration for the hosted/experience work · **Advances:** epics #1800 (SaaS sync &
+event-envelope hardening), #1091 (Team Kitty launch gate), #3322 (CLI auth & token-lifecycle
+reliability), #2173 (infra-to-logic ports), #2519 (charter authoring & lifecycle), #3549
+(event-log integrity).
+
+## Why now
+
+A **release-queue reconciliation on 2026-08-23** retired the `3.3.x` milestone (its open work
+re-triaged into 4.0.0 or Product backlog), repurposed the former `3.2.x` milestone (#4) into
+**Product backlog**, and split the near-term work into discrete **3.2.6** (stabilization,
+code-complete), **3.2.7** (post-reconciliation follow-ups — doctrine-term renames,
+profile-load consolidation, perf CI, dedups), and **4.0.0** (this cycle) milestones. 4.0.0
+is the largest open milestone (80 open issues) and had **no declaration-of-intent**, breaking
+the project's own [release-goals convention](release-goals.md) (one durable declaration per
+milestone). This document is that declaration. The taxonomy re-anchor that surfaced the gap
+is recorded in the milestone roadmap's
+[2026-09-04 addendum](../plans/3-2-x-milestone-roadmap.md#addendum-2026-09-04--milestone-taxonomy-re-anchor-the-delayed-action-r).
+
+## Theme
+
+With 3.2.x's **core-domain single-sources-of-truth** substantially in place and 3.2.6 shipped
+clean, 4.0.0 turns to **hosted collaboration and next-generation product capabilities** — the
+hosted Team Kitty surface (sync, consent/identity, auth, launch) and the charter/runtime depth
+that builds on the stabilized core. It is also the intended landing zone for the **open-core
+structural strangler** that 3.2.x exists to finish but that now sits, unscheduled, in Product
+backlog. Same discipline as the prior cycles: **no new shadow paths** — route or extract onto
+an existing authority, never build a parallel one.
+
+## Goals
+
+### G1 — Hosted collaboration (Team Kitty)
+
+Make the hosted surface a coherent, trustworthy product rather than a set of bolt-ons. The
+durable invariants and sub-areas are held by the
+[SaaS & Hosted Sync — Domain Plan](../plans/domains/saas-hosted-sync-domain-plan.md); this
+cycle ships their release-scoped work:
+
+- **Sync & event-envelope integrity** — sync never reports success while authored state is
+  stranded; every synced event carries a contract-valid envelope. Epic **#1800**; load-bearing
+  P0 **#3278** (sync false success while `MissionCreated` stranded).
+- **Consent & identity boundary** — only explicitly consenting projects transmit, under one
+  unambiguous project→identity resolution. Load-bearing P0 **#3178** (wrong-authority egress);
+  P1s **#3197 / #3196 / #3198**.
+- **Auth & token lifecycle** — a logged-in CLI stays authenticated, human auth is
+  browser-mediated, machine/CI auth has a supported path, refresh failures are named. Epic
+  **#3322** (owns #3279 / #3277 / #3233).
+- **Hosted rollout & launch gate** — fail-closed-by-default rollout, named readiness failures,
+  launch defaults. Epic **#1091**.
+- **Event-log integrity** — one canonical event store, honestly reported, delivered without
+  silent loss. Epic **#3549**.
+
+### G2 — Next-generation product capabilities
+
+Deepen the governance and runtime surfaces the stabilized core now supports:
+
+- **Charter authoring & lifecycle robustness** — the author/observe/reproduce paths, charter
+  domain events, deterministic intake. Epic **#2519** (moved 3.2.x → 4.0.0 in the
+  reconciliation; see the
+  [Doctrine & Charter Domain Plan](../plans/domains/doctrine-charter-domain-plan.md) §3.1).
+- **Infrastructure-to-logic separation** — inject ports for FS, Clock, GitOps, SaaSQueue,
+  Renderer; keep the core pure and stub-testable. Epic **#2173** (moved 3.2.x → 4.0.0).
+
+### G3 — Finish the open-core structural strangler (proposed)
+
+The G1/G2 strangler spine the 3.2.x cycle exists to finish — see
+[Candidate scope pending a release-milestone decision](#candidate-scope-pending-a-release-milestone-decision)
+— is the natural structural foundation for 4.0.0's hosted and next-gen work. It is **not yet
+committed to this milestone**: it currently sits in Product backlog and needs an explicit
+operator disposition. Homed here as candidate scope so the decision has a target.
+
+## Committed scope (verified milestone `4.0.0`, 2026-09-04)
+
+These epics and P0s carry milestone 4.0.0 on the live tracker:
+
+| Item | Role | Goal |
+|---|---|---|
+| **#1800** | Epic: SaaS sync & event-envelope hardening | G1 |
+| **#1091** | Epic: Team Kitty launch gate | G1 |
+| **#3322** | Epic: CLI auth & token-lifecycle reliability | G1 |
+| **#3549** | Epic: event-log integrity | G1 |
+| **#3278** | P0: sync reports success while `MissionCreated` stranded | G1 |
+| **#3178** | P0: wrong-authority egress (FR-007 not discharged by FR-002) | G1 |
+| **#2519** | Epic: charter authoring & lifecycle robustness | G2 |
+| **#2173** | Epic: infrastructure-to-logic separation (ports) | G2 |
+
+*Verify live state via `gh issue view <n> --repo Priivacy-ai/spec-kitty` before acting; the
+milestone description carries the one-line pointer back here.*
+
+## Candidate scope pending a release-milestone decision
+
+The open-core structural strangler spine now sits in **Product backlog** (validated, but on
+no committed release). Exit criterion 8 of the 3.2.x roadmap ("nothing rides into 3.3.x
+silently") fired in a blind spot: this work rode into Product backlog silently instead. Each
+epic needs an explicit operator call — **close / pull into 4.0.0 / mark as accepted backlog
+structural debt** — rather than remaining implicitly "3.2.x-cycle work" while off every
+release:
+
+| Epic | Role | Live milestone |
+|---|---|---|
+| **#1619** | mission-execution-context root (P0) | Product backlog |
+| **#1797** | degod / unshim delivery | Product backlog |
+| **#1868** | seam-binding enabler (WS4 / WS6) | Product backlog |
+| **#1746** | Mission Clarity Layer (P1) | Product backlog |
+| **#2160** | coord-artifact authority (P0) | Product backlog |
+| **#1676** | deterministic structured authoring (P0) | Product backlog |
+| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds | Product backlog |
+| **#2539** | pack trust / verified distribution | Product backlog |
+| **#645 / #3179** | stable public API surface for doctrine & charter | Product backlog |
+
+**Security-debt coupling.** The 21 SonarCloud security findings (the sole failing quality
+gate — 17 `S6350` subprocess + 3 `S2083` path-traversal, all pre-dating any current release
+candidate) map almost 1:1 onto the deferred degod slices above, so the security backlog and
+this structural remediation are stranded on the same unscheduled work. The 3 `S2083` blockers
+are a called-out ~90-min targeted fix independent of any wave.
+
+## Non-goals
+
+- **Re-opening the 3.2.x core-domain SSOTs** — they are the stabilized foundation 4.0.0 builds
+  on, not scope to re-litigate.
+- **The 3.2.7 stabilization tail** — doctrine-term renames, profile-load consolidation,
+  perf CI, and dedups ship under milestone [`3.2.7`](https://github.com/Priivacy-ai/spec-kitty/milestone/9),
+  not here.
+
+## Success criteria (placeholder — refine when the cycle activates)
+
+- [ ] Hosted sync holds the no-false-success and no-loss invariants under load; the P0 cluster
+      (#3178 / #3278) is closed and the consent/identity boundary is enforced, not instructed.
+- [ ] CLI auth stays authenticated across the device-flow and machine/CI paths; refresh
+      failures are diagnosed by name (#3322 discharged).
+- [ ] The Team Kitty launch gate (#1091) is met: default hosted URL, named readiness failures,
+      fail-closed-by-default rollout.
+- [ ] Charter authoring/lifecycle (#2519) and the infra ports (#2173) land against the
+      stabilized core with no new shadow path.
+- [ ] The candidate structural spine has an explicit release disposition (committed, closed,
+      or accepted backlog debt) — no epic is left implicitly "cycle work" while off every release.
+
+## Emergent patches
+
+Declared when the cycle activates (3.2.7 stabilization tail lands first). Following the
+[emergent-milestone model](release-goals.md): each patch advances one of the goals above; the
+milestone stays open until the goals are structurally met.
+
+## Links
+
+- Milestone: https://github.com/Priivacy-ai/spec-kitty/milestone/8 · Convention:
+  [`release-goals.md`](release-goals.md) · Prior cycle: [`3.2.x.md`](3.2.x.md)
+- Retired predecessor declaration: [`3.3.x.md`](3.3.x.md) (milestone
+  [`3.3.x`](https://github.com/Priivacy-ai/spec-kitty/milestone/5) closed 2026-08-23)
+- Durable domain plans: [SaaS & Hosted Sync](../plans/domains/saas-hosted-sync-domain-plan.md) ·
+  [Doctrine & Charter](../plans/domains/doctrine-charter-domain-plan.md)
+- Operator execution roadmap + taxonomy re-anchor:
+  [3.2.x Milestone Roadmap](../plans/3-2-x-milestone-roadmap.md#addendum-2026-09-04--milestone-taxonomy-re-anchor-the-delayed-action-r)

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -30,7 +30,8 @@ Where the project is going next — the declared intent of each release line:
 
 - [Release goals convention](release-goals.md) — how release goals are declared and tracked.
 - [3.2.x goals](3.2.x.md) — focus for the 3.2.x line.
-- [3.3.x goals](3.3.x.md) — focus for the 3.3.x line.
+- [3.3.x goals](3.3.x.md) — retired 2026-08-23 (work re-triaged into 4.0.0 / Product backlog); historical.
+- [4.0.0 goals](4.0.0.md) — hosted collaboration + the open-core structural finish.
 - [3.2.x milestone roadmap](../plans/3-2-x-milestone-roadmap.md) — operator-facing
   execution roadmap (a plans/ working document under the distil-then-retire lifecycle).
 

--- a/docs/changelog/release-goals.md
+++ b/docs/changelog/release-goals.md
@@ -57,4 +57,7 @@ issue types this plugs into.
 ## Declared cycles
 
 - [3.2.x goals](3.2.x.md) — focus for the 3.2.x line.
-- [3.3.x goals](3.3.x.md) — focus for the 3.3.x line.
+- [3.3.x goals](3.3.x.md) — **retired** (milestone closed 2026-08-23; work re-triaged into
+  4.0.0 or Product backlog). Kept as the historical declaration.
+- [4.0.0 goals](4.0.0.md) — hosted collaboration + the open-core structural finish;
+  supersedes the 3.3.x hosted/experience declaration.

--- a/docs/changelog/toc.yml
+++ b/docs/changelog/toc.yml
@@ -6,8 +6,10 @@
   href: release-goals.md
 - name: 3.2.x Goals
   href: 3.2.x.md
-- name: 3.3.x Goals
+- name: 3.3.x Goals (retired)
   href: 3.3.x.md
+- name: 4.0.0 Goals
+  href: 4.0.0.md
 - name: Spec Kitty 2.x (Archive)
   href: 2x/
 - name: Spec Kitty 1.x (Archive)

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5507,6 +5507,23 @@ pages:
     - {slug: "non-goals", text: "Non-goals", level: 2}
     - {slug: "success-criteria-placeholder-refine-when-the-cycle-activates", text: "Success criteria (placeholder — refine when the cycle activates)", level: 2}
     - {slug: "links", text: "Links", level: 2}
+  - path: "docs/changelog/4.0.0.md"
+    title: "4.0.0 — Hosted collaboration & the open-core structural finish"
+    divio_type: "explanation"
+    abstract: "Declaration of intent for the 4.0.0 cycle: hosted collaboration (sync, consent, auth) plus the open-core structural strangler finish deferred from 3.2.x."
+    anchors:
+    - {slug: "why-now", text: "Why now", level: 2}
+    - {slug: "theme", text: "Theme", level: 2}
+    - {slug: "goals", text: "Goals", level: 2}
+    - {slug: "g1-hosted-collaboration-team-kitty", text: "G1 — Hosted collaboration (Team Kitty)", level: 3}
+    - {slug: "g2-next-generation-product-capabilities", text: "G2 — Next-generation product capabilities", level: 3}
+    - {slug: "g3-finish-the-open-core-structural-strangler-proposed", text: "G3 — Finish the open-core structural strangler (proposed)", level: 3}
+    - {slug: "committed-scope-verified-milestone-4-0-0-2026-09-04", text: "Committed scope (verified milestone `4.0.0`, 2026-09-04)", level: 2}
+    - {slug: "candidate-scope-pending-a-release-milestone-decision", text: "Candidate scope pending a release-milestone decision", level: 2}
+    - {slug: "non-goals", text: "Non-goals", level: 2}
+    - {slug: "success-criteria-placeholder-refine-when-the-cycle-activates", text: "Success criteria (placeholder — refine when the cycle activates)", level: 2}
+    - {slug: "emergent-patches", text: "Emergent patches", level: 2}
+    - {slug: "links", text: "Links", level: 2}
   - path: "docs/changelog/CHANGELOG.md"
     title: "Changelog"
     divio_type: "none"
@@ -9548,6 +9565,7 @@ pages:
     divio_type: "none"
     abstract: "Executive/stakeholder synthesis of 3.2.x goals and progress since the 3.2.4 release — from a PO, C-suite, and customer point of view."
     anchors:
+    - {slug: "addendum-2026-09-04-the-milestone-map-moved-two-decisions-now-sit-with-the-po", text: "Addendum 2026-09-04 — the milestone map moved; two decisions now sit with the PO", level: 2}
     - {slug: "bottom-line", text: "Bottom line", level: 2}
     - {slug: "what-3-2-x-is-for-in-business-terms", text: "What 3.2.x is for (in business terms)", level: 2}
     - {slug: "progress-since-3-2-4-what-it-means-for-customers", text: "Progress since 3.2.4 — what it means for customers", level: 2}
@@ -9560,6 +9578,11 @@ pages:
     abstract: "Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items."
     anchors:
     - {slug: "intent-of-3-2-x", text: "Intent of 3.2.x", level: 2}
+    - {slug: "addendum-2026-09-04-milestone-taxonomy-re-anchor-the-delayed-action-r", text: "Addendum 2026-09-04 — milestone-taxonomy re-anchor (the delayed Action R)", level: 2}
+    - {slug: "1-the-milestone-taxonomy-the-body-speaks-no-longer-exists", text: "1. The milestone taxonomy the body speaks no longer exists", level: 3}
+    - {slug: "2-resolved-but-unstruck-items-in-this-doc-and-its-siblings", text: "2. Resolved-but-unstruck items in this doc and its siblings", level: 3}
+    - {slug: "3-g1-g2-code-claims-are-unrefreshed-2026-07-30-vintage", text: "3. G1 / G2 code claims are unrefreshed 2026-07-30 vintage", level: 3}
+    - {slug: "4-disposition-note-spine-epics-now-on-no-release-milestone-operator-decision-needed", text: "4. Disposition note — spine epics now on no release milestone (operator decision needed)", level: 3}
     - {slug: "addendum-2026-09-03-3-2-6-release-dag-fully-discharged-3692-closed", text: "Addendum 2026-09-03 — 3.2.6 release DAG fully discharged (#3692 closed)", level: 2}
     - {slug: "addendum-2026-08-12-release-posture-refresh-ci-green-except-the-standing-sonar-backlog", text: "Addendum 2026-08-12 — release-posture refresh (CI green except the standing Sonar backlog)", level: 2}
     - {slug: "addendum-2026-07-30-verified-status-re-read-spine-re-anchoring", text: "Addendum 2026-07-30 — verified status re-read + spine re-anchoring", level: 2}
@@ -10369,6 +10392,7 @@ pages:
     divio_type: "none"
     abstract: "Durable, version-spanning plan for the doctrine/charter surface: charter lifecycle, sole-door access, extensibility, activation, fail-closed reads, public API, and glossary."
     anchors:
+    - {slug: "addendum-2026-09-04-milestone-re-key-resolved-sub-areas-post-2026-08-23-reconciliation", text: "Addendum 2026-09-04 — milestone re-key + resolved sub-areas (post-2026-08-23 reconciliation)", level: 2}
     - {slug: "1-purpose-scope", text: "1. Purpose & scope", level: 2}
     - {slug: "2-where-doctrine-charter-planning-lives-today-honest-inventory", text: "2. Where doctrine/charter planning lives today (honest inventory)", level: 2}
     - {slug: "3-standing-concerns-the-durable-spine", text: "3. Standing concerns — the durable spine", level: 2}
@@ -10408,6 +10432,7 @@ pages:
     divio_type: "none"
     abstract: "Durable, version-spanning domain plan for the SaaS / hosted-sync surface: sync & event-envelope integrity, consent & identity, auth & token lifecycle, and hosted rollout readiness."
     anchors:
+    - {slug: "addendum-2026-09-04-milestone-re-key-post-2026-08-23-reconciliation", text: "Addendum 2026-09-04 — milestone re-key (post-2026-08-23 reconciliation)", level: 2}
     - {slug: "1-purpose-scope", text: "1. Purpose & scope", level: 2}
     - {slug: "2-where-saas-planning-lives-today-honest-inventory", text: "2. Where SaaS planning lives today (honest inventory)", level: 2}
     - {slug: "3-standing-concerns-the-durable-spine", text: "3. Standing concerns — the durable spine", level: 2}

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5517,9 +5517,9 @@ pages:
     - {slug: "goals", text: "Goals", level: 2}
     - {slug: "g1-hosted-collaboration-team-kitty", text: "G1 — Hosted collaboration (Team Kitty)", level: 3}
     - {slug: "g2-next-generation-product-capabilities", text: "G2 — Next-generation product capabilities", level: 3}
-    - {slug: "g3-finish-the-open-core-structural-strangler-proposed", text: "G3 — Finish the open-core structural strangler (proposed)", level: 3}
+    - {slug: "g3-finish-the-open-core-structural-strangler", text: "G3 — Finish the open-core structural strangler", level: 3}
     - {slug: "committed-scope-verified-milestone-4-0-0-2026-09-04", text: "Committed scope (verified milestone `4.0.0`, 2026-09-04)", level: 2}
-    - {slug: "candidate-scope-pending-a-release-milestone-decision", text: "Candidate scope pending a release-milestone decision", level: 2}
+    - {slug: "structural-strangler-spine-committed-to-4-0-0-2026-09-04", text: "Structural strangler spine — committed to 4.0.0 (2026-09-04)", level: 2}
     - {slug: "non-goals", text: "Non-goals", level: 2}
     - {slug: "success-criteria-placeholder-refine-when-the-cycle-activates", text: "Success criteria (placeholder — refine when the cycle activates)", level: 2}
     - {slug: "emergent-patches", text: "Emergent patches", level: 2}
@@ -9582,7 +9582,7 @@ pages:
     - {slug: "1-the-milestone-taxonomy-the-body-speaks-no-longer-exists", text: "1. The milestone taxonomy the body speaks no longer exists", level: 3}
     - {slug: "2-resolved-but-unstruck-items-in-this-doc-and-its-siblings", text: "2. Resolved-but-unstruck items in this doc and its siblings", level: 3}
     - {slug: "3-g1-g2-code-claims-are-unrefreshed-2026-07-30-vintage", text: "3. G1 / G2 code claims are unrefreshed 2026-07-30 vintage", level: 3}
-    - {slug: "4-disposition-note-spine-epics-now-on-no-release-milestone-operator-decision-needed", text: "4. Disposition note — spine epics now on no release milestone (operator decision needed)", level: 3}
+    - {slug: "4-disposition-spine-epics-committed-to-4-0-0-operator-decision-2026-09-04", text: "4. Disposition — spine epics committed to 4.0.0 (operator decision 2026-09-04)", level: 3}
     - {slug: "addendum-2026-09-03-3-2-6-release-dag-fully-discharged-3692-closed", text: "Addendum 2026-09-03 — 3.2.6 release DAG fully discharged (#3692 closed)", level: 2}
     - {slug: "addendum-2026-08-12-release-posture-refresh-ci-green-except-the-standing-sonar-backlog", text: "Addendum 2026-08-12 — release-posture refresh (CI green except the standing Sonar backlog)", level: 2}
     - {slug: "addendum-2026-07-30-verified-status-re-read-spine-re-anchoring", text: "Addendum 2026-07-30 — verified status re-read + spine re-anchoring", level: 2}

--- a/docs/development/3-2-page-inventory.yaml
+++ b/docs/development/3-2-page-inventory.yaml
@@ -1868,6 +1868,12 @@
   owning_workstream: none
   current_target: true
   notes: null
+- path: docs/changelog/4.0.0.md
+  tag: current
+  divio_type: explanation
+  owning_workstream: none
+  current_target: true
+  notes: null
 - path: docs/changelog/CHANGELOG.md
   tag: current
   divio_type: none

--- a/docs/plans/3-2-x-executive-overview.md
+++ b/docs/plans/3-2-x-executive-overview.md
@@ -2,7 +2,7 @@
 title: '3.2.x Executive Overview'
 description: 'Executive/stakeholder synthesis of 3.2.x goals and progress since the 3.2.4 release — from a PO, C-suite, and customer point of view.'
 doc_status: active
-updated: '2026-09-03'
+updated: '2026-09-04'
 related:
 - docs/changelog/3.2.x.md
 - docs/plans/3-2-x-milestone-roadmap.md
@@ -25,6 +25,42 @@ the [open-core delivery plan](3-2-x-open-core-delivery-plan.md), and what actual
 shipped is the [changelog](../changelog/index.md). Status was verified by two read-only
 audits on 2026-07-30; the delivery plan carries the evidence and the unverified-item
 flags.*
+
+## Addendum 2026-09-04 — the milestone map moved; two decisions now sit with the PO
+
+*Read-only reconciliation against live GitHub milestone state on 2026-09-04. The
+[2026-09-03 update](#release-readiness--risk-candid) below correctly reported that 3.2.6's
+release-blocking book is now empty; this addendum re-anchors the **milestone taxonomy** the
+rest of this overview still speaks, per the roadmap's own
+[2026-09-04 re-anchor](3-2-x-milestone-roadmap.md#addendum-2026-09-04--milestone-taxonomy-re-anchor-the-delayed-action-r).*
+
+**What changed under the plans.** A release-queue reconciliation on **2026-08-23**
+reorganised our release milestones. The single "3.2.x milestone" this overview is written
+against was **repurposed into "Product backlog"** (validated work not committed to any
+release), and the "3.3.x" milestone everything was "deferred to" was **retired** — its work
+re-triaged to **4.0.0** (hosted collaboration + next-generation product) or Product backlog.
+We now run three discrete milestones: **3.2.6** (shipped-clean stabilization, code-complete),
+**3.2.7** (a tight near-term follow-up: doctrine-term renames, profile-load reliability,
+perf-CI, dedups), and **4.0.0** (the hosted product plus the deferred structural work).
+
+**The strategic read is unchanged, but two things a stakeholder should hear plainly:**
+
+1. **The structural "finish the strangler" work this cycle exists for is currently on no
+   committed release.** The G1/G2 spine (execution-context root, degod/unshim, seam-binding,
+   the pack-ecosystem extensibility kinds) sits in **Product backlog** — validated and
+   largely designed, but unscheduled. 3.2.7 is scoped to the stabilization tail; 4.0.0 to
+   hosted product. This is a scheduling gap, not a regression: the foundation held (see
+   the strategic-position section), but the remaining structural push is unowned by a release.
+2. **The one failing quality gate (21 security findings) rides on that same unscheduled
+   work.** Our SonarCloud security backlog maps almost 1:1 onto the deferred structural
+   slices, so the security debt and the structural remediation are stranded together — with
+   the exception of 3 path-traversal blockers that are a called-out ~90-min fix on their own.
+
+**Decisions for the PO** (in addition to the release-timing call already noted below):
+give the Product-backlog spine epics an explicit release home — close, pull into 3.2.7/4.0.0,
+or mark as accepted backlog structural debt — rather than leaving them implicitly
+"3.2.x-cycle work" while off every release. The 4.0.0 goals are now declared in
+[`docs/changelog/4.0.0.md`](../changelog/4.0.0.md).
 
 ## Bottom line
 

--- a/docs/plans/3-2-x-executive-overview.md
+++ b/docs/plans/3-2-x-executive-overview.md
@@ -45,21 +45,20 @@ perf-CI, dedups), and **4.0.0** (the hosted product plus the deferred structural
 
 **The strategic read is unchanged, but two things a stakeholder should hear plainly:**
 
-1. **The structural "finish the strangler" work this cycle exists for is currently on no
-   committed release.** The G1/G2 spine (execution-context root, degod/unshim, seam-binding,
-   the pack-ecosystem extensibility kinds) sits in **Product backlog** — validated and
-   largely designed, but unscheduled. 3.2.7 is scoped to the stabilization tail; 4.0.0 to
-   hosted product. This is a scheduling gap, not a regression: the foundation held (see
-   the strategic-position section), but the remaining structural push is unowned by a release.
-2. **The one failing quality gate (21 security findings) rides on that same unscheduled
-   work.** Our SonarCloud security backlog maps almost 1:1 onto the deferred structural
-   slices, so the security debt and the structural remediation are stranded together — with
-   the exception of 3 path-traversal blockers that are a called-out ~90-min fix on their own.
+1. **The structural "finish the strangler" work this cycle exists for is now committed to
+   4.0.0** (operator decision 2026-09-04). The G1/G2 spine (execution-context root,
+   degod/unshim, seam-binding, the pack-ecosystem extensibility kinds) had sat unscheduled in
+   Product backlog; it now carries milestone 4.0.0. 3.2.7 remains the stabilization tail;
+   4.0.0 is the hosted product plus this deferred structural finish. The foundation held (see
+   the strategic-position section); the remaining structural push now has a release home.
+2. **The one failing quality gate (21 security findings) rides with that structural work —
+   now scheduled in 4.0.0.** Our SonarCloud security backlog maps almost 1:1 onto the degod
+   slices, so the security debt and the structural remediation land together — with the
+   exception of 3 path-traversal blockers that are a called-out ~90-min fix on their own.
 
-**Decisions for the PO** (in addition to the release-timing call already noted below):
-give the Product-backlog spine epics an explicit release home — close, pull into 3.2.7/4.0.0,
-or mark as accepted backlog structural debt — rather than leaving them implicitly
-"3.2.x-cycle work" while off every release. The 4.0.0 goals are now declared in
+**Decision resolved:** the strangler-spine epics are committed to 4.0.0 (2026-09-04), no
+longer implicitly "3.2.x-cycle work" off every release. The remaining PO call is release
+timing (noted below). The 4.0.0 goals are declared in
 [`docs/changelog/4.0.0.md`](../changelog/4.0.0.md).
 
 ## Bottom line

--- a/docs/plans/3-2-x-milestone-roadmap.md
+++ b/docs/plans/3-2-x-milestone-roadmap.md
@@ -2,7 +2,7 @@
 title: 3.2.x Milestone — Roadmap
 description: 'Operator-facing roadmap for the 3.2.x milestone: the epic dependency spine, degod/unshim wave status, milestone census, exit criteria, and watch items.'
 doc_status: active
-updated: '2026-09-03'
+updated: '2026-09-04'
 related:
 - docs/changelog/index.md
 - docs/plans/index.md
@@ -20,6 +20,114 @@ related:
 ## Intent of 3.2.x
 
 3.2.x is the **stabilization + structural debt paydown** cycle: (G1) deepen Doctrine/Charter/DRG impact on runtime execution, (G2) strangle the core domains — naming, identity, read/write paths — onto canonical SSOTs by *adopting* the existing execution-context machinery rather than building new construction, and (G3) land the DevEx enablers that make (G1)/(G2) enforceable. No new shadow paths. The milestone stays open until all three goals hold (full declaration: [`docs/release-goals/3.2.x.md`](../changelog/3.2.x.md)). Everything experience-shaped — UX, dashboard, SaaS tie-in — is deliberately deferred to 3.3.x, which builds on the SSOTs this cycle establishes. The SaaS deferral covers the hosted *product launch* (the #1800 / #1091 / #3322 epics, all milestone 3.3.x), **not** the core **sync and consent integrity P0s** (#3178 / #3278 / #3307), which are in-cycle 3.2.x stabilization work; the [SaaS & Hosted Sync — Domain Plan](domains/saas-hosted-sync-domain-plan.md) is the domain's canonical map of that split.
+
+## Addendum 2026-09-04 — milestone-taxonomy re-anchor (the delayed Action R)
+
+*Read-only reconciliation against live GitHub milestone/issue state on 2026-09-04
+(`gh api repos/Priivacy-ai/spec-kitty` with `GITHUB_TOKEN` unset). This addendum
+executes the taxonomy half of the [2026-07-30 Action R](#addendum-2026-07-30--verified-status-re-read--spine-re-anchoring)
+(re-anchor the tracker) that was filed but never run, and folds in the findings of the
+`work/3-2-x-checkup-2026-09-04/` roadmap checkup. The [2026-09-03 addendum](#addendum-2026-09-03--326-release-dag-fully-discharged-3692-closed)
+below correctly recorded the 3.2.6 DAG discharge but patched only that axis; the
+milestone map, the exit criteria, and the 2026-07-30 code claims were left stale. This
+addendum re-keys them. It does **not** rewrite the historical body — read the
+2026-07-04 spine, the 07-30 corrections, and every dated addendum through the milestone
+translation table below.*
+
+### 1. The milestone taxonomy the body speaks no longer exists
+
+A **release-queue reconciliation on 2026-08-23** reorganised the milestones. The entire
+corpus below (2026-07-04 body + the 07/08 addenda) is written in the *pre-reconciliation*
+dialect — "the 3.2.x milestone", "deferred to 3.3.x" — which is now obsolete. Live state:
+
+| # | Title | State | Open / Closed | What the body calls it |
+|---|---|---|---|---|
+| 4 | **Product backlog** | open | 552 / 468 | *"the 3.2.x milestone"* — repurposed; **validated but on no committed release** |
+| 5 | **3.3.x** | **closed** | 0 / 12 | *"deferred to 3.3.x"* — **retired 2026-08-23; work re-triaged to 4.0.0 or Product backlog** |
+| 7 | **3.2.6** | open | 0 / 67 | (post-body) stabilization — **code-complete, shipped-clean posture** |
+| 9 | **3.2.7** | open | 32 / 0 | (post-body) post-reconciliation follow-ups — doctrine-term renames, profile-load consolidation, perf CI, dedups (decision D10 / epic #830) |
+| 8 | **4.0.0** | open | 80 / 6 | (post-body) hosted collaboration + next-generation product |
+
+Milestone #5's own description is the citation: *"Retired after release-queue
+reconciliation on 2026-08-23. Open work was re-triaged into 4.0.0 or Product backlog."*
+
+**Translation table — read the body through this:**
+
+- Every *"3.2.x milestone"* / `milestone/4` link in the body now points at **Product
+  backlog** — a validated-but-uncommitted bucket, **not** a release. It is no longer the
+  cycle's burndown surface.
+- Every *"deferred to 3.3.x"* / `milestone/5` reference is stale — the 3.3.x milestone is
+  **closed/retired**; that work is now **4.0.0** (hosted product + deferred structural
+  epics) or **Product backlog** (uncommitted).
+- The clean GitHub boundary the plans never describe: **3.2.7** = finish the stabilization
+  tail cleanly (renames / profile-load / perf-CI / dedups); **4.0.0** = the hosted product
+  plus the deferred structural epics. The 4.0.0 declaration-of-intent is now written at
+  [`docs/changelog/4.0.0.md`](../changelog/4.0.0.md).
+
+### 2. Resolved-but-unstruck items in this doc and its siblings
+
+The following are asserted open in the body/exit-criteria but are demonstrably closed
+(verified 2026-09-04):
+
+- **Exit criterion 4 (`#2071` test-QA) cites an open blocker; #2071 CLOSED 2026-08-02.**
+  Read exit criterion 4 as satisfied-by-closure, not pending.
+- **The doctrine domain plan's §3.5 (meta.json fail-closed) lists #3230 / #3229 / #3228 /
+  #3240 as open children of epic #3259 — all five are CLOSED** (the children 2026-08-11,
+  the epic #3259 itself CLOSED). That whole sub-area is done; see the doctrine plan's own
+  2026-09-04 addendum.
+- **#3176** (the sole-door residual named in [Addendum 2026-08-04](#addendum-2026-08-04--charter-sole-door-bypass-closure-substantially-landed) item 3) is **CLOSED**.
+- **#2657 / #3183 / #2262** (doctrine arc / activation-availability) are **CLOSED**
+  (Aug 7 / — / Jul 26); the arc diagram and doctrine §3.3 still present them as pending.
+- **#3282 / #3307** (the P0s the exec overview and SaaS plan carried as open) are **CLOSED**
+  (#3282 under 3.2.6; #3307 discharged).
+
+### 3. G1 / G2 code claims are unrefreshed 2026-07-30 vintage
+
+The [2026-07-30 addendum](#addendum-2026-07-30--verified-status-re-read--spine-re-anchoring)
+G2 claims (`workflow.py`/`review.py` → 0 LOC, `core/execution_context.py` deleted, shim
+registry `shims: []`, only `_read_path_resolver` parked) are a **2026-07-30 audit that
+predates the entire 3.2.6 stabilization release** and has never been re-read against
+`3.2.7rc1` HEAD. They remain **unverified-as-of-current** here (a code re-audit is out of
+this doc-only pass's scope). Worse, they **contradict this roadmap's own Wave status
+board**: the [Wave board](#wave-status-board-degodunshim-roadmap) marks the coord-authority
+trio degod as `PARTIALLY QUEUED` (#2160 OPEN) while the 07-30 delivery claims it done.
+Two active documents disagree and neither carries a post-August read — the tie needs a
+single current code read before either claim drives a decision.
+
+### 4. Disposition note — spine epics now on no release milestone (operator decision needed)
+
+The G1/G2 strangler spine the cycle exists to finish now sits in **Product backlog**
+(validated, **not committed to any active release**) — it is neither 3.2.7 (renames/perf-CI)
+nor 4.0.0 (hosted product). Exit criterion 8's own anti-drift guard ("nothing rides into
+3.3.x silently") fired in a blind spot: the work rode into **Product backlog** silently
+instead. These need an **explicit release-milestone decision** (close / pull into 3.2.7 or
+4.0.0 / mark as backlog structural debt), not implicit "3.2.x cycle work" status:
+
+| Epic | Role | Live milestone |
+|---|---|---|
+| **#1619** | mission-execution-context root (P0) | Product backlog |
+| **#1797** | degod / unshim delivery | Product backlog |
+| **#1868** | seam-binding enabler (WS4/WS6) | Product backlog |
+| **#1746** | Mission Clarity Layer (P1, first functional pickup) | Product backlog |
+| **#2160** | coord-artifact authority (P0, Wave 2 anchor) | Product backlog |
+| **#1676** | deterministic structured authoring (P0, off-spine) | Product backlog |
+| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds (the declared G1 exit condition) | Product backlog |
+| **#2539** | pack trust / verified distribution | Product backlog |
+| **#3179 / #645** | stable public API surface | Product backlog |
+
+Already **moved to 4.0.0** by the reconciliation (no longer 3.2.x-cycle work): **#2173**
+(runtime ports) and **#2519** (charter authoring & lifecycle).
+
+**Security-debt coupling:** the 21 SonarCloud vulnerabilities (the sole failing gate —
+17 `S6350` subprocess + 3 `S2083` path-traversal, all pre-dating any current rc) are
+mapped by the [08-12 addendum](#addendum-2026-08-12--release-posture-refresh-ci-green-except-the-standing-sonar-backlog)
+onto the **QUEUED Wave 2/Wave 4 degod slices** — precisely the Product-backlog spine epics
+above. So the security red and the structural remediation are **stranded on the same
+unscheduled work**. The 3 `S2083` blockers remain a called-out ~90-min targeted fix
+independent of any wave.
+
+> **Doc-tooling note:** this re-anchor adds a new page, [`docs/changelog/4.0.0.md`](../changelog/4.0.0.md).
+> The docs retrieval index and page inventory will need regenerating so it is discoverable.
 
 ## Addendum 2026-09-03 — 3.2.6 release DAG fully discharged (#3692 closed)
 

--- a/docs/plans/3-2-x-milestone-roadmap.md
+++ b/docs/plans/3-2-x-milestone-roadmap.md
@@ -94,37 +94,35 @@ trio degod as `PARTIALLY QUEUED` (#2160 OPEN) while the 07-30 delivery claims it
 Two active documents disagree and neither carries a post-August read — the tie needs a
 single current code read before either claim drives a decision.
 
-### 4. Disposition note — spine epics now on no release milestone (operator decision needed)
+### 4. Disposition — spine epics committed to 4.0.0 (operator decision 2026-09-04)
 
-The G1/G2 strangler spine the cycle exists to finish now sits in **Product backlog**
-(validated, **not committed to any active release**) — it is neither 3.2.7 (renames/perf-CI)
-nor 4.0.0 (hosted product). Exit criterion 8's own anti-drift guard ("nothing rides into
-3.3.x silently") fired in a blind spot: the work rode into **Product backlog** silently
-instead. These need an **explicit release-milestone decision** (close / pull into 3.2.7 or
-4.0.0 / mark as backlog structural debt), not implicit "3.2.x cycle work" status:
+The G1/G2 strangler spine the cycle exists to finish is **committed to 4.0.0 by operator
+decision (2026-09-04)**. It had sat in **Product backlog** (validated, on no active release —
+exit criterion 8's anti-drift guard, "nothing rides into 3.3.x silently," fired in a blind
+spot as the work rode into Product backlog silently instead). The epics below now carry
+milestone 4.0.0 on the live tracker; full 4.0.0 scoping: [`docs/changelog/4.0.0.md`](../changelog/4.0.0.md):
 
-| Epic | Role | Live milestone |
+| Epic | Role | Milestone |
 |---|---|---|
-| **#1619** | mission-execution-context root (P0) | Product backlog |
-| **#1797** | degod / unshim delivery | Product backlog |
-| **#1868** | seam-binding enabler (WS4/WS6) | Product backlog |
-| **#1746** | Mission Clarity Layer (P1, first functional pickup) | Product backlog |
-| **#2160** | coord-artifact authority (P0, Wave 2 anchor) | Product backlog |
-| **#1676** | deterministic structured authoring (P0, off-spine) | Product backlog |
-| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds (the declared G1 exit condition) | Product backlog |
-| **#2539** | pack trust / verified distribution | Product backlog |
-| **#3179 / #645** | stable public API surface | Product backlog |
+| **#1619** | mission-execution-context root (P0) | 4.0.0 |
+| **#1797** | degod / unshim delivery | 4.0.0 |
+| **#1868** | seam-binding enabler (WS4/WS6) | 4.0.0 |
+| **#1746** | Mission Clarity Layer (P1, first functional pickup) | 4.0.0 |
+| **#2160** | coord-artifact authority (P0, Wave 2 anchor) | 4.0.0 |
+| **#1676** | deterministic structured authoring (P0, off-spine) | 4.0.0 |
+| **#2466 / #2467 / #2468** | pack ecosystem + extensibility kinds (the declared G1 exit condition) | 4.0.0 |
+| **#2539** | pack trust / verified distribution | 4.0.0 |
+| **#3179 / #645** | stable public API surface | 4.0.0 |
 
-Already **moved to 4.0.0** by the reconciliation (no longer 3.2.x-cycle work): **#2173**
-(runtime ports) and **#2519** (charter authoring & lifecycle).
+Also on **4.0.0** from the reconciliation: **#2173** (runtime ports) and **#2519** (charter
+authoring & lifecycle).
 
 **Security-debt coupling:** the 21 SonarCloud vulnerabilities (the sole failing gate —
 17 `S6350` subprocess + 3 `S2083` path-traversal, all pre-dating any current rc) are
 mapped by the [08-12 addendum](#addendum-2026-08-12--release-posture-refresh-ci-green-except-the-standing-sonar-backlog)
-onto the **QUEUED Wave 2/Wave 4 degod slices** — precisely the Product-backlog spine epics
-above. So the security red and the structural remediation are **stranded on the same
-unscheduled work**. The 3 `S2083` blockers remain a called-out ~90-min targeted fix
-independent of any wave.
+onto the Wave 2/Wave 4 degod slices — precisely the spine epics above — so the security
+backlog rides with the structural remediation, now both scheduled in 4.0.0. The 3 `S2083`
+blockers remain a called-out ~90-min targeted fix that can land independent of any wave.
 
 > **Doc-tooling note:** this re-anchor adds a new page, [`docs/changelog/4.0.0.md`](../changelog/4.0.0.md).
 > The docs retrieval index and page inventory will need regenerating so it is discoverable.

--- a/docs/plans/domains/doctrine-charter-domain-plan.md
+++ b/docs/plans/domains/doctrine-charter-domain-plan.md
@@ -2,11 +2,12 @@
 title: 'Doctrine & Charter — Domain Plan'
 description: 'Durable, version-spanning plan for the doctrine/charter surface: charter lifecycle, sole-door access, extensibility, activation, fail-closed reads, public API, and glossary.'
 doc_status: durable
-updated: '2026-08-12'
+updated: '2026-09-04'
 related:
 - docs/plans/index.md
 - docs/plans/3-2-x-open-core-delivery-plan.md
 - docs/plans/glossary-doctrine-overhaul-program.md
+- docs/changelog/4.0.0.md
 - docs/plans/doctrine/charter-sole-door-deferred-issues.md
 - docs/plans/doctrine/index.md
 - docs/plans/domains/saas-hosted-sync-domain-plan.md
@@ -27,6 +28,53 @@ related:
 > the canonical map; where they disagree on *what ships in a given tag*, the milestone
 > roadmap and the owning epic win. Keep this plan factual and current; do not let it
 > accrete release-scoped tracking that belongs in an epic.
+
+---
+
+## Addendum 2026-09-04 — milestone re-key + resolved sub-areas (post-2026-08-23 reconciliation)
+
+*This durable plan was last revised 2026-08-12, **11 days before** the 2026-08-23
+release-queue reconciliation; its milestone labels (§3 open-issue lists and the §5 table)
+predate it, and several sub-areas have since closed out. Per this plan's own status contract
+— "where they disagree on *what ships in a given tag*, the milestone roadmap and the owning
+epic win" — the labels and closed items are corrected here from live GitHub state (queried
+2026-09-04, `GITHUB_TOKEN` unset). The **invariants and sub-areas (the durable "why") are
+unchanged**; only the release-scoped "what ships when" moved. See the roadmap's
+[2026-09-04 re-anchor](../3-2-x-milestone-roadmap.md#addendum-2026-09-04--milestone-taxonomy-re-anchor-the-delayed-action-r)
+and the [4.0.0 declaration](../../changelog/4.0.0.md).*
+
+**Taxonomy change.** The **3.3.x** milestone was **retired** (closed 2026-08-23) and
+milestone #4 repurposed into **Product backlog**. Read every "3.3.x" label below as
+**4.0.0** unless the issue is closed; the structural/extensibility epics that were implicitly
+"3.2.x-cycle work" now sit in **Product backlog** — validated but on no committed release.
+
+**Owning epic re-milestoned 3.2.x → 4.0.0:** **#2519** (charter authoring & lifecycle
+robustness — §3.1 design-of-record and the §5 owning epic for the now-closed #3282). The
+extensibility/spine epics **#2466 / #2467 / #2468 / #2216** (§3.2), **#2652** (§3.3),
+**#645 / #3179** (§3.6), and **#2539** (deferred verified distribution) are all in **Product
+backlog** — none is committed to 3.2.7 or 4.0.0; they need an explicit release-milestone
+decision (see the roadmap addendum's disposition note).
+
+**§3.5 (meta.json fail-closed read routing) is DONE — strike the whole sub-area's open list.**
+Epic **#3259 is CLOSED**, and every child listed open — **#3230 / #3229 / #3228 / #3240** —
+**CLOSED** (the children 2026-08-11). The §3.5 "Open issues" block and its four §5 table rows
+are resolved; the invariant now holds as shipped state, not pending work.
+
+**Other resolved-but-unstruck items (verified 2026-09-04):**
+
+- **#3282 CLOSED** — the §3.1 load-bearing P0 (pointer-based charters lack mission-type
+  activations on upgrade) shipped under **3.2.6**; the §5 table carries it as open 3.2.x.
+- **#3176 CLOSED** — the §3.1 / §5 "last builder-unreachable site" P1 residual is discharged.
+- **#3183 CLOSED** and **#2657 CLOSED** — §3.3 lists both as open (#3183 the
+  activation-vs-loadability collision; #2657 the external blocker on #2659's provisioned
+  default charter). #2652 and #3251 remain open (Product backlog).
+- **#2262 CLOSED** — referenced under §3.4 of the SaaS plan; noted here for cross-consistency.
+
+**Still-live gaps (unchanged by the reconciliation):** §4 gap 1 (doctrine content-QA has no
+owning workstream — **#3275** still P3/no-milestone/no-epic) and §4 gap 4 (activation
+reachability R1/R2, unspecced and blast-radius-bearing) remain the domain's largest
+declared-vs-in-force gaps. Treat the §5 table's `Milestone` column as superseded by this
+addendum until it is next revised in place.
 
 ---
 

--- a/docs/plans/domains/saas-hosted-sync-domain-plan.md
+++ b/docs/plans/domains/saas-hosted-sync-domain-plan.md
@@ -2,11 +2,12 @@
 title: 'SaaS & Hosted Sync — Domain Plan'
 description: 'Durable, version-spanning domain plan for the SaaS / hosted-sync surface: sync & event-envelope integrity, consent & identity, auth & token lifecycle, and hosted rollout readiness.'
 doc_status: durable
-updated: '2026-08-12'
+updated: '2026-09-04'
 related:
 - docs/plans/index.md
 - docs/plans/3-2-x-open-core-delivery-plan.md
 - docs/plans/glossary-doctrine-overhaul-program.md
+- docs/changelog/4.0.0.md
 - docs/adr/3.x/2026-04-11-1-saas-rollout-and-readiness.md
 - docs/adr/3.x/2026-04-09-2-cli-saas-auth-is-browser-mediated-oauth-not-password.md
 - docs/adr/3.x/2026-04-19-1-cli-auth-uses-encrypted-file-only-session-storage.md
@@ -27,6 +28,47 @@ related:
 > canonical map; where they disagree on *what ships in a given tag*, the milestone
 > roadmap and the owning epic win. Keep this plan factual and current; do not let it
 > accrete release-scoped tracking that belongs in an epic.
+
+---
+
+## Addendum 2026-09-04 — milestone re-key (post-2026-08-23 reconciliation)
+
+*This durable plan was last revised 2026-08-12, **11 days before** the 2026-08-23
+release-queue reconciliation, so its milestone labels below (§3 open-issue lists, §4, and
+the §5 table) predate it. Per this plan's own status contract — "where they disagree on
+*what ships in a given tag*, the milestone roadmap and the owning epic win" — the labels are
+corrected here from live GitHub state (queried 2026-09-04, `GITHUB_TOKEN` unset). The
+**invariants and sub-areas (the durable "why") are unchanged**; only the release-scoped
+"what ships when" moved. See the roadmap's
+[2026-09-04 re-anchor](../3-2-x-milestone-roadmap.md#addendum-2026-09-04--milestone-taxonomy-re-anchor-the-delayed-action-r)
+and the [4.0.0 declaration](../../changelog/4.0.0.md).*
+
+**Taxonomy change.** The **3.3.x** milestone was **retired** (closed 2026-08-23; work
+re-triaged to 4.0.0 or Product backlog) and milestone #4 was repurposed into **Product
+backlog**. Read every "3.3.x" label below as **4.0.0** unless the issue is closed, and
+every "3.2.x" as either 4.0.0 (if still open — see below) or shipped/closed.
+
+**Owning epics re-milestoned 3.3.x → 4.0.0** (verified 2026-09-04): **#1800** (SaaS sync &
+event-envelope hardening), **#1091** (Team Kitty launch gate), **#3322** (CLI auth &
+token-lifecycle reliability). The entire hosted surface now lands under **4.0.0**.
+
+**Open P0/P1 sync & consent issues re-milestoned 3.2.x → 4.0.0** (they are no longer
+current-cycle stabilization work): **#3278** (P0, sync false success), **#3178** (P0,
+wrong-authority egress), **#3197 / #3196 / #3198** (P1, consent & identity). The auth
+issues **#3279 / #3277** (P1) and **#3233** (P2) — labelled 3.3.x in §3.3 — are likewise
+now **4.0.0** under #3322.
+
+**Resolved since the last revision (strike where carried as open):**
+
+- **#3307 CLOSED.** §3.1, §4 item 2, and the §5 table carry it as an open P0 ("envelope
+  contract; reparent done"); it is discharged — remove it from the open-P0 readiness view.
+- **#3262 CLOSED** (per-project sync consent opt-in; §3.2 / §5, was → #1091, 3.3.x).
+
+**Net readiness read.** The §4 gap-1 auth epic (#3322) and gap-2 (#3307 reparent) are both
+resolved-or-moved; the load-bearing consequence is that the **hosted-surface P0 cluster
+(#3178 / #3278) is now 4.0.0 work, not 3.2.x stabilization** — it does not gate the 3.2.6
+tag and is not committed to 3.2.7. Treat the §5 table's `Milestone` column as superseded by
+this addendum until it is next revised in place.
 
 ---
 


### PR DESCRIPTION
## Why

The **2026-08-23 release-queue reconciliation** retired the `3.3.x` milestone (work → 4.0.0 / Product backlog) and repurposed milestone #4, but the 3.2.x plan corpus still describes the old taxonomy, and there was **no 4.0.0 goal declaration** (breaks the release-goals convention). The **G1/G2 strangler spine** (#1619/#1797/#1868/#1746/#2466–2468) and the **21 SonarCloud security vulns** sit in Product backlog **on no release milestone**. Surfaced by the 2026-09-04 architecture/roadmap checkup.

## What (doc-only)

- **Re-anchor addenda (dated 2026-09-04)** on `3-2-x-milestone-roadmap.md`, `3-2-x-executive-overview.md`, and both `domains/*-domain-plan.md`: milestone translation table, struck resolved-but-unstruck items (e.g. exit-criterion cites #2071, closed 2026-08-02; doctrine §3.5 epic #3259 + children all closed), and a **disposition note** listing the spine epics that need an explicit release-milestone decision.
- **New `docs/changelog/4.0.0.md`** goal declaration (mirrors `3.2.x.md`): open-core/SaaS epics as committed scope, the strangler spine as candidate scope pending your milestone call, and the coupled security debt flagged.
- Release-goals / changelog index / `toc.yml`: 4.0.0 entry, 3.3.x marked retired. Docs retrieval index + page inventory regenerated.

## Decision this teed up for you
The strangler spine + 21-vuln security debt are **unscheduled** — they need an explicit assignment to a release milestone (4.0.0 candidate scope names them; the disposition note lists them).

**Verified:** R2 0 dangling · docs-freshness errors=0 · markdownlint 0 · terminology 10/10. Doc-only; the 2026-07-30 code claims are flagged-as-unrefreshed rather than restated (a code re-audit is out of a doc pass's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092081&installation_model_id=427282&pr_number=3875&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3875&signature=441fab598449f2225d55652b3d9d2cf1636d9adddf8eab5334560ad70fa54cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->