### PR TITLE
fix(ci): authorize automatic PR verdict comments and explain API refusals

### DIFF
--- a/.github/workflows/ci-fleet-verdict.yml
+++ b/.github/workflows/ci-fleet-verdict.yml
@@ -45,8 +45,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/scripts/ci/fleet_verdict.py
+++ b/scripts/ci/fleet_verdict.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import tempfile
+import urllib.error
 import urllib.parse
 import urllib.request
 from contextlib import ExitStack
@@ -94,6 +95,32 @@ def classify(runs: dict[str, dict[str, Any] | None], labels: set[str]) -> str:
     return "green" if all(r.get("status") == "completed" and r.get("conclusion") == "success" for r in present) else "running"
 
 
+def _http_failure(error: urllib.error.HTTPError, token: str) -> str:
+    """Expose bounded GitHub diagnostics without credentials or raw responses."""
+    message: Any = None
+    try:
+        with error:
+            payload = json.loads(error.read(4096))
+        if isinstance(payload, dict):
+            message = payload.get("message")
+    except (OSError, ValueError, RecursionError):
+        pass
+
+    def bounded(value: Any, limit: int) -> str:
+        text = value if isinstance(value, str) else "unavailable"
+        if token:
+            text = text.replace(token, "[redacted]")
+        # Quote control characters before bounding the final emitted text.
+        return json.dumps(text, ensure_ascii=True)[:limit]
+
+    headers = error.headers
+    return (
+        f"GitHub API HTTP {error.code}: message={bounded(message, 512)}; "
+        f"request_id={bounded(headers.get('X-GitHub-Request-Id') if headers else None, 128)}; "
+        f"accepted_permissions={bounded(headers.get('X-Accepted-GitHub-Permissions') if headers else None, 256)}"
+    )
+
+
 class GitHub:
     """Small authenticated API boundary; errors never include credentials."""
 
@@ -103,13 +130,17 @@ class GitHub:
         self.repository = repository
 
     def request(self, path: str, payload: dict[str, Any] | None = None) -> Any:
+        token = os.environ["GH_TOKEN"]
         request = urllib.request.Request(
             f"https://api.github.com/repos/{self.repository}/{path}",
             data=json.dumps(payload).encode() if payload is not None else None,
-            headers={"Authorization": f"Bearer {os.environ['GH_TOKEN']}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
         )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return json.load(response)
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            raise ValueError(_http_failure(error, token)) from None
 
     def pages(self, path: str, field: str | None = None) -> list[dict[str, Any]]:
         rows = []

--- a/tests/ci/test_fleet_api.py
+++ b/tests/ci/test_fleet_api.py
@@ -55,10 +55,12 @@ def test_http_post_success_sends_exact_payload_once(monkeypatch: pytest.MonkeyPa
         b"[123]",
         b'{"message": 123}',
         b'{"message": "' + b"x" * 9000 + b'"}',
+        None,
+        b"[" * 1500,
     ],
-    ids=["github-message", "non-json", "non-object", "non-string-message", "oversized"],
+    ids=["github-message", "non-json", "non-object", "non-string-message", "oversized", "read-error", "deeply-nested"],
 )
-def test_http_failure_is_bounded_safe_and_never_retries(monkeypatch: pytest.MonkeyPatch, body: bytes) -> None:
+def test_http_failure_is_bounded_safe_and_never_retries(monkeypatch: pytest.MonkeyPatch, body: bytes | None) -> None:
     calls = []
     reads = []
 
