### PR TITLE
ci: let the Blacksmith producer follow the repo move to spec-kitty/spec-kitty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,13 @@ env:
 
 jobs:
   suite:
-    # This is the private EXPERIMENTAL factory producer. The public promotion
-    # repository carries the same tree but must use its public release gates.
-    # Within EXPERIMENTAL, only squad-passed/exhausted heads (and main) run.
+    # This is the factory's deterministic CI producer for the CLI. The CLI moved
+    # from spec-kitty/EXPERIMENTAL-spec-kitty (archived 2026-09-05) to
+    # spec-kitty/spec-kitty on 2026-09-07 (planning#1914); the gate names the
+    # repository explicitly so a fork cannot trigger the producer against the
+    # planning repo. Only squad-passed/exhausted heads (and main) run.
     if: >-
-      github.repository == 'spec-kitty/EXPERIMENTAL-spec-kitty' &&
+      github.repository == 'spec-kitty/spec-kitty' &&
       (
         github.event_name != 'pull_request' ||
         contains(github.event.pull_request.labels.*.name, 'squad:passed') ||
@@ -81,7 +83,7 @@ jobs:
           mkdir -p "$SK_HOME"
           planning_repo="${GITHUB_REPOSITORY%/*}/EXPERIMENTAL-${REPO}-planning"
           git clone -q "https://github.com/${planning_repo}.git" "$SK_HOME/spec-kitty-planning"
-          git clone -q https://github.com/spec-kitty/EXPERIMENTAL-$REPO.git "$SK_HOME/$REPO"
+          git clone -q "https://github.com/${GITHUB_REPOSITORY}.git" "$SK_HOME/$REPO"
           git -C "$SK_HOME/$REPO" fetch -q origin "${{ steps.t.outputs.sha }}"
       - name: Run the suite (bin/ci-run.sh --sync)
         working-directory: ${{ env.SK_HOME }}/spec-kitty-planning

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -155,10 +155,13 @@ def test_ci_windows_install_uses_runner_temp() -> None:
     assert install_step["env"]["TEMP"] == "${{ runner.temp }}"
 
 
-def test_private_factory_ci_is_scoped_to_experimental_repo() -> None:
+def test_private_factory_ci_is_scoped_to_factory_repo() -> None:
+    # planning#1914 / spec-kitty#4004: the CLI factory moved to
+    # spec-kitty/spec-kitty on 2026-09-07 and the archived EXPERIMENTAL repo is
+    # gone from service, so the producer gate names the post-move repository.
     workflow = load_workflow("ci.yml")
 
-    assert "github.repository == 'spec-kitty/EXPERIMENTAL-spec-kitty'" in workflow["jobs"]["suite"]["if"]
+    assert "github.repository == 'spec-kitty/spec-kitty'" in workflow["jobs"]["suite"]["if"]
 
 
 def test_docs_pages_deploys_only_from_promotion_repo_and_fails_transient_setup_errors() -> None:


### PR DESCRIPTION
> ## ⛔ Closed as superseded (maintainer landing triage, 2026-09-09)
>
> **What this means for the repo:** the gap this PR set out to fix — CI running nowhere after the repo move — is already fixed on `main`, by a different and more complete design. There is nothing left for this branch to add.
>
> **Why:** `main` retired `.github/workflows/ci.yml` outright in commit `9370ec2c2` (2026-09-07) and landed a modular replacement pipeline (`ci-router` / `ci-modules` / `ci-aggregate` / `ci-nightly`, alongside `ci-quality` / `ci-windows`) that triggers on `pull_request` and `push` to `main`. The same commit added a governance guard (`tests/release/test_release_ci_ownership.py`) asserting `ci.yml == "never-restore"`. This PR edits `ci.yml`, so it is a modify/delete conflict *and* restoring the file would trip that guard — it cannot be rebased forward.
>
> **Decision:** `spec-kitty/spec-kitty-planning#2081` (sole CI producer: Blacksmith `ci.yml` (#3990) **vs** the `9370ec2c2` landed pipeline) is resolved toward the landed pipeline — option (b). Per this PR's own body, "resolving toward deletion voids this PR."
>
> **Residual, not lost:** the fleet-facing gap this PR referenced (no `[ci]` verdict posting from the landed pipeline + `SK_CI_TOKEN` PAT repo access) stays tracked on #4004. Consolidated squad MINORs remain on #4039.
>
> Thanks @LynnColeArt — the diagnosis was right; `main` just took the other branch of the same decision. Original PR description preserved below.
>
> ---
## Issue
refs #4004

This PR refs rather than closes #4004 because the outage that issue tracks is only half-addressed by this change, and the half that remains is not this PR's to fix: at main tip the reinstated pipeline (commit 9370ec2c2, 2026-09-08) runs the test suites on `pull_request` and `push` to `main` but posts **no** `[ci] green|red @<sha>` verdict comment (no workflow under `.github/` invokes planning's `bin/ci-run.sh`/`bin/ci-post.sh`), and the fine-grained PAT behind the `SK_CI_TOKEN` org secret has no repository access to `spec-kitty/spec-kitty` (verdict POST → HTTP 403). Both are tracked on #4004 and on the reserved architecture decision spec-kitty/spec-kitty-planning#2081.

## Change
Retarget the Blacksmith producer's gate and clone to the post-move repository: `ci.yml`'s `suite` gate now requires `github.repository == 'spec-kitty/spec-kitty'` (was the archived `spec-kitty/EXPERIMENTAL-spec-kitty`, which matched no live repo after the 2026-09-07 move, planning#1914 — every run since the move skipped unconditionally), and the repo-under-test clone follows `${GITHUB_REPOSITORY}` so a future move does not need this edit again. The planning clone is unchanged. Comments updated to name the move.

Fix round (88d3b78a3): the gate rename broke the owning governance test, which still asserted the pre-move repository name — `tests/release/test_release_ci_ownership.py` now pins `spec-kitty/spec-kitty` (test renamed `test_private_factory_ci_is_scoped_to_experimental_repo` → `test_private_factory_ci_is_scoped_to_factory_repo`; the guard still asserts the exact gate string, only the encoded repo name moved with the workflow).

**Status of this PR's premise, corrected in this round:** the original claim "Today it does not run anywhere / no tests have run on the CLI development line since 2026-09-05" was true when the branch was cut but is **false at main tip** — `ci-router.yml` (9370ec2c2) triggers on `pull_request` and `push` to `main`. What remains true at main tip is the fleet-facing gap stated under `## Issue` above. This PR is **parked pending spec-kitty/spec-kitty-planning#2081**: main deleted `ci.yml` outright and landed a replacement CI architecture, so this branch is in a modify/delete conflict whose two resolutions are exactly the two options of that open decision (resolving toward this PR resurrects a second producer next to the landed pipeline — the "one producer per repo" invariant in ci.yml's own header; resolving toward deletion voids this PR). No resolution is made here; per sk-merge's park (2026-09-08T13:34Z) the rebase/re-scope happens after #2081 resolves.

## Tests run
- `.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → passed (YAML parses)
- `.venv/bin/pytest tests/release/test_release_ci_ownership.py -q` → 21 passed / 0 failed (the test this PR changes; failed 1 before the fix-round assertion update)
- `.venv/bin/pytest tests/release/test_release_ci_ownership.py tests/characterization/test_trio_pure_cores.py tests/agent/cli/commands/test_agent_config.py tests/specify_cli/core/vcs/test_merge_base_diff_surface.py -q` → 122 passed / 0 failed (by-filename blast radius at head 88d3b78a3)
- `.venv/bin/pytest tests/architectural/ -q -n 6 --dist loadgroup -p no:randomly` → 1808 passed / 0 failed (2 skipped, 2 xfailed; guard suite, run at the branch head — the fix-round commit touches tests/release only, so the architectural tree is byte-identical to the pushed head)
- `.venv/bin/ruff check .` → All checks passed (repo-wide)
- `.venv/bin/ruff format --check .` → 1532 files already formatted (repo-wide)

Self-review:
- correctness: clean — gate and clone name the post-move repo exactly; fork triggers still blocked by the exact-repo gate
- deletion safety: clean — no deletions; nothing imports the changed test name besides the suite itself
- security: clean — no new secret handling; the exact-repo gate still prevents fork-triggered producer runs
- design fidelity: clean — follows planning#1914's rename ruling and #4004's proposed-fix rationale (rename is the smaller semantic change; the conjunct's original purpose is moot post-move)
- tests: clean after the fix round — the squad's "no pytest blast radius" was wrong; the owning governance test failed at the pre-fix head and is now green

## Blast radius
Discovery: git grep -l "ci.yml" -- tests/
Files: tests/agent/cli/commands/test_agent_config.py, tests/architectural/_gate_coverage.py, tests/characterization/test_trio_pure_cores.py, tests/release/test_release_ci_ownership.py, tests/specify_cli/core/vcs/test_merge_base_diff_surface.py
Subsystems: a workflow-only diff plus one governance test under `tests/release/` — the by-filename matches above are covered by the combined pytest run, `tests/architectural/_gate_coverage.py` is an architectural-suite helper covered by the full `tests/architectural/` run, and `tests/release/` is the owning subsystem of the changed test. No `src/` module is touched, so there is no source-mirror blast radius.

## Deferred
- spec-kitty/spec-kitty-planning#2081 — the reserved architecture decision (which CI architecture is the sole producer) that gates this PR's rebase/re-scope; this PR is parked until it resolves.
- spec-kitty#4004 — the residual fleet-facing outage: no `[ci]` verdict posting from the landed pipeline + `SK_CI_TOKEN` PAT repo access (owner step: PAT repo-list click or the planning#1878 App-token migration).
- spec-kitty#4039 — this PR's consolidated squad MINORs (planning-repo clone name relies on GitHub's rename redirect).

