### PR TITLE
[#4186] Infer org-pack DRG nodes from artifact files

### DIFF
--- a/docs/guides/how-to/governance/create-an-org-doctrine-pack.md
+++ b/docs/guides/how-to/governance/create-an-org-doctrine-pack.md
@@ -2,7 +2,7 @@
 title: How to Create an Org Doctrine Pack
 description: Author, validate, assemble, publish, and consume a spec-kitty org doctrine pack.
 doc_status: active
-updated: '2026-08-14'
+updated: '2026-09-10'
 type: how-to
 audience: docs/context/audience/external/tech-lead-evaluator.md
 related:
@@ -172,11 +172,41 @@ edges:
     relation: scope
 ```
 
+Nodes are inferred recursively from matching artifact files in `directives/`,
+`tactics/`, `styleguides/`, `toolguides/`, `paradigms/`, `procedures/`,
+`agent_profiles/`, `glossary_packs/`, `assets/`, and `mission_step_contracts/`.
+Discovery uses each kind's standard suffix (for example, `.agent.yaml`,
+`.glossary-pack.yaml`, and `.asset.yaml`). Agent profiles use `profile-id`;
+other artifacts use `id`. Filenames never supply an identity. Inference preserves
+these IDs exactly. Use canonical directive IDs such as
+`ACME_001_SECRET_HANDLING` for action-context delivery; node inference does not
+normalize directive IDs.
+
+Inference supplements an omitted, empty, or partially authored `nodes:` list.
+An explicit node with the same kind and ID takes precedence, including its title
+and body path. Use `id` and the **plural** node kind for an explicit declaration:
+
+```yaml
+nodes:
+  - id: ACME_001_SECRET_HANDLING
+    kind: directives
+    title: Secret handling policy
+    body_path: bodies/secret-handling.md
+```
+
+Mission types and templates still require explicit nodes; inference does not
+create graph-only anti-pattern nodes. Step-contract files infer the plural node
+kind `mission_steps`. Malformed or unreadable artifact YAML and missing or
+non-string IDs are skipped during discovery; run pack validation to diagnose
+artifact schema errors. Non-string optional titles/body paths are ignored.
+Explicit node schema errors still fail loading. No nodes are invented for missing
+edge endpoints, and artifact discovery does not infer scope or reference edges.
+
 **Write endpoints in full: `<kind>:<id>`.** The kind half must be a real node
 kind (`directive`, `tactic`, `styleguide`, `toolguide`, `paradigm`, `procedure`,
 `agent_profile`, `mission_step_contract`, `mission_type`, `template`, `asset`,
 `action`, `glossary_pack`, `anti_pattern`). A bare id with no kind prefix only
-works if the same fragment's own `nodes:` block declares it, or if it matches a
+works if the same fragment declares or infers it, or if it matches a
 built-in artifact — it will **not** find an artifact contributed by another pack,
 because pack-to-pack resolution would make the result depend on the order the
 packs are listed in. Anything that cannot be resolved is refused at merge time

--- a/docs/guides/how-to/governance/create-an-org-doctrine-pack.md
+++ b/docs/guides/how-to/governance/create-an-org-doctrine-pack.md
@@ -83,7 +83,7 @@ fields for its schema, and save it in the matching directory.
 
 ```yaml
 # directives/acme-001-secret-handling.directive.yaml
-id: acme-001-secret-handling
+id: ACME_001_SECRET_HANDLING
 title: Never commit credentials to the repository
 severity: high
 description: |
@@ -110,7 +110,7 @@ specialization:
   primary-focus: Feature implementation under ACME's secret-handling rules
   avoidance-boundary: Architectural decisions, release management
 directive-references:
-  - code: acme-001-secret-handling
+  - code: ACME_001_SECRET_HANDLING
     name: Never commit credentials to the repository
 ```
 
@@ -130,7 +130,7 @@ organisation-specific code:
 
 | Artifact type | File pattern | Recommended ID prefix |
 |---|---|---|
-| Directives | `*.directive.yaml` | `<org>-<seq>-<slug>` (e.g. `acme-001-secret-handling`) |
+| Directives | `*.directive.yaml` | `<ORG>_<SEQ>_<SLUG>` (e.g. `ACME_001_SECRET_HANDLING`) |
 | Tactics | `*.tactic.yaml` | `<org>-tac-<seq>` |
 | Styleguides | `*.styleguide.yaml` | `<org>-sty-<seq>` |
 | Toolguides | `*.toolguide.yaml` | `<org>-tg-<seq>` |
@@ -168,7 +168,7 @@ provenance_marker: org
 nodes: []   # nodes are inferred from the artifact files
 edges:
   - source: action:software-dev/implement
-    target: directive:acme-001-secret-handling
+    target: directive:ACME_001_SECRET_HANDLING
     relation: scope
 ```
 
@@ -234,8 +234,8 @@ interview_defaults:
   language: python
   test_framework: pytest
 required_directives:
-  - acme-001-secret-handling
-  - acme-002-code-review
+  - ACME_001_SECRET_HANDLING
+  - ACME_002_CODE_REVIEW
 governance_policies:
   - field: min_test_coverage
     value: "80"
@@ -279,7 +279,7 @@ Use the secret manager. Pre-commit hooks must scan staged content.
 **After** (`directives/acme-001-secret-handling.directive.yaml`):
 
 ```yaml
-id: acme-001-secret-handling
+id: ACME_001_SECRET_HANDLING
 title: Never commit credentials to the repository
 severity: high
 description: |

--- a/src/charter/offering/drg/org_pack_loader.py
+++ b/src/charter/offering/drg/org_pack_loader.py
@@ -559,11 +559,60 @@ def load_org_pack(
     )
 
     try:
-        return OrgDRGFragment.model_validate(fragment_data)
+        fragment = OrgDRGFragment.model_validate(fragment_data)
     except Exception as exc:  # noqa: BLE001
         raise OrgPackSchemaError(
             f"Org pack {pack_name!r}: schema validation error in {fragment_yaml}: {exc}"
         ) from exc
+
+    # Validate authored nodes first: alias normalization and schema failures must
+    # precede inference, and authored metadata wins for the same kind/identity.
+    seen = {(node.kind, node.id) for node in fragment.nodes}
+    for node in _collect_artifact_nodes(pack_root):
+        key = (node.kind, node.id)
+        if key not in seen:
+            fragment.nodes.append(node)
+            seen.add(key)
+    return fragment
+
+
+def _collect_artifact_nodes(pack_root: Path) -> list[_OrgDRGNode]:
+    """Discover file-backed org nodes; edges and topology remain author-owned.
+
+    Discovery is best-effort, like field projection: malformed artifacts are
+    left to pack validation, never assigned an identity from their filenames.
+    """
+    nodes: list[_OrgDRGNode] = []
+    plural_by_kind = {singular: plural for plural, singular in ORG_PLURAL_TO_SINGULAR_KIND.items()}
+    for kind in ArtifactKind:
+        plural = plural_by_kind.get(kind.value)
+        if plural is None or not kind.glob_pattern:
+            continue  # Graph-only kinds and templates have no org artifact files.
+        for path in sorted((pack_root / kind.plural).rglob(kind.glob_pattern)):
+            data = _load_artifact_data(path)
+            identity = data.get("profile-id" if kind is ArtifactKind.AGENT_PROFILE else "id")
+            if not isinstance(identity, str) or not identity.strip():
+                continue
+            title = data.get("title", data.get("name"))
+            body_path = data.get("body_path")
+            nodes.append(
+                _OrgDRGNode(
+                    id=identity,
+                    kind=plural,
+                    title=title if isinstance(title, str) else None,
+                    body_path=body_path if isinstance(body_path, str) else None,
+                )
+            )
+    return nodes
+
+
+def _load_artifact_data(path: Path) -> dict[str, Any]:
+    """Read artifact YAML best-effort for node and legacy edge discovery."""
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 # ---------------------------------------------------------------------------
@@ -613,12 +662,7 @@ def _projection_edges_for_file(
     the type IS the marker that says "machine-minted", and a dict would be
     validated into the plain author-facing :class:`_OrgDRGEdge` and lose it.
     """
-    try:
-        data = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
-        return []
-    if not isinstance(data, dict):
-        return []
+    data = _load_artifact_data(yaml_file)
     art_id = data.get("id")
     if not isinstance(art_id, str) or not art_id:
         return []

--- a/tests/doctrine/drg/test_org_pack_node_inference.py
+++ b/tests/doctrine/drg/test_org_pack_node_inference.py
@@ -1,0 +1,151 @@
+"""Org artifacts enter the DRG without duplicate hand-authored node manifests (#4186)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from charter.activation.action_doctrine_bundle import _load_action_doctrine_bundle
+from charter.offering.artifact_kinds import ArtifactKind
+from charter.offering.drg.org_pack_loader import OrgPackSchemaError, load_org_pack
+from specify_cli.cli.commands._doctrine_collect import _collect_org_layer_data
+
+pytestmark = pytest.mark.fast
+
+
+def _fragment(pack: Path, data: dict) -> None:
+    (pack / "drg").mkdir(parents=True, exist_ok=True)
+    (pack / "drg" / "fragment.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _artifact(pack: Path, kind: ArtifactKind, data: dict, name: str = "nested/artifact") -> Path:
+    path = pack / kind.plural / kind.glob_pattern.replace("*", name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize("authored", [False, True], ids=["inferred", "explicit-control"])
+def test_artifact_reaches_doctor_and_only_its_scoped_action(tmp_path: Path, authored: bool) -> None:
+    """Existing production seams must deliver a real directive, not just count a node."""
+    pack = tmp_path / "pack"
+    repo = tmp_path / "consumer"
+    (repo / ".kittify").mkdir(parents=True)
+    (repo / ".kittify" / "config.yaml").write_text(
+        yaml.safe_dump({"charter_packs": {"org": {"packs": [{"name": "acme", "local_path": str(pack)}]}}}),
+        encoding="utf-8",
+    )
+    directive = yaml.safe_load(
+        (Path(__file__).resolve().parents[3] / "packs/built-in/directives/001-architectural-integrity-standard.directive.yaml").read_text(encoding="utf-8")
+    )
+    directive["id"] = "ACME_001_FOO"
+    _artifact(pack, ArtifactKind.DIRECTIVE, directive, name="acme")
+    _fragment(
+        pack,
+        {
+            "nodes": [{"id": "ACME_001_FOO", "kind": "directives"}] if authored else [],
+            "edges": [{"source": "action:software-dev/implement", "target": "directive:ACME_001_FOO", "relation": "scope"}],
+        },
+    )
+
+    doctor = _collect_org_layer_data(repo)
+    assert doctor["errors"] == [], doctor
+    assert doctor["configured_packs"][0]["node_count"] == 1
+    for action, expected in (("implement", True), ("review", False)):
+        bundle = _load_action_doctrine_bundle(
+            repo_root=repo,
+            action=action,
+            effective_depth=3,
+            mission_type="software-dev",
+        )
+        assert ("ACME_001_FOO" in bundle.directive_ids) is expected
+        assert bundle.merged is not None
+        nodes = [node for node in bundle.merged.nodes if str(node.urn) == "directive:ACME_001_FOO"]
+        assert len(nodes) == 1
+        assert nodes[0].provenance == "org:acme"
+
+
+@pytest.mark.parametrize(
+    "kind,plural",
+    [
+        (ArtifactKind.DIRECTIVE, "directives"),
+        (ArtifactKind.TACTIC, "tactics"),
+        (ArtifactKind.STYLEGUIDE, "styleguides"),
+        (ArtifactKind.TOOLGUIDE, "toolguides"),
+        (ArtifactKind.PARADIGM, "paradigms"),
+        (ArtifactKind.PROCEDURE, "procedures"),
+        (ArtifactKind.AGENT_PROFILE, "agent_profiles"),
+        (ArtifactKind.GLOSSARY_PACK, "glossary_packs"),
+        (ArtifactKind.ASSET, "assets"),
+        (ArtifactKind.MISSION_STEP_CONTRACT, "mission_steps"),
+    ],
+)
+@pytest.mark.parametrize("nodes", [{}, {"nodes": []}])
+def test_supported_nested_artifacts_use_declared_identity(tmp_path: Path, kind: ArtifactKind, plural: str, nodes: dict) -> None:
+    _fragment(tmp_path, nodes)
+    identity = "profile-id" if kind is ArtifactKind.AGENT_PROFILE else "id"
+    _artifact(tmp_path, kind, {identity: "real-identity", "name": "Artifact name", "body_path": "bodies/example.md"})
+    fragment = load_org_pack("test", tmp_path, 2)
+    assert [node.model_dump() for node in fragment.nodes] == [
+        {"id": "real-identity", "kind": plural, "title": "Artifact name", "body_path": "bodies/example.md"},
+    ]
+    assert fragment.pack_name == "test"
+    assert fragment.layer_index == 2
+    assert fragment.edges == []
+
+
+def test_additive_inference_preserves_explicit_metadata_and_kind_identity(tmp_path: Path) -> None:
+    explicit = {"id": "shared", "kind": "mission_step_contracts", "title": "Authored", "body_path": "authored.md"}
+    _fragment(tmp_path, {"nodes": [explicit, {"id": "virtual", "kind": "templates"}]})
+    _artifact(tmp_path, ArtifactKind.MISSION_STEP_CONTRACT, {"id": "shared", "title": "Inferred"})
+    _artifact(tmp_path, ArtifactKind.DIRECTIVE, {"id": "shared", "title": "First"}, "a")
+    _artifact(tmp_path, ArtifactKind.DIRECTIVE, {"id": "shared", "title": "Last"}, "z")
+    fragment = load_org_pack("test", tmp_path, 1)
+    assert [node.model_dump() for node in fragment.nodes] == [
+        {**explicit, "kind": "mission_steps"},
+        {"id": "virtual", "kind": "templates", "title": None, "body_path": None},
+        {"id": "shared", "kind": "directives", "title": "First", "body_path": None},
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"id": "real", "kind": "invalid"},
+        {"id": "real", "kind": "directives", "title": []},
+        {"urn": "directive:real", "kind": "directives"},
+    ],
+)
+def test_invalid_explicit_nodes_still_fail_before_inference(tmp_path: Path, bad: dict) -> None:
+    _fragment(tmp_path, {"nodes": [bad]})
+    _artifact(tmp_path, ArtifactKind.DIRECTIVE, {"id": "real"})
+    with pytest.raises(OrgPackSchemaError):
+        load_org_pack("test", tmp_path, 1)
+
+
+def test_explicit_duplicates_are_not_silently_discarded(tmp_path: Path) -> None:
+    node = {"id": "same", "kind": "directives"}
+    _fragment(tmp_path, {"nodes": [node, node]})
+    _artifact(tmp_path, ArtifactKind.DIRECTIVE, {"id": "same"})
+    assert len(load_org_pack("test", tmp_path, 1).nodes) == 2
+
+
+@pytest.mark.parametrize("content", ["[", "- item", "null", "id: 42", "id: ''", "id: '   '", "name: No identity", "id: real\ntitle: []\nbody_path: 12"])
+def test_malformed_artifacts_do_not_invent_identity_or_break_loading(tmp_path: Path, content: str) -> None:
+    _fragment(tmp_path, {})
+    file = _artifact(tmp_path, ArtifactKind.DIRECTIVE, {})
+    file.write_text(content, encoding="utf-8")
+    fragment = load_org_pack("test", tmp_path, 1)
+    # Optional malformed metadata is ignored; a valid identity remains useful.
+    assert [(n.id, n.title, n.body_path) for n in fragment.nodes] == ([("real", None, None)] if content.startswith("id: real") else [])
+
+
+def test_unrelated_files_and_dangling_edge_targets_are_not_nodes(tmp_path: Path) -> None:
+    edge = {"source": "directive:real", "target": "directive:missing", "relation": "requires"}
+    _fragment(tmp_path, {"edges": [edge]})
+    _artifact(tmp_path, ArtifactKind.DIRECTIVE, {"id": "real", "title": "Actual"})
+    (tmp_path / "directives" / "unrelated.yaml").write_text("id: accidental", encoding="utf-8")
+    _artifact(tmp_path, ArtifactKind.ANTI_PATTERN, {"id": "not-file-backed"})
+    fragment = load_org_pack("test", tmp_path, 1)
+    assert [node.id for node in fragment.nodes] == ["real"]
+    assert [e.model_dump(exclude_none=True) for e in fragment.edges] == [edge]

--- a/tests/doctrine/drg/test_org_pack_node_inference.py
+++ b/tests/doctrine/drg/test_org_pack_node_inference.py
@@ -149,3 +149,12 @@ def test_unrelated_files_and_dangling_edge_targets_are_not_nodes(tmp_path: Path)
     fragment = load_org_pack("test", tmp_path, 1)
     assert [node.id for node in fragment.nodes] == ["real"]
     assert [e.model_dump(exclude_none=True) for e in fragment.edges] == [edge]
+
+
+def test_unreadable_artifact_and_non_utf8_yaml_are_skipped(tmp_path: Path) -> None:
+    _fragment(tmp_path, {})
+    artifact = _artifact(tmp_path, ArtifactKind.DIRECTIVE, {}, name="binary")
+    artifact.write_bytes(b"\xff\xfe")
+    # A directory matching the suffix reaches discovery but cannot be read.
+    (tmp_path / "directives" / "directory.directive.yaml").mkdir()
+    assert load_org_pack("test", tmp_path, 1).nodes == []


### PR DESCRIPTION
## Issue
Closes #4186.

## Change
Org packs following the documented `nodes: []` pattern now infer DRG nodes from supported artifact files. Previously, those packs loaded no artifact nodes and their scope edges remained dangling; the existing doctor and action-context paths now resolve the contributed directive.

The org-pack loader uses the canonical artifact kinds and file patterns, discovers nested files deterministically, and preserves explicit node metadata. It does not invent nodes from edge targets or change edge and layer semantics. The author guide states the supported scope and explicit-node format.

## Tests run
- Red-first regression commit `c32bb362d`: 24 failed / 12 passed before the fix; explicit-node control passed.
- `.venv/bin/pytest tests/doctrine/drg/test_org_pack_node_inference.py -q --cov=charter.offering.drg.org_pack_loader --cov-report=term-missing` → 37 passed; 31/31 new executable lines covered.
- `.venv/bin/pytest tests/charter tests/doctrine -n 4 --dist loadfile -q` → 5860 passed, 26 skipped.
- `.venv/bin/pytest tests/specify_cli/cli/commands/test_doctor_doctrine_org_layer.py tests/integration/test_org_pack_artifact_lifecycle.py tests/integration/test_org_pack_chain_delivery.py tests/integration/test_org_pack_subdir_e2e.py tests/specify_cli/cli/commands/charter/test_status_org_layer_completeness.py -n 4 --dist loadfile -q` → 35 passed.
- `.venv/bin/pytest tests/architectural/test_no_legacy_terminology.py -q` → 90 passed.
- `UV_NO_SYNC=1 PYTEST_XDIST_AUTO_NUM_WORKERS=4 make test-fast` → 1784 passed, 2 skipped, 2 subprocess timeouts. The moment-handler import timed out at 120 seconds; the hermetic status subprocess timed out at 300 seconds. A paired diagnostic ran both unchanged tests once on detached base `ab4636831` and once on the fixed checkout: 2 passed on each. Original failures are retained as load-sensitive timeout evidence, not reported as a green fast run.
- Scoped Ruff and strict mypy passed; `.venv/bin/ruff format --check .` passed.

- Documentation correction `32dd01a45`: targeted docs test 1 passed; 8 YAML snippets parsed and the declared fragment schema validated.
- Independent profile-loaded review: architect-alphonso, debugger-debbie, reviewer-renata found no source/test blockers. Their convergent minor documentation finding was corrected; Debbie independently replayed the original witness and ran all 37 focused tests successfully.

Self-review:
- correctness: existing doctor and action delivery paths covered, including unrelated-action exclusion
- deletion safety: explicit nodes and metadata preserved
- security: no new dependencies or credential handling
- design fidelity: inference stays in the canonical org-pack loader
- tests: red-first consumer regression and owning-subsystem coverage complete

## Blast radius
Discovery: `git diff --name-only ab4636831 HEAD`
Files: `src/charter/offering/drg/org_pack_loader.py`, `tests/doctrine/drg/test_org_pack_node_inference.py`, `docs/guides/how-to/governance/create-an-org-doctrine-pack.md`

The loader feeds org-pack graph merge, doctor diagnostics, and action-scoped charter delivery. Full charter/doctrine tests and downstream doctor, pack lifecycle, chain, subdirectory, and status tests cover these consumers.

## Deferred
Separate existing directive-ID normalization and charter selection defects remain tracked in #4000, #4185, and #3908. This change does not claim to fix them. The non-blocking [SonarCloud run](https://github.com/spec-kitty/spec-kitty/actions/runs/34444849105/job/102767416433) failed before analysis: the service could not retrieve PR `4190` for project `Priivacy-ai_spec-kitty`; the quality-gate step then lacked `.scannerwork/report-task.txt`. Sonar project/forge binding needs separate configuration review; this is not a code-quality finding from this patch.
