### PR TITLE
fix(ci): import datetime via the kernel.clock single door (FR-012(a))

### DIFF
--- a/scripts/ci/select_source_artifacts.py
+++ b/scripts/ci/select_source_artifacts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from datetime import datetime
+from kernel.clock import datetime
 from pathlib import Path
 from typing import Any
 

--- a/scripts/ci/select_source_artifacts.py
+++ b/scripts/ci/select_source_artifacts.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from kernel.clock import datetime
+import sys
 from pathlib import Path
 from typing import Any
+
+# Actions executes this trusted-checkout script before installing dependencies.
+# Resolve from the script, never the caller's cwd or the fetched source PR.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+from kernel.clock import datetime  # noqa: E402
 
 
 ARTIFACT = re.compile(r"module-tests-([A-Za-z0-9._-]+)-shard-([1-9][0-9]*)-of-([1-9][0-9]*)-attempt-([1-9][0-9]*)-reports")

--- a/tests/ci/test_aggregate_attempts.py
+++ b/tests/ci/test_aggregate_attempts.py
@@ -18,6 +18,34 @@ from tests.ci.test_aggregate_source import ROOT, source_fixture
 pytestmark = pytest.mark.fast
 
 
+def test_selector_respects_the_architectural_clock_import_boundary() -> None:
+    from tests.architectural.test_clock_import_ban import collect_import_ban_violations
+
+    assert collect_import_ban_violations([ROOT / "scripts/ci/select_source_artifacts.py"]) == []
+
+
+def test_selector_runs_before_installation_from_an_unrelated_directory(tmp_path: Path) -> None:
+    """Aggregate calls bare Python before dependency installation on its trusted checkout."""
+    source = {"run_id": 42, "run_attempt": 2, "head_sha": "a" * 40}
+    record = artifact("kernel", 1, 1)
+    record["workflow_run"]["head_sha"] = source["head_sha"]
+    execution = dict(job("kernel", 1), head_sha=source["head_sha"])
+    inputs = [source, [{"jobs": [execution]}], [{"artifacts": [record]}]]
+    paths = [tmp_path / name for name in ("source.json", "jobs.json", "artifacts.json")]
+    for path, value in zip(paths, inputs, strict=True):
+        path.write_text(json.dumps(value))
+    # Disable site packages, user paths and PYTHONPATH. The source checkout
+    # must supply its own zero-dependency clock, regardless of caller cwd.
+    result = subprocess.run(
+        [sys.executable, "-I", "-S", str(ROOT / "scripts/ci/select_source_artifacts.py"), *map(str, paths)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["has-artifacts=true", f"artifact-pattern={record['name']}"]
+
+
 def artifact(module: str, attempt: int, artifact_id: int) -> dict:
     return {
         "id": artifact_id,


### PR DESCRIPTION
## Issue

closes #4165

Red main on the CLI repo since 17:03Z (run 34377537146): `scripts/ci/select_source_artifacts.py:8` imported stdlib `datetime` directly, violating FR-012(a)'s single-door rule. The violating commit (#4142, 16:16Z) was scripts-only, so the code-scoped architectural battery skipped it and the violation merged unseen; the first src-touching head after it (#4153) inherited the red. Every src-touching head since fails the same single assertion (verified on run 34385207968: one violation, this path:line — no second regression).

## Change

Two commits at head `da9135e9b`:

1. **Door swap** (96413805): `from datetime import datetime` → `from kernel.clock import datetime` (line 8). `kernel.clock` re-exports `datetime` for the sanctioned parse/format case; the script's only use is `fromisoformat` on timestamps it already receives. No `_exemptions` entry — the ratchet stays at zero.
2. **Pre-installation bootstrap** (da9135e9b, Lynn's independently-verified executable finding, folded verbatim): the aggregate workflow invokes this script bare (`python3 scripts/...`) *before* dependency install, so commit 1 alone broke the entry point (`ModuleNotFoundError: kernel` from an uninstalled checkout — the architectural battery parses imports and cannot see entry-point resolution). Repair: resolve the trusted checkout's `src/` from `__file__` (never caller cwd / fetched PR data) onto `sys.path`, then import from `kernel.clock` unchanged. Mirrors the existing `scripts/docs/glossary_linker.py` bootstrap shape.

## Tests run

- self-review: diff is the import swap + a sys.path bootstrap anchored to `__file__`, plus two witness tests; no other behavior touched, no clock reads added.
- correctness: import resolves in the scripts context AND at the bare pre-install entry point — pinned by the new subprocess witness running `-I -S` from an unrelated cwd with site-packages disabled.
- deletion safety: nothing deleted; import block rewritten in place, tests appended.
- security: bootstrap resolves only the trusted checkout's own `src/` (not caller cwd, not fetched PR data); no new inputs, no network surface change.
- design fidelity: kernel.clock is the documented single door (FR-012(a)/SC-001); ratchet stays at zero.
- tests: local at `da9135e9b` — `tests/ci/test_aggregate_attempts.py` 28/28 (incl. both new witnesses: clock-boundary + bare-execution), `tests/architectural/test_clock_import_ban.py` 10/10 (the exact job red on main since run 34377537146), ruff check + format clean. Squad pass 1 on 96413805: passed, all five lenses, no findings; pass 2 reviews the fold-in.

## Blast radius

Discovery: `gh run view 34385207968 --log-failed | grep -E 'test_clock|E  '` (named `scripts/ci/select_source_artifacts.py:8` as the sole import violation), plus Lynn's independent executable finding on 96413805 (isolated `-I -S` subprocess repro of the pre-install entry point) and the local witness/battery runs at the patch head.
Files: `scripts/ci/select_source_artifacts.py` (import block + sys.path bootstrap), `tests/ci/test_aggregate_attempts.py` (two witness tests appended).

Unblocks: #4153 and #4157 (both squad:passed, waiting on green main), #4129's fix lane, and restores the stale `state/ci-baseline/spec-kitty.json` refresh path.

## Deferred

- #4167 (structural): the battery is code-scoped, so scripts-only heads skip it — scope predicate / merge-head coverage settled there, not in this fix.
- Baseline refresh for `spec-kitty` lands at the next green head per the standing watch item.
- Superseded remote branch `issue-4165-clock-import-ban` (2c9ea978, the reaped duplicate VM's variant) is dead work product — cleanup after merge.