### PR TITLE
fix(sync): use portable transport lease locking on Windows

### DIFF
--- a/src/specify_cli/sync/transport_lease.py
+++ b/src/specify_cli/sync/transport_lease.py
@@ -7,15 +7,17 @@ eligibility check, transport start, and result recording across processes.
 
 from __future__ import annotations
 
-import fcntl
 import os
-import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
+
+from filelock import FileLock
+
+from specify_cli.core.checkout_file_lock import acquire_or_raise
 
 from specify_cli.sync.feature_flags import is_saas_sync_enabled
 from specify_cli.sync.project_context import (
@@ -84,17 +86,14 @@ def acquire_project_transport_lease(
     identity = f"{label}:pid:{os.getpid()}:acquisition:{uuid.uuid4()}"
 
     path = store.egress_lock_path
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a+b") as handle:
-        deadline = time.monotonic() + lock_timeout_seconds
-        while True:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except BlockingIOError as exc:
-                if time.monotonic() >= deadline:
-                    raise ProjectStoreLockedError("project transport lease is locked") from exc
-                time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+    lock = FileLock(path)
+    acquire_or_raise(
+        lock,
+        path,
+        timeout_seconds=lock_timeout_seconds,
+        build_timeout_error=lambda: ProjectStoreLockedError("project transport lease is locked"),
+    )
+    try:
         try:
             _register_live_lease(
                 identity,
@@ -104,7 +103,8 @@ def acquire_project_transport_lease(
             yield TransportLeaseContext(store=store, lease_identity=identity, lock_path=path)
         finally:
             _unregister_live_lease(identity)
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock.release()
 
 
 def transport_lease_is_live(lease_identity: str | None) -> bool:

--- a/tests/sync/test_transport_result_lease.py
+++ b/tests/sync/test_transport_result_lease.py
@@ -160,6 +160,7 @@ def test_same_label_reacquisition_does_not_reactivate_cached_context(
             mark_transport_started(unit, stale_context, "attempt-lease")
 
 
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="Requires POSIX fork semantics")
 def test_forked_child_does_not_inherit_live_lease_authority(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Replace the unconditional POSIX-only fcntl import and flock loop in transport leases with the existing filelock dependency and canonical acquire_or_raise helper.
- Preserve the lock path, typed timeout error, and live-lease registration and release lifecycle.
- Skip the fork-inheritance test only on platforms without os.fork.

## Problem
On Windows, enabling SPEC_KITTY_ENABLE_SAAS_SYNC=1 makes tracker command loading fail because fcntl is unavailable. This prevents even tracker --help from starting.

## Verification
Windows targeted run on this commit: 19 passed, 1 skipped (POSIX fork semantics). git diff --check passed. Tracker help with SaaS sync enabled started successfully during local validation.

Command: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 SPEC_KITTY_ENABLE_SAAS_SYNC=1 PYTHONPATH=src python -m pytest --noconftest -o addopts='' tests/sync/test_transport_result_lease.py -q

The targeted run bypassed repository conftest and plugin autoload; two expected unknown asyncio configuration warnings were emitted. This is not a full-suite result. Linux behavior, including the fork test, still requires CI/reviewer validation. No live tracker synchronization was performed.

## Scope
Two files only; no new dependencies, generated skills, version changes, or data migration. A release-based equivalent is being used locally on Windows. This draft submits the main-based patch for review; no merge is requested automatically.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791142271&installation_model_id=427282&pr_number=3878&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3878&signature=29e6183dd0a08a6bf3a88f75d8557e098efdf45b764fe875bae30ba7dfe2f2eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->