### PR TITLE
Close live review findings

### DIFF
--- a/src/specify_cli/dashboard/handlers/features.py
+++ b/src/specify_cli/dashboard/handlers/features.py
@@ -296,12 +296,17 @@ class FeatureHandler(DashboardHandler):
         self.end_headers()
 
     def _handle_artifact_directory(self, path: str, directory_name: str, md_icon: str = "📝") -> None:
-        """Generic handler for artifact directories (contracts, checklists, etc).
+        """Serve an artifact-directory listing or a contained file.
+
+        The endpoint accepts ``/api/{directory_name}/{mission}`` for a JSON
+        listing and appends one URL-encoded repository-relative path to serve a
+        file.  The Mission planning directory is resolved through the canonical
+        planning seam; file requests that escape that directory receive ``404``.
 
         Args:
-            path: The request path
-            directory_name: Name of the subdirectory (e.g., 'contracts', 'checklists')
-            md_icon: Icon to use for .md files (default: '📝')
+            path: Request path, including the Mission selector and optional file.
+            directory_name: Artifact subdirectory, such as ``contracts``.
+            md_icon: Icon used for Markdown files in a listing.
         """
         parts = path.split("/")
         if len(parts) < 4:

--- a/src/specify_cli/dashboard/handlers/features.py
+++ b/src/specify_cli/dashboard/handlers/features.py
@@ -301,7 +301,8 @@ class FeatureHandler(DashboardHandler):
         The endpoint accepts ``/api/{directory_name}/{mission}`` for a JSON
         listing and appends one URL-encoded repository-relative path to serve a
         file.  The Mission planning directory is resolved through the canonical
-        planning seam; file requests that escape that directory receive ``404``.
+        planning seam; file requests must remain below the named artifact
+        directory or receive ``404``.
 
         Args:
             path: Request path, including the Mission selector and optional file.
@@ -358,9 +359,10 @@ class FeatureHandler(DashboardHandler):
             file_path_encoded = parts[4]
             file_path_str = urllib.parse.unquote(file_path_encoded)
             artifact_file = (feature_dir / file_path_str).resolve()
+            artifact_dir = (feature_dir / directory_name).resolve()
 
             try:
-                artifact_file.relative_to(feature_dir.resolve())
+                artifact_file.relative_to(artifact_dir)
             except ValueError:
                 self.send_response(404)
                 self.end_headers()

--- a/src/specify_cli/manifest.py
+++ b/src/specify_cli/manifest.py
@@ -5,7 +5,7 @@ This module generates and checks expected files based on the mission context.
 
 from specify_cli.core.constants import KITTY_SPECS_DIR
 from specify_cli.missions._read_path_resolver import candidate_feature_dir_for_mission
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 import subprocess
 
@@ -65,6 +65,24 @@ class FileManifest:
         return manifest
 
     @staticmethod
+    def _canonical_script_path(script_path: str) -> str | None:
+        """Return a canonical scripts-relative path, or reject unsafe input."""
+        prefix = ".kittify/scripts/"
+        if not script_path.startswith(prefix):
+            return None
+
+        relative_path = script_path.removeprefix(prefix)
+        parsed_path = PurePosixPath(relative_path)
+        if (
+            not relative_path
+            or "\\" in relative_path
+            or parsed_path.is_absolute()
+            or any(part in {".", ".."} for part in parsed_path.parts)
+        ):
+            return None
+        return str(PurePosixPath("scripts") / parsed_path)
+
+    @staticmethod
     def _parse_frontmatter_scripts(content: str, script_key: str) -> set[str]:
         """Extract .kittify/scripts/ paths from a command file's YAML frontmatter."""
         scripts: set[str] = set()
@@ -81,8 +99,9 @@ class FileManifest:
             if len(parts) != 2:
                 continue
             script_path = parts[1].strip().strip('"').strip("'").split()[0] if parts[1].strip() else ""
-            if script_path.startswith(".kittify/scripts/"):
-                scripts.add(script_path.replace(".kittify/", "", 1))
+            canonical_path = FileManifest._canonical_script_path(script_path)
+            if canonical_path is not None:
+                scripts.add(canonical_path)
         return scripts
 
     def _get_referenced_scripts(self) -> list[str]:

