### PR TITLE
docs(issue-tracker): document the full label taxonomy

### DIFF
--- a/docs/development/how-to/manage-issue-tracker.md
+++ b/docs/development/how-to/manage-issue-tracker.md
@@ -1,8 +1,8 @@
 ---
 title: Managing the Issue Tracker
-description: 'Conventions for the Spec Kitty issue tracker: epics vs meta-trackers, native sub-issue parenting, blocked_by dependencies, and triage (type, severity, release-blocking bugs).'
+description: 'Conventions for the Spec Kitty issue tracker: epics vs meta-trackers, native sub-issue parenting, blocked_by dependencies, triage (type, severity, release-blocking bugs), and the label taxonomy.'
 doc_status: active
-updated: '2026-07-17'
+updated: '2026-09-07'
 audience: docs/context/audience/internal/maintainer.md
 type: how-to
 related:
@@ -200,6 +200,102 @@ peripheral or tooling surface rather than a load-bearing one. One guardrail: if 
 carry real blast radius despite being a good entry point), require maintainer
 concurrence on the chosen approach **before** implementation — normal PR review
 then covers the rest.
+
+## Label taxonomy
+
+Two orthogonal axes carry the load and are documented above: the **native type**
+(`Bug` / `Feature` / `Task` — the sole kind carrier) and **priority**
+(`priority:P0`…`priority:P3`). Labels never encode kind — the retired `bug`
+label must not return. Beyond type and priority, labels fall into the families
+below. Apply as many as genuinely apply; a `catfooding` `reliability` `Bug` at
+`priority:P2` is a normal, well-triaged issue.
+
+### Classification labels — what *kind of work* it is
+
+These describe the nature of the work independently of the subsystem. They are
+orthogonal to native type (a `catfooding` issue is still a Bug, Feature, or Task).
+
+- `catfooding` — **Doctrine Catfooding**: dogfooding Spec Kitty's own
+  quality/doctrine practices. Applied to defects and frictions surfaced by
+  *running Spec Kitty on Spec Kitty* — a live mission session that exercises the
+  specify → plan → tasks → implement → review → merge loop and reports where the
+  tool fought its own operator. This is the dominant classifier for the
+  post-convergence dogfooding backlog; expect clusters of `catfooding`
+  `workflow`/`git`/`usability` issues that circle a single root cause.
+- `tidy-up` — Campsite / declutter / degodding cleanup surfaced *during other
+  work* (the boy-scout residue a mission couldn't fold in-line).
+- `tech-debt` — Accumulated lint, type-checking, static-analysis, and
+  code-quality debt.
+- `design-spike` — Foundational design work.
+- `research` — Research / experiment validation work.
+
+### Subsystem / domain labels — *where* the work lives
+
+Route an issue to its owning surface. Apply every domain that genuinely applies.
+
+- `reliability` — Runtime reliability, resiliency, observability, incident
+  prevention.
+- `usability` — Operator/user experience and ergonomics.
+- `workflow` — Workflow / UX improvements.
+- `git` — How Spec Kitty uses git.
+- `doctrine` — Doctrine system.
+- `agent-profiles` — Agent-profile system.
+- `schema-versioning` — Schema-versioning infrastructure.
+- `sync` — Local event sync, sync daemon, offline queue, projection delivery.
+- `saas` — Hosted SaaS projection, `saas_client`, auth, hosted teamspace.
+- `dashboard` — Dashboard features.
+- `windows` — Windows-specific issues.
+
+### Triage-state labels — transient hygiene state, not classification
+
+These record *where an issue sits in triage*. Remove them once resolved; they are
+working state, not a permanent property.
+
+- `triage:maybe-duplicate` — Suspected duplicate pending confirmation (as opposed
+  to the confirmed `duplicate`).
+- `triage:needs-revision` — Scope/spec needs rework before action.
+- `triage:stale` — Reproduce and close if no longer valid.
+- `triage:repro-needed` — Reported against behavior that may already be fixed;
+  needs live re-reproduction before implementing.
+
+### PR-workflow labels — for pull requests, not issues
+
+- `pr:needs-refresh` — PR branch drifted from `main`; rebase/refresh before review
+  or merge.
+- `pr:needs-revision` — PR has unresolved review findings that must be addressed
+  before it can merge.
+- `pr:kept-for-reference` — Kept open for reference/history; not intended to merge
+  as-is.
+- `pr:deferred` — Held under the 3.2.x doctrine-surface freeze; CI is skipped
+  until unblocked.
+- `pr:skip-ci` — Intentionally skip CI for this PR (docs / manual review only).
+- `ci:full` — Run the full CI suite on a draft PR (overrides `ci-quality`'s draft
+  exemption).
+
+### Lifecycle & community labels
+
+- `deferred` — Work paused pending an activation trigger.
+- `feedback-welcome` — Community feedback & brainstorming welcome; comment
+  ideas/objections, no code needed.
+- `good first issue` — a good *entry point* (see
+  [What "good first issue" means here](#what-good-first-issue-means-here)); not a
+  difficulty signal.
+- `help wanted` — Extra attention is needed.
+- `mvp` — Required for the current Private Teamspace MVP.
+- `release` — Release tracking and coordination.
+- `documentation` — Improvements or additions to documentation.
+- `enhancement` — GitHub's built-in label; treat it as a `Feature` synonym only.
+  Kind lives in the **native type** — prefer setting `--type Feature` over relying
+  on this label.
+- The stock GitHub defaults `duplicate`, `invalid`, `question`, and `wontfix`
+  keep their conventional meanings.
+
+### Grouping labels (documented above)
+
+`epic` and `meta-tracker` are covered in
+[Functional epics versus meta-trackers](#functional-epics-versus-meta-trackers) —
+they are not free-floating classification labels and carry structural obligations
+(native children vs. a body checklist).
 
 ## See also
 


### PR DESCRIPTION
## Summary

The tracker-management guide (`docs/development/how-to/manage-issue-tracker.md`) documented only native type, priority, `good first issue`, and epic/meta-tracker. The rest of the active label vocabulary was undocumented — including `catfooding`, now the dominant classifier for the post-convergence dogfooding backlog.

Adds a **"Label taxonomy"** section grouping every active label by family, each with its meaning and when to apply it:

- **Classification** — `catfooding`, `tidy-up`, `tech-debt`, `design-spike`, `research`
- **Subsystem / domain** — `reliability`, `usability`, `workflow`, `git`, `doctrine`, `agent-profiles`, `schema-versioning`, `sync`, `saas`, `dashboard`, `windows`
- **Triage-state** — `triage:maybe-duplicate` / `:needs-revision` / `:stale` / `:repro-needed`
- **PR-workflow** — `pr:needs-refresh` / `:needs-revision` / `:kept-for-reference` / `:deferred` / `:skip-ci`, `ci:full`
- **Lifecycle & community** — `deferred`, `feedback-welcome`, `good first issue`, `help wanted`, `mvp`, `release`, `documentation`, `enhancement` (+ the GitHub defaults)

Cross-links `epic`/`meta-tracker` back to their existing section, and refreshes the frontmatter `updated`/`description`.

Docs-only; no code or behavior change.

## Tests run

- `PWHEADLESS=1 .venv/bin/python -m pytest tests/architectural/test_no_legacy_terminology.py -q` → **10 passed** (the terminology guard CLAUDE.md requires for doctrine/prose changes; catches forbidden-term regressions the fast suites miss).

Blast radius is a single Markdown file under `docs/development/`, so the terminology guard is the applicable gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiucdiGKsxKrrtDdXY7pnQ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Priivacy-ai/codesmith/spec-kitty/pr/3974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791350567&installation_model_id=427282&pr_number=3974&repository=Priivacy-ai%2Fspec-kitty&return_to=https%3A%2F%2Fgithub.com%2FPriivacy-ai%2Fspec-kitty%2Fpull%2F3974&signature=cd438e45bc0da15f0550c94c50947298a6197a486c8ef1a117398457f7d373c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->