### PR TITLE
docs(internal-pack): branded-document + project-evolution-postmortem doctrine

### DIFF
--- a/packs/internal/README.md
+++ b/packs/internal/README.md
@@ -21,16 +21,32 @@ It is loaded as an **org-tier** pack (registered in `.kittify/config.yaml` under
 
 ```
 packs/internal/
-├── org-charter.yaml                              # pack name/description + required_* activation lists
-├── drg/fragment.yaml                             # SINGLE DRG fragment (org tier), not sharded *.graph.yaml;
-│                                                 #   declares the directive, glossary-pack, and procedure nodes below
+├── org-charter.yaml                                 # pack name + required_* activation lists
+├── drg/fragment.yaml                                # SINGLE DRG fragment (org tier), not sharded *.graph.yaml;
+│                                                    #   declares every node and edge below
 ├── directives/
-│   └── operator-signal-contract.directive.yaml   # OPERATOR_SIGNAL_CONTRACT node — a path that decides must also signal
+│   └── operator-signal-contract.directive.yaml      # OPERATOR_SIGNAL_CONTRACT — a path that decides must also signal
 ├── glossary_packs/
-│   └── spk-internal.glossary-pack.yaml           # spk-internal-glossary node — maintainer/engineering glossary
-└── procedures/
-    └── landing-contributor-prs.procedure.yaml    # landing-contributor-prs node — maintainer runbook
+│   └── spk-internal.glossary-pack.yaml              # spk-internal-glossary — maintainer/engineering glossary
+├── procedures/
+│   ├── landing-contributor-prs.procedure.yaml       # maintainer PR-landing runbook
+│   └── project-evolution-postmortem.procedure.yaml  # cycle post-mortem: research squads + branded report
+├── styleguides/
+│   └── report-writing.styleguide.yaml               # audience-first, anti-AI-prose, Spec Kitty voice
+├── tactics/
+│   └── branded-deliverable.tactic.yaml              # when and how to produce a branded document
+├── toolguides/
+│   ├── branded-document-generation.toolguide.yaml   # the branded-PDF pipeline manifest
+│   └── BRANDED_DOCUMENT_GENERATION.md               # its how-to guide
+└── assets/
+    ├── spec-kitty-branded-pdf.py                    # the Markdown -> branded-PDF generator
+    └── spec-kitty-branded-pdf.py.asset.yaml         # its asset sidecar
 ```
+
+The `project-evolution-postmortem` procedure `suggests` the `report-writing`
+styleguide and the `branded-deliverable` tactic; the tactic `requires` the
+`branded-document-generation` toolguide, which `requires` the
+`spec-kitty-branded-pdf` asset — one authoring chain, wired in `drg/fragment.yaml`.
 
 ## Reference, don't duplicate
 

--- a/packs/internal/README.md
+++ b/packs/internal/README.md
@@ -30,7 +30,7 @@ packs/internal/
 │   └── spk-internal.glossary-pack.yaml              # spk-internal-glossary — maintainer/engineering glossary
 ├── procedures/
 │   ├── landing-contributor-prs.procedure.yaml       # maintainer PR-landing runbook
-│   └── project-evolution-postmortem.procedure.yaml  # cycle post-mortem: research squads + branded report
+│   └── project-evolution-postmortem.procedure.yaml  # cycle postmortem: research squads + branded report
 ├── styleguides/
 │   └── report-writing.styleguide.yaml               # audience-first, anti-AI-prose, Spec Kitty voice
 ├── tactics/

--- a/packs/internal/assets/spec-kitty-branded-pdf.py
+++ b/packs/internal/assets/spec-kitty-branded-pdf.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Render a Markdown document to a Spec Kitty branded PDF.
+
+Maintainer tooling. Produces a light "cream/paper" print treatment that leads with
+the signature yellow (#F5C518) and dark-ink headings — the brand's print identity,
+NOT the dark-mode website surface and NOT the sage green (which tokens.css reserves
+for light-mode headings and is deliberately not used here). Typefaces: Falling Sky
+(display/headings), Swansea (body), JetBrains Mono (code/labels/eyebrow).
+
+First used for the 3.2.6 development-cycle postmortem (2026-09-04).
+
+Requirements
+------------
+- ``pandoc``   on PATH        (Markdown -> HTML)
+- ``weasyprint`` on PATH      (HTML -> PDF; honours @page, @font-face, local files)
+- the sibling ``spec-kitty-design`` repo for the fonts + logo (``--design-repo`` to
+  point elsewhere). Uses ``packages/tokens/dist/fonts`` and
+  ``packages/tokens/assets/logo.png``. If the fonts are absent WeasyPrint falls
+  back to system faces, so the PDF still renders, just off-brand.
+
+Usage
+-----
+    python spec-kitty-branded-pdf.py --input report.md --output report.pdf \
+        --title "3.2.6 Cycle Report" --subtitle "..." --lede "..." \
+        [--eyebrow "Spec Kitty · Release Report"] [--footer-center "3.2.6 CYCLE REPORT"] \
+        [--design-repo /path/to/spec-kitty-design]
+
+Colour + type values are reconciled with the Spec Kitty design system
+(``spec-kitty-design/packages/tokens/dist/tokens.css``).
+"""
+from __future__ import annotations
+
+import argparse
+import html as _html
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _default_design_repo() -> Path:
+    # Sibling of the spec-kitty repo by default: <...>/spec-kitty-design
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "spec-kitty-design"
+        if (cand / "packages/tokens/dist/fonts").is_dir():
+            return cand
+    return Path.home() / "spec-kitty-design"
+
+
+def _css(fonts: Path, logo: Path) -> str:
+    f = str(fonts)
+    return f"""
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+@font-face {{ font-family:'Falling Sky'; src:url('file://{f}/FallingSky-JKwK.otf');      font-weight:400; }}
+@font-face {{ font-family:'Falling Sky'; src:url('file://{f}/FallingSkyMedium-ved9.otf'); font-weight:500; }}
+@font-face {{ font-family:'Falling Sky'; src:url('file://{f}/FallingSkyBold-zemL.otf');   font-weight:700; }}
+@font-face {{ font-family:'Falling Sky'; src:url('file://{f}/FallingSkyBlack-GYXA.otf');  font-weight:900; }}
+@font-face {{ font-family:'Swansea'; src:url('file://{f}/Swansea-q3pd.ttf');          font-weight:400; font-style:normal; }}
+@font-face {{ font-family:'Swansea'; src:url('file://{f}/SwanseaBold-D0ox.ttf');      font-weight:700; font-style:normal; }}
+@font-face {{ font-family:'Swansea'; src:url('file://{f}/SwanseaItalic-AwqD.ttf');    font-weight:400; font-style:italic; }}
+@font-face {{ font-family:'Swansea'; src:url('file://{f}/SwanseaBoldItalic-p3Dv.ttf'); font-weight:700; font-style:italic; }}
+
+:root {{
+  --yellow:#F5C518; --yellow-deep:#C99A0E;
+  --page:#F8F5EC; --card:#FFFFFF; --input:#F5F1E6; --muted:#E8E2D0; --pill:#ECE7D8;
+  --ink:#231D12; --ink-soft:#5A5342; --hair:#DED6C2;
+  --display:'Falling Sky', ui-sans-serif, system-ui, sans-serif;
+  --body:'Swansea', Georgia, ui-serif, serif;
+  --mono:'JetBrains Mono', ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}}
+
+@page {{
+  size:A4; margin:20mm 25mm 18mm 25mm;
+  @bottom-left   {{ content:"Spec Kitty"; font-family:var(--mono); font-size:7pt; color:#8A8578; letter-spacing:.08em; }}
+  @bottom-center {{ content:"__FOOTER__"; font-family:var(--mono); font-size:7pt; color:#8A8578; letter-spacing:.14em; }}
+  @bottom-right  {{ content:counter(page)" / "counter(pages); font-family:var(--mono); font-size:7pt; color:#8A8578; }}
+}}
+@page:first {{ margin:0; @bottom-left{{content:none}} @bottom-center{{content:none}} @bottom-right{{content:none}} }}
+
+html {{ font-size:10.5pt; hyphens:none; }}
+body {{ font-family:var(--body); color:var(--ink); background:var(--page); line-height:1.5; margin:0; }}
+
+.cover {{ page-break-after:always; height:297mm; box-sizing:border-box; background:var(--page); padding:52mm 24mm 24mm; position:relative; }}
+.cover .rule-top {{ position:absolute; top:0; left:0; right:0; height:9mm; background:var(--yellow); }}
+.cover img.logo {{ width:33mm; height:33mm; display:block; margin-bottom:14mm; }}
+.cover .eyebrow {{ font-family:var(--mono); font-size:9pt; letter-spacing:.26em; text-transform:uppercase; color:#8A6A08; margin-bottom:8mm; }}
+.cover h1.title {{ font-family:var(--display); font-weight:900; font-size:44pt; line-height:1.02; color:var(--ink); margin:0 0 6mm; letter-spacing:-.01em; }}
+.cover .subtitle {{ font-family:var(--display); font-weight:500; font-size:15pt; color:var(--ink); margin:0 0 3mm; max-width:135mm; }}
+.cover .lede {{ font-size:11pt; color:var(--ink-soft); max-width:130mm; margin:0 0 14mm; line-height:1.55; }}
+.cover .meta {{ position:absolute; bottom:26mm; left:24mm; right:24mm; border-top:1.5pt solid var(--yellow); padding-top:5mm; display:flex; justify-content:space-between; font-family:var(--mono); font-size:8.5pt; color:var(--ink-soft); letter-spacing:.04em; }}
+.cover .meta b {{ color:var(--ink); font-weight:500; }}
+
+.content {{ padding:0; }}
+h1, h2, h3, h4 {{ font-family:var(--display); color:var(--ink); line-height:1.15; }}
+h1 {{ font-weight:900; font-size:22pt; margin:11mm 0 3mm; padding-bottom:2mm; border-bottom:2.5pt solid var(--yellow); page-break-after:avoid; }}
+h2 {{ font-weight:700; font-size:15pt; margin:8mm 0 2mm; padding-left:3mm; border-left:3pt solid var(--yellow); page-break-after:avoid; }}
+h3 {{ font-weight:600; font-size:12pt; color:var(--ink); margin:6mm 0 1.5mm; page-break-after:avoid; }}
+h4 {{ font-weight:600; font-size:10.5pt; color:var(--ink-soft); margin:4mm 0 1mm; }}
+p {{ margin:0 0 2.6mm; }}
+strong {{ font-weight:700; color:var(--ink); }}
+em {{ font-style:italic; }}
+a {{ color:var(--yellow-deep); text-decoration:none; border-bottom:.5pt solid var(--hair); }}
+ul, ol {{ margin:0 0 3mm; padding-left:6mm; }}
+li {{ margin:.8mm 0; }}
+ul li::marker {{ color:var(--yellow-deep); }}
+hr {{ border:none; border-top:1pt solid var(--hair); margin:6mm 0; }}
+
+code {{ font-family:var(--mono); font-size:8.4pt; background:var(--input); color:#6B4E00; padding:.3mm 1.2mm; border-radius:2px; }}
+pre {{ background:var(--muted); border:1pt solid var(--hair); border-left:3pt solid var(--yellow-deep); border-radius:3px; padding:3mm 4mm; overflow:hidden; page-break-inside:avoid; }}
+pre code {{ background:none; color:var(--ink); font-size:8pt; padding:0; line-height:1.45; }}
+
+blockquote {{ margin:3mm 0; padding:2mm 4mm; background:var(--card); border-left:3pt solid var(--yellow); color:var(--ink-soft); }}
+blockquote p {{ margin:1mm 0; }}
+
+table {{ width:100%; border-collapse:collapse; margin:3mm 0 4mm; font-size:8.8pt; page-break-inside:avoid; }}
+thead th {{ font-family:var(--display); font-weight:700; font-size:8.6pt; background:var(--yellow); color:var(--ink); text-align:left; padding:1.6mm 2.4mm; letter-spacing:.01em; }}
+tbody td {{ padding:1.4mm 2.4mm; border-bottom:.6pt solid var(--hair); vertical-align:top; }}
+tbody tr:nth-child(even) {{ background:var(--input); }}
+tbody code {{ font-size:7.8pt; }}
+.content > h1:first-child {{ margin-top:0; }}
+"""
+
+
+def build(args: argparse.Namespace) -> int:
+    design = Path(args.design_repo).resolve()
+    fonts = design / "packages/tokens/dist/fonts"
+    logo = design / "packages/tokens/assets/logo.png"
+    if not fonts.is_dir():
+        print(f"warning: brand fonts not found under {fonts}; PDF will use fallback faces", file=sys.stderr)
+
+    body = subprocess.run(
+        ["pandoc", "-f", "gfm", "-t", "html5", str(Path(args.input).resolve())],
+        check=True, capture_output=True, text=True,
+    ).stdout
+
+    css = _css(fonts, logo).replace("__FOOTER__", _html.escape(args.footer_center))
+    meta = "".join(
+        f"<span>{_html.escape(k)} <b>{_html.escape(v)}</b></span>"
+        for k, v in (args.meta or [])
+    )
+    cover = f"""
+<section class="cover">
+  <div class="rule-top"></div>
+  <img class="logo" src="file://{logo}" alt="Spec Kitty">
+  <div class="eyebrow">{_html.escape(args.eyebrow)}</div>
+  <h1 class="title">{args.title}</h1>
+  <div class="subtitle">{_html.escape(args.subtitle)}</div>
+  <p class="lede">{_html.escape(args.lede)}</p>
+  <div class="meta">{meta}</div>
+</section>""" if args.title else ""
+
+    doc = (
+        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<title>{_html.escape(args.title or Path(args.input).stem)}</title>"
+        f"<style>{css}</style></head><body>{cover}"
+        f"<section class=\"content\">{body}</section></body></html>"
+    )
+
+    out = Path(args.output).resolve()
+    tmp_html = out.with_suffix(".build.html")
+    tmp_html.write_text(doc, encoding="utf-8")
+    try:
+        import weasyprint  # type: ignore
+        weasyprint.HTML(filename=str(tmp_html)).write_pdf(str(out))
+    except ImportError:
+        wp = shutil.which("weasyprint")
+        if not wp:
+            print("error: weasyprint not importable and not on PATH; install it "
+                  "(pip install weasyprint) or run this with a Python that has it",
+                  file=sys.stderr)
+            return 1
+        subprocess.run([wp, str(tmp_html), str(out)], check=True)
+    tmp_html.unlink(missing_ok=True)
+    print(f"wrote {out}")
+    return 0
+
+
+def _meta_pair(value: str) -> tuple[str, str]:
+    label, _, val = value.partition("=")
+    return label.strip(), val.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Render Markdown to a Spec Kitty branded PDF.")
+    p.add_argument("--input", required=True, help="source Markdown file")
+    p.add_argument("--output", required=True, help="destination PDF path")
+    p.add_argument("--title", default="", help="cover title (HTML allowed for line breaks); omit for no cover")
+    p.add_argument("--subtitle", default="")
+    p.add_argument("--lede", default="")
+    p.add_argument("--eyebrow", default="Spec Kitty · Release Report")
+    p.add_argument("--footer-center", default="SPEC KITTY", help="centered running-footer label")
+    p.add_argument("--meta", type=_meta_pair, action="append",
+                   help="cover meta chip 'LABEL=value' (repeatable)")
+    p.add_argument("--design-repo", default=str(_default_design_repo()),
+                   help="path to the spec-kitty-design repo (fonts + logo)")
+    return build(p.parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packs/internal/assets/spec-kitty-branded-pdf.py
+++ b/packs/internal/assets/spec-kitty-branded-pdf.py
@@ -48,7 +48,7 @@ def _default_design_repo() -> Path:
     return Path.home() / "spec-kitty-design"
 
 
-def _css(fonts: Path, logo: Path) -> str:
+def _css(fonts: Path) -> str:
     f = str(fonts)
     return f"""
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
@@ -89,7 +89,12 @@ body {{ font-family:var(--body); color:var(--ink); background:var(--page); line-
 .cover h1.title {{ font-family:var(--display); font-weight:900; font-size:44pt; line-height:1.02; color:var(--ink); margin:0 0 6mm; letter-spacing:-.01em; }}
 .cover .subtitle {{ font-family:var(--display); font-weight:500; font-size:15pt; color:var(--ink); margin:0 0 3mm; max-width:135mm; }}
 .cover .lede {{ font-size:11pt; color:var(--ink-soft); max-width:130mm; margin:0 0 14mm; line-height:1.55; }}
-.cover .meta {{ position:absolute; bottom:26mm; left:24mm; right:24mm; border-top:1.5pt solid var(--yellow); padding-top:5mm; display:flex; justify-content:space-between; font-family:var(--mono); font-size:8.5pt; color:var(--ink-soft); letter-spacing:.04em; }}
+.cover .meta {{
+  position:absolute; bottom:26mm; left:24mm; right:24mm;
+  border-top:1.5pt solid var(--yellow); padding-top:5mm;
+  display:flex; justify-content:space-between;
+  font-family:var(--mono); font-size:8.5pt; color:var(--ink-soft); letter-spacing:.04em;
+}}
 .cover .meta b {{ color:var(--ink); font-weight:500; }}
 
 .content {{ padding:0; }}
@@ -108,14 +113,22 @@ ul li::marker {{ color:var(--yellow-deep); }}
 hr {{ border:none; border-top:1pt solid var(--hair); margin:6mm 0; }}
 
 code {{ font-family:var(--mono); font-size:8.4pt; background:var(--input); color:#6B4E00; padding:.3mm 1.2mm; border-radius:2px; }}
-pre {{ background:var(--muted); border:1pt solid var(--hair); border-left:3pt solid var(--yellow-deep); border-radius:3px; padding:3mm 4mm; overflow:hidden; page-break-inside:avoid; }}
+pre {{
+  background:var(--muted); border:1pt solid var(--hair);
+  border-left:3pt solid var(--yellow-deep); border-radius:3px;
+  padding:3mm 4mm; overflow:hidden; page-break-inside:avoid;
+}}
 pre code {{ background:none; color:var(--ink); font-size:8pt; padding:0; line-height:1.45; }}
 
 blockquote {{ margin:3mm 0; padding:2mm 4mm; background:var(--card); border-left:3pt solid var(--yellow); color:var(--ink-soft); }}
 blockquote p {{ margin:1mm 0; }}
 
 table {{ width:100%; border-collapse:collapse; margin:3mm 0 4mm; font-size:8.8pt; page-break-inside:avoid; }}
-thead th {{ font-family:var(--display); font-weight:700; font-size:8.6pt; background:var(--yellow); color:var(--ink); text-align:left; padding:1.6mm 2.4mm; letter-spacing:.01em; }}
+thead th {{
+  font-family:var(--display); font-weight:700; font-size:8.6pt;
+  background:var(--yellow); color:var(--ink); text-align:left;
+  padding:1.6mm 2.4mm; letter-spacing:.01em;
+}}
 tbody td {{ padding:1.4mm 2.4mm; border-bottom:.6pt solid var(--hair); vertical-align:top; }}
 tbody tr:nth-child(even) {{ background:var(--input); }}
 tbody code {{ font-size:7.8pt; }}
@@ -135,7 +148,7 @@ def build(args: argparse.Namespace) -> int:
         check=True, capture_output=True, text=True,
     ).stdout
 
-    css = _css(fonts, logo).replace("__FOOTER__", _html.escape(args.footer_center))
+    css = _css(fonts).replace("__FOOTER__", _html.escape(args.footer_center))
     meta = "".join(
         f"<span>{_html.escape(k)} <b>{_html.escape(v)}</b></span>"
         for k, v in (args.meta or [])
@@ -162,6 +175,9 @@ def build(args: argparse.Namespace) -> int:
     tmp_html = out.with_suffix(".build.html")
     tmp_html.write_text(doc, encoding="utf-8")
     try:
+        # weasyprint is an optional runtime dep: it ships no type stubs, and may
+        # be absent entirely (we fall back to the CLI below). A bare ignore covers
+        # both import-untyped and import-not-found without pinning an env-specific code.
         import weasyprint  # type: ignore
         weasyprint.HTML(filename=str(tmp_html)).write_pdf(str(out))
     except ImportError:

--- a/packs/internal/assets/spec-kitty-branded-pdf.py.asset.yaml
+++ b/packs/internal/assets/spec-kitty-branded-pdf.py.asset.yaml
@@ -1,0 +1,4 @@
+id: spec-kitty-branded-pdf
+mime: text/x-python
+path: assets/spec-kitty-branded-pdf.py
+title: Spec Kitty branded PDF generator (Markdown to cream/paper print PDF)

--- a/packs/internal/drg/fragment.yaml
+++ b/packs/internal/drg/fragment.yaml
@@ -35,7 +35,7 @@ nodes:
     body_path: styleguides/report-writing.styleguide.yaml
   - id: project-evolution-postmortem
     kind: procedures
-    title: "Project-Evolution Post-Mortem (research squads + branded report)"
+    title: "Project-Evolution Postmortem (research squads + branded report)"
     body_path: procedures/project-evolution-postmortem.procedure.yaml
 edges:
   # Reference-not-duplicate: the landing runbook refines built-in doctrine that
@@ -48,7 +48,7 @@ edges:
   - source: landing-contributor-prs
     target: "tactic:pr-agent-worktree-isolation"
     relation: refines
-  # Post-mortem authoring chain (all targets are local nodes declared above).
+  # Postmortem authoring chain (all targets are local nodes declared above).
   # The procedure suggests the writing styleguide and the branded-deliverable
   # tactic; the tactic requires the generation toolguide; the toolguide requires
   # the generator asset.

--- a/packs/internal/drg/fragment.yaml
+++ b/packs/internal/drg/fragment.yaml
@@ -16,6 +16,27 @@ nodes:
     kind: directives
     title: "Operator-Signal Contract — a path that decides must also signal"
     body_path: directives/operator-signal-contract.directive.yaml
+  # Branded-document + project-evolution-postmortem doctrine (maintainer authoring).
+  - id: spec-kitty-branded-pdf
+    kind: assets
+    title: "Spec Kitty branded PDF generator (Markdown to WeasyPrint)"
+    body_path: assets/spec-kitty-branded-pdf.py
+  - id: branded-document-generation
+    kind: toolguides
+    title: "Branded Document Generation (Spec Kitty PDF pipeline)"
+    body_path: toolguides/branded-document-generation.toolguide.yaml
+  - id: branded-deliverable
+    kind: tactics
+    title: "Branded Deliverable — when and how to produce a branded document"
+    body_path: tactics/branded-deliverable.tactic.yaml
+  - id: report-writing
+    kind: styleguides
+    title: "Report Writing (audience-first, anti-AI-prose, Spec Kitty voice)"
+    body_path: styleguides/report-writing.styleguide.yaml
+  - id: project-evolution-postmortem
+    kind: procedures
+    title: "Project-Evolution Post-Mortem (research squads + branded report)"
+    body_path: procedures/project-evolution-postmortem.procedure.yaml
 edges:
   # Reference-not-duplicate: the landing runbook refines built-in doctrine that
   # already ships publicly, rather than re-authoring it. Targets are
@@ -27,3 +48,19 @@ edges:
   - source: landing-contributor-prs
     target: "tactic:pr-agent-worktree-isolation"
     relation: refines
+  # Post-mortem authoring chain (all targets are local nodes declared above).
+  # The procedure suggests the writing styleguide and the branded-deliverable
+  # tactic; the tactic requires the generation toolguide; the toolguide requires
+  # the generator asset.
+  - source: project-evolution-postmortem
+    target: "styleguide:report-writing"
+    relation: suggests
+  - source: project-evolution-postmortem
+    target: "tactic:branded-deliverable"
+    relation: suggests
+  - source: branded-deliverable
+    target: "toolguide:branded-document-generation"
+    relation: requires
+  - source: branded-document-generation
+    target: "asset:spec-kitty-branded-pdf"
+    relation: requires

--- a/packs/internal/org-charter.yaml
+++ b/packs/internal/org-charter.yaml
@@ -1,5 +1,6 @@
 org_name: spec-kitty-internal
 required_procedures:
   - landing-contributor-prs
+  - project-evolution-postmortem
 required_glossary_packs:
   - spk-internal-glossary

--- a/packs/internal/procedures/project-evolution-postmortem.procedure.yaml
+++ b/packs/internal/procedures/project-evolution-postmortem.procedure.yaml
@@ -1,0 +1,134 @@
+schema_version: "1.0"
+id: project-evolution-postmortem
+name: Project Technical-Evolution Post-Mortem
+purpose: >
+  The maintainer workflow for producing a project-technical-evolution
+  post-mortem: a report that describes how the project moved over a cycle —
+  architecture and roadmap currency, code and design quality, bug trend,
+  contribution distribution, velocity, community-versus-maintainer authorship,
+  and the friction the Missions themselves surfaced. It is driven by parallel
+  profile-loaded research squads whose outputs are synthesized into one
+  least-technical-first report addressed to maintainers, stakeholders, and
+  investors at once. The deliverable is an evidence-backed narrative every
+  figure of which is attributed to its source; it is not a status dump and not
+  a roadmap.
+entry_condition: >
+  A maintainer has been asked to report on how the project evolved over a
+  defined window (a release cycle, a quarter, a run of Missions). The window,
+  the release line, and the confirmed team roster are known or can be
+  established before any figures are gathered.
+exit_condition: >
+  A single report exists carrying a one-line headline, a two-minute TL;DR
+  brief, and a full write-up with velocity, quality, bug, and distribution
+  tables plus a community-authorship analysis and forward recommendations.
+  Every reused figure is attributed to the squad output it came from and every
+  directly-gathered figure is labelled as such. The report has passed an
+  accuracy review and a terminology review, and all squad outputs and report
+  drafts live in the gitignored work/ directory.
+steps:
+  - title: Frame the cycle, the window, and the three audiences
+    description: >
+      Fix the reporting window (start and end commit or tag), the release line
+      it covers, and the three audiences the report serves at once: maintainers
+      who need the technical truth, stakeholders who need trajectory and risk,
+      and investors who need the headline outcome and trend. Write these down
+      before gathering anything, so every later figure has a known scope and a
+      known reader.
+    actor: agent
+
+  - title: Confirm the team roster before measuring authorship
+    description: >
+      Establish the maintainer roster against which the community-versus-
+      maintainer split will be computed, and confirm it with a human. Authorship
+      analysis folds multiple git and GitHub identities per person; without a
+      confirmed roster the fold is guesswork and the community share is wrong.
+    actor: agent
+    on_failure: >
+      If the roster cannot be confirmed, report the authorship split as
+      provisional and name the unresolved identities rather than asserting a
+      precise community percentage.
+
+  - title: Launch the research squads as governed, profile-loaded Ops
+    description: >
+      Run the examination as parallel squads, each profile-loaded and opened as
+      a governed spec-kitty dispatch Op so the work is tracked. The recommended
+      default set is three squads run concurrently. (1) Architecture and roadmap
+      checkup, loaded as architect-alphonso: plan coherence and currency, the
+      stated goal state, epic-spine status, milestone-taxonomy drift, and any
+      unscheduled critical-path work. (2) Code and design evolution, loaded as
+      general-purpose: the metric checklist below. (3) Tracer-friction
+      correlation, loaded as synthesizer-sam: cluster the recent Missions'
+      tracer files into recurring friction themes, correlate each theme to open
+      tickets and the roadmap, and flag friction that is tracked nowhere.
+    actor: agent
+
+  - title: Gather the code-and-design metric checklist
+    description: >
+      The code-and-design squad measures a fixed checklist so two runs are
+      comparable. Reported-bug volume trend: issues opened, closed, and net over
+      the window, broken out by priority label. Static code quality from the
+      SonarCloud API — coverage, vulnerabilities and security hotspots,
+      duplication, and cyclomatic complexity or code-smell count; read these
+      from the SonarCloud API directly, never from the regnology-mcp sonar
+      tools, which report a different project. Commit and PR distribution by
+      category with a percentage each: core-flow, charter-doctrine, saas-sync,
+      tech-debt-devex, and docs. Velocity: commits, PRs, and Missions per week,
+      plus release-candidate cadence. Community-versus-maintainer authorship:
+      git shortlog plus GitHub PR authors, multi-identity folded, measured
+      against the confirmed roster.
+    actor: agent
+    on_failure: >
+      If a metric cannot be gathered, record it as unavailable with the reason
+      rather than estimating; an unattributed guess is worse than a named gap.
+
+  - title: Run a synthesis and highlights pass over the squad outputs
+    description: >
+      Read the three squad outputs together and synthesize the highlights: the
+      handful of movements that actually characterize the cycle, the top risks,
+      and the through-lines where an architecture drift, a quality trend, and a
+      tracer-friction theme are the same story told three ways. This pass turns
+      three parallel evidence sets into one narrative spine; it does not average
+      them.
+    actor: agent
+
+  - title: Draft the report least-technical-first
+    description: >
+      Write the report in progressive disclosure so the least technical reader
+      gets value from the top. Lead with a one-line headline. Follow with a
+      two-minute TL;DR brief: what the project is, the headline outcomes, the
+      top risks, and the trajectory. Then the full write-up: the cycle
+      narrative, the velocity, quality, bug, and distribution tables, the
+      community analysis, an honest went-well and went-wrong, and forward
+      recommendations. Follow the report-writing styleguide for structure,
+      voice, and the anti-AI-prose discipline throughout — the brand voice is
+      composed, direct, and concrete, and the canonical term is Mission, never
+      feature.
+    actor: agent
+
+  - title: Attribute every figure to its source
+    description: >
+      Tie each reused number back to the squad output it came from, and label
+      each figure the report gathered directly. A reader must be able to see,
+      for any figure, whether it is a synthesized squad finding or a
+      first-hand measurement, and trace it. Unattributed numbers do not ship.
+    actor: agent
+
+  - title: Accuracy review then terminology review before circulation
+    description: >
+      Before the report leaves the maintainer circle, review it for accuracy —
+      spot-check the load-bearing figures against their sources — and for
+      terminology, so the canonical vocabulary holds and no forbidden term
+      slips in. Both reviews pass before circulation; neither is optional.
+    actor: agent
+    on_failure: >
+      If a figure fails its accuracy spot-check, pull it and re-derive from the
+      source rather than shipping a hedged number as fact.
+
+  - title: Render the branded deliverable and store the work
+    description: >
+      Render the reviewed report as a branded Spec Kitty deliverable for
+      circulation, following the branded-deliverable tactic and its PDF
+      generator. Keep every squad output and every report draft in the
+      gitignored work/ directory, so the evidence trail survives without
+      landing in version control.
+    actor: agent

--- a/packs/internal/procedures/project-evolution-postmortem.procedure.yaml
+++ b/packs/internal/procedures/project-evolution-postmortem.procedure.yaml
@@ -1,9 +1,9 @@
 schema_version: "1.0"
 id: project-evolution-postmortem
-name: Project Technical-Evolution Post-Mortem
+name: Project Technical-Evolution Postmortem
 purpose: >
   The maintainer workflow for producing a project-technical-evolution
-  post-mortem: a report that describes how the project moved over a cycle —
+  postmortem: a report that describes how the project moved over a cycle —
   architecture and roadmap currency, code and design quality, bug trend,
   contribution distribution, velocity, community-versus-maintainer authorship,
   and the friction the Missions themselves surfaced. It is driven by parallel

--- a/packs/internal/styleguides/report-writing.styleguide.yaml
+++ b/packs/internal/styleguides/report-writing.styleguide.yaml
@@ -1,7 +1,7 @@
 schema_version: "1.0"
 id: report-writing
 title: Report Writing Styleguide
-scope: guides
+scope: docs
 applies_to_languages: []
 
 principles:
@@ -9,7 +9,7 @@ principles:
   - "Name the audience and serve all of them at once. A project report speaks to maintainers, stakeholders, and investors in the same document; write each section knowing which of them it is for and what that reader needs to decide. Do not bury the stakeholder outcome under maintainer detail, and do not strip the maintainer detail to please the stakeholder."
   - "Attribute every number. Each figure is either traceable to the source that produced it or labelled as gathered first-hand for this report. A number without a source does not appear."
   - "Hedge honestly rather than overclaim. When a figure is provisional, an identity fold is incomplete, or a metric could not be gathered, say so plainly and name the gap. An honest gap builds more trust than a confident guess, and a confident guess is the failure this rule exists to prevent."
-  - "Prefer concrete nouns and verbs to abstraction. A named subsystem, a counted commit, and a dated release carry a report; adjectives about how the cycle felt do not."
+  - "Prefer concrete nouns and verbs to abstraction. A named subsystem and a counted commit carry a report; adjectives about how the cycle felt do not."
   - "Keep the Spec Kitty voice: composed, direct, and concrete. No exclamation marks. The canonical product term is Mission; never write feature for a Mission."
   - "Read your own prose for the tells of machine writing and cut them. The patterns below are the recurring ones; treat the list as a checklist you run before circulating, not as advice you apply when convenient."
 
@@ -70,17 +70,38 @@ anti_patterns:
       Opening with architecture detail or a metric table forces the stakeholder
       and investor to mine for the outcome, and most will stop before they find
       it. The outcome belongs in the first two lines.
+    bad_example: >
+      "## Architecture. The commit-boundary router now materialises the coord
+      worktree before origin-binding..." — page one, before any statement of
+      what the cycle delivered.
+    good_example: >
+      "Spec Kitty shipped 3.2.6: charter governance is now the default, and
+      release integrity holds end to end. Detail follows." Outcome first, then
+      the architecture section for the reader who wants it.
   - name: The unattributed hero number
     description: >
       A striking figure with no source is the fastest way to lose a report's
       credibility on review. If the number cannot be traced, it cannot be the
       headline.
+    bad_example: >
+      "Velocity tripled this cycle." No baseline, no window, no source — a
+      reviewer cannot check it and stops trusting the surrounding figures.
+    good_example: >
+      "320 commits and 41 merged PRs per week (git log over the 3.2.5..3.2.6
+      range, measured for this report)." The reader can reproduce it.
   - name: Em-dash sprawl and buzzword fog
     description: >
       A report where clauses are strung on em-dashes and sentences reach for
       "leverage", "robust", and "seamless" reads as generated regardless of how
       sound the underlying analysis is, and a skeptical reader discounts the
       whole thing.
+    bad_example: >
+      "We leveraged a robust, seamless pipeline — one that — across the cycle —
+      underscored our velocity." Three em-dashes and four buzzwords in one
+      sentence.
+    good_example: >
+      "The release pipeline ran unattended for every tag this cycle. It caught
+      the version-sync gap before publish." Two plain sentences.
 
 references:
   - "packs/built-in/styleguides/planning-and-tracking.styleguide.yaml"

--- a/packs/internal/styleguides/report-writing.styleguide.yaml
+++ b/packs/internal/styleguides/report-writing.styleguide.yaml
@@ -1,0 +1,86 @@
+schema_version: "1.0"
+id: report-writing
+title: Report Writing Styleguide
+scope: guides
+applies_to_languages: []
+
+principles:
+  - "Write least-technical-first. The top of the report must give the least technical reader something they can use before any detail arrives: a one-line headline, then a two-minute brief, then the full write-up. A reader who stops after two minutes should still leave with the outcome and the trajectory."
+  - "Name the audience and serve all of them at once. A project report speaks to maintainers, stakeholders, and investors in the same document; write each section knowing which of them it is for and what that reader needs to decide. Do not bury the stakeholder outcome under maintainer detail, and do not strip the maintainer detail to please the stakeholder."
+  - "Attribute every number. Each figure is either traceable to the source that produced it or labelled as gathered first-hand for this report. A number without a source does not appear."
+  - "Hedge honestly rather than overclaim. When a figure is provisional, an identity fold is incomplete, or a metric could not be gathered, say so plainly and name the gap. An honest gap builds more trust than a confident guess, and a confident guess is the failure this rule exists to prevent."
+  - "Prefer concrete nouns and verbs to abstraction. A named subsystem, a counted commit, and a dated release carry a report; adjectives about how the cycle felt do not."
+  - "Keep the Spec Kitty voice: composed, direct, and concrete. No exclamation marks. The canonical product term is Mission; never write feature for a Mission."
+  - "Read your own prose for the tells of machine writing and cut them. The patterns below are the recurring ones; treat the list as a checklist you run before circulating, not as advice you apply when convenient."
+
+patterns:
+  - name: Progressive-disclosure structure
+    description: >
+      Order the whole report so technical depth increases as the reader
+      descends. Headline in one line. TL;DR brief in two minutes: what the
+      thing is, the headline outcomes, the top risks, the trajectory. Full
+      write-up last: cycle narrative, the metric tables, the community
+      analysis, went-well and went-wrong, and forward recommendations. A reader
+      chooses their own depth by how far they read.
+  - name: Ration the em-dash
+    description: >
+      The sentence-joining em-dash is the strongest tell of machine prose.
+      Allow a handful across a whole report and no more; everywhere else use a
+      period, a comma, or a colon. If a sentence leans on two em-dashes to hold
+      its clauses together, it is two sentences.
+  - name: Say the thing plainly, not "not just X but Y"
+    description: >
+      The "not just X, but Y" and "it's not about X, it's about Y" constructions
+      manufacture false contrast to sound profound. State what is true directly.
+      Replace "this is not just a refactor, it's a rethink" with "this refactor
+      changes the module boundary."
+  - name: Cut empty intensifiers and throat-clearing
+    description: >
+      Delete "notably", "significantly", "importantly", "it's worth noting
+      that", "it's important to understand", and their kin. They add emphasis a
+      real figure earns on its own. "Coverage rose to 74 percent" needs no
+      "notably" in front of it.
+  - name: Drop the LLM buzzwords
+    description: >
+      Avoid "leverage" as a verb, "robust", "seamless", "delve", "underscore",
+      "tapestry", "realm", "landscape", and "testament to". Use the plain word:
+      "use", not "leverage"; "the report shows", not "the report underscores".
+  - name: Break the rule of three and the uniform bullet opener
+    description: >
+      Machine prose reaches for three-item triads and for lists where every
+      bullet opens with the same part of speech. Vary list length to what the
+      content actually holds — two items, or five — and let bullets begin
+      differently. A page of identically-shaped sentences reads as generated.
+  - name: No puffery
+    description: >
+      Cut self-congratulation and vague praise: "a strong quarter", "impressive
+      progress", "significant strides". Let the counted movement carry the
+      judgement. If velocity rose, show the per-week figure and let the reader
+      conclude it is strong.
+  - name: Label gathered versus synthesized figures
+    description: >
+      Mark, for each figure, whether the report measured it directly or reused
+      it from an upstream source such as a research-squad output. A consistent
+      label lets a reviewer spot-check the load-bearing numbers and lets a
+      later reader trust the ones that are not spot-checked.
+
+anti_patterns:
+  - name: Technical-first burial
+    description: >
+      Opening with architecture detail or a metric table forces the stakeholder
+      and investor to mine for the outcome, and most will stop before they find
+      it. The outcome belongs in the first two lines.
+  - name: The unattributed hero number
+    description: >
+      A striking figure with no source is the fastest way to lose a report's
+      credibility on review. If the number cannot be traced, it cannot be the
+      headline.
+  - name: Em-dash sprawl and buzzword fog
+    description: >
+      A report where clauses are strung on em-dashes and sentences reach for
+      "leverage", "robust", and "seamless" reads as generated regardless of how
+      sound the underlying analysis is, and a skeptical reader discounts the
+      whole thing.
+
+references:
+  - "packs/built-in/styleguides/planning-and-tracking.styleguide.yaml"

--- a/packs/internal/tactics/branded-deliverable.tactic.yaml
+++ b/packs/internal/tactics/branded-deliverable.tactic.yaml
@@ -1,0 +1,74 @@
+schema_version: "1.0"
+id: branded-deliverable
+name: Branded Deliverable
+purpose: >
+  Decide when a maintainer deliverable warrants the Spec Kitty brand, then take
+  it from Markdown source to a signed-off branded PDF. This is the decision and
+  workflow layer: it governs which documents earn branding (audience-facing
+  reports, postmortems, and announcements — not internal scratch), the
+  author-generate-review-iterate loop, and the guardrails that keep the output
+  on-brand (composed voice, the light cream/paper print treatment led by the
+  signature yellow, sage green never promoted to a lead colour, and a designer
+  sign-off on the rendered pages). The generation mechanics — dependencies,
+  the generator invocation and its flags, and verification — live in the
+  branded-document-generation toolguide, which this tactic uses as its how.
+steps:
+  - title: Decide whether the deliverable warrants branding
+    description: >
+      Brand a deliverable only when it is audience-facing and leaves the
+      maintainer team: release reports, development-cycle postmortems, launch
+      announcements, and comparable documents a reader outside the team will
+      hold. Internal scratch, working notes, in-flight investigation traces, and
+      throwaway drafts stay as plain Markdown — branding them wastes effort and
+      dilutes the treatment. When in doubt, ask who the reader is: an external
+      or cross-team audience argues for branding; a note to yourself does not.
+    examples:
+      - "A 3.2.6 development-cycle postmortem shared beyond the maintainers is branded."
+      - "A scratch list of merge gotchas kept in a mission worktree stays plain Markdown."
+  - title: Author and revise the source Markdown to the brand voice
+    description: >
+      Write and revise the source before generating anything — the generator
+      renders what you give it and does not fix prose. Apply the Spec Kitty
+      voice: composed, direct, concrete, sentence case, no emoji, and no
+      exclamation marks. Use the canonical terminology — "Mission" (never
+      "feature"), and "charter", "doctrine", and "orchestrator-api" as the
+      canon spells them. Keep the concrete outcome in front of the abstract
+      claim.
+    examples:
+      - "Rewrite 'All checks passed!' as 'All checks passed.' before rendering."
+      - "Replace 'the feature branch' with 'the Mission branch' throughout the source."
+  - title: Generate the branded PDF
+    description: >
+      Run the generator to produce the PDF, following the branded-document-generation
+      toolguide for the dependency setup, the exact invocation, and its cover and
+      running-footer flags. Supply a cover title, subtitle, lede, eyebrow, and
+      footer for an audience-facing deliverable; point --design-repo at the
+      spec-kitty-design checkout when you are not running from a sibling
+      directory. Run it with a Python that has WeasyPrint importable so the
+      pyenv-shim subprocess failure is avoided.
+    examples:
+      - "python assets/spec-kitty-branded-pdf.py --input report.md --output report.pdf --title '3.2.6 Cycle Report' --eyebrow 'Spec Kitty · Release Report' --design-repo /path/to/spec-kitty-design"
+      - "Omit --title for a bare content render when a cover page is not wanted."
+  - title: Render the pages and run a designer review before shipping
+    description: >
+      Do not ship on a zero exit code. Verify the PDF with pdfinfo, then
+      rasterise the pages to PNG with pdftoppm and inspect the real output. Run
+      a designer review pass (profile designer-dagmar) on the rendered pages —
+      this is where brand faults surface that are invisible in the source, such
+      as eyebrow contrast and body measure. Confirm the treatment reads as the
+      light cream/paper print identity led by the signature yellow, with
+      dark-ink headings, and that sage green has not crept in as a lead or
+      accent colour.
+    examples:
+      - "pdftoppm -png -r 150 report.pdf review-page, then a designer-dagmar pass on review-page-1.png onward."
+      - "The reviewer flags low eyebrow contrast against the cream surface; the finding goes back to the source or the generator, not into the shipped PDF."
+  - title: Iterate to a designer sign-off
+    description: >
+      Fold each review finding back into the source Markdown (for prose and
+      structure) or raise it against the generator (for treatment) and
+      regenerate. Repeat generate, render, and review until the designer signs
+      off. Only a rendered, reviewed, signed-off PDF is a shippable branded
+      deliverable — an unrendered or unreviewed PDF is not.
+    examples:
+      - "A pandoc GFM bold-span parse trap mangles a line; reword the source so two bold spans are not adjacent, regenerate, and re-review."
+      - "After the second render the designer signs off and the PDF is released."

--- a/packs/internal/toolguides/BRANDED_DOCUMENT_GENERATION.md
+++ b/packs/internal/toolguides/BRANDED_DOCUMENT_GENERATION.md
@@ -1,0 +1,136 @@
+# Branded Document Generation
+
+Maintainer tooling for turning a Markdown source into a Spec Kitty branded PDF.
+The pipeline is a two-stage render: `pandoc` converts Markdown to HTML, then
+WeasyPrint converts that HTML to a print-ready PDF that honours the brand's
+`@page`, `@font-face`, and local-file rules. The generator script lives beside
+this guide in the internal pack at `assets/spec-kitty-branded-pdf.py`.
+
+## Purpose and when to use
+
+Use this tool when a deliverable is audience-facing and warrants the Spec Kitty
+brand: release reports, development-cycle postmortems, announcements, and other
+documents that leave the maintainer team. It first served the 3.2.6
+development-cycle postmortem.
+
+Do not reach for it for internal scratch, notes, or throwaway drafts. The
+decision of *when* a deliverable warrants branding, and the review workflow
+around it, belong to the `branded-deliverable` tactic; this guide is the *how*.
+
+## What the pipeline enforces
+
+The generator bakes the Spec Kitty print identity into the output. These are
+constraints, not suggestions:
+
+- **Print treatment is light cream/paper.** The page surface is
+  `--sk-surface-page` in its print form, `#F8F5EC` (warm cream), with white
+  cards. This is deliberately NOT the dark-mode website surface (`#0D0E11`).
+- **Signature yellow leads.** `#F5C518` carries the top rule, heading
+  underlines and left-rules, table headers, and list markers. It is the lead
+  brand colour and is used with intent, never as body text.
+- **Dark ink for headings and body.** Headings and prose sit in `#231D12` ink
+  with a softer `#5A5342` for secondary text.
+- **Sage green is never a lead colour.** `--sk-color-sage` (`#4F8F4F`) is
+  reserved by the design system for light-mode *headings* only; the print
+  pipeline does not promote it to a lead or accent role. Do not reintroduce it.
+- **Typefaces.** Falling Sky for display and headings, Swansea for body,
+  JetBrains Mono for code, labels, and the eyebrow. The fonts are loaded from
+  the sibling `spec-kitty-design` repo.
+- **Voice.** Composed, direct, concrete. Sentence case. No emoji. No
+  exclamation marks. Source prose you feed the generator must already comply —
+  the tool renders what you give it.
+
+The brand authority for these values is the `spec-kitty-design` repo:
+`docs/design-system/brand-guidelines.md` and
+`packages/tokens/dist/tokens.css`.
+
+## Dependencies
+
+- **`pandoc`** on PATH — Markdown (GFM) to HTML.
+- **WeasyPrint** importable by the Python you run the generator with, or
+  `weasyprint` on PATH — HTML to PDF. The generator prefers the importable
+  library and falls back to the CLI.
+- **The sibling `spec-kitty-design` repo** — supplies the brand fonts
+  (`packages/tokens/dist/fonts`) and the logo
+  (`packages/tokens/assets/logo.png`). If the fonts are absent, WeasyPrint
+  falls back to system faces and the PDF renders off-brand.
+
+Install the Python dependencies into an environment that also has WeasyPrint's
+native libraries available:
+
+```bash
+pip install weasyprint
+# pandoc is a system package:
+#   macOS:        brew install pandoc
+#   Ubuntu/Debian: sudo apt install pandoc
+# verification tools ship with poppler:
+#   macOS:        brew install poppler
+#   Ubuntu/Debian: sudo apt install poppler-utils
+```
+
+## Generating the PDF
+
+The generator takes a Markdown input and a PDF output, plus optional cover and
+running-footer metadata. A `--title` produces a full branded cover page; omit
+it for a bare content render.
+
+```bash
+python assets/spec-kitty-branded-pdf.py \
+  --input report.md \
+  --output report.pdf \
+  --title "3.2.6 Cycle Report" \
+  --subtitle "Development-cycle postmortem" \
+  --lede "What shipped, what slipped, and what the team changed." \
+  --eyebrow "Spec Kitty · Release Report" \
+  --footer-center "3.2.6 CYCLE REPORT" \
+  --meta "DATE=2026-09-04" \
+  --meta "AUTHOR=Maintainer team" \
+  --design-repo /path/to/spec-kitty-design
+```
+
+Flags:
+
+- `--input` / `--output` — required source Markdown and destination PDF.
+- `--title` — cover title; omit for no cover page.
+- `--subtitle`, `--lede`, `--eyebrow` — cover copy. The eyebrow renders in
+  ALL-CAPS monospace with wide tracking.
+- `--footer-center` — the centred running-footer label on every non-cover page.
+- `--meta "LABEL=value"` — repeatable cover meta chip.
+- `--design-repo` — path to the `spec-kitty-design` repo. See the auto-detect
+  note below.
+
+## Verifying the output
+
+Do not trust that a PDF is correct because the command exited zero. Verify it:
+
+```bash
+# Confirm page count, size, and that a PDF was actually produced:
+pdfinfo report.pdf
+
+# Rasterise pages to PNG for a visual/design-review pass:
+pdftoppm -png -r 150 report.pdf review-page
+# produces review-page-1.png, review-page-2.png, ...
+```
+
+Rendering the pages to PNG is not optional polish — it is how the design-review
+step in the `branded-deliverable` tactic inspects real output. A designer
+review pass (profile `designer-dagmar`) on the rendered pages caught
+eyebrow-contrast and body-measure issues that were invisible in the source
+Markdown.
+
+## Known gotchas
+
+- **WeasyPrint under a pyenv shim fails with exit 127 in a subprocess.** If the
+  generator falls back to the `weasyprint` CLI and that CLI is a pyenv shim, the
+  subprocess can fail to resolve (`127`). Run the generator with a Python
+  interpreter that has `weasyprint` importable so the in-process path is taken,
+  rather than relying on a shimmed CLI on PATH.
+- **The design-repo auto-detect only finds a sibling checkout.** The generator
+  walks parent directories looking for a `spec-kitty-design` sibling. When you
+  run it from elsewhere, pass `--design-repo` explicitly, or the fonts and logo
+  will be missing and the PDF renders off-brand.
+- **pandoc GFM breaks a bold span that starts with `~`.** A `**~...**` bold span
+  placed immediately after another bold span on the same line can be
+  mis-parsed by pandoc's GFM reader (the `~` is read as strikethrough). Reword
+  the source so the two bold spans are not adjacent, or so the second does not
+  lead with `~`.

--- a/packs/internal/toolguides/BRANDED_DOCUMENT_GENERATION.md
+++ b/packs/internal/toolguides/BRANDED_DOCUMENT_GENERATION.md
@@ -34,8 +34,10 @@ constraints, not suggestions:
   reserved by the design system for light-mode *headings* only; the print
   pipeline does not promote it to a lead or accent role. Do not reintroduce it.
 - **Typefaces.** Falling Sky for display and headings, Swansea for body,
-  JetBrains Mono for code, labels, and the eyebrow. The fonts are loaded from
-  the sibling `spec-kitty-design` repo.
+  JetBrains Mono for code, labels, and the eyebrow. Falling Sky and Swansea are
+  loaded as local `@font-face` files from the sibling `spec-kitty-design` repo;
+  JetBrains Mono is pulled over the network via a Google Fonts `@import`, so an
+  offline run falls back to the platform monospace face for those spans.
 - **Voice.** Composed, direct, concrete. Sentence case. No emoji. No
   exclamation marks. Source prose you feed the generator must already comply —
   the tool renders what you give it.

--- a/packs/internal/toolguides/branded-document-generation.toolguide.yaml
+++ b/packs/internal/toolguides/branded-document-generation.toolguide.yaml
@@ -1,0 +1,24 @@
+schema_version: "1.0"
+id: branded-document-generation
+tool: spec-kitty-branded-pdf
+title: Branded Document Generation
+guide_path: packs/internal/toolguides/BRANDED_DOCUMENT_GENERATION.md
+applies_to_languages: []
+summary: >
+  How to turn a Markdown source into a Spec Kitty branded PDF using the
+  maintainer-only generator (Markdown to HTML via pandoc, HTML to PDF via
+  WeasyPrint). Documents the dependency setup, the generator invocation and
+  its cover/footer flags, the brand constraints the pipeline enforces (light
+  cream/paper print treatment led by the signature yellow with dark-ink
+  headings; Falling Sky / Swansea / JetBrains Mono type; composed voice with no
+  exclamation marks; sage green is never a lead colour), the sibling design-repo
+  dependency for fonts and logo, and how to verify the rendered PDF with
+  pdfinfo and pdftoppm. Covers the known gotchas: WeasyPrint's pyenv shim
+  failing under a subprocess, the design-repo path auto-detect needing
+  --design-repo when run from elsewhere, and a pandoc GFM bold-span parse trap.
+commands:
+  - pandoc
+  - weasyprint
+  - spec-kitty-branded-pdf.py
+  - pdfinfo
+  - pdftoppm


### PR DESCRIPTION
## What this changes

Two methodologies we proved during the 3.2.6 cycle now live as reusable **internal-pack doctrine** instead of tribal knowledge in a chat transcript:

1. **Branded documents** — turning a Markdown write-up into a Spec Kitty branded PDF (the treatment used for the 3.2.6 cycle report).
2. **Project-evolution post-mortems** — the research-squad + metrics + branded-report method used to produce that report.

Next time a maintainer needs either, the charter hands them the generator, the pipeline how-to, the "when to brand" judgement, the report template, and the writing style — wired together so activating the procedure pulls in everything it needs.

This is the **org-tier internal pack** (`packs/internal/`). It is maintainer-only doctrine and **never ships** to consumers — `pyproject.toml` narrows the wheel/sdist to `packs/built-in/`, and `test_packaging_safety.py` guards that boundary.

## What's added

**Branded-document chain**
- `assets/spec-kitty-branded-pdf.py` (+ sidecar) — the generator. pandoc (Markdown → HTML) → brand CSS → WeasyPrint. Pulls fonts/logo/tokens from the sibling `spec-kitty-design` repo. Light cream/paper print treatment led by the signature yellow (`#F5C518`), dark-ink headings; sage is never a lead colour.
- `toolguides/branded-document-generation` (+ `BRANDED_DOCUMENT_GENERATION.md`) — the pipeline how-to: dependencies, invocation and flags, `pdfinfo`/`pdftoppm` verification, brand constraints, and the real gotchas (WeasyPrint's pyenv-shim `127` under `subprocess`, `--design-repo` auto-detect from a scratch dir, the pandoc GFM `**~…**` bold-span trap).
- `tactics/branded-deliverable` — when to brand vs. leave plain, and the author → generate → designer review (`designer-dagmar`) → iterate loop.

**Project-evolution post-mortem chain**
- `procedures/project-evolution-postmortem` — the research-squad setup (architecture / metrics / tracer-friction lenses as governed dispatch Ops), the metric checklist (bug trend, SonarCloud static quality, commit/PR distribution, velocity, community-vs-maintainer split, tracer friction), the report template (headline → TL;DR → full write-up, for three audiences), and review discipline.
- `styleguides/report-writing` — audience-first progressive disclosure, the anti-AI-prose rules, the Spec Kitty brand voice, and evidence attribution.

**Wiring**
- `drg/fragment.yaml` — the procedure `suggests` the styleguide and the tactic; the tactic `requires` the toolguide; the toolguide `requires` the asset. One authoring chain.
- `org-charter.yaml` — activates the new procedure (`required_procedures`).
- `README.md` — layout + authoring-chain note.

## Provenance

Both methods were exercised end-to-end producing `work/…/spec-kitty-3.2.6-cycle-report.pdf` (the 10-page branded post-mortem). This PR captures the approach so it is repeatable and governed rather than re-derived.

## Review

Assigned to **@robertDouglass**. A profile-loaded review squad (DRG/correctness, convention/consistency, clarity/terminology) ran over the set before hand-off; notes folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791101742&installation_model_id=427282&pr_number=3877&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3877&signature=a32354e822ff0ac05f7c894ba9fc394b20b7ba4c49bd5ff9ace195ae64fb1841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->