### PR TITLE
[#4119] Surface main-push CI failures through fleet P0 intake

### DIFF
--- a/.github/workflows/ci-fleet-verdict.yml
+++ b/.github/workflows/ci-fleet-verdict.yml
@@ -15,8 +15,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       prs: ${{ steps.source.outputs.prs }}
+      main: ${{ steps.source.outputs.main }}
     steps:
-      # Both jobs use trusted default-branch code, never source PR code/artifacts.
+      # All jobs use trusted default-branch code, never source PR code/artifacts.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
@@ -62,4 +63,32 @@ jobs:
           REPORT_PR: ${{ matrix.pr }}
         run: |
           python3 scripts/ci/fleet_verdict.py --pr "$REPORT_PR" \
+            --repository "$REPORT_REPOSITORY" --reporter-id "$REPORT_ID" --attempt "$REPORT_ATTEMPT"
+
+  report-main:
+    needs: identify
+    if: needs.identify.outputs.main == 'true'
+    # Serialize across main heads: the survivor always rereads current main.
+    concurrency:
+      group: ci-fleet-verdict-main
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - run: python3 -m pip install --quiet --disable-pip-version-check pyyaml==6.0.2
+      - name: Reconcile main CI into the fleet P0 intake
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT_REPOSITORY: ${{ github.repository }}
+          REPORT_ID: ${{ github.run_id }}
+          REPORT_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          python3 -m scripts.ci.fleet_main \
             --repository "$REPORT_REPOSITORY" --reporter-id "$REPORT_ID" --attempt "$REPORT_ATTEMPT"

--- a/scripts/ci/fleet_main.py
+++ b/scripts/ci/fleet_main.py
@@ -1,0 +1,157 @@
+"""Reconcile main-push CI into the fleet's existing P0 issue intake.
+
+The reporter consumes metadata only. It uses the existing main-push CI gates,
+not the nightly/full release acceptance suite. PROGRAM.md section 9 and planning
+agents/ci.md step 6 own the red-main P0 policy; groom/controller consume the
+from:ci + status:triage queue. An open incident gets subsequent observations,
+including recovery, but only the fleet closes or changes its priority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.ci.fleet_verdict import AGGREGATE, PR_WORKFLOWS, GitHub, automatic_aggregate, classify, comment_body
+
+INCIDENT = "<!-- spec-kitty-main-ci-incident-v1 -->"
+
+
+def main_workflows(root: Path) -> tuple[set[str], set[str]]:
+    """Read unconditional and conditional main-push gates from trusted YAML."""
+    required: set[str] = set()
+    conditional: set[str] = set()
+    for name in PR_WORKFLOWS:
+        document = yaml.safe_load((root / ".github/workflows" / name).read_text(encoding="utf-8"))
+        trigger = document.get("on", document.get(True, {})).get("push")
+        if trigger is None:
+            continue
+        if set(trigger) - {"branches", "paths"}:
+            raise ValueError(f"unsupported main push policy in {name}")
+        if not any(fnmatch.fnmatchcase("main", pattern) for pattern in trigger.get("branches", [])):
+            continue
+        (conditional if trigger.get("paths") else required).add(name)
+    if not {"ci-router.yml", "ci-modules.yml", "ci-quality.yml", "packs.yml", "ci-windows.yml"} <= required:
+        raise ValueError("continuous main-push CI inventory changed")
+    return required, conditional
+
+
+def snapshot(api: GitHub, root: Path, workflow_ids: dict[str, int]) -> dict[str, Any]:
+    head = api.request("git/ref/heads/main")["object"]["sha"]
+    if not isinstance(head, str) or not re.fullmatch("[0-9a-f]{40}", head):
+        raise ValueError("main has an invalid head")
+    required, conditional = main_workflows(root)
+    found = api.pages(f"actions/runs?head_sha={head}&event=push&branch=main", "workflow_runs")
+    runs: dict[str, Any] = {}
+    for name in sorted(required | conditional):
+        matching = [
+            run
+            for run in found
+            if run.get("workflow_id") == workflow_ids[name]
+            and run.get("repository", {}).get("full_name") == api.repository
+            and run.get("head_repository", {}).get("full_name") == api.repository
+            and run.get("head_sha") == head
+            and run.get("head_branch") == "main"
+            and run.get("event") == "push"
+            and run.get("path") == f".github/workflows/{name}"
+            and type(run.get("id")) is int
+            and run["id"] > 0
+            and type(run.get("run_attempt")) is int
+            and run["run_attempt"] > 0
+        ]
+        latest = max(matching, key=lambda run: (run["id"], run["run_attempt"]), default=None)
+        if name in required or latest:
+            runs[name] = latest
+    modules = runs.get("ci-modules.yml")
+    runs[AGGREGATE] = (
+        automatic_aggregate(api, workflow_ids[AGGREGATE], modules, f"CI Aggregate source {modules['id']} attempt {modules['run_attempt']}") if modules else None
+    )
+    evidence = {
+        name: ({key: run.get(key) for key in ("id", "run_attempt", "head_sha", "event", "status", "conclusion", "html_url")} if run else None)
+        for name, run in sorted(runs.items())
+    }
+    return {
+        "head": head,
+        "state": classify(runs, set()),
+        "runs": evidence,
+        "scope": "continuous-main-push",
+        "conditional_gates_not_observed": sorted(conditional - runs.keys()),
+    }
+
+
+def body(repository: str, evidence: dict[str, Any], reporter_id: int, attempt: int) -> str:
+    report = comment_body(repository, evidence, reporter_id, attempt)
+    return report + (
+        "\nThis observes the current main head, not nightly/full-suite release acceptance. "
+        "Path-filtered gates are included when a matching push run exists; absent conditional gates are listed in the evidence.\n"
+        "\nRed main is P0 under PROGRAM.md section 9 and agents/ci.md step 6. "
+        "The fleet should investigate the named failing gates; this report does not attribute a culprit PR or test node. "
+        "A later green observation is recovery evidence for the fleet to assess, not automatic closure.\n"
+    )
+
+
+def report(api: GitHub, root: Path, ids: dict[str, int], reporter_id: int, attempt: int, *, dry_run: bool = False) -> None:
+    evidence = snapshot(api, root, ids)
+    text = body(api.repository, evidence, reporter_id, attempt)
+    if dry_run:
+        print(text, end="")
+        return
+    incidents = [
+        issue
+        for issue in api.pages("issues?state=open&labels=from%3Aci")
+        if not issue.get("pull_request") and issue.get("user", {}).get("type") == "Bot" and INCIDENT in (issue.get("body") or "")
+    ]
+    if len(incidents) > 1:
+        raise ValueError("multiple active main CI incidents; fleet must reconcile ownership")
+    incident = incidents[0] if incidents else None
+    fingerprint = "<!-- evidence: " + json.dumps(evidence, sort_keys=True) + " -->"
+    if incident:
+        comments = api.pages(f"issues/{incident['number']}/comments")
+        latest = next(
+            (comment for comment in reversed(comments) if comment.get("user", {}).get("type") == "Bot" and "<!-- evidence:" in comment.get("body", "")), incident
+        )
+        if fingerprint in latest.get("body", ""):
+            return
+    elif evidence["state"] != "red":
+        print(text, end="")
+        return
+    if snapshot(api, root, ids) != evidence:
+        raise ValueError("main head or CI attempts changed before publication; later event will reconcile")
+    if incident:
+        if api.request(f"issues/{incident['number']}")["state"] != "open":
+            raise ValueError("main CI incident closed before publication; later event will reconcile")
+        api.request(f"issues/{incident['number']}/comments", {"body": text})
+    else:
+        api.request(
+            "issues",
+            {
+                "title": f"main-push CI is red at {evidence['head'][:12]}",
+                "body": INCIDENT + "\n\n" + text,
+                "labels": ["type:fix", "priority:P0", "from:ci", "status:triage"],
+            },
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--reporter-id", type=int, required=True)
+    parser.add_argument("--attempt", type=int, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    api = GitHub(args.repository)
+    definitions = api.pages("actions/workflows", "workflows")
+    ids = {Path(row["path"]).name: row["id"] for row in definitions if row["path"].startswith(".github/workflows/")}
+    if not (PR_WORKFLOWS | {AGGREGATE}) <= ids.keys():
+        raise ValueError("required Actions workflow definition missing")
+    report(api, Path(__file__).resolve().parents[2], ids, args.reporter_id, args.attempt, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/fleet_verdict.py
+++ b/scripts/ci/fleet_verdict.py
@@ -275,7 +275,8 @@ def comment_body(repository: str, evidence: dict[str, Any], reporter_id: int, at
     provenance = evidence.get("replay", {})
     host = provenance.get("host", "github-actions")
     session = provenance.get("session", f"github-actions-{reporter_id}")
-    lines = [f"[ci] {state} @{head} on {host}", "", MARKER, "Existing Actions gates for this exact PR head; no additional test run.", ""]
+    scope = "main-push head" if evidence.get("scope") == "continuous-main-push" else "PR head"
+    lines = [f"[ci] {state} @{head} on {host}", "", MARKER, f"Existing Actions gates for this exact {scope}; no additional test run.", ""]
     if state == "running":
         lines.append("Evidence is pending, incomplete, cancelled, or intentionally deferred; this is not a code failure verdict.")
     for name, run in evidence["runs"].items():
@@ -383,13 +384,28 @@ def main() -> None:
     if name not in PR_WORKFLOWS | {AGGREGATE} or trigger["workflow_id"] != ids[name]:
         raise ValueError("unrecognized triggering workflow")
     source = api.request(f"actions/runs/{trigger['id']}")
+    if (
+        source.get("id") != trigger["id"]
+        or source.get("workflow_id") != ids[name]
+        or source.get("path") != f".github/workflows/{name}"
+        or source.get("repository", {}).get("full_name") != api.repository
+    ):
+        raise ValueError("triggering run does not match the trusted workflow")
     if name == AGGREGATE:
         match = re.fullmatch(r"CI Aggregate source ([1-9][0-9]*) attempt ([1-9][0-9]*)", source["display_title"])
         if not match or source.get("event") != "workflow_run":
             return
         source = api.request(f"actions/runs/{match.group(1)}")
-        if source.get("workflow_id") != ids["ci-modules.yml"]:
+        if (
+            source.get("workflow_id") != ids["ci-modules.yml"]
+            or source.get("path") != ".github/workflows/ci-modules.yml"
+            or source.get("repository", {}).get("full_name") != api.repository
+        ):
             raise ValueError("aggregate source is not CI Modules")
+    if source.get("event") == "push" and source.get("head_branch") == "main":
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            output.write("main=true\n")
+        return
     if source.get("event") != "pull_request" or source.get("repository", {}).get("full_name") != api.repository:
         return
     references = source.get("pull_requests", [])

--- a/tests/ci/test_fleet_main.py
+++ b/tests/ci/test_fleet_main.py
@@ -1,0 +1,33 @@
+"""Main-push CI reaches the fleet through the reporter's existing CLI entry point."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import fleet_verdict
+from tests.ci.test_fleet_verdict import API, IDS, REPO
+
+pytestmark = pytest.mark.fast
+
+
+def test_main_push_event_selects_main_reporting(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    api = API()
+    source = api.runs["ci-modules.yml"][0]
+    source.update(event="push", head_branch="main", pull_requests=[])
+    event = tmp_path / "event.json"
+    event.write_text(json.dumps({"workflow_run": source}))
+    output = tmp_path / "output"
+    output.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setattr(fleet_verdict, "GitHub", lambda repository: api)
+    monkeypatch.setattr(sys, "argv", ["fleet_verdict.py", "--event", str(event), "--repository", REPO, "--reporter-id", "123", "--attempt", "1"])
+
+    fleet_verdict.main()
+
+    assert "main=true\n" in output.read_text()
+    assert IDS["ci-modules.yml"] == source["workflow_id"]
+    assert not api.posts

--- a/tests/ci/test_fleet_main.py
+++ b/tests/ci/test_fleet_main.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
-from scripts.ci import fleet_verdict
-from tests.ci.test_fleet_verdict import API, IDS, REPO
+from scripts.ci import fleet_main, fleet_verdict
+from tests.ci.test_fleet_verdict import API, HEAD, IDS, REPO, ROOT
 
 pytestmark = pytest.mark.fast
 
@@ -31,3 +33,213 @@ def test_main_push_event_selects_main_reporting(tmp_path: Path, monkeypatch: pyt
     assert "main=true\n" in output.read_text()
     assert IDS["ci-modules.yml"] == source["workflow_id"]
     assert not api.posts
+
+
+class MainAPI(API):
+    def __init__(self):
+        super().__init__()
+
+        self.head = HEAD
+        self.incidents = []
+        self.mutations = []
+        self.head_reads = 0
+        self.move_on_second_read = False
+        for name, rows in self.runs.items():
+            if name != fleet_verdict.AGGREGATE:
+                for row in rows:
+                    row.update(event="push", head_branch="main", head_repository={"full_name": REPO}, pull_requests=[])
+
+    def request(self, path, payload=None):
+
+        if payload is not None:
+            self.mutations.append((path, copy.deepcopy(payload)))
+            if path == "issues":
+                self.incidents.append({"number": 20, "state": "open", "user": {"type": "Bot"}, **payload})
+            else:
+                self.comments.append({"user": {"type": "Bot"}, **payload})
+            return {}
+        if path == "git/ref/heads/main":
+            self.head_reads += 1
+            return {"object": {"sha": "c" * 40 if self.move_on_second_read and self.head_reads > 1 else self.head}}
+        if path == "issues/20":
+            return copy.deepcopy(self.incidents[0])
+        return super().request(path, payload)
+
+    def pages(self, path, field=None):
+
+        if path == "issues?state=open&labels=from%3Aci":
+            return copy.deepcopy(self.incidents)
+        if path == "issues/20/comments":
+            return copy.deepcopy(self.comments)
+        return super().pages(path, field)
+
+
+def test_red_main_reaches_existing_fleet_p0_intake_and_deduplicates() -> None:
+
+    api = MainAPI()
+    api.runs["ci-quality.yml"][0]["conclusion"] = "failure"
+    fleet_main.report(api, ROOT, IDS, 123, 1)
+    path, payload = api.mutations[0]
+    assert path == "issues"
+    assert payload["labels"] == ["type:fix", "priority:P0", "from:ci", "status:triage"]
+    assert f"[ci] red @{HEAD}" in payload["body"]
+    assert '"run_attempt": 1' in payload["body"]
+    fleet_main.report(api, ROOT, IDS, 124, 1)
+    assert len(api.mutations) == 1
+
+
+def test_recovery_is_appended_without_closure_or_new_incident() -> None:
+
+    api = MainAPI()
+    quality = api.runs["ci-quality.yml"][0]
+    quality["conclusion"] = "failure"
+    fleet_main.report(api, ROOT, IDS, 123, 1)
+    quality.update(conclusion="success", run_attempt=2)
+    fleet_main.report(api, ROOT, IDS, 124, 1)
+    assert len(api.mutations) == 2
+    path, payload = api.mutations[1]
+    assert path == "issues/20/comments"
+    assert "[ci] green @" in payload["body"]
+    assert '"run_attempt": 2' in payload["body"]
+    assert set(payload) == {"body"}
+    fleet_main.report(api, ROOT, IDS, 125, 1)
+    assert len(api.mutations) == 2
+
+
+@pytest.mark.parametrize("conclusion", ["cancelled", "skipped", None])
+def test_incomplete_main_evidence_cannot_claim_green_or_open_p0(conclusion) -> None:
+
+    api = MainAPI()
+    api.runs["ci-modules.yml"][0].update(conclusion=conclusion)
+    assert fleet_main.snapshot(api, ROOT, IDS)["state"] == "running"
+    fleet_main.report(api, ROOT, IDS, 123, 1)
+    assert not api.mutations
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("event", "pull_request"),
+        ("head_sha", "b" * 40),
+        ("head_branch", "branch"),
+        ("workflow_id", 999),
+        ("path", ".github/workflows/fake.yml"),
+        ("repository", {"full_name": "other/repo"}),
+        ("head_repository", {"full_name": "other/repo"}),
+        ("id", None),
+        ("run_attempt", 0),
+    ],
+)
+def test_mismatched_push_run_never_supplies_evidence(field, value) -> None:
+
+    api = MainAPI()
+    api.runs["ci-quality.yml"][0][field] = value
+    evidence = fleet_main.snapshot(api, ROOT, IDS)
+    assert evidence["runs"]["ci-quality.yml"] is None
+    assert evidence["state"] == "running"
+
+
+def test_main_move_before_publication_refuses_obsolete_p0() -> None:
+
+    api = MainAPI()
+    api.runs["ci-quality.yml"][0]["conclusion"] = "failure"
+    api.move_on_second_read = True
+    with pytest.raises(ValueError, match="main head or CI attempts changed"):
+        fleet_main.report(api, ROOT, IDS, 123, 1)
+    assert not api.mutations
+
+
+def test_aggregate_must_match_current_modules_attempt() -> None:
+
+    api = MainAPI()
+    api.runs["ci-modules.yml"][0]["run_attempt"] = 2
+    evidence = fleet_main.snapshot(api, ROOT, IDS)
+    assert evidence["runs"][fleet_verdict.AGGREGATE] is None
+    assert evidence["state"] == "running"
+
+
+def test_main_report_job_has_only_issue_write_permission() -> None:
+
+    workflow = yaml.safe_load((ROOT / ".github/workflows/ci-fleet-verdict.yml").read_text())
+    job = workflow["jobs"]["report-main"]
+    assert job["permissions"] == {"contents": "read", "actions": "read", "issues": "write"}
+    assert job["concurrency"] == {"group": "ci-fleet-verdict-main", "cancel-in-progress": False}
+    assert job["if"] == "needs.identify.outputs.main == 'true'"
+    checkout = job["steps"][0]
+    assert "ref" not in checkout["with"]
+    assert checkout["with"]["persist-credentials"] is False
+
+
+def test_latest_run_attempt_supersedes_old_failure() -> None:
+    api = MainAPI()
+    old = api.runs["ci-quality.yml"][0]
+    old["conclusion"] = "failure"
+    api.runs["ci-quality.yml"].append({**old, "run_attempt": 2, "conclusion": "success"})
+    evidence = fleet_main.snapshot(api, ROOT, IDS)
+    assert evidence["state"] == "green"
+    assert evidence["runs"]["ci-quality.yml"]["run_attempt"] == 2
+
+
+def test_absent_conditional_gate_is_explicit_and_its_failure_is_observed() -> None:
+    api = MainAPI()
+    drift = api.runs.pop("check-spec-kitty-events-alignment.yml")
+    evidence = fleet_main.snapshot(api, ROOT, IDS)
+    assert evidence["scope"] == "continuous-main-push"
+    assert evidence["conditional_gates_not_observed"] == ["check-spec-kitty-events-alignment.yml"]
+    assert evidence["state"] == "green"
+    drift[0]["conclusion"] = "failure"
+    api.runs["check-spec-kitty-events-alignment.yml"] = drift
+    assert fleet_main.snapshot(api, ROOT, IDS)["state"] == "red"
+
+
+def test_existing_incident_gets_new_main_head_without_duplicate_p0() -> None:
+    api = MainAPI()
+    api.runs["ci-quality.yml"][0]["conclusion"] = "failure"
+    fleet_main.report(api, ROOT, IDS, 123, 1)
+    api.head = "d" * 40
+    for name, rows in api.runs.items():
+        if name != fleet_verdict.AGGREGATE:
+            for row in rows:
+                row["head_sha"] = api.head
+    fleet_main.report(api, ROOT, IDS, 124, 1)
+    assert [path for path, _ in api.mutations] == ["issues", "issues/20/comments"]
+    assert f"[ci] red @{api.head}" in api.mutations[-1][1]["body"]
+
+
+def test_dry_run_never_creates_incident(capsys) -> None:
+    api = MainAPI()
+    api.runs["ci-quality.yml"][0]["conclusion"] = "failure"
+    fleet_main.report(api, ROOT, IDS, 123, 1, dry_run=True)
+    assert f"[ci] red @{HEAD}" in capsys.readouterr().out
+    assert not api.mutations
+
+
+def test_attempt_change_during_publication_refuses_stale_verdict() -> None:
+    class RerunAPI(MainAPI):
+        def request(self, path, payload=None):
+            if path == "git/ref/heads/main" and self.head_reads == 1:
+                self.runs["ci-quality.yml"][0].update(run_attempt=2, status="in_progress", conclusion=None)
+            return super().request(path, payload)
+
+    api = RerunAPI()
+    api.runs["ci-quality.yml"][0]["conclusion"] = "failure"
+    with pytest.raises(ValueError, match="main head or CI attempts changed"):
+        fleet_main.report(api, ROOT, IDS, 123, 1)
+    assert not api.mutations
+
+
+def test_duplicate_open_incidents_refuse_ambiguous_ownership() -> None:
+    api = MainAPI()
+    api.incidents = [{"number": n, "body": fleet_main.INCIDENT, "user": {"type": "Bot"}} for n in [20, 21]]
+    with pytest.raises(ValueError, match="multiple active"):
+        fleet_main.report(api, ROOT, IDS, 123, 1)
+    assert not api.mutations
+
+
+def test_main_cli_dry_run_is_read_only(monkeypatch, capsys) -> None:
+    api = MainAPI()
+    monkeypatch.setattr(fleet_main, "GitHub", lambda repository: api)
+    monkeypatch.setattr(sys, "argv", ["fleet_main", "--repository", REPO, "--reporter-id", "123", "--attempt", "1", "--dry-run"])
+    fleet_main.main()
+    assert f"[ci] green @{HEAD}" in capsys.readouterr().out
+    assert not api.mutations


### PR DESCRIPTION
## Issue

refs #4119. The issue stays open until the trusted default-branch workflow is activated and a real main-push failure produces an issue receipt consumed by the fleet. Local tests establish the reporting behavior; they do not establish live fleet consumption.

## Change

A completed main-push CI failure previously stopped at the reporter's PR-only event filter. Main events now reconcile the current branch head and existing push gates, then open one `type:fix priority:P0 from:ci status:triage` incident through the fleet's established intake. An open incident receives changed evidence and recovery observations; the fleet retains closure and priority decisions.

The reporter verifies repository, source workflow, head, run ID, and attempt, binds Aggregate to the current Modules attempt, and rereads main and CI evidence before publishing. Missing, skipped, cancelled, or incomplete evidence cannot become green. The main job serializes publication and has only issue write permission alongside metadata reads; it executes trusted default-branch code and no source artifacts.

Acceptance scope is continuous main-push failure detection. Path-filtered gates contribute when matching runs exist, with unobserved conditional gates explicitly listed. The archived baseline file, initial-green persistence, and nightly/full-suite release acceptance are outside this change.

## Tests run

- RED-first `uv run --frozen pytest tests/ci/test_fleet_main.py -q` on test-only commit `565f90cee` → 0 passed / 1 failed: a valid main-push event emitted no main-reporting output.
- `uv run --frozen --with defusedxml pytest tests/ci -q` → 176 passed / 0 failed.
- `uv run --frozen --with defusedxml pytest tests/ci/test_fleet_main.py -q --cov=scripts.ci.fleet_main --cov-report=term-missing` → 25 passed / 0 failed; new reporter coverage 92%.
- `PYTEST_XDIST_AUTO_NUM_WORKERS=4 make test-fast` → 1784 passed / 0 failed / 2 skipped.
- `uv run --frozen --with ruff ruff check .` and `uv run --frozen --with ruff ruff format --check .` → passed (1696 formatted files).
- `uv run --frozen --with mypy mypy --strict scripts/ci/fleet_main.py` → passed.
- Read-only snapshot against live main `81d862e3ae326ac2ab75b4125563222d238f379a` → running: Modules `34364158952` and Router `34364158534` were in progress, with no matching Aggregate; no issue mutation performed.

The first owning-suite invocation without `defusedxml` had 33 dependency setup failures; provisioning that existing test requirement resolved them. No product source or dependency declarations were changed for this environment correction.

Self-review:
- correctness: clean; current-head and attempt changes refuse stale publication, incidents deduplicate, recovery does not close issues
- deletion safety: clean; no source deletion
- security: clean; trusted reporter code, metadata reads, isolated issue write permission
- design fidelity: clean; existing fleet P0 intake and source producer remain authoritative
- tests: clean; owning suite, baseline, new-code coverage, lint, formatting, and typing pass

## Blast radius

Discovery: `rg --files scripts/ci tests/ci .github/workflows | rg 'fleet'`
Files: `.github/workflows/ci-fleet-verdict.yml`, `tests/ci/test_fleet_api.py`, `tests/ci/test_fleet_verdict.py`, `tests/ci/test_fleet_main.py`, `scripts/ci/fleet_verdict.py`, `scripts/ci/fleet_main.py`

The change affects the fleet metadata reporter's event selection, shared comment rendering, and a separate main-incident publisher. The complete `tests/ci` suite exercises existing PR reporting, HTTP boundaries, source/aggregate provenance, and the new main intake behavior. The shared fast baseline covers the normal CLI/runtime regression surface.

## Deferred

[Issue #4119](https://github.com/spec-kitty/spec-kitty/issues/4119) retains trusted default-branch activation and a live fleet-consumed receipt as acceptance work. This PR does not refresh the old planning baseline or prove full-release acceptance. Aggregate attempt-scoping is tracked separately in [#4118](https://github.com/spec-kitty/spec-kitty/issues/4118).