@@ -66,30 +68,36 @@ def test_http_failure_is_bounded_safe_and_never_retries(monkeypatch: pytest.Monk
         def read(self, size=-1):
             reads.append(size)
             assert 0 < size <= 4096
+            if body is None:
+                raise OSError(f"private read failure {TOKEN}")
             return super().read(size)
 
     headers = Message()
-    headers["X-GitHub-Request-Id"] = "TEST:REQUEST:ID"
-    headers["X-Accepted-GitHub-Permissions"] = "pull_requests=write"
+    headers["X-GitHub-Request-Id"] = f"TEST:REQUEST:ID {TOKEN}\n" + "x" * 1000
+    headers["X-Accepted-GitHub-Permissions"] = f"pull_requests=write {TOKEN}\t" + "x" * 1000
     headers["Authorization"] = f"Bearer {TOKEN}"
     headers["X-Private"] = "private-header-value"
 
     def refuse(request, *, timeout):
         calls.append(request)
-        raise urllib.error.HTTPError(request.full_url, 403, TOKEN, headers, BoundedResponse(body))
+        raise urllib.error.HTTPError(request.full_url, 403, TOKEN, headers, BoundedResponse(body or b""))
 
     monkeypatch.setenv("GH_TOKEN", TOKEN)
     monkeypatch.setattr(fleet_verdict.urllib.request, "urlopen", refuse)
+    payload = {"body": "verdict-private"}
     with pytest.raises(ValueError) as caught:
-        fleet_verdict.GitHub("spec-kitty/spec-kitty").request("issues/7/comments", {"body": "verdict-private"})
+        fleet_verdict.GitHub("spec-kitty/spec-kitty").request("issues/7/comments", payload)
     output = "".join(traceback.format_exception(caught.value))
     assert "HTTP 403" in str(caught.value)
     assert "TEST:REQUEST:ID" in output
     assert "pull_requests=write" in output
     assert all(secret not in output for secret in [TOKEN, "raw-body-private", "private-header-value", "verdict-private"])
     assert len(str(caught.value)) < 1100
+    assert "\n" not in str(caught.value)
+    assert "\t" not in str(caught.value)
+    assert "[redacted]" in output
     assert len(calls) == 1
     assert reads == [4096]
-    if body.startswith(b'{"message": "Resource'):
+    if body and body.startswith(b'{"message": "Resource'):
         assert "Resource not accessible by integration" in output
         assert "[redacted]" in output

--- a/tests/ci/test_fleet_api.py
+++ b/tests/ci/test_fleet_api.py
@@ -1,0 +1,95 @@
+"""Exercise the real HTTP boundary used by the automatic PR reporter."""
+
+from __future__ import annotations
+
+import io
+import json
+import traceback
+import urllib.error
+from email.message import Message
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.ci import fleet_verdict
+
+pytestmark = pytest.mark.fast
+TOKEN = "test-private-token-should-never-appear"
+
+
+def test_report_job_has_only_pr_comment_write_permission() -> None:
+    workflow = yaml.safe_load((Path(__file__).resolve().parents[2] / ".github/workflows/ci-fleet-verdict.yml").read_text())
+    assert workflow["permissions"] == {"contents": "read", "actions": "read"}
+    assert workflow["jobs"]["report"]["permissions"] == {
+        "contents": "read",
+        "actions": "read",
+        "pull-requests": "write",
+    }
+    assert "permissions" not in workflow["jobs"]["identify"]
+
+
+def test_http_post_success_sends_exact_payload_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def respond(request, *, timeout):
+        calls.append(request)
+        assert request.get_method() == "POST"
+        assert request.full_url == "https://api.github.com/repos/spec-kitty/spec-kitty/issues/7/comments"
+        assert request.get_header("Authorization") == f"Bearer {TOKEN}"
+        assert json.loads(request.data) == {"body": "actual verdict"}
+        assert timeout == 30
+        return io.BytesIO(b'{"id": 123}')
+
+    monkeypatch.setenv("GH_TOKEN", TOKEN)
+    monkeypatch.setattr(fleet_verdict.urllib.request, "urlopen", respond)
+    assert fleet_verdict.GitHub("spec-kitty/spec-kitty").request("issues/7/comments", {"body": "actual verdict"}) == {"id": 123}
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        json.dumps({"message": f"Resource not accessible by integration {TOKEN}\n" + "x" * 900, "secret": "raw-body-private"}).encode(),
+        b"not JSON raw-body-private",
+        b"[123]",
+        b'{"message": 123}',
+        b'{"message": "' + b"x" * 9000 + b'"}',
+    ],
+    ids=["github-message", "non-json", "non-object", "non-string-message", "oversized"],
+)
+def test_http_failure_is_bounded_safe_and_never_retries(monkeypatch: pytest.MonkeyPatch, body: bytes) -> None:
+    calls = []
+    reads = []
+
+    class BoundedResponse(io.BytesIO):
+        def read(self, size=-1):
+            reads.append(size)
+            assert 0 < size <= 4096
+            return super().read(size)
+
+    headers = Message()
+    headers["X-GitHub-Request-Id"] = "TEST:REQUEST:ID"
+    headers["X-Accepted-GitHub-Permissions"] = "pull_requests=write"
+    headers["Authorization"] = f"Bearer {TOKEN}"
+    headers["X-Private"] = "private-header-value"
+
+    def refuse(request, *, timeout):
+        calls.append(request)
+        raise urllib.error.HTTPError(request.full_url, 403, TOKEN, headers, BoundedResponse(body))
+
+    monkeypatch.setenv("GH_TOKEN", TOKEN)
+    monkeypatch.setattr(fleet_verdict.urllib.request, "urlopen", refuse)
+    with pytest.raises(ValueError) as caught:
+        fleet_verdict.GitHub("spec-kitty/spec-kitty").request("issues/7/comments", {"body": "verdict-private"})
+    output = "".join(traceback.format_exception(caught.value))
+    assert "HTTP 403" in str(caught.value)
+    assert "TEST:REQUEST:ID" in output
+    assert "pull_requests=write" in output
+    assert all(secret not in output for secret in [TOKEN, "raw-body-private", "private-header-value", "verdict-private"])
+    assert len(str(caught.value)) < 1100
+    assert len(calls) == 1
+    assert reads == [4096]
+    if body.startswith(b'{"message": "Resource'):
+        assert "Resource not accessible by integration" in output
+        assert "[redacted]" in output


