### PR TITLE
Release 3.2.6.2

### DIFF
--- a/.github/workflows/check-spec-kitty-events-alignment.yml
+++ b/.github/workflows/check-spec-kitty-events-alignment.yml
@@ -2,7 +2,7 @@ name: Check Shared Package Drift
 
 on:
   pull_request:
-    branches: [main, develop, "2.x"]
+    branches: [main, develop, "2.x", release/3.2.6.x]
     paths:
       - 'pyproject.toml'
       - 'uv.lock'
@@ -10,7 +10,7 @@ on:
       - 'scripts/release/**'
       - '.github/workflows/check-spec-kitty-events-alignment.yml'
   push:
-    branches: [main, develop, "2.x"]
+    branches: [main, develop, "2.x", release/3.2.6.x]
     paths:
       - 'pyproject.toml'
       - 'uv.lock'
@@ -18,7 +18,7 @@ on:
       - 'scripts/release/**'
       - '.github/workflows/check-spec-kitty-events-alignment.yml'
   schedule:
-    # Nightly shared-package and SaaS pin drift monitor.
+    # Nightly shared-package pin drift monitor.
     - cron: '11 2 * * *'
   workflow_dispatch:
 
@@ -37,6 +37,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: candidate-package-metadata
+          include-hidden-files: true
           path: |
             pyproject.toml
             uv.lock
@@ -48,11 +49,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'pr:deferred') && !contains(github.event.pull_request.labels.*.name, 'pr:skip-ci') }}
     needs: [prepare-candidate-metadata]
-    env:
-      REPO_OWNER: ${{ github.repository_owner }}
-      # For public spec-kitty -> private spec-kitty-saas comparisons, add
-      # SPEC_KITTY_SAAS_READ_TOKEN (repo:read) as a repository secret.
-      HAS_SAAS_READ_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' }}
     steps:
       - name: Check out trusted validation scripts
         uses: actions/checkout@v6
@@ -75,42 +71,7 @@ jobs:
           name: candidate-package-metadata
           path: candidate
 
