### PR TITLE
fix(cli): name the coord identity once on teardown, render baseline notices

### DIFF
--- a/src/specify_cli/cli/commands/agent/workflow.py
+++ b/src/specify_cli/cli/commands/agent/workflow.py
@@ -1698,6 +1698,9 @@ def _prepare_review_workspace(
 
     # Concurrent review isolation: acquire review lock or apply env-var
     # isolation — only after the workspace is proven to exist.
+    from rich.markup import escape
+
+    from specify_cli.cli.console import console
     from specify_cli.review.lock import ReviewLock, ReviewLockError, _get_isolation_config, _apply_env_var_isolation
 
     isolation_config = _get_isolation_config(main_repo_root)
@@ -1707,7 +1710,10 @@ def _prepare_review_workspace(
         try:
             ReviewLock.acquire(Path(workspace.worktree_path), wp_id, agent or "unknown")
         except ReviewLockError as e:
-            print(f"[red]{e}[/red]")
+            # #4163: the builtin ``print`` echoed these tags literally, and the
+            # lock message carries arbitrary text (agent handles, paths), so it
+            # is escaped before it reaches the markup renderer.
+            console.print(f"[red]{escape(str(e))}[/red]")
             raise typer.Exit(1) from e
 
     return workspace

--- a/src/specify_cli/cli/commands/agent/workflow_executor.py
+++ b/src/specify_cli/cli/commands/agent/workflow_executor.py
@@ -1210,6 +1210,7 @@ def implement_capture_baseline(
 
     w = _wf()
     try:
+        from specify_cli.cli.console import console
         from specify_cli.review.baseline import capture_baseline
         from specify_cli.review.scope_source import resolve_scope_source
 
@@ -1230,10 +1231,12 @@ def implement_capture_baseline(
             wp_slug=wp_slug,
             scope_source=resolve_scope_source(main_repo_root),
         )
+        # Rich markup only renders through the CLI console seam; the builtin
+        # print emitted the tags literally (#4163).
         if baseline is not None and baseline.failed > 0:
-            print(f"[dim]Baseline: {baseline.failed} pre-existing test failure(s) captured[/dim]")
+            console.print(f"[dim]Baseline: {baseline.failed} pre-existing test failure(s) captured[/dim]")
         elif baseline is not None and baseline.failed == -1:
-            print("[yellow]Warning: baseline test capture failed — no baseline context available[/yellow]")
+            console.print("[yellow]Warning: baseline test capture failed — no baseline context available[/yellow]")
 
         # Commit the baseline artifact whenever capture actually wrote one
         # (any non-sentinel result, clean OR dirty) — NOT only when
@@ -1286,7 +1289,7 @@ def implement_capture_baseline(
                 # owned file" with no trace of WHY the commit was refused (e.g.
                 # a protected target / SafeCommitHeadMismatch).
                 logger.warning("Baseline artifact commit failed: %s", bl_commit_exc)
-                print(
+                console.print(
                     f"[yellow]Warning: baseline artifact was not committed "
                     f"({bl_commit_exc}); a later move to for_review may block on it.[/yellow]"
                 )

--- a/src/specify_cli/cli/commands/agent/workflow_executor.py
+++ b/src/specify_cli/cli/commands/agent/workflow_executor.py
@@ -1210,6 +1210,8 @@ def implement_capture_baseline(
 
     w = _wf()
     try:
+        from rich.markup import escape
+
         from specify_cli.cli.console import console
         from specify_cli.review.baseline import capture_baseline
         from specify_cli.review.scope_source import resolve_scope_source
@@ -1289,9 +1291,12 @@ def implement_capture_baseline(
                 # owned file" with no trace of WHY the commit was refused (e.g.
                 # a protected target / SafeCommitHeadMismatch).
                 logger.warning("Baseline artifact commit failed: %s", bl_commit_exc)
+                # The refusal text is arbitrary (git output such as
+                # ``! [rejected] main -> main``): escape it so Rich neither
+                # swallows bracketed words nor raises MarkupError on it.
                 console.print(
                     f"[yellow]Warning: baseline artifact was not committed "
-                    f"({bl_commit_exc}); a later move to for_review may block on it.[/yellow]"
+                    f"({escape(str(bl_commit_exc))}); a later move to for_review may block on it.[/yellow]"
                 )
     except Exception as bl_err:
         logger.warning("Baseline capture error: %s", bl_err)

--- a/src/specify_cli/cli/commands/mission_type.py
+++ b/src/specify_cli/cli/commands/mission_type.py
@@ -990,6 +990,7 @@ def _teardown_coordination_worktree(
     # with completion provenance.
     from specify_cli.coordination.teardown import teardown_coordination_topology
     from specify_cli.coordination.workspace import CoordinationWorkspace
+    from specify_cli.lanes.branch_naming import coord_mission_dir_name
 
     teardown_coordination_topology(
         repo_root, mission_slug, mid8_value, provenance_kind=provenance_kind
@@ -1000,9 +1001,12 @@ def _teardown_coordination_worktree(
             "present after teardown; manual cleanup may be required."
         )
     else:
+        # The slug read from the feature dir already embeds the mid8, so name
+        # the identity through the seam's idempotent composer instead of
+        # appending the mid8 a second time (#4163).
         console.print(
             f"[green]✓[/green] Coordination worktree torn down for "
-            f"{mission_slug}-{mid8_value}"
+            f"{coord_mission_dir_name(mission_slug, mid8=mid8_value)}"
         )
 
 

--- a/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
+++ b/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
@@ -57,3 +57,37 @@ def test_baseline_notice_is_rendered_not_echoed_as_markup(
     assert expected in out
     assert "[dim]" not in out
     assert "[yellow]" not in out
+
+
+def test_commit_refusal_reason_is_shown_verbatim_not_parsed_as_markup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """The artifact-not-committed warning carries arbitrary git text; it must be escaped."""
+    feature_dir = tmp_path / "kitty-specs" / "m-01ABCDEF"
+    artifact = feature_dir / "tasks" / "WP01-thing" / "baseline-tests.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{}")
+
+    monkeypatch.setattr("specify_cli.review.baseline.capture_baseline", lambda **kwargs: _baseline(0))
+    monkeypatch.setattr("specify_cli.review.scope_source.resolve_scope_source", lambda root: None)
+    monkeypatch.setattr(workflow_executor, "_baseline_artifact_needs_commit", lambda root, art: True)
+    monkeypatch.setattr("specify_cli.cli.commands.agent.workflow._resolve_workflow_placement", lambda **kwargs: None)
+
+    def _refuse(**kwargs: object) -> None:
+        raise RuntimeError("! [rejected] main -> main (protected) [/]")
+
+    monkeypatch.setattr("specify_cli.cli.commands.agent.workflow.safe_commit", _refuse)
+
+    workflow_executor.implement_capture_baseline(
+        workspace_path=tmp_path,
+        target_branch="main",
+        normalized_wp_id="WP01",
+        mission_slug="m-01ABCDEF",
+        feature_dir=feature_dir,
+        wp_slug="WP01-thing",
+        main_repo_root=tmp_path,
+    )
+
+    out = capsys.readouterr().out
+    assert "Warning: baseline artifact was not committed" in out
+    # Without escaping, Rich eats ``[rejected]`` and raises on the stray ``[/]``.
+    assert "! [rejected] main -> main (protected) [/]" in out
+    assert "[yellow]" not in out

--- a/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
+++ b/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
@@ -1,0 +1,59 @@
+"""``implement_capture_baseline`` renders its notices through the CLI console (#4163).
+
+The baseline notices were written with the builtin ``print``, so the Rich
+markup (``[dim]…[/dim]``, ``[yellow]…[/yellow]``) reached the terminal
+literally. They now go through the canonical console seam like every other
+CLI line, which renders the markup instead of echoing it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.cli.commands.agent import workflow_executor
+from specify_cli.review.baseline import BaselineTestResult
+
+
+def _baseline(failed: int) -> BaselineTestResult:
+    return BaselineTestResult(
+        wp_id="WP01",
+        captured_at="2026-09-10T00:00:00Z",
+        base_branch="main",
+        base_commit="abc1234",
+        test_runner="pytest",
+        total=3,
+        passed=3 - max(failed, 0),
+        failed=failed,
+        skipped=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("failed", "expected"),
+    [
+        (1, "Baseline: 1 pre-existing test failure(s) captured"),
+        (-1, "Warning: baseline test capture failed"),
+    ],
+)
+def test_baseline_notice_is_rendered_not_echoed_as_markup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], failed: int, expected: str
+) -> None:
+    monkeypatch.setattr("specify_cli.review.baseline.capture_baseline", lambda **kwargs: _baseline(failed))
+    monkeypatch.setattr("specify_cli.review.scope_source.resolve_scope_source", lambda root: None)
+
+    workflow_executor.implement_capture_baseline(
+        workspace_path=tmp_path,
+        target_branch="main",
+        normalized_wp_id="WP01",
+        mission_slug="m-01ABCDEF",
+        feature_dir=tmp_path / "kitty-specs" / "m-01ABCDEF",
+        wp_slug="WP01-thing",
+        main_repo_root=tmp_path,
+    )
+
+    out = capsys.readouterr().out
+    assert expected in out
+    assert "[dim]" not in out
+    assert "[yellow]" not in out

--- a/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
+++ b/tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py
@@ -87,7 +87,10 @@ def test_commit_refusal_reason_is_shown_verbatim_not_parsed_as_markup(tmp_path: 
     )
 
     out = capsys.readouterr().out
-    assert "Warning: baseline artifact was not committed" in out
+    # The notice is longer than a default terminal, so the reason can be folded
+    # across lines: normalize whitespace instead of pinning the harness width.
+    folded = " ".join(out.split())
+    assert "Warning: baseline artifact was not committed" in folded
     # Without escaping, Rich eats ``[rejected]`` and raises on the stray ``[/]``.
-    assert "! [rejected] main -> main (protected) [/]" in out
+    assert "! [rejected] main -> main (protected) [/]" in folded
     assert "[yellow]" not in out

--- a/tests/specify_cli/cli/commands/agent/test_review_lock_error_output.py
+++ b/tests/specify_cli/cli/commands/agent/test_review_lock_error_output.py
@@ -1,0 +1,44 @@
+"""``_prepare_review_workspace`` renders the review lock refusal (#4163).
+
+The ``ReviewLockError`` leg was the last builtin ``print`` in ``src/`` carrying
+Rich markup, so ``[red]…[/red]`` reached the terminal literally. It now goes
+through the CLI console seam, with the message escaped: lock messages name
+agents, work packages and paths, and a bracketed one would otherwise be eaten
+as a tag (or raise ``MarkupError`` on a stray closing tag).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+from specify_cli.cli.commands.agent import workflow
+
+
+def test_review_lock_refusal_is_rendered_and_escaped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    from specify_cli.review.lock import ReviewLock, ReviewLockError
+
+    reason = "[locked] WP01 held by agent [claude] since 10:00 [/]"
+
+    def _refuse(*args: object, **kwargs: object) -> None:
+        raise ReviewLockError(reason)
+
+    monkeypatch.setattr("specify_cli.review.lock._get_isolation_config", lambda root: None)
+    monkeypatch.setattr(ReviewLock, "acquire", staticmethod(_refuse))
+
+    workspace = SimpleNamespace(
+        worktree_path=tmp_path,
+        branch_name="kitty/wp01",
+        is_husk=False,
+        exists=True,
+    )
+
+    with pytest.raises(typer.Exit):
+        workflow._prepare_review_workspace(workspace, tmp_path, "WP01", "claude")
+
+    out = " ".join(capsys.readouterr().out.split())
+    assert reason in out
+    assert "[red]" not in out

--- a/tests/specify_cli/cli/commands/test_mission_close_teardown_message.py
+++ b/tests/specify_cli/cli/commands/test_mission_close_teardown_message.py
@@ -1,0 +1,36 @@
+"""``_teardown_coordination_worktree`` names the coordination identity once (#4163).
+
+The slug read from the feature directory already embeds the mid8
+(``relcheck-01M21R2T``); the success line appended the mid8 a second time and
+printed ``relcheck-01M21R2T-01M21R2T``. The message now composes the identity
+through the seam's idempotent :func:`coord_mission_dir_name`, so a slug with
+or without the embedded mid8 renders the same name the branch line uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli.cli.commands import mission_type
+from specify_cli.coordination.workspace import CoordinationWorkspace
+
+MID8 = "01M21R2T"
+
+
+@pytest.mark.parametrize("mission_slug", ["relcheck-01M21R2T", "relcheck"])
+def test_teardown_success_line_does_not_double_the_mid8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], mission_slug: str
+) -> None:
+    monkeypatch.setattr(
+        "specify_cli.coordination.teardown.teardown_coordination_topology",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(CoordinationWorkspace, "is_present", classmethod(lambda cls, *args, **kwargs: False))
+
+    mission_type._teardown_coordination_worktree(tmp_path, mission_slug, MID8)
+
+    out = capsys.readouterr().out
+    assert f"Coordination worktree torn down for relcheck-{MID8}" in out
+    assert f"{MID8}-{MID8}" not in out


### PR DESCRIPTION
## Summary

- `mission close --discard` no longer prints the mission ULID twice in the "Coordination worktree torn down for …" line.
- `implement` renders its baseline notices instead of echoing literal Rich markup, and the same is done for the review lock refusal in `agent/workflow.py`, the last builtin `print` in `src/` that carried Rich tags.

Fixes #4163.

## Why Now

Both lines end up in operator reports and were wrong on every run of the affected paths (3/3 on the issue's macOS and Linux reproductions).

## What This PR Does

- `cli/commands/mission_type.py` `_teardown_coordination_worktree`: the slug read from the feature directory already embeds the mid8, and the message appended `-{mid8_value}` again. It now composes the identity through `coord_mission_dir_name(mission_slug, mid8=…)`, the seam's idempotent composer that the coord worktree and branch names already use, so the line matches the "Deleted coordination branch" line for slugs with or without the embedded mid8.
- `cli/commands/agent/workflow_executor.py` `implement_capture_baseline`: the three notices (`[dim]Baseline: …`, the capture-failed warning, the artifact-not-committed warning) used the builtin `print`; they now go through `specify_cli.cli.console.console`, which the same module already uses for its other lines. No message text changes.
- `cli/commands/agent/workflow.py` `_prepare_review_workspace`: the `ReviewLockError` leg printed `[red]{e}[/red]` with the builtin `print`, the same defect one module over. It goes through the console seam with `escape(str(e))`, since a lock message names agents, work packages and paths.
- Both exception texts (`bl_commit_exc`, the lock error) are escaped before they reach the renderer: git refusals such as `! [rejected] main -> main` would otherwise lose the bracketed word, and a stray `[/]` would raise `MarkupError` that the outer handler logs as something else.
- No formatting-only diffs; both source files are on the formatter ratchet list and were left as they are.

## Effect on Existing Projects

- Runtime / compatibility: output only; no behaviour, exit code or artifact changes.
- Upgrade / migration: none.
- Operator / reviewer impact: the teardown line names the same identity as the branch line; baseline notices are dim/yellow instead of showing tags.

## Validation

- [x] Relevant tests pass locally: the three new modules (6 tests), plus `tests/specify_cli/coordination/test_teardown_seam_persist_before_destroy.py`, `tests/integration/test_mission_close_discard_coord_teardown.py`, `tests/architectural/test_cli_console_single_seam.py`, `tests/architectural/test_arch_shard_marker_completeness.py` (23 passed). Copying only the three new test modules into a worktree at the merge base gives 5 failed, 1 passed, so five of the six new tests fail on `main`.
- [x] Backward compatibility impact considered (none).
- [x] Follow-up work called out if intentionally deferred (none).

New tests: `tests/specify_cli/cli/commands/test_mission_close_teardown_message.py` drives `_teardown_coordination_worktree` with the seam and `is_present` stubbed and checks the line for `relcheck-01M21R2T` and `relcheck`; `tests/specify_cli/cli/commands/agent/test_implement_capture_baseline_output.py` runs `implement_capture_baseline` with `capture_baseline` stubbed to 1 failure and to the `-1` sentinel and checks the rendered line carries no `[dim]`/`[yellow]`.

`ruff check` clean; `ruff format --check --force-exclude` clean.

## Tickets / Contracts

| Ticket | Relationship |
|--------|--------------|
| #4163 | Fixes |

## Mission Artifacts

- Spec: n/a (small fix outside a mission)
- Plan: n/a
- Research: n/a
- Review: n/a
- PR summary: n/a

## Follow-ups

- None.

