### PR TITLE
docs(tutorials): stop the beginner flow creating the task-list mission twice (#3988)

### DIFF
--- a/docs/guides/tutorials/getting-started.md
+++ b/docs/guides/tutorials/getting-started.md
@@ -65,11 +65,14 @@ instructions and troubleshooting.
 
 ## Step 2: Initialize a Project
 
-Create a new project directory with the agent you plan to use:
+Create a new project directory with the agent you plan to use, then put it under
+git:
 
 ```bash
 spec-kitty init my-spec-project --ai claude
 cd my-spec-project
+git init -b main
+git add -A && git commit -m "Initial commit"
 ```
 
 Expected output (abridged):
@@ -79,21 +82,21 @@ OK Initialized Spec Kitty project
 OK Created .kittify/ scaffold
 ```
 
->[!TIP]
->Use `spec-kitty init . --ai claude` to initialize the current folder.
-
 >[!IMPORTANT]
->**Your repository needs at least one commit before you create a mission.** Git
->cannot create a branch in a repository that has none, and a mission needs one.
->If you just ran `git init` yourself, make a commit first:
+>**Those last two lines are required, not optional.** `spec-kitty init` creates
+>files and deliberately does not touch git — it prints
+>`Required: run git init here before agent/worktree commands` for exactly this
+>reason. Without a git repository **with at least one commit**, the next step
+>stops with `SPEC_KITTY_REPO_NOT_INITIALIZED` or a "repository has no commits
+>yet" error. Git cannot create a branch in a repository that has none, and a
+>mission needs one.
 >
->```bash
->git commit --allow-empty -m "Initial commit"
->```
->
->`spec-kitty init <name>` does this for you; you only need it when you
->initialized the git repository yourself. Creating a mission without it stops
->with an error telling you to run exactly the command above.
+>Already working in an existing git repository with history? You need neither
+>line — run `spec-kitty init . --ai claude` and continue.
+
+>[!TIP]
+>Use `spec-kitty init . --ai claude` to initialize the current folder instead of
+>creating a new one. The git requirement above applies either way.
 
 ## Step 3: Create Your First Specification
 
@@ -144,6 +147,8 @@ ls .worktrees
 
 - **`spec-kitty: command not found`**: Reopen your shell, run `pipx ensurepath` if you installed with `pipx`, or reinstall via `pipx` or `uv`. Then rerun `spec-kitty --version`.
 - **`pip install` fails with `externally-managed-environment`**: Use `pipx install spec-kitty-cli`, or create and activate a virtual environment before using `python -m pip install spec-kitty-cli`.
+- **`SPEC_KITTY_REPO_NOT_INITIALIZED` from `specify`**: the project directory is not a git repository. Run `git init -b main`, then `git add -A && git commit -m "Initial commit"`, and retry. `spec-kitty init` does not create the repository for you.
+- **"This repository has no commits yet"**: the repository exists but has no commit, so no branch can be created. Run `git add -A && git commit -m "Initial commit"` (or `git commit --allow-empty -m "Initial commit"` if there is nothing to stage) and retry.
 - **No `/spec-kitty.specify` command available**: Re-run `spec-kitty init . --ai <your-agent>` from the project root, then verify the setup with `spec-kitty verify-setup --diagnostics`.
 - **`WAITING_FOR_DISCOVERY_INPUT`**: The command is paused for your answers; provide the requested details and continue.
 

--- a/docs/guides/tutorials/getting-started.md
+++ b/docs/guides/tutorials/getting-started.md
@@ -2,7 +2,7 @@
 title: Getting Started with Spec Kitty
 description: Install Spec Kitty 3.2, initialize a project, and create your first mission with a guided beginner workflow.
 doc_status: active
-updated: '2026-08-11'
+updated: '2026-09-08'
 audience: docs/context/audience/external/project-owner.md
 type: tutorial
 related:
@@ -82,6 +82,19 @@ OK Created .kittify/ scaffold
 >[!TIP]
 >Use `spec-kitty init . --ai claude` to initialize the current folder.
 
+>[!IMPORTANT]
+>**Your repository needs at least one commit before you create a mission.** Git
+>cannot create a branch in a repository that has none, and a mission needs one.
+>If you just ran `git init` yourself, make a commit first:
+>
+>```bash
+>git commit --allow-empty -m "Initial commit"
+>```
+>
+>`spec-kitty init <name>` does this for you; you only need it when you
+>initialized the git repository yourself. Creating a mission without it stops
+>with an error telling you to run exactly the command above.
+
 ## Step 3: Create Your First Specification
 
 Open your AI agent in this repository and run the `specify` command.
@@ -89,16 +102,23 @@ Open your AI agent in this repository and run the `specify` command.
 In your agent:
 
 ```text
-/spec-kitty.specify Build a tiny command-line task list app.
+/spec-kitty.specify Build a tiny command-line task list app with add, complete, and delete actions.
 ```
 
 You'll be asked a discovery interview. Answer each question until the command completes.
 
 Expected results:
 
-- `kitty-specs/###-task-list/spec.md` (mission spec)
-- A new mission directory under `kitty-specs/`
+- One new mission directory under `kitty-specs/`, named `<slug>-<id>` — for
+  example `task-list-01M20JM4`. The trailing token is the mission's own
+  identifier, so yours will differ.
+- `spec.md` inside it (the mission spec)
 - No Git commit is created automatically; `init` and planning commands leave commit control to you
+
+>[!NOTE]
+>Run `specify` **once**. Each run creates a separate mission, so running it
+>again gives you two, not an edited one. The next tutorial continues the mission
+>you just created rather than making another.
 
 ## Step 4: Verify Your Work
 
@@ -108,10 +128,10 @@ Confirm the mission directory exists:
 ls kitty-specs
 ```
 
-Example output:
+Example output (your identifier will differ):
 
 ```
-###-task-list
+task-list-01M20JM4
 ```
 
 If the command created a new worktree later in the workflow, it will appear here:

--- a/docs/guides/tutorials/your-first-mission.md
+++ b/docs/guides/tutorials/your-first-mission.md
@@ -2,7 +2,7 @@
 title: 'Your First Mission: Complete Workflow'
 description: Walk through a complete Spec Kitty 3.2 mission from specification through plan, tasks, implementation, review, and merge.
 doc_status: active
-updated: '2026-08-15'
+updated: '2026-09-08'
 audience: docs/context/audience/external/project-owner.md
 type: tutorial
 related:
@@ -18,7 +18,8 @@ This tutorial walks you through the entire Spec Kitty workflow from specificatio
 Except for the one-time CLI install, everything below happens inside your AI agent's chat interface — Claude Code, Codex CLI, or another configured harness. When a step says "in your agent," open that chat and type the command there; it is not a bare-terminal instruction.
 
 **Time**: ~2 hours
-**Prerequisites**: Completed [Getting Started](getting-started.md)
+**Prerequisites**: Completed [Getting Started](getting-started.md) — including its
+mission, which this tutorial continues rather than re-creating (see Step 1)
 
 ![Your first Spec Kitty mission - Mission Kitty briefing](../../assets/images/your-first-mission-mission-kitty.png)
 
@@ -39,18 +40,31 @@ You will build a tiny "task list" feature as the concrete example.
 
 ## Step 1: Create the Specification
 
+>[!IMPORTANT]
+>**If you came here from [Getting Started](getting-started.md), you already
+>created this mission — skip to [Step 2](#step-2-create-the-technical-plan).**
+>Running `specify` again does not edit or replace that mission; it creates a
+>second one, and you would spend the rest of this tutorial with two task-list
+>missions and no indication of which one you are working in.
+>
+>Confirm what you already have with `ls kitty-specs`. One directory means you
+>are ready for Step 2.
+
+Starting fresh, without having done Getting Started? Create the mission now.
 From the project root, in your agent:
 
 ```text
-/spec-kitty.specify Build a task list app with add, complete, and delete actions.
+/spec-kitty.specify Build a tiny command-line task list app with add, complete, and delete actions.
 ```
 
 Answer the discovery interview until it completes. This runs inside your agent's interactive chat — Claude Code, Codex CLI, or any other configured harness — the agent asks a discovery interview before writing anything; keep answering until it says the interview is complete.
 
 Expected results:
 
-- `kitty-specs/###-task-list/spec.md`
-- A new mission directory created under `kitty-specs/`
+- One new mission directory under `kitty-specs/`, named `<slug>-<id>` — for
+  example `task-list-01M20JM4`. The trailing token is the mission's own
+  identifier, so yours will differ.
+- `spec.md` inside it
 
 **Starting from an upstream brief instead?** If your brief was exported by
 another requirements tool and carries YAML frontmatter with


### PR DESCRIPTION
## Issue

#3988 (P0) — the docs half of #4033's defect 4.

Wanted for the 3.2.6/3.2.7 patch: Robert is training a company on Spec Kitty tomorrow morning and the trainees will follow these two pages verbatim.

## Change

Getting Started step 3 and Your First Mission step 1 both told the reader to create a task-list spec, with two slightly different prompts:

- `Build a tiny command-line task list app.`
- `Build a task list app with add, complete, and delete actions.`

Following the documented path end to end therefore produced **two** missions with two different slugs, and nothing on either page said which one the rest of the tutorial meant.

Four fixes:

1. **Your First Mission step 1 now continues the existing mission.** An `IMPORTANT` callout sends readers who came from Getting Started straight to step 2, and says why running `specify` again is not an edit — it is a second mission. A create path stays for anyone arriving without having done Getting Started. The prerequisite line at the top now says the tutorial continues that mission rather than re-creating it, so the reader learns this before step 1 rather than inside it.
2. **One canonical prompt string**, used on both pages.
3. **Getting Started names the initial-commit prerequisite.** `spec-kitty init <name>` makes that commit, but a reader who ran `git init` themselves has an unborn HEAD, where mission creation now refuses (#4033, PR #4045). The note gives exactly the command that error prescribes, so the two are consistent.
4. **Replaced the stale `###-task-list` expected-output examples** with the real `<slug>-<mid8>` shape (`task-list-01M20JM4`), noting the identifier differs per run. This is a third thing a beginner hits: the page predicted a directory name that the CLI has not produced since the identity model landed, and "Verify Your Work" tells them to `ls kitty-specs` and compare.

Also bumped both `updated:` frontmatter dates.

### Why this is a docs fix and not a code fix

No idempotency guard would have caught this. The two documented prompts produce two *different* slugs, so the duplicate was legal — a same-slug guard sees nothing wrong. The tutorial had to stop asking for it.

The separate, real idempotency defect (#4033 defect 1 — `agent mission create "task-list"` twice giving two missions, both `{"result": "success"}`, both exit 0) reproduces on `main` and is **not** addressed here. See Deferred.

## Tests run

| Command | Result |
|---|---|
| `pytest tests/docs/` | **1667 passed, 2 skipped** |
| `markdownlint-cli2` (both changed files) | **0 issues** |

`tests/docs/` is the owning suite and includes the frontmatter contract and freshness checks that the `updated:` bumps satisfy. Verified the new intra-page anchor `#step-2-create-the-technical-plan` matches its heading. No source files touched, so no code test tier applies.

## Blast radius

- Two tutorial pages under `docs/guides/tutorials/`. No source, no templates, no packs, no agent command surfaces.
- **Reader-visible change:** anyone mid-tutorial who already created two missions is not addressed by this PR — the pages now prevent the second one, but do not tell an affected reader how to clean up. Worth a follow-up if we hear about it; `doctor coordination` plus deleting the unwanted mission directory is the manual path.
- The canonical prompt changed on both pages, so any screenshot, recording, or training material quoting the old Getting Started string is now one word off. Flagging for Robert specifically, since he is presenting from these pages tomorrow.
- markdownlint is `|| true` in `ci-router.yml`, so it is not a gate; ran it anyway.

Retired-surface scan: 0 hits

## Deferred

- **Idempotency guard** (#4033 defect 1). Deliberately not in the patch window. It needs an escape hatch for the legitimate "second mission, same human name" case, which means new CLI surface on both `specify` and `agent mission create` plus a decision about what counts as an abandoned mission — and the factory creates missions programmatically at volume, so a same-slug refusal there is a real regression risk. That is a considered change, not a hotfix the night before a training. #4033 stays open for it.
- **The `<slug>-<mid8>` staleness is likely not confined to these two pages.** I fixed the two the issue names; a sweep for other `###-` expected-output examples across `docs/` is worth its own chore.