-      - name: Fetch compatibility references
-        id: fetch_refs
-        env:
-          CROSS_REPO_TOKEN: ${{ secrets.SPEC_KITTY_SAAS_READ_TOKEN != '' && secrets.SPEC_KITTY_SAAS_READ_TOKEN || github.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/spec-kitty-release-contracts
-
-          if [ "${HAS_SAAS_READ_TOKEN}" != "true" ]; then
-            # The cross-repo drift evidence requires read access to the private
-            # spec-kitty-saas repo. That secret is unavailable to fork PRs (and to
-            # repos without it configured), so skip gracefully instead of hard-failing
-            # — the push-to-main CI, which has the secret, still enforces drift.
-            echo "::notice::SPEC_KITTY_SAAS_READ_TOKEN not available (e.g. fork PR); skipping shared-package/SaaS drift evidence. Enforced by push-to-main CI."
-            echo "skip_drift=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          SAAS_PYPROJECT_URL="https://api.github.com/repos/${REPO_OWNER}/spec-kitty-saas/contents/pyproject.toml?ref=main"
-
-          if curl -fsSL \
-            -H "Authorization: Bearer ${CROSS_REPO_TOKEN}" \
-            -H "Accept: application/vnd.github.raw" \
-            "$SAAS_PYPROJECT_URL" \
-            -o /tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml; then
-            echo "Fetched spec-kitty-saas/pyproject.toml."
-          else
-            echo "Unable to fetch spec-kitty-saas/pyproject.toml from main."
-            echo "Configure SPEC_KITTY_SAAS_READ_TOKEN secret with read access to private repo ${REPO_OWNER}/spec-kitty-saas."
-            exit 1
-          fi
-
-          echo "saas_pyproject=/tmp/spec-kitty-release-contracts/spec-kitty-saas-pyproject.toml" >> "$GITHUB_OUTPUT"
-
       - name: Validate shared package drift
-        if: steps.fetch_refs.outputs.skip_drift != 'true'
         run: |
           MANIFEST_ARGS=()
           if python scripts/release/check_shared_package_drift.py --help | grep -q -- '--compatibility-manifest'; then
@@ -122,5 +83,4 @@ jobs:
           python scripts/release/check_shared_package_drift.py \
             --pyproject candidate/pyproject.toml \
             --lockfile candidate/uv.lock \
-            "${MANIFEST_ARGS[@]}" \
-            --saas-pyproject "${{ steps.fetch_refs.outputs.saas_pyproject }}"
+            "${MANIFEST_ARGS[@]}"

--- a/.kittify/metadata.yaml
+++ b/.kittify/metadata.yaml
@@ -3,7 +3,7 @@
 # DO NOT EDIT MANUALLY
 
 spec_kitty:
-  version: 3.2.6.1
+  version: 3.2.6.2
   initialized_at: '2026-04-07T09:10:40.826207'
   last_upgraded_at: '2026-06-11T05:07:36.243731'
   schema_version: 3

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The standalone shared-package drift workflow now checks the maintenance release line without fetching the retired SaaS comparison.** Candidate metadata, lockfile and release-manifest consistency remain mandatory, including when no cross-repository secret is configured.
+
 - **Resynthesis resolves activated IDs across built-in, org and project layers** (#4101). Project profiles use the same precedence as profile inspection. Eager activation checks synthesis prerequisites and the proposed selection before writing activations; lookup errors identify the charter activation store and searched layers.
 
 - **Agent-profile cascade reaches directly authored project guidance** (#4100). `--cascade all` activates referenced procedures, directives, tactics and styleguides from a clean deactivated state, and missing project references produce explicit warnings.

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.6.2] - 2026-09-09
+
 ### Added
 
 - **The `migrate-project-guidance-to-spec-kitty-charter` procedure now captures the source's vocabulary in the glossary** (#4103). A new step between classification and drafting extracts the terms the guidance defines or uses with a specific meaning, triages them through the `glossary-maintenance-workflow` procedure into the narrowest owning scope, and makes the accepted surfaces the vocabulary the drafted artifacts must use verbatim. The exit condition and the parity-comparison step now require every defined term to resolve in the glossary or be excluded with a reason, and the procedure references `procedure:glossary-maintenance-workflow` in the DRG.

--- a/docs/development/3-2-docs-retrieval-index.yaml
+++ b/docs/development/3-2-docs-retrieval-index.yaml
@@ -5519,6 +5519,7 @@ pages:
     abstract: "Canonical changelog for the Spec Kitty CLI and templates, following Keep a Changelog and Semantic Versioning, with added, breaking, and fixed entries per release."
     anchors:
     - {slug: "unreleased", text: "[Unreleased]", level: 2}
+    - {slug: "3-2-6-2-2026-09-09", text: "[3.2.6.2] - 2026-09-09", level: 2}
     - {slug: "added", text: "Added", level: 3}
     - {slug: "fixed", text: "Fixed", level: 3}
     - {slug: "3-2-6-1-2026-09-08", text: "[3.2.6.1] - 2026-09-08", level: 2}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-cli"
-version = "3.2.6.1"
+version = "3.2.6.2"
 description = "Spec Kitty, a tool for Specification Driven Development (SDD) agentic projects, with kanban and git worktree isolation."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/acceptance/test_first_run_path_3_2_6_1.py
+++ b/tests/acceptance/test_first_run_path_3_2_6_1.py
@@ -45,6 +45,7 @@ import json
 import os
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -319,10 +320,12 @@ def test_unborn_head_error_names_a_remedy_that_works(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_version_is_the_patch_release(project: Path) -> None:
+def test_version_matches_release_metadata(project: Path) -> None:
+    with (_REPO_ROOT / "pyproject.toml").open("rb") as source:
+        expected = tomllib.load(source)["project"]["version"]
     result = _cli(project, "--version")
     assert result.returncode == 0
-    assert "3.2.6.1" in _unwrapped(result)
+    assert _unwrapped(result) == f"spec-kitty-cli version {expected}"
 
 
 def test_no_retired_org_in_user_facing_urls() -> None:

--- a/tests/release/test_release_ci_ownership.py
+++ b/tests/release/test_release_ci_ownership.py
@@ -86,6 +86,8 @@ def workflow_script_text(name: str) -> str:
 @pytest.mark.parametrize(
     ("workflow_name", "event"),
     [
+        ("check-spec-kitty-events-alignment.yml", "pull_request"),
+        ("check-spec-kitty-events-alignment.yml", "push"),
         ("ci-quality.yml", "pull_request"),
         ("ci-quality.yml", "push"),
         ("release-readiness.yml", "pull_request"),
@@ -218,13 +220,16 @@ def test_shared_drift_has_scheduled_and_manual_monitoring() -> None:
     assert "workflow_dispatch" in workflow_on
 
 
-def test_shared_drift_secret_job_uses_trusted_scripts_only() -> None:
+def test_shared_drift_checks_candidate_metadata_without_retired_consumer() -> None:
     workflow = load_workflow("check-spec-kitty-events-alignment.yml")
     jobs = workflow["jobs"]
 
     prepare_dump = repr(jobs["prepare-candidate-metadata"])
     assert "SPEC_KITTY_SAAS_READ_TOKEN" not in prepare_dump
     assert "python -m build" not in prepare_dump
+    upload = next(step for step in jobs["prepare-candidate-metadata"]["steps"] if step.get("name") == "Upload candidate package metadata")
+    assert upload["with"]["include-hidden-files"] is True
+    assert set(upload["with"]["path"].split()) == {"pyproject.toml", "uv.lock", ".kittify/release/shared-package-compatibility.json"}
 
     verify = jobs["verify-drift"]
     verify_dump = repr(verify)
@@ -235,8 +240,12 @@ def test_shared_drift_secret_job_uses_trusted_scripts_only() -> None:
     assert "check_shared_package_drift.py --help" in verify_dump
     assert "MANIFEST_ARGS" in verify_dump
 
-    fetch_step = next(step for step in verify["steps"] if step.get("id") == "fetch_refs")
-    assert "CROSS_REPO_TOKEN" in fetch_step["env"]
+    for retired in ("fetch_refs", "CROSS_REPO_TOKEN", "--saas-pyproject", "SPEC_KITTY_SAAS_READ_TOKEN"):
+        assert retired not in verify_dump
+    validate = next(step for step in verify["steps"] if step.get("name") == "Validate shared package drift")
+    assert "if" not in validate
+    assert "--pyproject candidate/pyproject.toml" in validate["run"]
+    assert "--lockfile candidate/uv.lock" in validate["run"]
 
 
 def test_ci_quality_has_no_saas_consumer_compatibility_job() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2283,7 +2283,7 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-cli"
-version = "3.2.6.1"
+version = "3.2.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
Prepare **3.2.6.2** from `release/3.2.6.x`, after merging #4104 at `299e749acc84cb2d8dc34ad8a19f66f23f46baf1` (based on released `v3.2.6.1`).

Synchronize `pyproject.toml`, `uv.lock`, and project metadata; finalize the changelog for all six project-doctrine fixes. Refresh the generated docs retrieval index.

The full release run exposed two maintenance leftovers: the version acceptance test pinned the previous release, and the standalone shared-package workflow still fetched the SaaS comparison already retired from this release line. The test now compares actual CLI output with source metadata. The workflow unconditionally validates candidate metadata, lockfile, and compatibility manifest; it includes the hidden manifest in its narrowly scoped artifact upload and runs on this maintenance branch. Independent review found and verified the artifact inclusion requirement.

## Verification

- Release tests: 173 passed, 6 skipped; updated workflow ownership tests: 39 passed.
- Version subprocess acceptance: 1 passed. Dashboard Playwright tests: 4 passed.
- Branch/tag metadata validation, shared-package drift, Ruff, wheel/sdist build, and clean exact-wheel install: passed.
- Full/extended CI on the corrected head: https://github.com/spec-kitty/spec-kitty/actions/runs/34313404135 (passed).
- Corrected shared-package workflow: https://github.com/spec-kitty/spec-kitty/actions/runs/34313406006 (passed).
- #4104 merge tree exactly matches the accepted source tree; all six functional requirements retain their accepted test and fresh-repository evidence.

## Release-specific cross-repo/canary waiver

The old cross-repo test repository redirects to `spec-kitty/EXPERIMENTAL-spec-kitty-end-to-end-testing` at `74f6251c180e2e7943e590260fe4337f9d1a4fc9`. Its offline scenarios produced 4 passes and 1 failure on the release candidate. The failing dependent-WP planning lifecycle cannot claim WP04 after self-healing ancestry for approved dependency lane-c. The identical scenario fails on pristine `v3.2.6.1` (`e2fe25502`) in an independent frozen environment: a confirmed pre-existing failure, not green evidence.

The experimental Docker topology and live Linear/SaaS canary were not run: no running Docker daemon or configured authenticated canary target. `RELEASE_CHECKLIST.md` requires new release-specific evidence or an explicit maintainer waiver; the #4048 waiver applies only to 3.2.6.1. On 2026-09-09, Robert explicitly instructed: "ignore the cross repo canary gate" for this 3.2.6.2 release. This records that release-specific waiver. The failed baseline scenario and unrun live canary remain reported accurately; full CLI CI and package publication checks remain required.

## Final release commit

Merged as `e40f9978b11e4f680dab26a908c5890a53dc13d0`; tree identical to the reviewed candidate. Full final-commit CI passed: https://github.com/spec-kitty/spec-kitty/actions/runs/34315062005 . Release readiness, shared-package drift, Windows CI, and drift detection also passed on that commit. Annotated tag `v3.2.6.2` was pushed after those gates passed; automated PyPI publication completed: https://github.com/spec-kitty/spec-kitty/actions/runs/34316647052 . Wheel, sdist, checksums, and SBOM are available in the GitHub release. PyPI exact-install verification passed after the initial index-propagation delay; only that failed verification job was rerun after the new version became visible in both simple-index representations. Published package: https://pypi.org/project/spec-kitty-cli/3.2.6.2/ .