--- a/src/specify_cli/upgrade/migrations/m_0_4_8_gitignore_agents.py
+++ b/src/specify_cli/upgrade/migrations/m_0_4_8_gitignore_agents.py
@@ -57,7 +57,7 @@ class GitignoreAgentsMigration(BaseMigration):
             try:
                 # Test read access; tolerate BOM and ignore invalid UTF-8 bytes
                 gitignore.read_text(encoding="utf-8-sig", errors="ignore")
-            except (OSError, UnicodeDecodeError):
+            except OSError:
                 return False, ".gitignore is not readable"
 
         return True, ""

--- a/src/specify_cli/upgrade/migrations/m_0_8_0_worktree_agents_symlink.py
+++ b/src/specify_cli/upgrade/migrations/m_0_8_0_worktree_agents_symlink.py
@@ -41,11 +41,8 @@ class WorktreeAgentsSymlinkMigration(BaseMigration):
         for worktree in worktrees_dir.iterdir():
             if worktree.is_dir() and not worktree.name.startswith("."):
                 wt_agents = worktree / ".kittify" / "AGENTS.md"
-                # Check if missing or broken symlink
-                if not wt_agents.exists() and not wt_agents.is_symlink():
-                    return True
-                # Also check for broken symlinks
-                if wt_agents.is_symlink() and not wt_agents.exists():
+                # ``exists()`` is false for both a missing path and a broken symlink.
+                if not wt_agents.exists():
                     return True
 
         return False

--- a/tests/cross_cutting/packaging/test_manifest_cli_filtering.py
+++ b/tests/cross_cutting/packaging/test_manifest_cli_filtering.py
@@ -11,10 +11,9 @@ attribute (feature 054 – state architecture cleanup phase 2, WP02).
 import platform
 from pathlib import Path
 
-from specify_cli.manifest import FileManifest
-
-
 import pytest
+
+from specify_cli.manifest import FileManifest
 
 pytestmark = [pytest.mark.integration]
 
@@ -96,6 +95,27 @@ sh: .kittify/scripts/helper.sh
         assert "scripts/helper.ps1" in scripts
     else:
         assert "scripts/helper.sh" in scripts
+
+
+def test_noncanonical_kittify_script_paths_are_excluded(tmp_path: Path):
+    """Only files below the canonical scripts directory may enter the manifest."""
+    kittify_dir = tmp_path / ".kittify"
+    missions_dir = kittify_dir / "missions" / "software-dev"
+    commands_dir = missions_dir / "command-templates"
+    commands_dir.mkdir(parents=True)
+    (missions_dir / "mission.yaml").write_text("name: software-dev\n")
+
+    command_content = """---
+description: Paths outside scripts must not be accepted
+sh: .kittify/scripts/../templates/injected.sh
+---
+# Invalid script reference
+"""
+    (commands_dir / "invalid-script-path.md").write_text(command_content)
+
+    manifest = FileManifest(kittify_dir, mission_type="software-dev")
+
+    assert manifest._get_referenced_scripts() == []
 
 
 def test_other_system_commands_filtered(tmp_path: Path):

--- a/tests/specify_cli/mission_step_contracts/test_executor.py
+++ b/tests/specify_cli/mission_step_contracts/test_executor.py
@@ -16,7 +16,7 @@ from ruamel.yaml import YAML
 from charter.activation._drg_helpers import load_validated_graph
 from charter.drg import resolve_context
 from charter.offering.missions.step_contracts import MissionStepContractRepository