### PR DESCRIPTION
## Issue
refs #4066 — final automatic publication, real factory consumption and combined-main validation have passed; the issue is now closed.

## Change
Draft opened with regression-only starter `40d41925ea7014d6ab2f360ef3736dc75b2f87cb` before production edits. Real automatic Fleet runs34296316679 on PR4104 and34296422540 on PR4099 fail at the final comment POST with HTTP403. Actual job permissions include Issues:write and PullRequests:read; the exception currently drops useful response details. Existing issue evidence: https://github.com/spec-kitty/spec-kitty/issues/4066#issuecomment-5594050857 .

The correction at `d49fe0d7fa3fada0466e9ef8ed54208fe301c125` scopes the PR-only report job to PullRequests:write and adds safe HTTP-error diagnostics: status, bounded parsed GitHub message, request ID and accepted-permissions only. Identification remains read-only. The permission explanation remains an inference until actual automatic publication passes. GitHub lists PR-write as a supported comment permission: https://docs.github.com/en/rest/issues/comments#create-an-issue-comment .

## Tests run

Final landed follow-through: current main `bcb7fe37669ef93f45b21bb08f10faf9032b5c04` passed all35 Modules jobs (19,555 tests passed), all other applicable native workflows and automatic Aggregate34301982162 (34/34 current reports,zero stale fallback). The final architectural audit passed2334 tests with3 skips/2 expected failures and unchanged warnings. Actual automatic Fleet34300029273 posted Actions-bot running then green5594457386 on4099; the real canonical factory refused incomplete evidence, accepted green and performed the guarded merge. This is separate from earlier reviewed-host bootstrap evidence. #4066 is closed with [final receipts](https://github.com/spec-kitty/spec-kitty/issues/4066#issuecomment-5594737788); #4074 is closed. Older candidate recovery remains on4004/planning2081, and nonblocking diagnostics remain4109.

Independent source review PASS on exact `d49fe0d7fa3fada0466e9ef8ed54208fe301c125`, tree `6bdba850fe5cea65b83bc44a9b8c6487d4309ee3`, clean. Four positive controls passed and four in-memory counterfactuals were caught: old permissions, missing token redaction, exposed HTTPError chaining, and missing recursion-error refusal. All three file blobs matched the independently reviewed source. Automatic publication was pending at source review and is now verified in the landed follow-through above.

