### PR TITLE
fix(skills): serialize portable manifest paths

### DIFF
--- a/src/specify_cli/skills/manifest.py
+++ b/src/specify_cli/skills/manifest.py
@@ -18,7 +18,10 @@ MANIFEST_FILENAME = "skills-manifest.json"
 
 @dataclass
 class ManagedFileEntry:
-    """A single file installed by the skill manager."""
+    """A single file installed by the skill manager.
+
+    Manifest paths are portable relative paths and always use POSIX separators.
+    """
 
     skill_name: str  # e.g., "spec-kitty-setup-doctor"
     source_file: str  # Relative within skill dir, e.g., "SKILL.md"
@@ -28,6 +31,11 @@ class ManagedFileEntry:
     content_hash: str  # "sha256:<hex>"
     installed_at: str  # ISO 8601 UTC
     delivery_mode: str = "copy"  # "copy" or "symlink"
+
+    def __post_init__(self) -> None:
+        """Normalize paths produced on Windows or loaded from older manifests."""
+        self.source_file = self.source_file.replace("\\", "/")
+        self.installed_path = self.installed_path.replace("\\", "/")
 
 
 @dataclass
@@ -46,11 +54,7 @@ class ManagedSkillManifest:
         Shared-root agents intentionally share ``installed_path`` so deduplication
         must include ``agent_key`` to avoid collapsing entries for different agents.
         """
-        self.entries = [
-            e
-            for e in self.entries
-            if not (e.installed_path == entry.installed_path and e.agent_key == entry.agent_key)
-        ]
+        self.entries = [e for e in self.entries if not (e.installed_path == entry.installed_path and e.agent_key == entry.agent_key)]
         self.entries.append(entry)
 
     def remove_entries_for_agent(self, agent_key: str) -> list[ManagedFileEntry]:

--- a/tests/specify_cli/skills/test_manifest.py
+++ b/tests/specify_cli/skills/test_manifest.py
@@ -19,6 +19,7 @@ import pytest
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
+
 def _make_entry(
     skill_name: str = "test-skill",
     source_file: str = "SKILL.md",
@@ -46,6 +47,16 @@ def test_create_manifest_with_defaults() -> None:
     assert m.updated_at == ""
     assert m.spec_kitty_version == ""
     assert m.entries == []
+
+
+def test_managed_file_entry_normalizes_paths_to_posix() -> None:
+    entry = _make_entry(
+        source_file=r"references\architecture.md",
+        installed_path=r".claude\skills\test-skill\SKILL.md",
+    )
+
+    assert entry.source_file == "references/architecture.md"
+    assert entry.installed_path == ".claude/skills/test-skill/SKILL.md"
 
 
 def test_add_entry() -> None:


### PR DESCRIPTION
## Issue
closes #3852

## Change
`ManagedFileEntry` (src/specify_cli/skills/manifest.py) normalizes `source_file` and `installed_path` to POSIX separators in `__post_init__` (authored by @be-student, commit 24917b65). On Windows, `str(Path.relative_to(...))` in the installer yields backslash-separated paths, so serialized manifests carried non-portable values and the six issue-listed assertions failed. Because every entry — constructed by the installer or loaded from an older manifest by the manifest parser — goes through the `ManagedFileEntry` constructor, this single boundary normalizes both producers and loads. On POSIX the normalization is a no-op. A regression test constructs an entry with Windows-style paths and asserts POSIX output.

Consumer-comparison note (corrected per squad pass 1 MINOR, #4073): the `.as_posix()` comparisons this fix aligns Windows-built entries with are, at the PR head, in `src/specify_cli/tool_surface/providers/managed_skills.py:384-388` (also `:420`, `:423`); the `installer.py:205, :306, :347, :525` sites cited by the earlier body are the corresponding comparisons in current `main` (the merge target, where the installer carries them) — the earlier body cited those line numbers without saying which tree they named.

Known limitation (the other squad MINOR, #4073): the unconditional `replace("\\", "/")` in `__post_init__` would also rewrite a POSIX filename that legally contains a literal backslash. This is accepted: manifest paths are declared POSIX-separator relative paths by this change, and shipped skill packs do not contain backslash filenames. A docstring note to that effect belongs on the contributor's fork branch (deferred to #4073); this body records the trade-off.

Fleet-implementer rounds: the PR head is a contributor-fork branch (`be-student:issue-3852-portable-manifest-paths`) that the fleet cannot push to, so both fleet rounds (2026-09-08T19:19Z and this fix round) are verification + PR-body upkeep; the head commit 24917b65 is unchanged.

## Tests run
This fix round (body-only; head unchanged at 24917b65, own base c0054153b; every count below from a fresh run on 2026-09-08):

- `uv run --frozen python -m pytest tests/specify_cli/skills/test_e2e.py::test_per_class_distribution tests/specify_cli/skills/test_e2e.py::test_multiple_agents_mixed_classes tests/specify_cli/skills/test_installer.py::TestInstallNativeRootAgent::test_files_placed_in_native_root tests/specify_cli/skills/test_installer.py::TestInstallSharedRootAgent::test_files_placed_in_shared_root tests/specify_cli/skills/test_installer.py::TestManifestEntriesCreated::test_entry_fields_correct tests/specify_cli/skills/test_installer.py::TestInstallCopiesReferencesAndScripts::test_entry_source_file_is_relative_within_skill -q -p no:cacheprovider` → 6/0 (the six issue-listed node IDs)
- `uv run --frozen --all-extras python -m pytest tests/adversarial/test_distribution.py tests/architectural/test_no_dead_modules.py tests/architectural/test_no_dead_symbols.py tests/review/test_dirty_classifier.py tests/specify_cli/cli/commands/test_agent_config.py tests/specify_cli/cli/commands/test_doctor_skills.py tests/specify_cli/cli/commands/test_init_manifest_coexistence.py tests/specify_cli/cli/commands/test_init_pi_letta.py tests/specify_cli/cli/commands/test_init_vibe.py tests/specify_cli/integration/test_rc44_migration_fixture.py tests/specify_cli/skills/test_command_installer.py tests/specify_cli/skills/test_e2e.py tests/specify_cli/skills/test_installer.py tests/specify_cli/skills/test_manifest.py tests/specify_cli/skills/test_manifest_repair.py tests/specify_cli/skills/test_manifest_store.py tests/specify_cli/skills/test_registry.py tests/specify_cli/skills/test_verifier.py tests/specify_cli/test_gitignore_contract.py tests/specify_cli/test_state_contract.py tests/specify_cli/tool_surface/integration/_compat_support.py tests/specify_cli/tool_surface/integration/test_compat_support.py tests/specify_cli/tool_surface/integration/test_doctor_tool_surfaces_cli.py tests/specify_cli/tool_surface/profiles/test_manifest.py tests/specify_cli/tool_surface/providers/test_command_skills.py tests/specify_cli/tool_surface/providers/test_managed_skills.py tests/specify_cli/tool_surface/test_docs.py tests/specify_cli/tool_surface/test_surface_repair_wiring.py tests/specify_cli/upgrade/migrations/test_m_3_2_0rc45_retire_standalone_skill_surface.py tests/specify_cli/upgrade/migrations/test_m_3_2_5_agents_skills_gitignore.py tests/specify_cli/upgrade/test_m_3_2_0rc35_codex_to_skills.py tests/upgrade/migrations/test_m_2_0_11_install_skills.py tests/upgrade/migrations/test_m_2_1_1_repair_skill_pack.py tests/upgrade/migrations/test_m_3_0_3_globalize_skill_pack.py tests/upgrade/migrations/test_m_3_2_0rc35_spk_skill_pack.py tests/upgrade/test_gitignore_backfill_untrack.py tests/upgrade/test_upgrade_auto_commit_unit.py -q -p no:cacheprovider` → 568/0 (the 37 files the Blast-radius Discovery command names, run directly)
- `uv run --frozen --all-extras python -m pytest tests/specify_cli/skills/ tests/architectural/ -q -p no:cacheprovider` → 2051/2 (2 skipped, 2 xfailed). Both failures are in `tests/architectural/`, and both are stale-base artifacts of the branch base being 738 commits behind main, measured per PROGRAM.md §6 in detached worktrees:
  - `test_golden_count_ban.py::test_convert_sites_do_not_exceed_frozen_baseline` fails identically at the head's own base `c0054153b` (detached worktree, no diff) — it pre-dates this PR and is green on clean `origin/main`.
  - `test_ruff_format_exclude_ratchet.py::test_every_exclude_entry_still_genuinely_reformats` passes at the base but fails at the head: this diff leaves `src/specify_cli/skills/manifest.py` and `tests/specify_cli/skills/test_manifest.py` ruff-format-clean, so their `[tool.ruff.format].exclude` entries — live (still genuinely reformatting) in the base tree — become dead entries there. On the merge target those entries are still live: both tests pass on clean `origin/main` and on the exact merge result (`origin/main` + 24917b65, merge commit 0c75bc709, built and tested in a scratch worktree) → 19/0. Deleting the two exclude entries to appease the head-tree ratchet would be wrong: they are live on main, and removing them would turn `ruff format --check .` red post-merge.
- `uv run --frozen ruff check .` → All checks passed!
- `uv run --frozen ruff format --check .` → 1532 files already formatted
- `uv run --frozen --with mypy mypy src/specify_cli/skills/manifest.py tests/specify_cli/skills/test_manifest.py` → Success: no issues found in 2 source files

Prior fleet round (2026-09-08T19:19Z, same head 24917b65), same diff rebased onto then-current main @ 296a9ddd5 (head c550fde78): six node IDs → 6/0; `tests/specify_cli/skills/` → 395/1 (the 1 failure, `test_e2e.py::test_drift_detection_and_repair`, reproduces identically on a clean detached worktree of origin/main @ 296a9ddd5 — pre-existing); `PWHEADLESS=1 uv run --frozen --all-extras python -m pytest tests/architectural/ -q -p no:cacheprovider` → 2282/0; `make test-fast` → 1782/0 (2 skipped); ruff/mypy clean.

Self-review:
- correctness: clean — normalization at the single constructor boundary every producer and loader passes through; no-op on POSIX; squad pass 1 independently verified the producers, the loader, and that the verifier's escape guard runs on the normalized value
- deletion safety: clean — nothing deleted
- security: clean — pure string normalization of relative manifest paths; no new I/O, parsing, or trust boundary; squad pass 1 confirmed no new traversal surface
- design fidelity: clean — smallest change that closes the issue; matches its acceptance ("serialized manifest paths remain portable across platforms")
- tests: clean — six issue node IDs green; every one of the 37 Discovery-listed test files green (568/0); owning subsystem + guard suites run in full with both reds proven stale-base artifacts and the merge result green

## Blast radius
Discovery: `grep -rl "skills.manifest\|skills/manifest\|ManagedFileEntry\|ManagedSkillManifest" tests/ --include="*.py"`
Files: tests/adversarial/test_distribution.py, tests/architectural/test_no_dead_modules.py, tests/architectural/test_no_dead_symbols.py, tests/review/test_dirty_classifier.py, tests/specify_cli/cli/commands/test_agent_config.py, tests/specify_cli/cli/commands/test_doctor_skills.py, tests/specify_cli/cli/commands/test_init_manifest_coexistence.py, tests/specify_cli/cli/commands/test_init_pi_letta.py, tests/specify_cli/cli/commands/test_init_vibe.py, tests/specify_cli/integration/test_rc44_migration_fixture.py, tests/specify_cli/skills/test_command_installer.py, tests/specify_cli/skills/test_e2e.py, tests/specify_cli/skills/test_installer.py, tests/specify_cli/skills/test_manifest.py, tests/specify_cli/skills/test_manifest_repair.py, tests/specify_cli/skills/test_manifest_store.py, tests/specify_cli/skills/test_registry.py, tests/specify_cli/skills/test_verifier.py, tests/specify_cli/test_gitignore_contract.py, tests/specify_cli/test_state_contract.py, tests/specify_cli/tool_surface/integration/_compat_support.py, tests/specify_cli/tool_surface/integration/test_compat_support.py, tests/specify_cli/tool_surface/integration/test_doctor_tool_surfaces_cli.py, tests/specify_cli/tool_surface/profiles/test_manifest.py, tests/specify_cli/tool_surface/providers/test_command_skills.py, tests/specify_cli/tool_surface/providers/test_managed_skills.py, tests/specify_cli/tool_surface/test_docs.py, tests/specify_cli/tool_surface/test_surface_repair_wiring.py, tests/specify_cli/upgrade/migrations/test_m_3_2_0rc45_retire_standalone_skill_surface.py, tests/specify_cli/upgrade/migrations/test_m_3_2_5_agents_skills_gitignore.py, tests/specify_cli/upgrade/test_m_3_2_0rc35_codex_to_skills.py, tests/upgrade/migrations/test_m_2_0_11_install_skills.py, tests/upgrade/migrations/test_m_2_1_1_repair_skill_pack.py, tests/upgrade/migrations/test_m_3_0_3_globalize_skill_pack.py, tests/upgrade/migrations/test_m_3_2_0rc35_spk_skill_pack.py, tests/upgrade/test_gitignore_backfill_untrack.py, tests/upgrade/test_upgrade_auto_commit_unit.py

The `Files:` list above is the full output of the Discovery command, re-run fresh at head 24917b65 (37 files; squad pass 1's MAJOR — the earlier body listed only the 2 changed files). It is the by-filename blast radius of this diff: every test file that references the manifest module or its dataclasses. All 37 were run directly this round (568/0). The owning subsystem (`tests/specify_cli/skills/`, 9 of the 37) and the guard suites (`tests/architectural/` in full, including the dead-module/dead-symbol gates that name the manifest module) were additionally run in full as every spec-kitty PR's standing guard obligation. The change is a dataclass-only normalization with no new imports or call sites, so no runtime module beyond `specify_cli.skills.manifest` (and its test) is affected.

## Deferred
Squad pass 1 MINORs, filed by the squad as #4073 (non-blocking): the docstring limitation note (needs a change on the contributor's fork; the trade-off is recorded in ## Change above) and the body citation-tree drift (addressed in this body edit). The pre-existing `test_drift_detection_and_repair` red on current main is outside this issue's scope (fails identically without this PR); CI will classify it.