-from specify_cli.invocation.writer import EVENTS_DIR
+from specify_cli.invocation.writer import EVENTS_DIR, INDEX_PATH
 from specify_cli.mission_step_contracts.executor import (
     StepContractExecutionContext,
     StepContractExecutionError,
@@ -25,6 +25,8 @@ from specify_cli.mission_step_contracts.executor import (
 
 
 pytestmark = pytest.mark.fast
+
+_OPS_INDEX_FILENAME = Path(INDEX_PATH).name
 
 
 def test_charter_mission_steps_facade_reexports_step_inputs() -> None:
@@ -375,7 +377,7 @@ def test_three_delegated_steps_execute_end_to_end_via_profile_invocation_executo
     jsonl_files = sorted(
         path
         for path in (repo_root / EVENTS_DIR).glob("*.jsonl")
-        if "index" not in path.name  # exclude the ops-index file (lives in EVENTS_DIR since #1714)
+        if path.name != _OPS_INDEX_FILENAME
     )
     assert len(jsonl_files) == 3
 

--- a/tests/specify_cli/mission_step_contracts/test_software_dev_composition.py
+++ b/tests/specify_cli/mission_step_contracts/test_software_dev_composition.py
@@ -29,7 +29,7 @@ from unittest.mock import patch
 import pytest
 
 from charter.offering.missions.step_contracts import MissionStepContractRepository
-from specify_cli.invocation.writer import EVENTS_DIR
+from specify_cli.invocation.writer import EVENTS_DIR, INDEX_PATH
 from specify_cli.mission_step_contracts.executor import (
     _ACTION_PROFILE_DEFAULTS,
     StepContractExecutionContext,
@@ -38,6 +38,8 @@ from specify_cli.mission_step_contracts.executor import (
 
 
 pytestmark = pytest.mark.fast
+
+_OPS_INDEX_FILENAME = Path(INDEX_PATH).name
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +221,23 @@ def _read_jsonl_records(path: Path) -> list[dict[str, object]]:
     return records
 
 
+def _invocation_jsonl_files(events_dir: Path) -> list[Path]:
+    """Return per-invocation logs without hiding filenames that contain ``index``."""
+    return sorted(
+        path for path in events_dir.glob("*.jsonl") if path.name != _OPS_INDEX_FILENAME
+    )
+
+
+def test_invocation_jsonl_files_excludes_only_ops_index(tmp_path: Path) -> None:
+    """A legitimate invocation log such as ``reindex.jsonl`` remains observable."""
+    ops_index = tmp_path / _OPS_INDEX_FILENAME
+    reindex = tmp_path / "reindex.jsonl"
+    ops_index.touch()
+    reindex.touch()
+
+    assert _invocation_jsonl_files(tmp_path) == [reindex]
+
+
 def _run_software_dev_specify(
     repo_root: Path,
     *,
@@ -290,11 +309,7 @@ def test_governance_context_uses_contract_action_when_hint_supplied(tmp_path: Pa
 
     result = _run_software_dev_specify(repo_root)
 
-    jsonl_files = sorted(
-        path
-        for path in (repo_root / EVENTS_DIR).glob("*.jsonl")
-        if "index" not in path.name  # exclude the ops-index file (lives in EVENTS_DIR since #1714)
-    )
+    jsonl_files = _invocation_jsonl_files(repo_root / EVENTS_DIR)
     assert len(jsonl_files) == len(result.steps)
 
     for path in jsonl_files:
@@ -314,11 +329,7 @@ def test_composed_action_pairs_started_with_completed(tmp_path: Path) -> None:
 
     result = _run_software_dev_specify(repo_root)
 
-    jsonl_files = sorted(
-        path
-        for path in (repo_root / EVENTS_DIR).glob("*.jsonl")
-        if "index" not in path.name  # exclude the ops-index file (lives in EVENTS_DIR since #1714)
-    )
+    jsonl_files = _invocation_jsonl_files(repo_root / EVENTS_DIR)
     assert len(jsonl_files) == len(result.steps)
 
     for path in jsonl_files:
@@ -381,11 +392,7 @@ def test_composed_step_failure_writes_failed_completion(tmp_path: Path) -> None:
             )
         )
 
-    jsonl_files = sorted(
-        path
-        for path in (repo_root / EVENTS_DIR).glob("*.jsonl")
-        if "index" not in path.name  # exclude the ops-index file (lives in EVENTS_DIR since #1714)
-    )
+    jsonl_files = _invocation_jsonl_files(repo_root / EVENTS_DIR)
     # Two invocations: the first closed with done, the second closed with failed.
     assert len(jsonl_files) == 2
 
@@ -535,11 +542,7 @@ def test_composed_action_outcome_is_done_even_though_composition_does_not_run_ll
 
     result = _run_software_dev_specify(repo_root)
 
-    jsonl_files = sorted(
-        path
-        for path in (repo_root / EVENTS_DIR).glob("*.jsonl")
-        if "index" not in path.name  # exclude the ops-index file (lives in EVENTS_DIR since #1714)
-    )
+    jsonl_files = _invocation_jsonl_files(repo_root / EVENTS_DIR)
     assert len(jsonl_files) == len(result.steps)
     assert jsonl_files, "expected at least one composed-step JSONL"
 

--- a/tests/test_dashboard/test_api_handler.py
+++ b/tests/test_dashboard/test_api_handler.py
@@ -248,6 +248,73 @@ class TestFeaturesEndpointErrorHandling:
             features_module.FeatureHandler.handle_artifact(handler, "/api/artifact/001-test/spec")
 
 
+class TestArtifactDirectoryEndpoint:
+    """Artifact-directory routes return only the directory they advertise."""
+
+    @staticmethod
+    def _handler(project_dir: Path) -> MagicMock:
+        handler = MagicMock()
+        handler.project_dir = str(project_dir)
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.wfile = io.BytesIO()
+        return handler
+
+    def test_contract_listing_returns_files_below_contracts_directory(self, tmp_path: Path):
+        from specify_cli.dashboard.handlers import features as features_module
+
+        mission_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        contracts_dir = mission_dir / "contracts"
+        contracts_dir.mkdir(parents=True)
+        (contracts_dir / "api.md").write_text("# API contract\n")
+        (mission_dir / "spec.md").write_text("# Mission specification\n")
+        handler = self._handler(tmp_path)
+
+        with patch.object(
+            features_module,
+            "resolve_feature_planning_dir",
+            return_value=mission_dir,
+        ):
+            features_module.FeatureHandler._handle_artifact_directory(
+                handler,
+                "/api/contracts/001-test-mission",
+                "contracts",
+            )
+
+        handler.send_response.assert_called_once_with(200)
+        response = json.loads(handler.wfile.getvalue())
+        assert response == {
+            "files": [
+                {"name": "api.md", "path": "contracts/api.md", "icon": "📝"},
+            ]
+        }
+
+    def test_contract_endpoint_refuses_file_outside_contracts_directory(self, tmp_path: Path):
+        from specify_cli.dashboard.handlers import features as features_module
+
+        mission_dir = tmp_path / "kitty-specs" / "001-test-mission"
+        contracts_dir = mission_dir / "contracts"
+        contracts_dir.mkdir(parents=True)
+        (mission_dir / "spec.md").write_text("# Mission specification\n")
+        handler = self._handler(tmp_path)
+
+        with patch.object(
+            features_module,
+            "resolve_feature_planning_dir",
+            return_value=mission_dir,
+        ):
+            features_module.FeatureHandler._handle_artifact_directory(
+                handler,
+                "/api/contracts/001-test-mission/spec.md",
+                "contracts",
+            )
+
+        handler.send_response.assert_called_once_with(404)
+        handler.wfile.seek(0)
+        assert handler.wfile.read() == b""
+
+
 class TestDossierEndpointRouting:
     def _make_handler(self, tmp_path, path: str):
         from specify_cli.dashboard.handlers import api as api_module


### PR DESCRIPTION
## Summary
- retain invocation logs whose filename contains index while excluding only the canonical operations index
- reject non-canonical script references in manifests
- simplify the broken-symlink migration guard and remove an unreachable decode exception
- confine dashboard artifact endpoint file reads to their named directories, with direct regression coverage

## Validation
- 30 mission-step-contract tests passed
- 2 migration tests passed
- 62 manifest and dashboard tests passed
- Ruff passed for every changed file
- The new logic is mypy-clean; unchanged dashboard and migration base classes emit existing untyped-base-class diagnostics when checked in isolation

Addresses current review findings from #1721, #56, #57, #59, and #82.