RED first on unchanged production main4455: new real GitHub.request boundary/workflow contract suite reports6 failed,1 passed in63.06s. It covers the actual POST success/error seam, safe diagnostics, malformed/nonobject/oversized responses and the PR-only grant. Ruff check/format passed on the regression starter. 

Final candidate validation:

- `PYTHONPATH=src /home/lynn/projects/spec-kitty-projects/wt-ci-main-20260908/.venv/bin/python -m pytest tests/ci/test_fleet_api.py -q -n0` — 9 passed, 0 failed in 41.42 seconds. Includes hostile allowed-header values, exact-token redaction before truncation, escaped controls, body-read errors and deeply nested JSON, with one POST attempt on success and failure.
- `PYTHONPATH=src /home/lynn/projects/spec-kitty-projects/wt-ci-main-20260908/.venv/bin/python -m pytest tests/ci tests/architectural/test_coverage_artefact_contract.py -q -n 4 --dist loadfile` — 168 passed, 0 failed in 33.30 seconds.
- `ruff check scripts/ci/fleet_verdict.py tests/ci/test_fleet_api.py`, `ruff format tests/ci/test_fleet_api.py`, `mypy --strict scripts/ci/fleet_verdict.py`, and `git diff --check` — passed.
- `uv sync --frozen --all-extras` completed in an isolated candidate environment. `PYTEST_XDIST_AUTO_NUM_WORKERS=4 make test-fast` passed **1782 tests,2 skipped,4 warnings in209.74s**, exit0, on the exact clean candidate. Independent exact-head review passed as recorded above.

The initial post-change safety run exposed a test-harness issue: formatting the complete traceback also includes the caller's source line, which contained the literal fake private payload. The unchanged payload was moved into a local variable so the assertion tests actual exception leakage. Confidentiality assertions remain intact. An independent review also identified and reproduced nested-JSON `RecursionError`; that parser exception now uses the same safe fallback and has a dedicated control.

Self-review:

- correctness: failed HTTP publication stays nonzero; no POST retry or hidden success. Live permission diagnosis remains an inference until automatic acceptance.
- deletion safety: removes the issue-write grant; no source, artifacts or comments are deleted.
- security: the PR-only writer requests PR write; identification remains read-only. Only three bounded diagnostic fields plus HTTP status are exposed; current token, raw body and other headers are excluded.
- design fidelity: preserves the existing metadata-only workflow and all gate/source validation; adds no producer, credentials or repository policy changes.
- tests: actual HTTP boundary and exact workflow grant covered; 9 focused and 168 owning checks passed. The fast baseline also passed; real automatic acceptance remains pending.

## Blast radius
Discovery: git diff --name-only 4455c02cad5f14f6c54e5b8c56b08caafefdf517 HEAD
Files: .github/workflows/ci-fleet-verdict.yml, scripts/ci/fleet_verdict.py, tests/ci/test_fleet_api.py
The actual three-path correction touches the PR report job permission and HTTP transport boundary, with direct transport and workflow regression coverage. Existing source/attempt validation, all native CI gates and guarded merge requirements apply.

Deployment acceptance:

Exact-head native Modules34297547032 passed all35 jobs; Quality34297546769, Router34297546786, Windows34297291715 and Packs34297546775 passed. Reviewed Aggregate34299333739 collected34/34 current reports with zero stale fallback and passed completeness; its critical comparison is legitimately empty for this workflow/scripts/tests-only patch. Actual factory squad passed exactd49 in comment5594410324; three nonblocking diagnostic follow-ups are tracked in #4109. Actual factory CI bot comment5594432988 was generated by the reviewed reporter on sk-dispatch and its returned Bot identity/body were verified against the read-only preview (only the completed squad label changed). This establishes deployment readiness. It is bootstrap evidence: #4066/#4074/planning2081 remain open until the deployed automatic Actions reporter publishes a real verdict and the factory consumes it.

## Deferred
Actual automatic Actions publication and factory consumption are complete; #4066/#4074 are closed. Planning2081 retains only the separate older-candidate recovery accounting. No repository-wide policy change, manual green replacement, extra producer or retry of an ambiguous POST is proposed. Existing planning2107 separately owns the supported merger CLI method/405 diagnostic fix.
