### PR TITLE
ci(release): drop the private-git-dependency token step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,17 +37,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
 
-      - name: Configure private git dependencies
-        env:
-          GH_TOKEN: ${{ secrets.SK_CI_TOKEN }}
-        run: |
-          if [ -z "$GH_TOKEN" ]; then
-            echo "::error::SK_CI_TOKEN is required to install the pinned private git dependencies."
-            exit 1
-          fi
-          git config --global "url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf" "https://github.com/"
-        shell: bash
-
       - name: Install tooling
         run: |
           uv sync --python "$(which python)" --extra test --extra lint


### PR DESCRIPTION
## Issue

refs spec-kitty/spec-kitty-planning#1990

The migration epic remains open because this PR only removes the obsolete CLI release credential requirement; the remaining migration and release work is tracked there. This is an executable prerequisite for the release tracked by spec-kitty/spec-kitty-planning#1999, whose version and acceptance decisions remain outside this PR.

## Change

Remove the `build-release` step that aborts when `SK_CI_TOKEN` is unavailable and installs a global Git credential rewrite. The CLI's locked dependencies resolve from PyPI, including `spec-kitty-events==9.1.6` and `spec-kitty-tracker==0.5.2`; the lock graph has no Git source that consumes that credential.

Rebase the existing PR onto current main `d8f1f59b4c4c1f7eb8f0322a88495b16bb90aeec`. The resulting diff remains one deleted 11-line step. Parsed YAML comparison confirms that all other release steps, permissions, triggers, package versions, and publication behavior are unchanged.

## Tests run

Validation rerun on head `78e1f1a2a9d21a769fa2e7ca69827b672528765a`, locally on Linux/Python 3.11.15 after `uv sync --frozen --all-extras`:

- `env -u FORCE_COLOR NO_COLOR=1 PWHEADLESS=1 .venv/bin/pytest tests/release -n 4 --dist loadfile -p no:cacheprovider -q` → 208 passed, 0 failed, 5 skipped (89.71s; dogfood cases require `SPEC_KITTY_DOGFOOD_TEST=1`).
- `PYTEST_XDIST_AUTO_NUM_WORKERS=4 make test-fast` → 1786 passed, 0 failed, 2 skipped, 3 warnings (297.53s).
- `env -u FORCE_COLOR NO_COLOR=1 .venv/bin/pytest tests/architectural/test_suite_jobs_gate_blocking.py -n 0 -q` → 5 passed, 0 failed (40.53s).
- `uv run --frozen ruff format --check .` → 1703 files already formatted; `uv run --frozen ruff check src/` → clean; `git diff --check origin/main...HEAD` → clean.
- `env -u GH_TOKEN -u GITHUB_TOKEN -u SK_CI_TOKEN GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 uv build` → 1 source distribution and 1 wheel built successfully.
- `env -u GH_TOKEN -u GITHUB_TOKEN -u SK_CI_TOKEN GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 .venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-cli --console-script spec-kitty --console-arg=--version` → exact wheel install and CLI version smoke passed in a clean environment.
- Bounded local deletion check → 3 checks passed: original step exits 1 with its token unset; the parsed workflow differs only by the removed step; the lock graph has no Git dependency source.

Self-review:
- correctness: clean — tooling installation can proceed without the unused secret; release gates remain intact.
- deletion safety: clean — no locked dependency consumes the deleted Git credential setup, and the exact wheel installs without GitHub credentials.
- security: clean — removes an unnecessary secret consumer and global credential rewrite; no credential or permission is added.
- design fidelity: clean — implements the existing PR's release prerequisite without changing release version or acceptance policy.
- tests: clean — fresh release subsystem, mandatory fast tier, workflow gate guards, formatting, build, and clean install evidence above. These are local implementation checks; factory CI and squad review must judge the refreshed head.

## Blast radius

Discovery: `git grep -l -E 'build-release|test_public_ci_uses_released_dependencies|spec-kitty-events|spec-kitty-tracker' -- .github/workflows/release.yml tests/release/test_release_ci_ownership.py pyproject.toml uv.lock`
Files: `.github/workflows/release.yml`, `pyproject.toml`, `tests/release/test_release_ci_ownership.py`, `uv.lock`

Only `.github/workflows/release.yml` changes. The dependency declarations, lock graph, and release ownership tests establish why the deleted step has no consumer. The complete `tests/release` package covers the owning subsystem, and the wheel check exercises installation from the built artifact.

`python scripts/ci/local_gate_parity.py --base-ref origin/main` selects 9 jobs and 0 code shards for this workflow-only diff: commit-msg, import-linter, layer-rules, markdownlint, regen-check, router-gate, ruff, terminology, and uv-lock. The explicit local release suite supplies coverage the path router does not select. The PR's September 7 checks precede this rebase and are not evidence for the refreshed head.

## Deferred

Release version/acceptance disposition remains in spec-kitty/spec-kitty-planning#1999; the cross-repository event compatibility and policy decision remains in spec-kitty/spec-kitty-planning#2000. This change does not close either decision or publish an artifact. The factory retains CI, squad review, and merge ownership.
