### PR TITLE
[#4118] Reuse reports from shard executions retained by CI reruns

### DIFF
--- a/.github/workflows/ci-aggregate.yml
+++ b/.github/workflows/ci-aggregate.yml
@@ -9,12 +9,13 @@
 # `*-reports` artefacts through a cross-run `actions/download-artifact`
 # (`run-id:` pointed at the triggering run) and never re-runs pytest (FR-007).
 # Coverage basenames are deduped and collisions fail loudly. PR coverage uses
-# only the exact CI Modules attempt, with no stale fallback. Its registry and
+# only executions retained by the exact CI Modules attempt, including shards
+# carried forward by rerun-failed-jobs, with no cross-run fallback. Its registry and
 # diff come from the verified synthetic merge tree (parents must match the
 # source run's immutable tested workflow reference); the trusted default-branch checkout remains
 # in place. Missing source provenance or a current shard fails closed.
 # Automatic non-PR diagnostic runs retain the successful-run stale fallback;
-# manual replay always requires complete evidence from its exact source attempt.
+# manual replay always requires complete evidence retained by its exact source attempt.
 #
 # `mode` (pr|full) is honored in THIS workflow's own fail-fast/`needs`
 # behavior: pr short-circuits the diff-cover gate the moment `collect` cannot
@@ -92,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ && "$SOURCE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
-          gh api "repos/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > "$RUNNER_TEMP/source-run.json"
+          gh api "repos/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT" > "$RUNNER_TEMP/source-run.json"
           python3 scripts/ci/aggregate_source.py "$RUNNER_TEMP/source-run.json" \
             --repository "$SOURCE_REPOSITORY" --run-id "$SOURCE_RUN_ID" --attempt "$SOURCE_RUN_ATTEMPT"
 
@@ -119,12 +120,27 @@ jobs:
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
           echo "ci-aggregate: resolved mode=$mode"
 
+      - name: Select reports from executions retained by the source attempt
+        id: select-current
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt || inputs.source_run_attempt }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api --paginate "repos/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT/jobs?per_page=100" | jq --slurp . > "$RUNNER_TEMP/source-jobs.json"
+          gh api --paginate "repos/$SOURCE_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100" | jq --slurp . > "$RUNNER_TEMP/source-artifacts.json"
+          python3 scripts/ci/select_source_artifacts.py out/aggregate/source/source.json \
+            "$RUNNER_TEMP/source-jobs.json" "$RUNNER_TEMP/source-artifacts.json" >> "$GITHUB_OUTPUT"
+
       - name: Download the triggering run's shard artefacts
         id: download-current
         continue-on-error: true
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          pattern: 'module-tests-*-attempt-${{ github.event.workflow_run.run_attempt || inputs.source_run_attempt }}-reports'
+          pattern: ${{ steps.select-current.outputs.artifact-pattern }}
           path: out/aggregate/current
           merge-multiple: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-aggregate.yml
+++ b/.github/workflows/ci-aggregate.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Download the triggering run's shard artefacts
         id: download-current
+        if: steps.select-current.outputs.has-artifacts == 'true'
         continue-on-error: true
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/scripts/ci/aggregate_source.py
+++ b/scripts/ci/aggregate_source.py
@@ -35,6 +35,8 @@ def prepare_source(run: dict[str, Any], repository: str, run_id: int, attempt: i
         ".github/workflows/ci-modules.yml",
     ):
         raise ValueError("source run identity, attempt, repository or workflow does not match")
+    if run.get("status") != "completed":
+        raise ValueError("source run attempt has not completed")
     head = run.get("head_sha", "")
     if not isinstance(head, str) or not re.fullmatch("[0-9a-f]{40}", head):
         raise ValueError("source head is not a full commit SHA")

--- a/scripts/ci/select_source_artifacts.py
+++ b/scripts/ci/select_source_artifacts.py
@@ -87,7 +87,8 @@ def main() -> None:
     names = select_artifacts(source, jobs, artifacts)
     # download-artifact's pinned minimatch supports brace alternatives. Only
     # validated ASCII artifact names enter this expression or GITHUB_OUTPUT.
-    pattern = "{" + ",".join(names) + "}" if len(names) > 1 else next(iter(names), "no-source-shard-reports")
+    pattern = "{" + ",".join(names) + "}" if len(names) > 1 else next(iter(names), "")
+    print(f"has-artifacts={str(bool(names)).lower()}")
     print(f"artifact-pattern={pattern}")
 
 

