### PR TITLE
fix(git): preserve protected branch return type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ convergence-census: ## Fetch upstream and report convergence dispositions
 	uv run --frozen python scripts/convergence/census_status.py
 
 typecheck: ## Run targeted mypy strict type checking
-	uv run --frozen mypy --strict src/specify_cli/runtime/agent_commands.py
+	uv run --frozen mypy --strict \
+	  src/specify_cli/runtime/agent_commands.py \
+	  src/specify_cli/git/commit_helpers.py
 
 # The subsystem directories an implementer's blast radius typically covers
 # (see AGENTS.md "Test policy"). `make test-fast` is a baseline, not a

--- a/src/specify_cli/git/commit_helpers.py
+++ b/src/specify_cli/git/commit_helpers.py
@@ -75,7 +75,7 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from mission_runtime import CommitTarget
 from kernel.paths import to_posix
@@ -489,7 +489,7 @@ def protected_branches(repo_path: Path) -> frozenset[str]:
     For production code that needs the full policy (including the hatch state),
     prefer :class:`ProtectionPolicy` directly.
     """
-    return ProtectionPolicy.resolve(repo_path).protected_branches
+    return cast(frozenset[str], ProtectionPolicy.resolve(repo_path).protected_branches)
 
 
 def assert_not_protected_branch(repo_path: Path, *, operation: str = "commit") -> None:


### PR DESCRIPTION
## Summary

- Preserve the concrete `frozenset[str]` return type at the public protected-branches delegate.
- Add `commit_helpers.py` to the repository's normal strict typecheck target.

## Why Now

The focused strict-mypy command from #3719 reports `no-any-return` because the intentional skipped-import policy treats the imported `ProtectionPolicy` module as `Any`, even though the owning dataclass field is concretely typed.

## What This PR Does

The delegate explicitly narrows the imported attribute with `cast(frozenset[str], ...)`. `make typecheck` now checks this delegate on every normal typecheck run, alongside the existing runtime target.

## Effect on Existing Projects

- Runtime / compatibility: No runtime behavior changes; the delegate returns the same frozen set.
- Upgrade / migration: None.
- Operator / reviewer impact: The reported narrow strict-mypy command and the normal typecheck target now pass.

## Validation

- [x] The issue's strict-mypy reproduction failed before the change and passes afterward
- [x] `make typecheck` passed for both maintained targets
- [x] 31 ownership and protection tests passed
- [x] `make test-fast` passed: 1,642 tests
- [x] Ruff and git diff checks passed
- [x] Backward compatibility impact considered
- [x] Follow-up work called out if intentionally deferred

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| #3719 | Closes |

## Mission Artifacts

- Not applicable; this is a bounded typecheck fix.

## Follow-ups

- None.

Closes #3719

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791283227&installation_model_id=427282&pr_number=3906&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3906&signature=169691d7d29abdbe2f7f066f5e572baef729a64cce40b2ffd20289f017a73c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->