--- a/scripts/ci/select_source_artifacts.py
+++ b/scripts/ci/select_source_artifacts.py
@@ -1,0 +1,95 @@
+"""Select reports belonging to the jobs retained by an exact CI Modules attempt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+ARTIFACT = re.compile(r"module-tests-([A-Za-z0-9._-]+)-shard-([1-9][0-9]*)-of-([1-9][0-9]*)-attempt-([1-9][0-9]*)-reports")
+JOB = re.compile(r"(module-tests \(([A-Za-z0-9._-]+) shard ([1-9][0-9]*)/([1-9][0-9]*)\)) / \1")
+
+
+def timestamp(value: Any) -> datetime:
+    """Require timezone-aware API timestamps; missing evidence is not a match."""
+    if not isinstance(value, str):
+        raise ValueError("missing execution/upload timestamp")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("execution/upload timestamp has no timezone")
+    return parsed
+
+
+def select_artifacts(source: dict[str, Any], jobs: list[dict[str, Any]], artifacts: list[dict[str, Any]]) -> list[str]:
+    """Bind same-run reports to each shard's actual execution, including reuse.
+
+    The attempt jobs API projects carried-forward successes into attempt N with
+    their original started_at/completed_at. run_attempt alone cannot distinguish
+    them from rerun jobs. An upload must belong to that execution interval, and
+    its name must never exceed N, even when replaying after attempt N+1.
+    """
+    executions = {}
+    for job in jobs:
+        match = JOB.fullmatch(job.get("name", ""))
+        if match is None:
+            if job.get("name", "").startswith("module-tests"):
+                raise ValueError("unrecognized module shard job name")
+            continue
+        key = match.group(2, 3, 4)
+        if job.get("run_id") != source["run_id"] or job.get("head_sha") != source["head_sha"] or job.get("run_attempt") != source["run_attempt"]:
+            raise ValueError("job does not belong to the requested source run, head and attempt")
+        if job.get("status") != "completed":
+            raise ValueError("source shard job has not completed")
+        interval = timestamp(job.get("started_at")), timestamp(job.get("completed_at"))
+        if interval[0] > interval[1] or key in executions:
+            raise ValueError("ambiguous source shard execution")
+        executions[key] = interval
+
+    selected: dict[tuple[str, ...], str] = {}
+    seen_names: set[str] = set()
+    for artifact in artifacts:
+        match = ARTIFACT.fullmatch(artifact.get("name", ""))
+        if match is None or int(match[4]) > source["run_attempt"]:
+            continue
+        key = match.group(1, 2, 3)
+        if key not in executions:
+            continue
+        if artifact["name"] in seen_names:
+            raise ValueError("multiple artifacts share a source report name")
+        seen_names.add(artifact["name"])
+        run = artifact.get("workflow_run", {})
+        if run.get("id") != source["run_id"] or run.get("head_sha") != source["head_sha"]:
+            raise ValueError("artifact does not belong to the requested source run and head")
+        created = timestamp(artifact.get("created_at"))
+        start, end = executions[key]
+        if not start <= created <= end or artifact.get("expired") is not False:
+            continue
+        if key in selected:
+            raise ValueError("multiple artifacts belong to the same shard execution")
+        selected[key] = artifact["name"]
+    return sorted(selected.values())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("jobs", type=Path)
+    parser.add_argument("artifacts", type=Path)
+    args = parser.parse_args()
+    source = json.loads(args.source.read_text(encoding="utf-8"))
+    # gh api --paginate | jq --slurp . produces one object per response page.
+    jobs = [job for page in json.loads(args.jobs.read_text(encoding="utf-8")) for job in page["jobs"]]
+    artifacts = [artifact for page in json.loads(args.artifacts.read_text(encoding="utf-8")) for artifact in page["artifacts"]]
+    names = select_artifacts(source, jobs, artifacts)
+    # download-artifact's pinned minimatch supports brace alternatives. Only
+    # validated ASCII artifact names enter this expression or GITHUB_OUTPUT.
+    pattern = "{" + ",".join(names) + "}" if len(names) > 1 else next(iter(names), "no-source-shard-reports")
+    print(f"artifact-pattern={pattern}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_aggregate_attempts.py
+++ b/tests/ci/test_aggregate_attempts.py
@@ -65,7 +65,10 @@ def collect(tmp_path: Path, artifacts: list[dict], jobs: list[dict], *, latest: 
     bindir.mkdir()
     gh = bindir / "gh"
     gh.write_text(
-        f"#!{sys.executable}\nimport json, os, sys\nendpoint = next(a for a in sys.argv if a.startswith('repos/'))\nprint(json.dumps(json.load(open(os.environ['FAKE_API']))[endpoint]))\n"
+        f"#!{sys.executable}\nimport json, os, sys\n"
+        "endpoint = next(a for a in sys.argv if a.startswith('repos/'))\n"
+        "result = json.load(open(os.environ['FAKE_API']))[endpoint]\n"
+        "print('\\n'.join(json.dumps(page) for page in result) if isinstance(result, list) else json.dumps(result))\n"
     )
     gh.chmod(0o755)
     (repo / "scripts").symlink_to(ROOT / "scripts", target_is_directory=True)
@@ -131,3 +134,115 @@ def test_manual_replay_uses_requested_attempt_after_a_newer_rerun(tmp_path: Path
         event="workflow_dispatch",
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_selection_binds_timestamps_inclusively_and_normalizes_offsets() -> None:
+    from scripts.ci.select_source_artifacts import select_artifacts
+
+    source = {"run_id": 42, "run_attempt": 2, "head_sha": "a" * 40}
+    record = artifact("kernel", 1, 1)
+    record["workflow_run"]["head_sha"] = source["head_sha"]
+    execution = dict(job("kernel", 1), head_sha=source["head_sha"])
+    for created in ("2026-09-09T01:00:00Z", "2026-09-09T01:10:00Z", "2026-09-08T20:05:00-05:00"):
+        record["created_at"] = created
+        assert select_artifacts(source, [execution], [record]) == [record["name"]]
+    for created in ("2026-09-09T00:59:59Z", "2026-09-09T01:10:01Z"):
+        record["created_at"] = created
+        assert select_artifacts(source, [execution], [record]) == []
+
+
+@pytest.mark.parametrize("mutation", ["rerun_without_upload", "expired", "future_only", "absent"])
+def test_missing_current_evidence_never_borrows_an_old_report(tmp_path: Path, mutation: str) -> None:
+    records = [artifact("kernel", 1, 1), artifact("charter", 2, 2)]
+    executions = [job("kernel", 1), job("charter", 2)]
+    if mutation == "rerun_without_upload":
+        executions[0] = job("kernel", 2)
+    elif mutation == "expired":
+        records[0]["expired"] = True
+    elif mutation == "future_only":
+        records[0] = artifact("kernel", 3, 3)
+    else:
+        records.pop(0)
+    result = collect(tmp_path, records, executions)
+    assert result.returncode != 0
+    assert "registry-expected shard(s) missing" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "mutation,diagnostic",
+    [
+        ("foreign_run", "artifact does not belong"),
+        ("foreign_head", "artifact does not belong"),
+        ("job_run", "job does not belong"),
+        ("job_head", "job does not belong"),
+        ("job_attempt", "job does not belong"),
+        ("job_running", "has not completed"),
+        ("missing_start", "missing execution/upload timestamp"),
+        ("missing_end", "missing execution/upload timestamp"),
+        ("missing_created", "missing execution/upload timestamp"),
+        ("naive_created", "has no timezone"),
+        ("reversed_interval", "ambiguous source shard execution"),
+        ("duplicate_job", "ambiguous source shard execution"),
+        ("duplicate_artifact", "multiple artifacts"),
+        ("duplicate_name_outside_execution", "multiple artifacts"),
+        ("duplicate_execution_artifact", "multiple artifacts"),
+        ("bad_job_name", "unrecognized module shard job name"),
+    ],
+)
+def test_ambiguous_provenance_fails_closed(mutation: str, diagnostic: str) -> None:
+    from scripts.ci.select_source_artifacts import select_artifacts
+
+    source = {"run_id": 42, "run_attempt": 2, "head_sha": "a" * 40}
+    record = artifact("kernel", 1, 1)
+    record["workflow_run"]["head_sha"] = source["head_sha"]
+    execution = dict(job("kernel", 1), head_sha=source["head_sha"])
+    records, executions = [record], [execution]
+    if mutation in {"foreign_run", "foreign_head"}:
+        record["workflow_run"].update({"foreign_run": {"id": 43}, "foreign_head": {"head_sha": "b" * 40}}[mutation])
+    elif mutation == "job_run":
+        execution["run_id"] = 43
+    elif mutation == "job_head":
+        execution["head_sha"] = "b" * 40
+    elif mutation == "job_attempt":
+        execution["run_attempt"] = 3
+    elif mutation == "job_running":
+        execution["status"] = "in_progress"
+    elif mutation == "missing_start":
+        execution.pop("started_at")
+    elif mutation == "missing_end":
+        execution.pop("completed_at")
+    elif mutation == "missing_created":
+        record.pop("created_at")
+    elif mutation == "naive_created":
+        record["created_at"] = "2026-09-09T01:05:00"
+    elif mutation == "reversed_interval":
+        execution["completed_at"] = "2026-09-09T00:00:00Z"
+    elif mutation == "duplicate_job":
+        executions.append(dict(execution))
+    elif mutation == "duplicate_artifact":
+        records.append(dict(record, id=2))
+    elif mutation == "duplicate_name_outside_execution":
+        records.append(dict(record, id=2, created_at="2026-09-09T02:05:00Z"))
+    elif mutation == "duplicate_execution_artifact":
+        records.append(dict(record, id=2, name=record["name"].replace("attempt-1", "attempt-2")))
+    else:
+        execution["name"] = "module-tests (kernel shard 1/1) / other"
+    with pytest.raises(ValueError, match=diagnostic):
+        select_artifacts(source, executions, records)
+
+
+def test_selector_cli_outputs_safe_patterns_for_empty_or_one_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    from scripts.ci.select_source_artifacts import main
+
+    source = {"run_id": 42, "run_attempt": 2, "head_sha": "a" * 40}
+    record = artifact("kernel", 1, 1)
+    record["workflow_run"]["head_sha"] = source["head_sha"]
+    execution = dict(job("kernel", 1), head_sha=source["head_sha"])
+    paths = [tmp_path / name for name in ("source.json", "jobs.json", "artifacts.json")]
+    paths[0].write_text(json.dumps(source))
+    paths[1].write_text(json.dumps([{"jobs": [{"name": "Generate module-shard matrix"}]}, {"jobs": [execution]}]))
+    monkeypatch.setattr(sys, "argv", ["select_source_artifacts.py", *map(str, paths)])
+    for records, pattern in (([], "no-source-shard-reports"), ([record], record["name"])):
+        paths[2].write_text(json.dumps([{"artifacts": [{"name": "unrelated-report"}]}, {"artifacts": records}]))
+        main()
+        assert capsys.readouterr().out == f"artifact-pattern={pattern}\n"

--- a/tests/ci/test_aggregate_attempts.py
+++ b/tests/ci/test_aggregate_attempts.py
@@ -1,0 +1,133 @@
+"""Execute the shipped collector with a partial rerun's Actions API evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.ci.test_aggregate_source import ROOT, source_fixture
+
+pytestmark = pytest.mark.fast
+
+
+def artifact(module: str, attempt: int, artifact_id: int) -> dict:
+    return {
+        "id": artifact_id,
+        "name": f"module-tests-{module}-shard-1-of-1-attempt-{attempt}-reports",
+        "expired": False,
+        "created_at": f"2026-09-09T0{attempt}:05:00Z",
+        "workflow_run": {"id": 42},
+    }
+
+
+def job(module: str, execution_attempt: int) -> dict:
+    leaf = f"module-tests ({module} shard 1/1)"
+    return {
+        "run_id": 42,
+        # GitHub projects inherited jobs onto the requested attempt, keeping
+        # their original execution timestamps (observed on run 34302853928/2).
+        "run_attempt": 2,
+        "name": f"{leaf} / {leaf}",
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": f"2026-09-09T0{execution_attempt}:00:00Z",
+        "completed_at": f"2026-09-09T0{execution_attempt}:10:00Z",
+    }
+
+
+def collect(tmp_path: Path, artifacts: list[dict], jobs: list[dict], *, latest: int = 2, event: str = "workflow_run") -> subprocess.CompletedProcess[str]:
+    repo, run, _ = source_fixture(tmp_path)
+    run.update(run_attempt=2, status="completed", conclusion="success")
+    for record in artifacts:
+        record["workflow_run"].setdefault("head_sha", run["head_sha"])
+    for record in jobs:
+        record.setdefault("head_sha", run["head_sha"])
+    api = tmp_path / "api.json"
+    api.write_text(
+        json.dumps(
+            {
+                "repos/spec-kitty/spec-kitty/actions/runs/42": dict(run, run_attempt=latest),
+                "repos/spec-kitty/spec-kitty/actions/runs/42/attempts/2": run,
+                "repos/spec-kitty/spec-kitty/actions/runs/42/attempts/2/jobs?per_page=100": [{"jobs": jobs[:1]}, {"jobs": jobs[1:]}],
+                "repos/spec-kitty/spec-kitty/actions/runs/42/artifacts?per_page=100": [{"artifacts": artifacts[:1]}, {"artifacts": artifacts[1:]}],
+            }
+        )
+    )
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(
+        f"#!{sys.executable}\nimport json, os, sys\nendpoint = next(a for a in sys.argv if a.startswith('repos/'))\nprint(json.dumps(json.load(open(os.environ['FAKE_API']))[endpoint]))\n"
+    )
+    gh.chmod(0o755)
+    (repo / "scripts").symlink_to(ROOT / "scripts", target_is_directory=True)
+    output = tmp_path / "outputs"
+    env = dict(
+        os.environ,
+        PATH=f"{bindir}:{Path(sys.executable).parent}:{os.environ['PATH']}",
+        FAKE_API=str(api),
+        SOURCE_RUN_ID="42",
+        SOURCE_RUN_ATTEMPT="2",
+        SOURCE_REPOSITORY="spec-kitty/spec-kitty",
+        RUNNER_TEMP=str(tmp_path),
+        GITHUB_OUTPUT=str(output),
+    )
+    steps = yaml.safe_load((ROOT / ".github/workflows/ci-aggregate.yml").read_text())["jobs"]["collect"]["steps"]
+    prepare = next(s for s in steps if s.get("name", "").startswith("Prepare exact source"))
+    result = subprocess.run(["bash", "-c", prepare["run"]], cwd=repo, env=env, capture_output=True, text=True)
+    if result.returncode:
+        return result
+    # The pre-existing reconcile entrypoint consumes the verified registry.
+    (repo / "out/aggregate/source/ci-module-registry.yml").write_text(
+        "modules:\n- {module: kernel, tier: standard, shard_count: 1}\n- {module: charter, tier: standard, shard_count: 1}\n"
+    )
+    selection = next((s for s in steps if s.get("id") == "select-current"), None)
+    if selection:
+        result = subprocess.run(["bash", "-c", selection["run"]], cwd=repo, env=env, capture_output=True, text=True)
+        if result.returncode:
+            return result
+    context = {
+        "github.event.workflow_run.run_attempt": "2" if event == "workflow_run" else "",
+        "inputs.source_run_attempt": "2" if event == "workflow_dispatch" else "",
+    }
+    if output.exists():
+        context.update({f"steps.select-current.outputs.{k}": v for k, v in (line.split("=", 1) for line in output.read_text().splitlines())})
+    download = next(s for s in steps if s.get("id") == "download-current")
+    pattern = re.sub(r"\$\{\{\s*(.*?)\s*\}\}", lambda m: next(context[k.strip()] for k in m[1].split("||") if context.get(k.strip())), download["with"]["pattern"])
+    # Model download-artifact's minimatch against returned names, including
+    # brace alternatives. Only this remote action boundary is substituted.
+    patterns = pattern[1:-1].split(",") if pattern.startswith("{") else [pattern]
+    for record in artifacts:
+        if any(fnmatchcase(record["name"], p) for p in patterns):
+            module = record["name"].split("-shard-")[0].removeprefix("module-tests-")
+            directory = repo / "out/aggregate/current" / record["name"]
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / f"coverage-standard-{module}-shard1-of-1.xml").write_text("<coverage/>")
+    reconcile = next(s for s in steps if s.get("id") == "reconcile")
+    return subprocess.run(["bash", "-c", reconcile["run"]], cwd=repo, env=env, capture_output=True, text=True)
+
+
+@pytest.mark.parametrize("event", ["workflow_run", "workflow_dispatch"])
+def test_partial_rerun_collects_carried_forward_shard_and_latest_replacement(tmp_path: Path, event: str) -> None:
+    result = collect(tmp_path, [artifact("kernel", 1, 1), artifact("charter", 1, 2), artifact("charter", 2, 3)], [job("kernel", 1), job("charter", 2)], event=event)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "resolved 2/2" in result.stdout
+
+
+def test_manual_replay_uses_requested_attempt_after_a_newer_rerun(tmp_path: Path) -> None:
+    result = collect(
+        tmp_path,
+        [artifact("kernel", 1, 1), artifact("charter", 2, 2), artifact("kernel", 3, 3), artifact("charter", 3, 4)],
+        [job("kernel", 1), job("charter", 2)],
+        latest=3,
+        event="workflow_dispatch",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/ci/test_aggregate_attempts.py
+++ b/tests/ci/test_aggregate_attempts.py
@@ -104,12 +104,17 @@ def collect(tmp_path: Path, artifacts: list[dict], jobs: list[dict], *, latest: 
     if output.exists():
         context.update({f"steps.select-current.outputs.{k}": v for k, v in (line.split("=", 1) for line in output.read_text().splitlines())})
     download = next(s for s in steps if s.get("id") == "download-current")
-    pattern = re.sub(r"\$\{\{\s*(.*?)\s*\}\}", lambda m: next(context[k.strip()] for k in m[1].split("||") if context.get(k.strip())), download["with"]["pattern"])
+    condition = download.get("if")
+    should_download = True
+    if condition:
+        key, expected = condition.split("==")
+        should_download = context.get(key.strip()) == expected.strip(" '")
+    pattern = re.sub(r"\$\{\{\s*(.*?)\s*\}\}", lambda m: next(context[k.strip()] for k in m[1].split("||") if k.strip() in context), download["with"]["pattern"])
     # Model download-artifact's minimatch against returned names, including
     # brace alternatives. Only this remote action boundary is substituted.
     patterns = pattern[1:-1].split(",") if pattern.startswith("{") else [pattern]
     for record in artifacts:
-        if any(fnmatchcase(record["name"], p) for p in patterns):
+        if should_download and any(fnmatchcase(record["name"], p) for p in patterns):
             module = record["name"].split("-shard-")[0].removeprefix("module-tests-")
             directory = repo / "out/aggregate/current" / record["name"]
             directory.mkdir(parents=True, exist_ok=True)
@@ -243,10 +248,10 @@ def test_selector_cli_outputs_safe_patterns_for_empty_or_one_report(tmp_path: Pa
     paths[0].write_text(json.dumps(source))
     paths[1].write_text(json.dumps([{"jobs": [{"name": "Generate module-shard matrix"}]}, {"jobs": [execution]}]))
     monkeypatch.setattr(sys, "argv", ["select_source_artifacts.py", *map(str, paths)])
-    for records, pattern in (([], "no-source-shard-reports"), ([record], record["name"])):
+    for records, pattern in (([], ""), ([record], record["name"])):
         paths[2].write_text(json.dumps([{"artifacts": [{"name": "unrelated-report"}]}, {"artifacts": records}]))
         main()
-        assert capsys.readouterr().out == f"artifact-pattern={pattern}\n"
+        assert capsys.readouterr().out == f"has-artifacts={str(bool(records)).lower()}\nartifact-pattern={pattern}\n"
 
 
 def test_empty_selection_cannot_download_a_sentinel_named_artifact(tmp_path: Path) -> None:

--- a/tests/ci/test_aggregate_attempts.py
+++ b/tests/ci/test_aggregate_attempts.py
@@ -113,7 +113,8 @@ def collect(tmp_path: Path, artifacts: list[dict], jobs: list[dict], *, latest: 
             module = record["name"].split("-shard-")[0].removeprefix("module-tests-")
             directory = repo / "out/aggregate/current" / record["name"]
             directory.mkdir(parents=True, exist_ok=True)
-            (directory / f"coverage-standard-{module}-shard1-of-1.xml").write_text("<coverage/>")
+            for name in record.get("coverage_names", [f"coverage-standard-{module}-shard1-of-1.xml"]):
+                (directory / name).write_text("<coverage/>")
     reconcile = next(s for s in steps if s.get("id") == "reconcile")
     return subprocess.run(["bash", "-c", reconcile["run"]], cwd=repo, env=env, capture_output=True, text=True)
 
@@ -246,3 +247,14 @@ def test_selector_cli_outputs_safe_patterns_for_empty_or_one_report(tmp_path: Pa
         paths[2].write_text(json.dumps([{"artifacts": [{"name": "unrelated-report"}]}, {"artifacts": records}]))
         main()
         assert capsys.readouterr().out == f"artifact-pattern={pattern}\n"
+
+
+def test_empty_selection_cannot_download_a_sentinel_named_artifact(tmp_path: Path) -> None:
+    forged = {
+        "name": "no-source-shard-reports",
+        "workflow_run": {"id": 42},
+        "coverage_names": ["coverage-standard-kernel-shard1-of-1.xml", "coverage-standard-charter-shard1-of-1.xml"],
+    }
+    result = collect(tmp_path, [forged], [job("kernel", 1), job("charter", 2)])
+    assert result.returncode != 0, "collector accepted unselected coverage from the sentinel-named artifact"
+    assert "registry-expected shard(s) missing" in result.stdout

--- a/tests/ci/test_aggregate_source.py
+++ b/tests/ci/test_aggregate_source.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
-from fnmatch import fnmatchcase
 import subprocess
 import sys
 from pathlib import Path
@@ -48,6 +46,7 @@ def source_fixture(tmp_path: Path) -> tuple[Path, dict, str]:
     run = {
         "id": 42,
         "run_attempt": 1,
+        "status": "completed",
         "path": ".github/workflows/ci-modules.yml",
         "event": "pull_request",
         "head_sha": head,
@@ -84,6 +83,7 @@ def test_source_registry_and_diff_are_from_pr_while_checkout_stays_trusted(tmp_p
 @pytest.mark.parametrize(
     "mutation,diagnostic",
     [
+        ("in_progress", "source run attempt has not completed"),
         ("stale_attempt", "source run identity, attempt, repository or workflow does not match"),
         ("wrong_run", "source run identity, attempt, repository or workflow does not match"),
         ("wrong_repo", "source run identity, attempt, repository or workflow does not match"),
@@ -98,7 +98,9 @@ def test_source_registry_and_diff_are_from_pr_while_checkout_stays_trusted(tmp_p
 )
 def test_source_rejects_ambiguous_or_stale_evidence(tmp_path: Path, mutation: str, diagnostic: str) -> None:
     repo, run, trusted = source_fixture(tmp_path)
-    if mutation == "stale_attempt":
+    if mutation == "in_progress":
+        run["status"] = "in_progress"
+    elif mutation == "stale_attempt":
         run["run_attempt"] = 2
     elif mutation == "wrong_run":
         run["id"] = 43
@@ -214,36 +216,6 @@ def test_immutable_reference_must_bind_the_source_head(tmp_path: Path) -> None:
     result = run_source(repo, run)
     assert result.returncode != 0
     assert "tested merge parents" in result.stderr
-
-
-@pytest.mark.parametrize("event", ["workflow_run", "workflow_dispatch"])
-def test_current_download_matches_only_the_producers_source_attempt(event: str) -> None:
-    workflows = ROOT / ".github/workflows"
-    producer = yaml.safe_load((workflows / "module-tests.yml").read_text())
-    upload = next(step["with"]["name"] for job in producer["jobs"].values() for step in job["steps"] if step.get("uses", "").startswith("actions/upload-artifact@"))
-    aggregate = yaml.safe_load((workflows / "ci-aggregate.yml").read_text())
-    current = next(step["with"]["pattern"] for job in aggregate["jobs"].values() for step in job.get("steps", []) if step.get("id") == "download-current")
-    # Resolve the actual shipped expressions for each supported trigger. The
-    # aggregate's own attempt is deliberately different from its source run.
-    context = {
-        "inputs.module": "kernel",
-        "steps.shard-info.outputs.slug": "2-of-4",
-        "github.run_attempt": "9",
-        "github.event.workflow_run.run_attempt": "3" if event == "workflow_run" else "",
-        "inputs.source_run_attempt": "3" if event == "workflow_dispatch" else "",
-    }
-
-    def render(template: str, values: dict[str, str]) -> str:
-        def resolve(match: re.Match[str]) -> str:
-            return next(value for key in match.group(1).split("||") if (value := values[key.strip()]))
-
-        return re.sub(r"\$\{\{\s*(.*?)\s*\}\}", resolve, template)
-
-    pattern = render(current, context)
-    matching_upload = render(upload, dict(context, **{"github.run_attempt": "3"}))
-    older_upload = render(upload, dict(context, **{"github.run_attempt": "2"}))
-    assert fnmatchcase(matching_upload, pattern), (matching_upload, pattern)
-    assert not fnmatchcase(older_upload, pattern), (older_upload, pattern)
 
 
 CRITICAL_EXAMPLES = (


### PR DESCRIPTION
## Issue

refs #4118

This issue stays open until a hosted CI Aggregate run verifies both partial-rerun collection and replay of an exact older source attempt after a newer attempt exists. Local tests establish the collector behavior; the hosted workflow must run the published change before the issue can close.

## Change

After `rerun-failed-jobs`, successful shards retain reports uploaded by earlier attempts. The collector previously required every report to carry the newest attempt number, so it reported missing coverage even when all retained test jobs passed. Historical replay also fetched the latest run metadata and rejected the requested older attempt.

Fetch attempt-specific run and job metadata, then select reports from the same run and head whose upload times fall inside the retained shard jobs' execution intervals. Artifact attempt numbers cannot exceed the requested attempt. This admits carried-forward successful executions while rejecting old reports from a shard that reran without uploading, future attempts, expired artifacts, and ambiguous provenance. Existing completeness and collision checks remain in force. An empty selection explicitly skips the download action, so an arbitrary artifact cannot supply coverage through a sentinel name.

Independent review found the empty-selection sentinel gap; its failing reproduction was committed before the fix. The fix-round review found no remaining blocking finding. No producer workflow or fleet-verdict code changes are included.

## Tests run

- `uv run --frozen pytest tests/ci tests/architectural/test_coverage_artefact_contract.py tests/architectural/test_dual_mode_contract.py -q --no-cov` → **226 passed / 0 failed** on final commit `feb16e90d`.
- `make test-fast` → **1784 passed / 0 failed / 2 skipped**. The sentinel fix does not touch this baseline's source or test surface; the full owning suite above was rerun after that fix.
- `uv run --frozen pytest tests/ci/test_aggregate_attempts.py --confcutdir=tests/ci -q --cov=scripts.ci.select_source_artifacts --cov-report=term-missing` → **26 passed / 0 failed**, **97% selector coverage**. This is supplemental isolated coverage measurement; the owning-suite run above uses normal project fixtures.
- `uv run --frozen ruff check scripts/ci/select_source_artifacts.py scripts/ci/aggregate_source.py tests/ci/test_aggregate_attempts.py tests/ci/test_aggregate_source.py` → passed.
- `uv run --frozen mypy --strict scripts/ci/select_source_artifacts.py scripts/ci/aggregate_source.py` → passed, 2 source files.
- `uv run --frozen ruff format --check .` → passed, 1696 files already formatted.
- Live read-only verification against source run `34302853928`, attempt 3: the selector accepted **34/34 reports from 35 jobs**, using paginated jobs/artifact API responses. This verifies the real API shape and execution intervals; it is not hosted partial-rerun acceptance.

Red-first history: `6373d5d4b` committed three failing tests through the existing workflow preparation/reconciliation entrypoints before implementation `1753d04d6`: two missing-shard failures for the supported triggers and one historical-replay identity failure. The original command was `uv run --frozen pytest tests/ci/test_aggregate_attempts.py -q --no-cov` (**3 intentionally failed**). Review reproduction `e91f9badf` then demonstrated false success when a sentinel-named artifact contained all expected coverage filenames; direct execution of that test failed before repair `feb16e90d`. Final tests execute the shipped collector steps and evaluate the download condition, with the remote Actions download boundary substituted by API-shaped fixtures.

Self-review:
- correctness: clean; partial reruns, historical replay, timestamp boundaries/timezones, pagination, and unavailable evidence are exercised.
- deletion safety: clean; the obsolete single-attempt pattern assertion is replaced by collector behavior tests; no production files are deleted.
- security: clean; source identity, head, attempt, timestamps, ambiguity, and empty-selection guards fail closed; no credentials are logged.
- design fidelity: clean; exact-source collection and existing coverage completeness policy remain authoritative.
- tests: clean; final owning suite passes, both defects have committed failing-first evidence, and independent fix-round review found no remaining blocker.

## Blast radius

Discovery: `rg --files scripts/ci tests/ci tests/architectural .github/workflows | rg '(aggregate|select_source_artifacts|coverage_artefact_contract|dual_mode_contract)'`

Files: `.github/workflows/ci-aggregate.yml`, `scripts/ci/select_source_artifacts.py`, `scripts/ci/aggregate_source.py`, `tests/architectural/test_dual_mode_contract.py`, `tests/architectural/test_coverage_artefact_contract.py`, `tests/ci/test_aggregate_source.py`, `tests/ci/test_aggregate_attempts.py`.

The affected subsystem is CI Aggregate source preparation and artifact collection. The full `tests/ci` suite covers CI consumers, and the two architectural contract files cover artifact naming, completeness, collision handling, fallback, and mode behavior. The standard fast baseline checks unrelated integration assumptions. The trusted checkout remains in place; PR code is not executed by source preparation.

## Deferred

[Issue #4118](https://github.com/spec-kitty/spec-kitty/issues/4118) retains hosted acceptance: observe an exact-attempt partial rerun and replay that attempt after a newer attempt exists, without cross-run coverage borrowing. Historical reports from the originally cited failing runs are no longer available after full-rerun recovery, so their original mixed-attempt downloads cannot be reconstructed; regression fixtures use the observed API shape instead.

Missing or invalid job execution timestamps deliberately fail closed before artifact reconciliation, including skipped jobs lacking those timestamps. Consequently, automatic non-PR diagnostic fallback cannot recover that provenance failure. The change does not weaken that boundary or claim such runs are covered.
